### PR TITLE
Update http468.ts

### DIFF
--- a/projects/app/src/service/moduleDispatch/tools/http468.ts
+++ b/projects/app/src/service/moduleDispatch/tools/http468.ts
@@ -130,6 +130,7 @@ export const dispatchHttp468Request = async (props: HttpRequestProps): Promise<H
       ...results
     };
   } catch (error) {
+    const err = httpRequestErrorResponseData(error)
     return {
       [ModuleOutputKeyEnum.failed]: true,
       [ModuleOutputKeyEnum.responseData]: {
@@ -137,7 +138,7 @@ export const dispatchHttp468Request = async (props: HttpRequestProps): Promise<H
         params: Object.keys(params).length > 0 ? params : undefined,
         body: Object.keys(requestBody).length > 0 ? requestBody : undefined,
         headers: Object.keys(headers).length > 0 ? headers : undefined,
-        httpResult: { error }
+        httpResult: { error: err }
       }
     };
   }
@@ -278,4 +279,22 @@ function removeUndefinedSign(obj: Record<string, any>) {
     }
   }
   return obj;
+}
+function httpRequestErrorResponseData(error: any) {
+    try {
+        return {
+            message: error?.message || undefined,
+            name: error?.name || undefined,
+            method: error?.config?.method || undefined,
+            baseURL: error?.config?.baseURL || undefined,
+            url: error?.config?.url || undefined,
+            code: error?.code || undefined,
+            status: error?.status || undefined
+        }
+    } catch (error) {
+        return {
+            message: 'Request Failed',
+            name: "AxiosError",
+        };
+    }
 }


### PR DESCRIPTION
修复HTTP模块，http请求错误的stack堆栈信息长度冗余导致超过MongoDB数据库限制从而导致聊天对话插入数据库失败，修复方法为修改为如果http请求错误只返回几项重要信息而不是整个堆栈数据