### PR TITLE
updated: docs/docker.md，修改 config.json 的地址

### DIFF
--- a/docSite/content/zh-cn/docs/development/docker.md
+++ b/docSite/content/zh-cn/docs/development/docker.md
@@ -110,7 +110,7 @@ brew install orbstack
 
 非 Linux 环境或无法访问外网环境，可手动创建一个目录，并下载配置文件和对应版本的`docker-compose.yml`，在这个文件夹中依据下载的配置文件运行docker，若作为本地开发使用推荐`docker-compose-pgvector`版本，并且自行拉取并运行`sandbox`和`fastgpt`，并在docker配置文件中注释掉`sandbox`和`fastgpt`的部分
 
-- [config.json](https://github.com/labring/FastGPT/blob/main/projects/app/data/config.json)
+- [config.json](https://raw.githubusercontent.com/labring/FastGPT/refs/heads/main/projects/app/data/config.json)
 - [docker-compose.yml](https://github.com/labring/FastGPT/blob/main/files/docker) (注意，不同向量库版本的文件不一样)
 
 {{% alert icon="🤖" context="success" %}}


### PR DESCRIPTION
原先 config.json 的地址是：
https://github.com/labring/FastGPT/blob/main/projects/app/data/config.json

如果没有考虑太多，直接 wget "https://github.com/labring/FastGPT/blob/main/projects/app/data/config.json"，则会下载到网页版的 `config.json`。这不是一个 json 文件，而是 github 的网页。

所以，修改为 `https://raw.githubusercontent.com/labring/FastGPT/refs/heads/main/projects/app/data/config.json` 更加合理