### PR TITLE
Fix typo location of python bge-rerank

### DIFF
--- a/python/bge-rerank/README.md
+++ b/python/bge-rerank/README.md
@@ -22,9 +22,9 @@
 
 3 个模型代码分别为：
 
-1. [https://github.com/labring/FastGPT/tree/main/python/reranker/bge-reranker-base](https://github.com/labring/FastGPT/tree/main/python/reranker/bge-reranker-base)
-2. [https://github.com/labring/FastGPT/tree/main/python/reranker/bge-reranker-large](https://github.com/labring/FastGPT/tree/main/python/reranker/bge-reranker-large)
-3. [https://github.com/labring/FastGPT/tree/main/python/reranker/bge-reranker-v2-m3](https://github.com/labring/FastGPT/tree/main/python/reranker/bge-reranker-v2-m3)
+1. [https://github.com/labring/FastGPT/tree/main/python/bge-rerank/bge-reranker-base](https://github.com/labring/FastGPT/tree/main/python/bge-rerank/bge-reranker-base)
+2. [https://github.com/labring/FastGPT/tree/main/python/bge-rerank/bge-reranker-large](https://github.com/labring/FastGPT/tree/main/python/bge-rerank/bge-reranker-large)
+3. [https://github.com/labring/FastGPT/tree/main/python/bge-rerank/bge-reranker-v2-m3](https://github.com/labring/FastGPT/tree/main/python/bge-rerank/bge-reranker-v2-m3)
 
 ### 3. 安装依赖
 


### PR DESCRIPTION
Fix typo location of python bge-rerank