### PR TITLE
perf: dataset upload process render

### DIFF
--- a/projects/app/src/pages/dataset/detail/components/Import/components/FileSelector.tsx
+++ b/projects/app/src/pages/dataset/detail/components/Import/components/FileSelector.tsx
@@ -111,7 +111,8 @@ const FileSelector = ({
                     ? {
                         ...item,
                         dbFileId: uploadFileId,
-                        isUploading: false
+                        isUploading: false,
+                        uploadedFileRate: 100
                       }
                     : item
                 )

--- a/projects/app/src/pages/dataset/detail/components/Import/diffSource/FileLocal.tsx
+++ b/projects/app/src/pages/dataset/detail/components/Import/diffSource/FileLocal.tsx
@@ -49,7 +49,7 @@ const SelectFile = React.memo(function SelectFile() {
 
   const onclickNext = useCallback(() => {
     // filter uploaded files
-    setSelectFiles((state) => state.filter((item) => (item.uploadedFileRate || 0) >= 100));
+    setSelectFiles((state) => state.filter((item) => item.dbFileId));
     goToNext();
   }, [goToNext]);
 


### PR DESCRIPTION
After the file is uploaded, the progress is forcibly updated, and the progress is not used to determine whether the upload is complete.
May solve https://github.com/labring/FastGPT/issues/2148