### PR TITLE
优化应用中，文件夹内的新增按钮，根据文件夹权进行显示

### DIFF
--- a/projects/app/src/pages/app/list/index.tsx
+++ b/projects/app/src/pages/app/list/index.tsx
@@ -179,8 +179,10 @@ const MyApps = () => {
 
             {isPc && RenderSearchInput}
 
-            {userInfo?.team.permission.hasWritePer &&
-              folderDetail?.type !== AppTypeEnum.httpPlugin && (
+            {(folderDetail?.permission
+              ? folderDetail?.permission.hasWritePer
+              : userInfo?.team.permission.hasWritePer &&
+                folderDetail?.type !== AppTypeEnum.httpPlugin) && (
                 <MyMenu
                   iconSize="2rem"
                   Button={


### PR DESCRIPTION
目前文件夹的新增按钮是根据团队的权限，在文件夹内没有权限的话，还是显示新增按钮，要等提交时才会报错没有权限