### PR TITLE
fix: Add patch for mdast-util-gfm-autolink-literal@2.0.1

### DIFF
--- a/patches/mdast-util-gfm-autolink-literal@2.0.1.patch
+++ b/patches/mdast-util-gfm-autolink-literal@2.0.1.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/index.js b/lib/index.js
+index c5ca771c24dd914e342f791716a822431ee32b3a..9e9dc090d4be5cf882316ed2eced4c471c40407b 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -132,7 +132,7 @@ function transformGfmAutolinkLiterals(tree) {
+     tree,
+     [
+       [/(https?:\/\/|www(?=\.))([-.\w]+)([^ \t\r\n]*)/gi, findUrl],
+-      [/(?<=^|\s|\p{P}|\p{S})([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/gu, findEmail]
++      [/([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/g, findEmail]
+     ],
+     {ignore: ['link', 'linkReference']}
+   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  mdast-util-gfm-autolink-literal@2.0.1:
+    hash: b03e2c531618296b99e716d479b68761f6ebc6c81dcd1e9359e80b71e6b5ee8e
+    path: patches/mdast-util-gfm-autolink-literal@2.0.1.patch
+
 importers:
 
   .:
@@ -16887,7 +16892,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-autolink-literal@2.0.1:
+  mdast-util-gfm-autolink-literal@2.0.1(patch_hash=b03e2c531618296b99e716d479b68761f6ebc6c81dcd1e9359e80b71e6b5ee8e):
     dependencies:
       '@types/mdast': 4.0.4
       ccount: 2.0.1
@@ -16935,7 +16940,7 @@ snapshots:
   mdast-util-gfm@3.1.0:
     dependencies:
       mdast-util-from-markdown: 2.0.2
-      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-autolink-literal: 2.0.1(patch_hash=b03e2c531618296b99e716d479b68761f6ebc6c81dcd1e9359e80b71e6b5ee8e)
       mdast-util-gfm-footnote: 2.1.0
       mdast-util-gfm-strikethrough: 2.0.0
       mdast-util-gfm-table: 2.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,7 @@
 packages:
-  - 'packages/*'
-  - 'projects/*'
-  - 'scripts/icon'
+  - packages/*
+  - projects/*
+  - scripts/icon
+
+patchedDependencies:
+  mdast-util-gfm-autolink-literal@2.0.1: patches/mdast-util-gfm-autolink-literal@2.0.1.patch


### PR DESCRIPTION
Compatibility patch for Safari versions below 16.4