### PR TITLE
添加一个参数控制接口是否返回answer: [DONE] Update completions.ts

### DIFF
--- a/projects/app/src/pages/api/v1/chat/completions.ts
+++ b/projects/app/src/pages/api/v1/chat/completions.ts
@@ -114,6 +114,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
     stream = false,
     detail = false,
+    done = true,
     messages = [],
     variables = {},
     responseChatItemId = getNanoid()
@@ -354,12 +355,14 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
           finish_reason: 'stop'
         })
       });
-      responseWrite({
-        res,
-        event: detail ? SseResponseEventEnum.answer : undefined,
-        data: '[DONE]'
-      });
-
+      if(done) {
+          responseWrite({
+          res,
+          event: detail ? SseResponseEventEnum.answer : undefined,
+          data: '[DONE]'
+        });
+      }
+      
       if (detail) {
         if (responseDetail || isPlugin) {
           responseWrite({


### PR DESCRIPTION
添加一个参数来控制是否需要返回answer: [DONE]，这个对JSON解析场景不太友好，所有的answer都是json格式，唯独这个不是，在有的端做解析时候没办法区分，比如java的webflux 中webclient的解码器，会默认解析为json，还没办法过滤。