### PR TITLE
解决第二次运行pnpm i时报错：File exists

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,4 +1,4 @@
 # 创建临时文件目录
-mkdir projects/app/tmp
+mkdir -p projects/app/tmp
 # 初始化UI库的自定义ts类型
 pnpm run gen:theme-typings


### PR DESCRIPTION
/app # pnpm i Scope: all 8 workspace projects Lockfile is up to date, resolution step is skipped Already up to date . postinstall$ sh ./scripts/postinstall.sh │ mkdir: can't create directory 'projects/app/tmp': File exists └─ Failed in 16ms at /app  ELIFECYCLE  Command failed with exit code 1.
