### PR TITLE
Fixs:当最后一条数据因大模型没返回数据时导致调试时前端报错。

### DIFF
--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts
@@ -51,6 +51,7 @@ export const checkIsInteractiveByHistories = (chatHistories: ChatSiteItemType[])
   ] as AIChatItemValueItemType;
 
   return (
+    lastMessageValue &&
     lastMessageValue.type === ChatItemValueTypeEnum.interactive &&
     !!lastMessageValue?.interactive?.params &&
     // 如果用户选择了，则不认为是交互模式（可能是上一轮以交互结尾，发起的新的一轮对话）


### PR DESCRIPTION
### 修改内容
在调试页面，当调试时，大模型没有反回值，会导致页面崩溃。

### 原因
lastMessageValue取值时需要提前判断空值，否则取出来的值为空对象。

### 图片
<img width="1104" alt="image" src="https://github.com/user-attachments/assets/07923e9e-612c-44c5-8196-a57ef0c64a64">
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/b4604594-1906-4785-82d8-a9e13ad513db">
