### PR TITLE
feat(dataset): 支持重排序模型选择

### DIFF
--- a/packages/global/core/app/type.d.ts
+++ b/packages/global/core/app/type.d.ts
@@ -92,6 +92,7 @@ export type AppSimpleEditFormType = {
     similarity?: number;
     limit?: number;
     usingReRank?: boolean;
+    reRankModel?: string;
     datasetSearchUsingExtensionQuery?: boolean;
     datasetSearchExtensionModel?: string;
     datasetSearchExtensionBg?: string;

--- a/packages/global/core/app/utils.ts
+++ b/packages/global/core/app/utils.ts
@@ -90,6 +90,10 @@ export const appWorkflow2Form = ({
         node.inputs,
         NodeInputKeyEnum.datasetSearchUsingReRank
       );
+      defaultAppForm.dataset.reRankModel = findInputValueByKey(
+        node.inputs,
+        NodeInputKeyEnum.datasetSearchReRankModel
+      );
       defaultAppForm.dataset.datasetSearchUsingExtensionQuery = findInputValueByKey(
         node.inputs,
         NodeInputKeyEnum.datasetSearchUsingExtensionQuery

--- a/packages/global/core/workflow/constants.ts
+++ b/packages/global/core/workflow/constants.ts
@@ -155,6 +155,7 @@ export enum NodeInputKeyEnum {
   datasetMaxTokens = 'limit',
   datasetSearchMode = 'searchMode',
   datasetSearchUsingReRank = 'usingReRank',
+  datasetSearchReRankModel = 'reRankModel',
   datasetSearchUsingExtensionQuery = 'datasetSearchUsingExtensionQuery',
   datasetSearchExtensionModel = 'datasetSearchExtensionModel',
   datasetSearchExtensionBg = 'datasetSearchExtensionBg',

--- a/packages/global/core/workflow/template/system/datasetSearch.ts
+++ b/packages/global/core/workflow/template/system/datasetSearch.ts
@@ -72,6 +72,12 @@ export const DatasetSearchModule: FlowNodeTemplateType = {
       value: false
     },
     {
+      key: NodeInputKeyEnum.datasetSearchReRankModel,
+      renderTypeList: [FlowNodeInputTypeEnum.hidden],
+      label: '',
+      valueType: WorkflowIOValueTypeEnum.string
+    },
+    {
       key: NodeInputKeyEnum.datasetSearchUsingExtensionQuery,
       renderTypeList: [FlowNodeInputTypeEnum.hidden],
       label: '',

--- a/packages/service/core/workflow/dispatch/dataset/search.ts
+++ b/packages/service/core/workflow/dispatch/dataset/search.ts
@@ -6,7 +6,7 @@ import { formatModelChars2Points } from '../../../../support/wallet/usage/utils'
 import type { SelectedDatasetType } from '@fastgpt/global/core/workflow/api.d';
 import type { SearchDataResponseItemType } from '@fastgpt/global/core/dataset/type';
 import type { ModuleDispatchProps } from '@fastgpt/global/core/workflow/runtime/type';
-import { getEmbeddingModel } from '../../../ai/model';
+import { getReRankModel, getEmbeddingModel } from '../../../ai/model';
 import { deepRagSearch, defaultSearchDatasetData } from '../../../dataset/search/controller';
 import { NodeInputKeyEnum, NodeOutputKeyEnum } from '@fastgpt/global/core/workflow/constants';
 import { DispatchNodeResponseKeyEnum } from '@fastgpt/global/core/workflow/runtime/constants';
@@ -25,6 +25,7 @@ type DatasetSearchProps = ModuleDispatchProps<{
   [NodeInputKeyEnum.datasetSearchMode]: `${DatasetSearchModeEnum}`;
   [NodeInputKeyEnum.userChatInput]?: string;
   [NodeInputKeyEnum.datasetSearchUsingReRank]: boolean;
+  [NodeInputKeyEnum.datasetSearchReRankModel]: string;
   [NodeInputKeyEnum.collectionFilterMatch]: string;
   [NodeInputKeyEnum.authTmbId]?: boolean;
 
@@ -54,6 +55,7 @@ export async function dispatchDatasetSearch(
       similarity,
       limit = 1500,
       usingReRank,
+      reRankModel,
       searchMode,
       userChatInput = '',
       authTmbId = false,
@@ -111,6 +113,8 @@ export async function dispatchDatasetSearch(
     (await MongoDataset.findById(datasets[0].datasetId, 'vectorModel').lean())?.vectorModel
   );
 
+  const usedReRankModel = getReRankModel(reRankModel);
+
   // start search
   const searchData = {
     histories,
@@ -123,6 +127,7 @@ export async function dispatchDatasetSearch(
     datasetIds,
     searchMode,
     usingReRank: usingReRank && (await checkTeamReRankPermission(teamId)),
+    reRankModel: usedReRankModel.model,
     collectionFilterMatch
   };
   const {

--- a/projects/app/src/global/core/dataset/api.d.ts
+++ b/projects/app/src/global/core/dataset/api.d.ts
@@ -65,6 +65,7 @@ export type SearchTestProps = {
   [NodeInputKeyEnum.datasetSearchMode]?: `${DatasetSearchModeEnum}`;
   [NodeInputKeyEnum.datasetSearchUsingReRank]?: boolean;
 
+  [NodeInputKeyEnum.datasetSearchReRankModel]?: string;
   [NodeInputKeyEnum.datasetSearchUsingExtensionQuery]?: boolean;
   [NodeInputKeyEnum.datasetSearchExtensionModel]?: string;
   [NodeInputKeyEnum.datasetSearchExtensionBg]?: string;
@@ -80,6 +81,7 @@ export type SearchTestResponse = {
   limit: number;
   searchMode: `${DatasetSearchModeEnum}`;
   usingReRank: boolean;
+  reRankModel?: string;
   similarity: number;
   queryExtensionModel?: string;
 };

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/render/RenderInput/templates/SelectDatasetParams.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/render/RenderInput/templates/SelectDatasetParams.tsx
@@ -26,6 +26,7 @@ const SelectDatasetParam = ({ inputs = [], nodeId }: RenderInputProps) => {
     limit: 5,
     similarity: 0.5,
     usingReRank: false,
+    reRankModel: defaultModels.rerank?.model,
     datasetSearchUsingExtensionQuery: true,
     datasetSearchExtensionModel: defaultModels.llm?.model,
     datasetSearchExtensionBg: ''

--- a/projects/app/src/pageComponents/dataset/detail/Test.tsx
+++ b/projects/app/src/pageComponents/dataset/detail/Test.tsx
@@ -39,6 +39,7 @@ type FormType = {
     similarity?: number;
     limit?: number;
     usingReRank?: boolean;
+    reRankModel?: string;
     datasetSearchUsingExtensionQuery?: boolean;
     datasetSearchExtensionModel?: string;
     datasetSearchExtensionBg?: string;
@@ -67,6 +68,7 @@ const Test = ({ datasetId }: { datasetId: string }) => {
       searchParams: {
         searchMode: DatasetSearchModeEnum.embedding,
         usingReRank: false,
+        reRankModel: defaultModels.rerank?.model,
         limit: 5000,
         similarity: 0,
         datasetSearchUsingExtensionQuery: false,
@@ -105,6 +107,7 @@ const Test = ({ datasetId }: { datasetId: string }) => {
           duration: res.duration,
           searchMode: res.searchMode,
           usingReRank: res.usingReRank,
+          reRankModel: res.reRankModel,
           limit: res.limit,
           similarity: res.similarity,
           queryExtensionModel: res.queryExtensionModel

--- a/projects/app/src/pages/api/core/dataset/searchTest.ts
+++ b/projects/app/src/pages/api/core/dataset/searchTest.ts
@@ -25,6 +25,7 @@ async function handler(req: ApiRequestProps<SearchTestProps>): Promise<SearchTes
     similarity,
     searchMode,
     usingReRank,
+    reRankModel,
 
     datasetSearchUsingExtensionQuery = false,
     datasetSearchExtensionModel,
@@ -63,7 +64,8 @@ async function handler(req: ApiRequestProps<SearchTestProps>): Promise<SearchTes
     similarity,
     datasetIds: [datasetId],
     searchMode,
-    usingReRank: usingReRank && (await checkTeamReRankPermission(teamId))
+    usingReRank: usingReRank && (await checkTeamReRankPermission(teamId)),
+    reRankModel
   };
   const { searchRes, tokens, queryExtensionResult, deepSearchResult, ...result } = datasetDeepSearch
     ? await deepRagSearch({

--- a/projects/app/src/web/core/app/utils.ts
+++ b/projects/app/src/web/core/app/utils.ts
@@ -282,6 +282,13 @@ export function form2AppWorkflow(
           value: formData.dataset.usingReRank
         },
         {
+          key: 'reRankModel',
+          renderTypeList: [FlowNodeInputTypeEnum.hidden],
+          label: '',
+          valueType: WorkflowIOValueTypeEnum.string,
+          value: formData.dataset.reRankModel
+        },
+        {
           key: 'datasetSearchUsingExtensionQuery',
           renderTypeList: [FlowNodeInputTypeEnum.hidden],
           label: '',

--- a/projects/app/src/web/core/dataset/store/searchTest.ts
+++ b/projects/app/src/web/core/dataset/store/searchTest.ts
@@ -14,6 +14,7 @@ export type SearchTestStoreItemType = {
   searchMode: `${DatasetSearchModeEnum}`;
   limit: number;
   usingReRank: boolean;
+  reRankModel?: string;
   similarity: number;
   queryExtensionModel?: string;
 };


### PR DESCRIPTION
# 知识库搜索使用结果重排时，支持选择重排模型 

*效果如下*：

- 不使用结果重排：
<img width="550" alt="image" src="https://github.com/user-attachments/assets/21ae4dea-be59-4c90-93bc-d11a28c531e8" />


- 使用结果重排：
<img width="560" alt="image" src="https://github.com/user-attachments/assets/c2f5081b-b8e3-43ac-9bf4-e4b09c7c3d72" />
