### PR TITLE
修复：设置NEXT_PUBLIC_BASE_URL时，图片文件读取URL不正确

### DIFF
--- a/packages/service/common/file/image/controller.ts
+++ b/packages/service/common/file/image/controller.ts
@@ -35,7 +35,7 @@ export async function uploadMongoImg({
     shareId
   });
 
-  return `${process.env.FE_DOMAIN || ''}${imageBaseUrl}${String(_id)}.${extension}`;
+  return `${process.env.FE_DOMAIN || ''}${process.env.NEXT_PUBLIC_BASE_URL || ''}${imageBaseUrl}${String(_id)}.${extension}`;
 }
 
 export async function readMongoImg({ id }: { id: string }) {


### PR DESCRIPTION
在当前实现中，当设置了子路径（NEXT_PUBLIC_BASE_URL）时，图片文件的读取路径不正确，导致图片无法正常显示或访问。具体表现为生成的图片 URL 缺少子路径部分，导致请求失败。

**解决方案**：
在生成图片 URL 时，增加对 NEXT_PUBLIC_BASE_URL 环境变量的处理 `${process.env.NEXT_PUBLIC_BASE_URL || ''}`，确保在设置子路径时，URL 能够正确包含子路径部分。
```js
return `${process.env.FE_DOMAIN || ''}${process.env.NEXT_PUBLIC_BASE_URL || ''}${imageBaseUrl}${String(_id)}.${extension}`;
```