### PR TITLE
fix(prompt): typo template tag

### DIFF
--- a/packages/global/core/ai/prompt/agent.ts
+++ b/packages/global/core/ai/prompt/agent.ts
@@ -20,7 +20,7 @@ A2:
 
 <Context>
 {{text}}
-<Context/>
+</Context>
 `
 };
 


### PR DESCRIPTION
I find `<Context/>` , i think this is wrong tag.