### PR TITLE
fix: 文本提取不支持arrayString,arrayNumber等jsonSchema

### DIFF
--- a/packages/service/core/workflow/dispatch/agent/extract.ts
+++ b/packages/service/core/workflow/dispatch/agent/extract.ts
@@ -9,7 +9,11 @@ import {
 import { ChatItemValueTypeEnum, ChatRoleEnum } from '@fastgpt/global/core/chat/constants';
 import { createChatCompletion } from '../../../ai/config';
 import type { ContextExtractAgentItemType } from '@fastgpt/global/core/workflow/template/system/contextExtract/type';
-import { NodeInputKeyEnum, NodeOutputKeyEnum } from '@fastgpt/global/core/workflow/constants';
+import {
+  NodeInputKeyEnum,
+  NodeOutputKeyEnum,
+  toolValueTypeList
+} from '@fastgpt/global/core/workflow/constants';
 import { DispatchNodeResponseKeyEnum } from '@fastgpt/global/core/workflow/runtime/constants';
 import type { ModuleDispatchProps } from '@fastgpt/global/core/workflow/runtime/type';
 import { Prompt_ExtractJson } from '@fastgpt/global/core/ai/prompt/agent';
@@ -192,8 +196,11 @@ ${description ? `- ${description}` : ''}
     }
   > = {};
   extractKeys.forEach((item) => {
+    const jsonSchema = (
+      toolValueTypeList.find((type) => type.value === item.valueType) || toolValueTypeList[0]
+    )?.jsonSchema;
     properties[item.key] = {
-      type: item.valueType || 'string',
+      ...jsonSchema,
       description: item.desc,
       ...(item.enum ? { enum: item.enum.split('\n') } : {})
     };


### PR DESCRIPTION
fix issue #3915 

有些模型不支持
 ```JSON
{"type": "arrayString"}
``` 
统一用这种
```JSON
{
      "type": "array",
      "items": {
        "type": "string"
      }
}
```
  就好了  