### PR TITLE
修复拖动聊天图标容易中断问题

### DIFF
--- a/projects/app/public/js/iframe.js
+++ b/projects/app/public/js/iframe.js
@@ -76,7 +76,8 @@ function embedChatbot() {
 
     chatBtnDown = true;
   });
-  ChatBtn.addEventListener('mousemove', (e) => {
+
+  window.addEventListener('mousemove', (e) => {
     e.stopPropagation();
     if (!canDrag || !chatBtnDown) return;
 
@@ -86,12 +87,8 @@ function embedChatbot() {
 
     ChatBtn.style.transform = `translate3d(${transformX}px, ${transformY}px, 0)`;
   });
-  ChatBtn.addEventListener('mouseup', (e) => {
-    chatBtnDragged = false;
-    chatBtnDown = false;
-  });
+
   window.addEventListener('mouseup', (e) => {
-    chatBtnDragged = false;
     chatBtnDown = false;
   });
 


### PR DESCRIPTION
修复因鼠标移动速度过快导致拖拽聊天图标容易中断的问题。