### PR TITLE
添加AI对话时隐藏头部的功能，主要是适配移动端

### DIFF
--- a/projects/app/src/pages/chat/share.tsx
+++ b/projects/app/src/pages/chat/share.tsx
@@ -49,12 +49,14 @@ const OutLink = ({ appName, appIntro, appAvatar }: Props) => {
     shareId = '',
     chatId = '',
     showHistory = '1',
+    showHead = '1',
     authToken,
     ...customVariables
   } = router.query as {
     shareId: string;
     chatId: string;
     showHistory: '0' | '1';
+    showHead: '0' | '1',
     authToken: string;
     [key: string]: string;
   };
@@ -294,12 +296,16 @@ const OutLink = ({ appName, appIntro, appAvatar }: Props) => {
             flexDirection={'column'}
           >
             {/* header */}
-            <ChatHeader
+            {showHead === "1" ? (
+              <ChatHeader
               appAvatar={chatData.app.avatar}
               appName={chatData.app.name}
               history={chatData.history}
               showHistory={showHistory === '1'}
             />
+            ) : (
+              null
+            )}
             {/* chat box */}
             <Box flex={1}>
               <ChatBox


### PR DESCRIPTION
添加了通过使用iframe引用chat页面时隐藏头部的功能，主要是应对多个iframe引用多个页面的情况，具体应用情况看下图吧：
![4891eef003ef9e08649fdace6cc63ad](https://github.com/labring/FastGPT/assets/57851281/5209286f-40cf-45ed-8013-827f061e69f3)
我知道这功能挺傻的，但老板要加╮(╯▽╰)╭
我想，还是提个PR，看看会不会被合到主代码里，免得以后主代码升级了，我都必去拉源码来本地编译开发。
唉~，生活不易！