### PR TITLE
Add a switch to toggle whether or not quotes is shown in the answer result

### DIFF
--- a/packages/global/core/module/constants.ts
+++ b/packages/global/core/module/constants.ts
@@ -56,6 +56,7 @@ export enum ModuleInputKeyEnum {
   aiChatQuoteTemplate = 'quoteTemplate',
   aiChatQuotePrompt = 'quotePrompt',
   aiChatDatasetQuote = 'quoteQA',
+  aiChatDatasetQuoteShow = 'quoteShow',
 
   // dataset
   datasetSelectList = 'datasets',

--- a/packages/global/core/module/template/system/aiChat.ts
+++ b/packages/global/core/module/template/system/aiChat.ts
@@ -132,6 +132,16 @@ export const AiChatModule: FlowModuleTemplateType = {
       showTargetInApp: true,
       showTargetInPlugin: true
     },
+    {
+      key: ModuleInputKeyEnum.aiChatDatasetQuoteShow,
+      type: FlowNodeInputTypeEnum.switch,
+      label: '显示引用',
+      description: "是否在回答的结果中显示引用的知识库条目",
+      valueType: ModuleDataTypeEnum.boolean,
+      connected: false,
+      showTargetInApp: true,
+      showTargetInPlugin: true
+    },
     Input_Template_History,
     Input_Template_UserChatInput
   ],

--- a/projects/app/src/service/moduleDispatch/chat/oneapi.ts
+++ b/projects/app/src/service/moduleDispatch/chat/oneapi.ts
@@ -28,6 +28,7 @@ export type ChatProps = ModuleDispatchProps<
     [ModuleInputKeyEnum.userChatInput]: string;
     [ModuleInputKeyEnum.history]?: ChatItemType[];
     [ModuleInputKeyEnum.aiChatDatasetQuote]?: SearchDataResponseItemType[];
+    [ModuleInputKeyEnum.aiChatDatasetQuoteShow]?: boolean;
   }
 >;
 export type ChatResponse = {
@@ -50,6 +51,7 @@ export const dispatchChatCompletion = async (props: ChatProps): Promise<ChatResp
       maxToken = 4000,
       history = [],
       quoteQA = [],
+      quoteShow = false,
       userChatInput,
       isResponseAnswerText = true,
       systemPrompt = '',
@@ -188,7 +190,7 @@ export const dispatchChatCompletion = async (props: ChatProps): Promise<ChatResp
       tokens: totalTokens,
       query: userChatInput,
       maxToken: max_tokens,
-      quoteList: filterQuoteQA,
+      quoteList: quoteShow ? filterQuoteQA : undefined,
       historyPreview: getHistoryPreview(completeMessages)
     },
     history: completeMessages


### PR DESCRIPTION
Sometimes multiple knowledge bases are added to an orchestration, and one or more certain knowledge bases don't want to show up as referenced in the answer results. Maybe we could add a switch button to implement.