### PR TITLE
feat: 插件调用增加支持返回值提取

### DIFF
--- a/packages/global/core/workflow/utils.ts
+++ b/packages/global/core/workflow/utils.ts
@@ -51,6 +51,7 @@ import { getNanoid } from '../../common/string/tools';
 import { ChatRoleEnum } from '../../core/chat/constants';
 import { runtimePrompt2ChatsValue } from '../../core/chat/adapt';
 import { getPluginRunContent } from '../../core/app/plugin/utils';
+import { Output_Template_AddOutput } from './template/output';
 
 export const getHandleId = (nodeId: string, type: 'source' | 'target', key: string) => {
   return `${nodeId}-${type}-${key}`;
@@ -220,6 +221,11 @@ export const pluginData2FlowNodeIO = ({
       : [],
     outputs: pluginOutput
       ? [
+          {
+            ...Output_Template_AddOutput,
+            label: i18nT('workflow:http_extract_output'),
+            description: i18nT('workflow:http_extract_output_description')
+          },
           ...pluginOutput.inputs.map((item) => ({
             id: item.key,
             type: FlowNodeOutputTypeEnum.static,


### PR DESCRIPTION
希望能在插件调用的返回值部分增加动态参数类似http模块参数提取的功能，便于类似于数据库连接这样的插件使用，直接绑定具体返回值到字段，而不必再后面再加代码节点取数据了。
![image](https://github.com/user-attachments/assets/2a615e51-5800-4808-9036-028c49cbbc6f)
