### PR TITLE
fix: 解决工具调用,同一个工具调用多次,相同参数的值被后面覆盖的问题

### DIFF
--- a/packages/service/core/workflow/dispatch/agent/runTool/toolChoice.ts
+++ b/packages/service/core/workflow/dispatch/agent/runTool/toolChoice.ts
@@ -360,11 +360,16 @@ export const runToolWithToolChoice = async (
           }
         })();
 
-        initToolNodes(runtimeNodes, [toolNode.nodeId], startParams);
-        const toolRunResponse = await dispatchWorkFlow({
-          ...workflowProps,
-          isToolCall: true
-        });
+        const newRuntimeNodes = initToolNodes(
+            [...workflowProps.runtimeNodes],
+            [toolNode.nodeId],
+            startParams
+          );
+          const toolRunResponse = await dispatchWorkFlow({
+            ...workflowProps,
+            runtimeNodes: newRuntimeNodes, // 使用新的节点数组
+            isToolCall: true
+          });
 
         const stringToolResponse = formatToolResponse(toolRunResponse.toolResponses);
 

--- a/packages/service/core/workflow/dispatch/agent/runTool/utils.ts
+++ b/packages/service/core/workflow/dispatch/agent/runTool/utils.ts
@@ -59,12 +59,14 @@ export const initToolNodes = (
   entryNodeIds: string[],
   startParams?: Record<string, any>
 ) => {
-  nodes.forEach((node) => {
+  return nodes.map((node) => {
     if (entryNodeIds.includes(node.nodeId)) {
-      node.isEntry = true;
+      const newNode = { ...node, isEntry: true };
       if (startParams) {
-        node.inputs = updateToolInputValue({ params: startParams, inputs: node.inputs });
+        newNode.inputs = updateToolInputValue({ params: startParams, inputs: [...node.inputs] });
       }
+      return newNode;
     }
+    return node;
   });
 };


### PR DESCRIPTION
工作流:
![image](https://github.com/user-attachments/assets/2486b48b-05b7-48fd-8e40-710f18883d81)
插件配置:
![image](https://github.com/user-attachments/assets/f83935a8-c488-453e-af0f-30abe0b30f32)


问题:
当工具调用该插件多次时,前面的参数会被覆盖

查询10月和11月份的数据
但是执行的时候,month参数都是取的11月
![17339035912729](https://github.com/user-attachments/assets/fdb665b0-d12f-4a8a-b072-1e7fe7b389f1)
![image](https://github.com/user-attachments/assets/7dd6b264-d7a8-45f8-a4d6-a27c6e96a1b4)
![image](https://github.com/user-attachments/assets/81cf3a1f-9f0f-410a-b4d6-3924c2fddba0)
