### PR TITLE
bugfix: 修复训练任务过早过期的问题

### DIFF
--- a/packages/service/core/dataset/training/schema.ts
+++ b/packages/service/core/dataset/training/schema.ts
@@ -107,7 +107,7 @@ try {
   // get training data and sort
   TrainingDataSchema.index({ weight: -1 });
   TrainingDataSchema.index({ lockTime: 1 });
-  TrainingDataSchema.index({ expireAt: 1 }, { expireAfterSeconds: 7 * 24 * 60 });
+  TrainingDataSchema.index({ expireAt: 1 }, { expireAfterSeconds: 7 * 24 * 60 * 60 }); // 7 days
 } catch (error) {
   console.log(error);
 }


### PR DESCRIPTION
bugfix: 修复训练任务过早过期的问题

-> 改成了正确的7天过期时间