### PR TITLE
fix: 插件输入和表单输入的数字输入框无法输入0

### DIFF
--- a/projects/app/src/pages/app/detail/components/WorkflowComponents/Flow/nodes/NodePluginIO/InputTypeConfig.tsx
+++ b/projects/app/src/pages/app/detail/components/WorkflowComponents/Flow/nodes/NodePluginIO/InputTypeConfig.tsx
@@ -250,7 +250,7 @@ const InputTypeConfig = ({
               max={50000}
               onChange={(e) => {
                 // @ts-ignore
-                setValue('maxLength', e || '');
+                setValue('maxLength', e ?? '');
               }}
             />
           </Flex>
@@ -266,7 +266,7 @@ const InputTypeConfig = ({
                 value={max}
                 onChange={(e) => {
                   // @ts-ignore
-                  setValue('max', e || '');
+                  setValue('max', e ?? '');
                 }}
               />
             </Flex>
@@ -278,7 +278,7 @@ const InputTypeConfig = ({
                 value={min}
                 onChange={(e) => {
                   // @ts-ignore
-                  setValue('min', e || '');
+                  setValue('min', e ?? '');
                 }}
               />
             </Flex>
@@ -298,7 +298,7 @@ const InputTypeConfig = ({
                   max={max}
                   onChange={(e) => {
                     // @ts-ignore
-                    setValue('defaultValue', e || '');
+                    setValue('defaultValue', e ?? '');
                   }}
                 />
               )}


### PR DESCRIPTION
* 表单输入的数字输入框无法输入0
![image](https://github.com/user-attachments/assets/c3936781-b18b-4f00-a156-45ed67a0c719)

* 插件输入的数字输入框无法输入0
![image](https://github.com/user-attachments/assets/e4cf764f-c74a-4ac3-a4a5-546f7d97d9cc)
