### PR TITLE
fix(dataset): 知识库列表右下角类型的名称上下居中

### DIFF
--- a/projects/app/src/components/core/dataset/DatasetTypeTag.tsx
+++ b/projects/app/src/components/core/dataset/DatasetTypeTag.tsx
@@ -19,6 +19,7 @@ const DatasetTypeTag = ({ type, ...props }: { type: `${DatasetTypeEnum}` } & Fle
       py={'6px'}
       borderRadius={'md'}
       fontSize={'xs'}
+      alignItems={'center'}
       {...props}
     >
       <MyIcon name={item.icon as any} w={'16px'} mr={2} color={'myGray.400'} />


### PR DESCRIPTION
知识库列表右下角类型名称垂直居中
before:
![image](https://github.com/user-attachments/assets/5455c2bc-6941-403f-a16b-8bdbed959ad0)
after:
![image](https://github.com/user-attachments/assets/c8d8fa4d-98aa-4078-bad0-a2b6be2df727)
