### PR TITLE
perf: regex patch for backward compatibility

### DIFF
--- a/patches/mdast-util-gfm-autolink-literal@2.0.1.patch
+++ b/patches/mdast-util-gfm-autolink-literal@2.0.1.patch
@@ -1,13 +1,79 @@
 diff --git a/lib/index.js b/lib/index.js
-index c5ca771c24dd914e342f791716a822431ee32b3a..9e9dc090d4be5cf882316ed2eced4c471c40407b 100644
+index c5ca771c24dd914e342f791716a822431ee32b3a..457d9f8c4625f7d9c7ea1e9ffc13616db1fc6fef 100644
 --- a/lib/index.js
 +++ b/lib/index.js
-@@ -132,7 +132,7 @@ function transformGfmAutolinkLiterals(tree) {
+@@ -126,8 +126,37 @@ function exitLiteralAutolink(token) {
+   this.exit(token)
+ }
+ 
+-/** @type {FromMarkdownTransform} */
++// Regex support detector, for backward compatibility
++// Ref: https://github.com/syntax-tree/mdast-util-gfm-autolink-literal/pull/14
++const regexSupport = {
++  lookbehind: (() => {
++    try {
++      // Using regex literal instead of RegExp constructor
++      ;/(?<=x)/.test('x')
++      return true
++    } catch {
++      return false
++    }
++  })()
++}
++
++/**
++ * Main transform function that uses the appropriate version based on regex support
++ * @type {FromMarkdownTransform}
++ */
+ function transformGfmAutolinkLiterals(tree) {
++  if (regexSupport.lookbehind) {
++    modernAutolinkTransform(tree)
++  } else {
++    legacyAutolinkTransform(tree)
++  }
++}
++
++/**
++ * Modern version of autolink transform using lookbehind
++ * @type {FromMarkdownTransform}
++ */
++function modernAutolinkTransform(tree) {
+   findAndReplace(
      tree,
      [
-       [/(https?:\/\/|www(?=\.))([-.\w]+)([^ \t\r\n]*)/gi, findUrl],
--      [/(?<=^|\s|\p{P}|\p{S})([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/gu, findEmail]
-+      [/([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/g, findEmail]
-     ],
-     {ignore: ['link', 'linkReference']}
+@@ -138,6 +167,35 @@ function transformGfmAutolinkLiterals(tree) {
    )
+ }
+ 
++
++/**
++ * Legacy version of autolink transform for older Node.js versions
++ * @type {FromMarkdownTransform}
++ */
++function legacyAutolinkTransform(tree) {
++  findAndReplace(
++    tree,
++    [
++      [/(https?:\/\/|www(?=\.))([-.\w]+)([^ \t\r\n]*)/gi, findUrl],
++      // [/([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/g, findEmail] # NOTE: original regex in 2.0.0
++      [/(^|\s|\p{P}|\p{S})([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/gu, findEmailLegacy]
++    ],
++    {ignore: ['link', 'linkReference']}
++  )
++}
++
++/**
++ * Helper function for legacy email matching
++ * @param {string} _ - Unused parameter
++ * @param {string} prefix - Email prefix
++ * @param {string} name - Email name
++ * @param {string} domain - Email domain
++ * @returns {*} The processed email
++ */
++function findEmailLegacy(_, prefix, name, domain) {
++  return findEmail(name + '@' + domain)
++}
++
+ /**
+  * @type {ReplaceFunction}
+  * @param {string} _

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   mdast-util-gfm-autolink-literal@2.0.1:
-    hash: b03e2c531618296b99e716d479b68761f6ebc6c81dcd1e9359e80b71e6b5ee8e
+    hash: f63d515781110436299ab612306211a9621c6dfaec1ce1a19e2f27454dc70251
     path: patches/mdast-util-gfm-autolink-literal@2.0.1.patch
 
 importers:
@@ -16892,7 +16892,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-autolink-literal@2.0.1(patch_hash=b03e2c531618296b99e716d479b68761f6ebc6c81dcd1e9359e80b71e6b5ee8e):
+  mdast-util-gfm-autolink-literal@2.0.1(patch_hash=f63d515781110436299ab612306211a9621c6dfaec1ce1a19e2f27454dc70251):
     dependencies:
       '@types/mdast': 4.0.4
       ccount: 2.0.1
@@ -16940,7 +16940,7 @@ snapshots:
   mdast-util-gfm@3.1.0:
     dependencies:
       mdast-util-from-markdown: 2.0.2
-      mdast-util-gfm-autolink-literal: 2.0.1(patch_hash=b03e2c531618296b99e716d479b68761f6ebc6c81dcd1e9359e80b71e6b5ee8e)
+      mdast-util-gfm-autolink-literal: 2.0.1(patch_hash=f63d515781110436299ab612306211a9621c6dfaec1ce1a19e2f27454dc70251)
       mdast-util-gfm-footnote: 2.1.0
       mdast-util-gfm-strikethrough: 2.0.0
       mdast-util-gfm-table: 2.0.0


### PR DESCRIPTION
A polyfill patch without compromising performance on modern browser.

Ref: https://github.com/syntax-tree/mdast-util-gfm-autolink-literal/pull/14