### PR TITLE
Optimize apk install process in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,7 @@ ARG name
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
-RUN sed -i 's/https/http/' /etc/apk/repositories
-RUN apk add curl \
-  && apk add ca-certificates \
+RUN apk add --no-cache curl ca-certificates \
   && update-ca-certificates
 
 # copy running files


### PR DESCRIPTION
Merge two apk install commands and use the `--no-cache` parameter to minimize the temporary files left in the Docker image.

I also noticed that there were different apk install processes in the Dockerfile. The second one has the process to replace https with http in `/etc/apk/repositories` before the installation, but the first one doesn't, meaning the process is unnecessary.