### PR TITLE
修复使用代理情况下走流返回，出现的返回吞字问题

### DIFF
--- a/client/src/service/utils/chat/index.ts
+++ b/client/src/service/utils/chat/index.ts
@@ -189,16 +189,16 @@ export const V2_StreamResponse = async ({
   let truncateData = '';
   const clientRes = async (data: string) => {
     //部分代理会导致流式传输时的数据被截断，不为json格式，这里做一个兼容
-
     const { content = '' } = (() => {
       try {
         if (truncateData) {
           try {
+            //判断是否为json，如果是的话直接跳过后续拼装操作，注意极端情况下可能出现截断成3截以上情况也可以兼容
             JSON.parse(data);
           } catch (e) {
             data = truncateData + data;
-            truncateData = '';
           }
+          truncateData = '';
         }
         const json = JSON.parse(data);
         const content: string = json?.choices?.[0].delta.content || '';


### PR DESCRIPTION
多进行了一次判断流返回是否为json，如果不为json存储起来并在下一次继续进行判断，组装成功或出现完整json时一个流程结束回到原始状态，极端情况下可能出现截断成3截以上情况也可以兼容