### PR TITLE
feat(image): metadata support image mime type

### DIFF
--- a/packages/global/common/file/image/type.d.ts
+++ b/packages/global/common/file/image/type.d.ts
@@ -9,6 +9,7 @@ export type MongoImageSchemaType = {
   type: `${MongoImageTypeEnum}`;
 
   metadata?: {
+    mime?: string; // image mime type.
     relatedId?: string; // This id is associated with a set of images
   };
 };

--- a/projects/app/src/pages/api/system/img/[id].ts
+++ b/projects/app/src/pages/api/system/img/[id].ts
@@ -10,9 +10,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     await connectToDatabase();
     const { id } = req.query as { id: string };
 
-    const binary = await readMongoImg({ id });
+    const { binary, metadata } = await readMongoImg({ id });
 
-    res.setHeader('Content-Type', guessBase64ImageType(binary.toString('base64')));
+    res.setHeader('Content-Type', metadata?.mime ?? guessBase64ImageType(binary.toString('base64')));
     res.send(binary);
   } catch (error) {
     jsonRes(res, {


### PR DESCRIPTION
在解析文件的过程中，我发现了类似于 `image/tiff` 的图片格式，我尝试将解析图片的 base64 `mime` 类型记录在 `metadata` 中，以便响应正确的类型，并且后续如果需要对图片进行更多处理的话，可以用到这个字段。