### PR TITLE
修复config.json中配置的个性化内容被默认配置覆盖的问题

### DIFF
--- a/projects/app/src/pages/api/common/system/getInitData.ts
+++ b/projects/app/src/pages/api/common/system/getInitData.ts
@@ -90,8 +90,7 @@ export async function initSystemConfig() {
   // get config from database
   const config: FastGPTConfigFileType = {
     feConfigs: {
-      ...fileRes?.feConfigs,
-      ...defaultFeConfigs,
+      ...(fileRes?.feConfigs || defaultFeConfigs),
       ...(dbConfig.feConfigs || {}),
       isPlus: !!FastGPTProUrl
     },


### PR DESCRIPTION
如题