### PR TITLE
fix: 知识库QA生成，答案中有“Q”会导致提前截断。

### DIFF
--- a/projects/app/src/service/events/generateQA.ts
+++ b/projects/app/src/service/events/generateQA.ts
@@ -176,7 +176,7 @@ ${replaceVariable(Prompt_AgentQA.fixedText, { text })}`;
  */
 function formatSplitText(text: string, rawText: string) {
   text = text.replace(/\\n/g, '\n'); // 将换行符替换为空格
-  const regex = /Q\d+:(\s*)(.*)(\s*)A\d+:(\s*)([\s\S]*?)(?=Q|$)/g; // 匹配Q和A的正则表达式
+  const regex = /Q\d+:(\s*)(.*)(\s*)A\d+:(\s*)([\s\S]*?)(?=Q\d|$)/g; // 匹配Q和A的正则表达式
   const matches = text.matchAll(regex); // 获取所有匹配到的结果
 
   const result: PushDatasetDataChunkProps[] = []; // 存储最终的结果


### PR DESCRIPTION
### fix: 知识库QA生成，答案中有“Q”会导致提前截断。

> 当前QA生成的Q格式为`Q\d+`，因此将匹配Q和A的正则表达式调整为 `Q\d` 作为判断

----
**example:**
```
text = 'Q1: 什么是SQL？\nA1: SQL代表结构化查询语言（Structured Query Language），它是用于管理关系型数据库系统的标准化语言。SQL允许用户执行各种任务，如从数据库中检索数据、插入新数据、更新现有数据以及删除数据。通过SQL，用户可以与数据库进行交互，并执行诸如查询、更新、插入和删除等操作。'
```
> old: `/Q\d+:(\s*)(.*)(\s*)A\d+:(\s*)([\s\S]*?)(?=Q|$)/g;`

```
Q: 什么是SQL？
A: S
```

> new:  `/Q\d+:(\s*)(.*)(\s*)A\d+:(\s*)([\s\S]*?)(?=Q\d|$)/g;`

```
Q: 什么是SQL？
A: SQL代表结构化查询语言（Structured Query Language），它是用于管理关系型数据库系统的标准化语言。SQL允许用户执行各种任务，如从数据库中检索数据、插入新数据、更新现有数据以及删除数据。通过SQL，用户可以与数据库进行交互，并执行诸如查询、更新、插入和删除等操作。
```
