### PR TITLE
fix: Stream模式下使用toolChoice,toolCall的function和type可能为null

### DIFF
--- a/packages/service/core/workflow/dispatch/agent/runTool/toolChoice.ts
+++ b/packages/service/core/workflow/dispatch/agent/runTool/toolChoice.ts
@@ -423,8 +423,8 @@ async function streamResponse({
         // Start call tool
         if (toolCall.id) {
           callingTool = {
-            name: toolCall.function.name || '',
-            arguments: toolCall.function.arguments || ''
+            name: toolCall.function?.name || '',
+            arguments: toolCall.function?.arguments || ''
           };
         } else if (callingTool) {
           // Continue call
@@ -442,6 +442,7 @@ async function streamResponse({
           toolCalls.push({
             ...toolCall,
             id: toolId,
+            type: 'function',
             function: toolFunction,
             toolName: toolNode.name,
             toolAvatar: toolNode.avatar


### PR DESCRIPTION
# 不同的模型在strem模式下返回的参数顺序可能不一样，导致异常
## 第一种情况
**第一次返回不带function对象** 
![image](https://github.com/user-attachments/assets/67ad0095-07d8-44fb-a53a-4303838560f6)
![image](https://github.com/user-attachments/assets/4b0ef2f4-bbbe-43b4-a864-9a46ce77ca5e)
## 第二种情况
**第二次返回不带type字段**
![image](https://github.com/user-attachments/assets/21e38b40-9795-4c72-9f93-f8b1fa4b3e6e)
![image](https://github.com/user-attachments/assets/c482e308-2f3e-430d-b439-056c5742931d)
