### PR TITLE
fix: claude3 image type verification failed (#1038)

### DIFF
--- a/packages/service/common/file/utils.ts
+++ b/packages/service/common/file/utils.ts
@@ -9,3 +9,21 @@ export const removeFilesByPaths = (paths: string[]) => {
     });
   });
 };
+
+const imageTypeMap: Record<string, string> = {
+  '/': 'image/jpeg',
+  i: 'image/png',
+  R: 'image/gif',
+  U: 'image/webp',
+  Q: 'image/bmp'
+};
+
+export const guessImageTypeFromBase64 = (str: string) => {
+  const defaultType = 'image/jpeg';
+  if (typeof str !== 'string' || str.length === 0) {
+    return defaultType;
+  }
+
+  const firstChar = str.charAt(0);
+  return imageTypeMap[firstChar] || defaultType;
+};

--- a/projects/app/src/pages/api/system/img/[id].ts
+++ b/projects/app/src/pages/api/system/img/[id].ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { jsonRes } from '@fastgpt/service/common/response';
 import { connectToDatabase } from '@/service/mongo';
 import { readMongoImg } from '@fastgpt/service/common/file/image/controller';
+import { guessImageTypeFromBase64 } from '@fastgpt/service/common/file/utils';
 
 // get the models available to the system
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -9,9 +10,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     await connectToDatabase();
     const { id } = req.query as { id: string };
 
-    res.setHeader('Content-Type', 'image/jpeg');
-
-    res.send(await readMongoImg({ id }));
+    const binary = await readMongoImg({ id });
+    const imageType = guessImageTypeFromBase64(binary.toString('base64'));
+    res.setHeader('Content-Type', imageType);
+    res.send(binary);
   } catch (error) {
     jsonRes(res, {
       code: 500,


### PR DESCRIPTION
1.  添加根据 base64 首字母推测图片类型的函数。
2. 修复由于图片下载丢失原类型（统一为 image/jpeg），导致的 claude3 多模态接口无法使用的问题。 #1038 