### PR TITLE
fixed: permission error when viewing database search node responses

### DIFF
--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/QuoteList.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/QuoteList.tsx
@@ -18,7 +18,7 @@ const QuoteList = React.memo(function QuoteList({
   rawSearch: SearchDataResponseItemType[];
 }) {
   const theme = useTheme();
-  const { chatId, appId, outLinkAuthData } = useChatStore();
+  const { appId, outLinkAuthData } = useChatStore();
 
   const RawSourceBoxProps = useContextSelector(ChatBoxContext, (v) => ({
     chatItemDataId,
@@ -39,10 +39,11 @@ const QuoteList = React.memo(function QuoteList({
         collectionIdList: [...new Set(rawSearch.map((item) => item.collectionId))],
         chatItemDataId,
         appId,
-        chatId,
+        chatId: RawSourceBoxProps.chatId,
         ...outLinkAuthData
       }),
     {
+      refreshDeps: [rawSearch, RawSourceBoxProps.chatId],
       manual: false
     }
   );


### PR DESCRIPTION
当使用免登录窗口 / API 调用一个含有“知识库搜索”节点的工作流时，在“对话日志”中查看“知识库搜索”节点的完整响应会提示“无权操作该数据集”，非免登录窗口/API调用的日志则可正常显示

截图为使用 [官网版本 FastGPT](https://cloud.tryfastgpt.ai/) 查看免登录窗口的对话日志时的错误提示：
<img width="1065" alt="image" src="https://github.com/user-attachments/assets/2ff24aa3-b1c1-4253-873d-95351c16f296" />

经检查为传递的 `chatId` 参数有误，已进行更正