### PR TITLE
fix: init pg error error: CREATE INDEX CONCURRENTLY cannot run inside…

### DIFF
--- a/packages/service/common/vectorStore/pg/controller.ts
+++ b/packages/service/common/vectorStore/pg/controller.ts
@@ -22,7 +22,11 @@ export async function initPg() {
           data_id VARCHAR(50) NOT NULL,
           createTime TIMESTAMP DEFAULT CURRENT_TIMESTAMP
       );
-      CREATE INDEX CONCURRENTLY IF NOT EXISTS vector_index ON ${PgDatasetTableName} USING hnsw (vector vector_ip_ops) WITH (m = 32, ef_construction = 64);
+    `);
+
+    await PgClient.query(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS vector_index ON ${PgDatasetTableName}
+      USING hnsw (vector vector_ip_ops) WITH (m = 32, ef_construction = 64);
     `);
 
     console.log('init pg successful');


### PR DESCRIPTION
- bug: init pg error error: CREATE INDEX CONCURRENTLY cannot run inside a transaction block
- fix: packages\service\common\vectorStore\pg\controller.ts
```
export async function initPg() {
  try {
    await connectPg();
    await PgClient.query(`
      CREATE EXTENSION IF NOT EXISTS vector;
      CREATE TABLE IF NOT EXISTS ${PgDatasetTableName} (
          id BIGSERIAL PRIMARY KEY,
          vector VECTOR(1536) NOT NULL,
          team_id VARCHAR(50) NOT NULL,
          tmb_id VARCHAR(50) NOT NULL,
          dataset_id VARCHAR(50) NOT NULL,
          collection_id VARCHAR(50) NOT NULL,
          data_id VARCHAR(50) NOT NULL,
          createTime TIMESTAMP DEFAULT CURRENT_TIMESTAMP
      );
    `);

    await PgClient.query(`
    CREATE INDEX CONCURRENTLY IF NOT EXISTS vector_index ON ${PgDatasetTableName}
      USING hnsw (vector vector_ip_ops) WITH (m = 32, ef_construction = 64);
    `);

    console.log('init pg successful');
  } catch (error) {
    console.log('init pg error', error);
  }
}
```