### PR TITLE
api调用场景下，如果大量调用带有图片或视频，产生的聊天记录会导致后台mongo数据库异常

### DIFF
--- a/packages/service/core/chat/saveChat.ts
+++ b/packages/service/core/chat/saveChat.ts
@@ -51,6 +51,8 @@ export async function saveChat({
   content,
   metadata = {}
 }: Props) {
+  if (!chatId) return;
+
   try {
     const chat = await MongoChat.findOne(
       {

--- a/projects/app/src/pages/api/v1/chat/completions.ts
+++ b/projects/app/src/pages/api/v1/chat/completions.ts
@@ -330,7 +330,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       [DispatchNodeResponseKeyEnum.nodeResponse]: flowResponses
     };
 
-    const saveChatId = chatId || getNanoid(24);
+    const saveChatId = chatId === 'no-history-sT$hjq*K!vmx' ? '' : chatId || getNanoid(24);
     if (isInteractiveRequest) {
       await updateInteractiveChat({
         chatId: saveChatId,


### PR DESCRIPTION
程序api调用场景下，如果大量调用带有图片或视频，产生的聊天记录会导致后台mongo数据库异常。这个修改给api客户端一个禁止生成聊天记录的选项，避免这个后果。