### PR TITLE
Fix: log error when the loop input array is too long

### DIFF
--- a/packages/service/core/workflow/dispatch/loop/runLoop.ts
+++ b/packages/service/core/workflow/dispatch/loop/runLoop.ts
@@ -33,7 +33,7 @@ export const dispatchLoop = async (props: Props): Promise<Response> => {
     ? Number(process.env.WORKFLOW_MAX_LOOP_TIMES)
     : 50;
   if (loopInputArray.length > maxLength) {
-    return Promise.reject('Input array length cannot be greater than 50');
+    return Promise.reject(`Input array length cannot be greater than ${maxLength}`);
   }
 
   const outputValueArr = [];


### PR DESCRIPTION
when the loop input array is too long, the log always show the max length is 50.
![image](https://github.com/user-attachments/assets/d763bfe6-3e8a-4b3d-8fb0-b2171c9a2848)
