### PR TITLE
fix: upload office file (.pptx) encoding error

### DIFF
--- a/packages/service/worker/readFile/parseOffice.ts
+++ b/packages/service/worker/readFile/parseOffice.ts
@@ -46,11 +46,9 @@ const parsePowerPoint = async ({
   // Returning an array of all the xml contents read using fs.readFileSync
   const xmlContentArray = await Promise.all(
     files.map((file) => {
-      try {
-        return fs.promises.readFile(`${decompressPath}/${file.path}`, encoding);
-      } catch (err) {
+      return fs.promises.readFile(`${decompressPath}/${file.path}`, encoding).catch(() => {
         return fs.promises.readFile(`${decompressPath}/${file.path}`, 'utf-8');
-      }
+      });
     })
   );
 


### PR DESCRIPTION
更新本地导入pptx文件提示文件编码错误
The argument 'windows-1252' is invalid encoding. Received 'encoding'