### PR TITLE
fix document

### DIFF
--- a/docSite/content/zh-cn/docs/development/openapi/dataset.md
+++ b/docSite/content/zh-cn/docs/development/openapi/dataset.md
@@ -735,7 +735,7 @@ data 为集合的 ID。
 
 **4.8.19+**
 ```bash
-curl --location --request POST 'http://localhost:3000/api/core/dataset/collection/listv2' \
+curl --location --request POST 'http://localhost:3000/api/core/dataset/collection/listV2' \
 --header 'Authorization: Bearer {{authorization}}' \
 --header 'Content-Type: application/json' \
 --data-raw '{


### PR DESCRIPTION
V2版本“获取集合列表”接口的path区分了大小写，使用/api/core/dataset/collection/listv2会返回404，必须使用大写V