### PR TITLE
openai格式的API调用时，用户可以通过variables指定oneapi的ai key

### DIFF
--- a/packages/service/core/workflow/dispatch/index.ts
+++ b/packages/service/core/workflow/dispatch/index.ts
@@ -133,6 +133,17 @@ export async function dispatchWorkFlow(data: Props): Promise<DispatchFlowRespons
     ...props
   } = data;
 
+  const handleApiKey = () => {
+    //api调用指定了key的情况下，使用这个key
+    if (variables.ChatApiKey) {
+      externalProvider.openaiAccount = {
+        key: variables.ChatApiKey,
+        baseUrl: '' //使用系统默认的base url
+      };
+    }
+  };
+  handleApiKey();
+
   // 初始化深度和自动增加深度，避免无限嵌套
   if (!props.workflowDispatchDeep) {
     props.workflowDispatchDeep = 1;


### PR DESCRIPTION
虽然此pr和fastgpt产品的设计不相一致，但是考虑到这个长尾场景的潜在开发者数量，也许会对本项目的星图有帮助吧。建议考虑合并一下吧。