### PR TITLE
Fix: Custom delimiter does not take effect when document type is link

### DIFF
--- a/packages/service/core/dataset/collection/utils.ts
+++ b/packages/service/core/dataset/collection/utils.ts
@@ -159,7 +159,8 @@ export const reloadCollectionChunks = async ({
   // split data
   const { chunks } = splitText2Chunks({
     text: newRawText,
-    chunkLen: col.chunkSize || 512
+    chunkLen: col.chunkSize || 512,
+    customReg: col.chunkSplitter ? [col.chunkSplitter] : [],
   });
 
   // insert to training queue


### PR DESCRIPTION
When the knowledge base input, select the type is the link input method, preview the segment, the custom segment takes effect, but click Next to upload, the custom segment does not take effect, according to the source code analysis, did not pass the custom separator to the slice method.