### PR TITLE
Fix history in classifyQuestion and extract modules

### DIFF
--- a/projects/app/src/service/moduleDispatch/agent/classifyQuestion.ts
+++ b/projects/app/src/service/moduleDispatch/agent/classifyQuestion.ts
@@ -125,7 +125,7 @@ const getFunctionCallSchema = ({
               ? `<背景知识>
     ${systemPrompt}
     </背景知识>
-    
+
     问题: "${userChatInput}"
           `
               : userChatInput
@@ -284,7 +284,9 @@ const completions = async ({
               typeList: agents
                 .map((item) => `{"questionType": "${item.value}", "typeId": "${item.key}"}`)
                 .join('\n'),
-              history: histories.map((item) => `${item.obj}:${item.value}`).join('\n'),
+              history: histories
+                .map((item) => `${item.obj}:${item.value[0].text.content}`)
+                .join('\n'),
               question: userChatInput
             })
           }

--- a/projects/app/src/service/moduleDispatch/agent/classifyQuestion.ts
+++ b/projects/app/src/service/moduleDispatch/agent/classifyQuestion.ts
@@ -24,6 +24,7 @@ import {
   ChatCompletionTool
 } from '@fastgpt/global/core/ai/type';
 import { DispatchNodeResultType } from '@fastgpt/global/core/module/runtime/type';
+import { chatValue2RuntimePrompt } from '@fastgpt/global/core/chat/adapt';
 
 type Props = ModuleDispatchProps<{
   [ModuleInputKeyEnum.aiModel]: string;
@@ -285,7 +286,7 @@ const completions = async ({
                 .map((item) => `{"questionType": "${item.value}", "typeId": "${item.key}"}`)
                 .join('\n'),
               history: histories
-                .map((item) => `${item.obj}:${item.value[0].text.content}`)
+                .map((item) => `${item.obj}:${chatValue2RuntimePrompt(item.value).text}`)
                 .join('\n'),
               question: userChatInput
             })

--- a/projects/app/src/service/moduleDispatch/agent/extract.ts
+++ b/projects/app/src/service/moduleDispatch/agent/extract.ts
@@ -160,7 +160,7 @@ const getFunctionCallSchema = ({
           - 字符串不要换行。
           - 结合上下文和当前问题进行获取。
           """
-          
+
           当前问题: "${content}"`
           }
         }
@@ -325,8 +325,8 @@ const completions = async ({
                     }}`
                 )
                 .join('\n'),
-              text: `${histories.map((item) => `${item.obj}:${item.value}`).join('\n')}
-      Human: ${content}`
+              text: `${histories.map((item) => `${item.obj}:${item.value[0].text.content}`).join('\n')}
+Human: ${content}`
             })
           }
         }

--- a/projects/app/src/service/moduleDispatch/agent/extract.ts
+++ b/projects/app/src/service/moduleDispatch/agent/extract.ts
@@ -25,6 +25,7 @@ import {
 } from '@fastgpt/global/core/ai/type';
 import { ChatCompletionRequestMessageRoleEnum } from '@fastgpt/global/core/ai/constants';
 import { DispatchNodeResultType } from '@fastgpt/global/core/module/runtime/type';
+import { chatValue2RuntimePrompt } from '@fastgpt/global/core/chat/adapt';
 
 type Props = ModuleDispatchProps<{
   [ModuleInputKeyEnum.history]?: ChatItemType[];
@@ -325,7 +326,7 @@ const completions = async ({
                     }}`
                 )
                 .join('\n'),
-              text: `${histories.map((item) => `${item.obj}:${item.value[0].text.content}`).join('\n')}
+              text: `${histories.map((item) => `${item.obj}:${chatValue2RuntimePrompt(item.value).text}`).join('\n')}
 Human: ${content}`
             })
           }


### PR DESCRIPTION
It seems that classifyQuestion and extract modules do not process the chat histories correctly. 

It passes **Object** rather than the **text** to the LLM

![screenshot-20240318-171935](https://github.com/labring/FastGPT/assets/10344448/b8b26981-0193-4b1b-bec8-dc908a4b2b95)


