### PR TITLE
fix: base64 image undefined

### DIFF
--- a/packages/service/core/chat/utils.ts
+++ b/packages/service/core/chat/utils.ts
@@ -6,6 +6,7 @@ import type {
 } from '@fastgpt/global/core/ai/type.d';
 import axios from 'axios';
 import { ChatCompletionRequestMessageRoleEnum } from '@fastgpt/global/core/ai/constants';
+import { guessBase64ImageType } from '../../common/file/utils';
 
 /* slice chat context by tokens */
 const filterEmptyMessages = (messages: ChatCompletionMessageParam[]) => {
@@ -242,7 +243,11 @@ export const loadChatImgToBase64 = async (content: string | ChatCompletionConten
         responseType: 'arraybuffer'
       });
       const base64 = Buffer.from(response.data).toString('base64');
-      item.image_url.url = `data:${response.headers['content-type']};base64,${base64}`;
+      let imageType = response.headers['content-type'];
+      if (imageType === undefined) {
+        imageType = guessBase64ImageType(base64);
+      }
+      item.image_url.url = `data:${imageType};base64,${base64}`;
       return item;
     })
   );


### PR DESCRIPTION
修复通过 API 访问调用多模态模型应用接口，传入 `Data URI` 由于图片类型 `undefined` 接口报错的问题。  #1217