### PR TITLE
Fix: issue with InputDataModal and controller.ts

### DIFF
--- a/projects/app/src/pages/dataset/detail/components/InputDataModal.tsx
+++ b/projects/app/src/pages/dataset/detail/components/InputDataModal.tsx
@@ -295,9 +295,6 @@ const InputDataModal = ({
                       </Box>
                       <DeleteIcon
                         onClick={() => {
-                          if (indexes.length <= 1) {
-                            appendIndexes(getDefaultIndex({ dataId: `${Date.now()}` }));
-                          }
                           removeIndexes(i);
                         }}
                       />

--- a/projects/app/src/service/core/dataset/data/controller.ts
+++ b/projects/app/src/service/core/dataset/data/controller.ts
@@ -45,7 +45,7 @@ export async function insertData2Dataset({
     Array.isArray(indexes) && indexes.length > 0
       ? indexes.map((index) => ({
           // @ts-ignore
-          ...index.toObject(),
+          ...index,
           dataId: undefined,
           defaultIndex: index.text.trim() === qaStr
         }))


### PR DESCRIPTION
![image](https://github.com/labring/FastGPT/assets/10344448/ed32a336-e97f-4d07-9fb7-75b1f4a2e14f)

1. **projects/app/src/service/core/dataset/data/controller.ts**, indexes is a list.
2. **projects/app/src/pages/dataset/detail/components/InputDataModal.tsx** getDefaultIndex creates an Index with empty text, which cannot be parsed correctly in **controller.ts**. I moved it because it can be auto created at [here](https://github.com/Fengrui-Liu/FastGPT/blob/92e5d0a2fafa9ec3d5300d9d147cbf51dba34191/projects/app/src/service/core/dataset/data/controller.ts#L54)

how to replay this bug:
1. add a new index
![image](https://github.com/labring/FastGPT/assets/10344448/d2350607-47d1-48b3-9137-209fea8111af)
2. delete the new index
3. import it

