### PR TITLE
Update docker-compose.yml

### DIFF
--- a/files/deploy/fastgpt/docker-compose.yml
+++ b/files/deploy/fastgpt/docker-compose.yml
@@ -51,7 +51,7 @@ services:
           })
         }' > /data/initReplicaSet.js
         # 启动MongoDB服务
-        exec docker-entrypoint.sh "$@" &
+        exec docker-entrypoint.sh "$$@" &
 
         # 等待MongoDB服务启动
         until mongo -u myusername -p mypassword --authenticationDatabase admin --eval "print('waited for connection')" > /dev/null 2>&1; do
@@ -63,7 +63,7 @@ services:
         mongo -u myusername -p mypassword --authenticationDatabase admin /data/initReplicaSet.js
 
         # 等待docker-entrypoint.sh脚本执行的MongoDB服务进程
-        wait $!
+        wait $$!
   fastgpt:
     container_name: fastgpt
     image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.7 # git


### PR DESCRIPTION
Fix `docker-compose up -d`  Error : 
 ```
ERROR: Invalid interpolation format for "entrypoint" option in service "mongo": "openssl rand -base64 128 > /data/mongodb.key
```
修复docker-compose.yml中环境变量替换问题

由于docker-compose在解析entrypoint中的$字符时会将其误认为环境变量，导致无法正确处理脚本里的特殊变量（如 "$@"）。通过将$字符替换为$$来避免这一问题，确保了docker-compose可以正确解析并执行MongoDB初始化脚本。