### PR TITLE
fix: 修复部分参数丢失的问题

### DIFF
--- a/packages/global/core/app/utils.ts
+++ b/packages/global/core/app/utils.ts
@@ -70,6 +70,26 @@ export const appWorkflow2Form = ({
         node.inputs,
         NodeInputKeyEnum.history
       );
+      defaultAppForm.aiSettings.aiChatReasoning = findInputValueByKey(
+        node.inputs,
+        NodeInputKeyEnum.aiChatReasoning
+      );
+      defaultAppForm.aiSettings.aiChatTopP = findInputValueByKey(
+        node.inputs,
+        NodeInputKeyEnum.aiChatTopP
+      );
+      defaultAppForm.aiSettings.aiChatStopSign = findInputValueByKey(
+        node.inputs,
+        NodeInputKeyEnum.aiChatStopSign
+      );
+      defaultAppForm.aiSettings.aiChatResponseFormat = findInputValueByKey(
+        node.inputs,
+        NodeInputKeyEnum.aiChatResponseFormat
+      );
+      defaultAppForm.aiSettings.aiChatJsonSchema = findInputValueByKey(
+        node.inputs,
+        NodeInputKeyEnum.aiChatJsonSchema
+      );
     } else if (node.flowNodeType === FlowNodeTypeEnum.datasetSearchNode) {
       defaultAppForm.dataset.datasets = findInputValueByKey(
         node.inputs,


### PR DESCRIPTION
部分参数 (Reasoning, TopP, StopSign, ResponseFormat, JsonSchema) 保存完后重新进入不显示，并且在某些情况（包括但不限于保存应用操作）会导致用空值覆盖数据库的值从而丢失这个参数值