### PR TITLE
Load models error Error: ENOENT: no such file or directory, scandir

### DIFF
--- a/packages/service/core/ai/config/utils.ts
+++ b/packages/service/core/ai/config/utils.ts
@@ -27,7 +27,10 @@ import { delay } from '@fastgpt/global/common/system/utils';
 export const loadSystemModels = async (init = false) => {
   const getProviderList = () => {
     const currentFileUrl = new URL(import.meta.url);
-    const modelsPath = path.join(path.dirname(currentFileUrl.pathname), 'provider');
+    const modelsPath = path.join(
+      path.dirname(currentFileUrl.pathname.replace(/^\/+/, '')),
+      'provider'
+    );
 
     return fs.readdirSync(modelsPath) as string[];
   };


### PR DESCRIPTION
本地windows平台开发，加载model列表出现两次盘符导致加载失败，修改代码确保生成的路径不会包含重复的盘符，从而避免 ENOENT 错误。