### PR TITLE
fix: mongoose strictquery to false

### DIFF
--- a/packages/service/common/mongo/init.ts
+++ b/packages/service/common/mongo/init.ts
@@ -16,7 +16,7 @@ export async function connectMongo(): Promise<Mongoose> {
 
   console.log('mongo start connect');
   try {
-    connectionMongo.set('strictQuery', true);
+    connectionMongo.set('strictQuery', false);
 
     connectionMongo.connection.on('error', async (error) => {
       console.log('mongo error', error);


### PR DESCRIPTION
fix #3744

refer: https://mongoosejs.com/docs/guide.html#strictQuery

TLDR: strictQuery option should be false. Then when you pass something, which is not in the Schema, the query will not be filtered and pass to mongodb directly. Thus it will not query the whole document.

```ts
// strictQuery === true
Model.find({ somethingNotInSchema: 'something' }) // the whole document
// strictQuery === false
Model.find({ somethingNotInSchema: 'something' }) // empty
```
