### PR TITLE
fix: chat detail order in export chat logs

### DIFF
--- a/projects/app/src/pages/api/core/app/exportChatLogs.ts
+++ b/projects/app/src/pages/api/core/app/exportChatLogs.ts
@@ -88,6 +88,7 @@ async function handler(req: ApiRequestProps<ExportChatLogsBody, {}>, res: NextAp
                 }
               }
             },
+            { $sort: { _id: 1 } },
             {
               $project: {
                 value: 1,


### PR DESCRIPTION
fix #3889 