### PR TITLE
in case of multiple AI chat flow with vision, query is only needed for the first chat node

### DIFF
--- a/packages/service/core/workflow/dispatch/index.ts
+++ b/packages/service/core/workflow/dispatch/index.ts
@@ -312,6 +312,11 @@ export async function dispatchWorkFlow(data: Props): Promise<DispatchFlowRespons
       return {};
     })();
 
+    // in case of multiple AI chat flow with vision, query is only needed for the first chat node
+    if (node.flowNodeType === FlowNodeTypeEnum.chatNode) {
+      props.query = [];
+    }
+
     // format response data. Add modulename and module type
     const formatResponseData: ChatHistoryItemResType = (() => {
       if (!dispatchRes[DispatchNodeResponseKeyEnum.nodeResponse]) return undefined;


### PR DESCRIPTION
with a flow that the first chat node is vision, the second is text generation, query with files field will make the second chat node fail to generate.Set it blank to avoid the issue.