### PR TITLE
feat: python sandbox execute with a temporary file

### DIFF
--- a/projects/sandbox/src/sandbox/constants.ts
+++ b/projects/sandbox/src/sandbox/constants.ts
@@ -112,11 +112,11 @@ def run_pythonCode(data:dict):
         output_code = output_code[:-2] + ")\\n"
     output_code = output_code + "    print(res)"
     code = imports + "\\n" + seccomp_prefix + "\\n" + var_def + "\\n" + code + "\\n" + output_code
-    file_path = os.path.join(os.getcwd(), "subProcess.py")
-    with open(file_path, "w", encoding="utf-8") as f:
+    tmp_file = os.path.join(data["tempDir"], "subProcess.py")
+    with open(tmp_file, "w", encoding="utf-8") as f:
         f.write(code)
     try:
-        result = subprocess.run(["python3", file_path], capture_output=True, text=True, timeout=10)
+        result = subprocess.run(["python3", tmp_file], capture_output=True, text=True, timeout=10)
         if result.returncode == -31:
             return {"error": "Dangerous behavior detected."}
         if result.stderr != "":

--- a/projects/sandbox/src/sandbox/utils.ts
+++ b/projects/sandbox/src/sandbox/utils.ts
@@ -1,6 +1,9 @@
 import { RunCodeDto, RunCodeResponse } from 'src/sandbox/dto/create-sandbox.dto';
 import IsolatedVM, { ExternalCopy, Isolate, Reference } from 'isolated-vm';
-
+import { mkdtemp, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { rmSync } from 'fs';
 import { countToken } from './jsFn/tiktoken';
 import { timeDelay } from './jsFn/delay';
 import { strToBase64 } from './jsFn/str2Base64';
@@ -9,7 +12,7 @@ import { createHmac } from './jsFn/crypto';
 import { spawn } from 'child_process';
 import { pythonScript } from './constants';
 const CustomLogStr = 'CUSTOM_LOG';
-
+const PythonScriptFileName = 'main.py';
 export const runJsSandbox = async ({
   code,
   variables = {}
@@ -119,8 +122,8 @@ print(json.dumps(res))
 `;
 
   const fullCode = [pythonScript, mainCallCode].filter(Boolean).join('\n');
-
-  const pythonProcess = spawn('python3', ['-u', '-c', fullCode]);
+  const { path: tempFilePath, cleanup } = await createTempFile(fullCode);
+  const pythonProcess = spawn('python3', ['-u', tempFilePath]);
 
   const stdoutChunks: string[] = [];
   const stderrChunks: string[] = [];
@@ -137,7 +140,9 @@ print(json.dumps(res))
       }
     });
   });
-  const stdout = await stdoutPromise;
+  const stdout = await stdoutPromise.finally(() => {
+    cleanup();
+  });
 
   try {
     const parsedOutput = JSON.parse(stdout);
@@ -154,3 +159,25 @@ print(json.dumps(res))
     return Promise.reject(`Run failed: ${err}`);
   }
 };
+
+// write full code into a tmp file
+async function createTempFile(context: string) {
+  const tempFileDirPath = await mkdtemp(join(tmpdir(), 'python_script_tmp_'));
+  const tempFilePath = join(tempFileDirPath, PythonScriptFileName);
+
+  try {
+    await writeFile(tempFilePath, context);
+    return {
+      path: tempFilePath,
+      cleanup: () => {
+        rmSync(tempFilePath);
+        rmSync(tempFileDirPath, {
+          recursive: true,
+          force: true
+        });
+      }
+    };
+  } catch (err) {
+    return Promise.reject(`write file err: ${err}`);
+  }
+}


### PR DESCRIPTION
我在使用fastgpt的代码执行节点时，因为前置节点从http请求中获得了大量的数据，导致python代码无法正确执行。
我将python代码从字符串形式执行修改为写入临时文件的方式执行，以便支持大数据量参数的执行。

When using the code execution node in FastGPT, I encountered an issue where the Python code failed to execute correctly due to the large amount of data obtained from the HTTP request in the preceding node.

I modified the Python code execution from a string-based approach to writing it into a temporary file for execution, in order to support the execution of large data parameters.