### PR TITLE
fix:修复aiproxy固定写死V1的URL的问题

### DIFF
--- a/packages/service/core/ai/config.ts
+++ b/packages/service/core/ai/config.ts
@@ -12,7 +12,7 @@ import { OpenaiAccountType } from '@fastgpt/global/support/user/team/type';
 import { getLLMModel } from './model';
 
 const aiProxyBaseUrl = process.env.AIPROXY_API_ENDPOINT
-  ? `${process.env.AIPROXY_API_ENDPOINT}/v1`
+  ? `${process.env.AIPROXY_API_ENDPOINT}`
   : undefined;
 const openaiBaseUrl = aiProxyBaseUrl || process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1';
 const openaiBaseKey = process.env.AIPROXY_API_TOKEN || process.env.CHAT_API_KEY || '';


### PR DESCRIPTION
修复和处理config.ts中固定写死V1的逻辑，导致很多模型无法使用，都会拼接V1的问题

#4063 