### PR TITLE
fix: 知识库 QA 导入无法选择 md 和 html 文件

### DIFF
--- a/projects/app/src/pages/dataset/detail/components/Import/QA.tsx
+++ b/projects/app/src/pages/dataset/detail/components/Import/QA.tsx
@@ -9,7 +9,7 @@ import { useImportStore, SelectorContainer, PreviewFileOrChunk } from './Provide
 import { useDatasetStore } from '@/web/core/dataset/store/dataset';
 import { useTranslation } from 'next-i18next';
 
-const fileExtension = '.txt, .docx, .pdf, .md .html';
+const fileExtension = '.txt, .docx, .pdf, .md, .html';
 
 const QAImport = () => {
   const { t } = useTranslation();


### PR DESCRIPTION
知识库-导入-QA 中提示可以选择 md 和 html 文件，但是确无法选择 md 和 html 文件。是因为 QA.tsx中定义的fileExtension变量少写了一个逗号，我加上了这个逗号。