### PR TITLE
fix [issue-515]: corner case handling in splitText2Chunks

### DIFF
--- a/packages/global/common/string/textSplitter.ts
+++ b/packages/global/common/string/textSplitter.ts
@@ -27,9 +27,6 @@ export const splitText2Chunks = (props: { text: string; maxLen: number; overlapL
     9: /([，]|,\s)/g
   };
 
-  const sliceOverlapText = (chunk: string = '') =>
-    chunk.slice(Math.max(0, chunk.length - overlapLen), chunk.length);
-
   const splitTextRecursively = ({ text = '', step }: { text: string; step: number }) => {
     if (text.length <= maxLen) {
       return [text];
@@ -60,6 +57,7 @@ export const splitText2Chunks = (props: { text: string; maxLen: number; overlapL
     })();
 
     let chunks: string[] = [];
+    let preChunk: string = '';
     let chunk: string = '';
     for (let i = 0; i < splitTexts.length; i++) {
       let text = splitTexts[i];
@@ -72,11 +70,12 @@ export const splitText2Chunks = (props: { text: string; maxLen: number; overlapL
           chunks.push(chunk);
           // size overlapLen, push it to next chunk
           innerChunks = splitTextRecursively({
-            text: isMarkdownSplit ? text : sliceOverlapText(chunk) + text,
+            text: isMarkdownSplit ? text : preChunk + text,
             step: step + 1
           });
         }
         chunk = '';
+        preChunk = '';
         if (innerChunks.length === 0) continue;
         // If the last chunk is too small, it is merged into the next chunk
         if (innerChunks[innerChunks.length - 1].length <= tooSmallLen) {
@@ -89,10 +88,14 @@ export const splitText2Chunks = (props: { text: string; maxLen: number; overlapL
       }
 
       chunk += text;
+      // size over lapLen, push it to next chunk
+      if (chunk.length > maxLen - overlapLen) {
+        preChunk += text;
+      }
       if (chunk.length >= maxLen) {
         chunks.push(chunk);
-        // size overlapLen, push it to next chunk
-        chunk = isMarkdownSplit ? '' : sliceOverlapText(chunk);
+        chunk = isMarkdownSplit ? '' : preChunk;
+        preChunk = '';
       }
     }
 


### PR DESCRIPTION
fix issue https://github.com/labring/FastGPT/issues/515

Please focus on the logic and review it carefully.
This is a quick fix.
I have not test it in local env.

--------------------------------------------------------------------

This PR is based on the [old/clean version](https://github.com/labring/FastGPT/blob/2b8ff7d32c9f911c29ab25f036824d9cac7fa387/projects/app/src/global/common/string/tools.ts) and merges the new features in the [new version](https://github.com/labring/FastGPT/blob/main/packages/global/common/string/textSplitter.ts), eg. markdown, hyper parameter, into it.


--------------------------------------------------------------------

**问题描述**
Corner case handling in `splitText2Chunks`

I have reviewed two versions of `splitText2Chunks` implementation. Both of them have bugs.

Bugs in [new version]
https://github.com/labring/FastGPT/blob/main/packages/global/common/string/textSplitter.ts
```
      //                                                                                                                                                               
        // BUG 1: there is no overlap length when we call splitTextRecursively recursively.                                                                              
        //
        // BUG 2: too small chunk at the end of returned chunks of splitTextRecursively cannot be merged into next chunk when we call splitTextRecursively recursively.                                                        
        //                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
        // BUG 3: text may be reordered                                                                                                                                  
        // if:                                                                                                                                                           
        //  splitTexts = [                                                                                                                                               
        //    text1 = smallChunk1,                                                                                                                                        
        //    text2 = ' '.join(normalChunks),
        //    text3 = smallChunk3,                                                                                                   
        //  ]                                                                                                                                                            
        // then:                                                                                                                                                         
        //  chunks = [...normalChunks, smallChunk1 + smallChunk3]                                                                                                 
        //                                                                                                                                                               

```
Bugs in [old/clean version] https://github.com/labring/FastGPT/blob/2b8ff7d32c9f911c29ab25f036824d9cac7fa387/projects/app/src/global/common/string/tools.ts
```
      //                                                                                                                                                               
        // BUG 1: there is no overlap length when we call splitTextRecursively recursively.                                                                              
        //                                                                                                                                                               
        // BUG 2: too small chunk cannot be merged into next chunk when we call splitTextRecursively recursively.                                                        
        //                                                                                                                                                               
        // BUG 3: text may be reordered                                                                                                                                  
        // if:                                                                                                                                                           
        //  splitTexts = [                                                                                                                                               
        //    text1 = smallChunk,                                                                                                                                        
        //    text2 = ' '.join([...normalChunks, tooSmallLastChunk])                                                                                                   
        //  ]                                                                                                                                                            
        // then:                                                                                                                                                         
        //  chunks = [...normalChunks, smallChunk + tooSmallLastChunk]                                                                                                 
        //                                                                                                                                                               

```
