### PR TITLE
feat: 增加使用连接串的数据库查询插件，以便配置各类额外连接参数

### DIFF
--- a/packages/plugins/register.ts
+++ b/packages/plugins/register.ts
@@ -27,6 +27,7 @@ const packagePluginList = [
   'drawing/baseChart',
   'wiki',
   'databaseConnection',
+  'databaseQuery',
   'Doc2X',
   'Doc2X/PDF2text',
   'searchXNG',

--- a/packages/plugins/src/databaseQuery/index.ts
+++ b/packages/plugins/src/databaseQuery/index.ts
@@ -1,0 +1,51 @@
+import { Client as PgClient } from 'pg'; // PostgreSQL 客户端
+import mysql from 'mysql2/promise'; // MySQL 客户端
+import mssql from 'mssql'; // SQL Server 客户端
+
+type Props = {
+  databaseType: string;
+  connectionString: string;
+  sql: string;
+};
+
+type Response = Promise<{
+  result: any; // 根据你的 SQL 查询结果类型调整
+}>;
+
+const main = async ({ databaseType, connectionString, sql }: Props): Response => {
+  let result;
+  try {
+    if (databaseType === 'PostgreSQL') {
+      const client = new PgClient(connectionString);
+
+      await client.connect();
+      const res = await client.query(sql);
+      result = res.rows;
+      await client.end();
+    } else if (databaseType === 'MySQL') {
+      const connection = await mysql.createConnection(connectionString);
+
+      const [rows] = await connection.execute(sql);
+      result = rows;
+      await connection.end();
+    } else if (databaseType === 'Microsoft SQL Server') {
+      const pool = await mssql.connect(connectionString);
+
+      result = await pool.query(sql);
+      await pool.close();
+    }
+    return {
+      result
+    };
+  } catch (error: unknown) {
+    // 使用类型断言来处理错误
+    if (error instanceof Error) {
+      console.error('Database query error:', error.message);
+      return Promise.reject(error.message);
+    }
+    console.error('Database query error:', error);
+    return Promise.reject('An unknown error occurred');
+  }
+};
+
+export default main;

--- a/packages/plugins/src/databaseQuery/template.json
+++ b/packages/plugins/src/databaseQuery/template.json
@@ -1,0 +1,462 @@
+{
+  "author": "zhangjun",
+  "version": "1.0.0",
+  "name": "数据库查询",
+  "avatar": "core/workflow/template/datasource",
+  "intro": "可连接常用数据库，并执行查询语句",
+  "showStatus": true,
+  "weight": 10,
+  "isTool": true,
+  "templateType": "tools",
+
+  "workflow": {
+    "nodes": [
+      {
+        "nodeId": "pluginInput",
+        "name": "workflow:template.plugin_start",
+        "intro": "workflow:intro_plugin_input",
+        "avatar": "core/workflow/template/workflowStart",
+        "flowNodeType": "pluginInput",
+        "showStatus": false,
+        "position": {
+          "x": 334.24111198705634,
+          "y": -260.8285440670886
+        },
+        "version": "481",
+        "inputs": [
+          {
+            "renderTypeList": ["select", "reference"],
+            "selectedTypeIndex": 0,
+            "valueType": "string",
+            "canEdit": true,
+            "key": "databaseType",
+            "label": "databaseType",
+            "description": "数据库的类型",
+            "defaultValue": "",
+            "list": [
+              {
+                "label": "MySQL",
+                "value": "MySQL"
+              },
+              {
+                "label": "PostgreSQL",
+                "value": "PostgreSQL"
+              },
+              {
+                "label": "Microsoft SQL Server",
+                "value": "Microsoft SQL Server"
+              }
+            ],
+            "required": true
+          },
+          {
+            "renderTypeList": ["input", "reference"],
+            "selectedTypeIndex": 0,
+            "valueType": "string",
+            "canEdit": true,
+            "key": "connectionString",
+            "label": "connectionString",
+            "description": "数据库连接串\n\nmysql://someuser:somepass@somehost：3306/somedb\n\npostgres://someuser:somepassword@somehost:5432/somedb\n\nServer=somehost1433;Database=somedb;User Id=someuser;Password=somepassword\n\n更多连接串格式及参数表参考mysql2(mysqljs)、mssql、pg-connection-string等文档",
+            "defaultValue": "",
+            "required": true,
+            "list": [
+              {
+                "label": "",
+                "value": ""
+              }
+            ]
+          },
+          {
+            "renderTypeList": ["input", "reference"],
+            "selectedTypeIndex": 0,
+            "valueType": "string",
+            "canEdit": true,
+            "key": "sql",
+            "label": "sql",
+            "description": "sql语句，可以传入sql语句直接执行",
+            "defaultValue": "",
+            "list": [
+              {
+                "label": "",
+                "value": ""
+              }
+            ],
+            "required": true,
+            "toolDescription": "sql语句，可以传入sql语句直接执行"
+          }
+        ],
+        "outputs": [
+          {
+            "id": "databaseType",
+            "valueType": "string",
+            "key": "databaseType",
+            "label": "databaseType",
+            "type": "hidden"
+          },
+          {
+            "id": "connectionString",
+            "valueType": "string",
+            "key": "connectionString",
+            "label": "connectionString",
+            "type": "hidden"
+          },
+          {
+            "id": "sql",
+            "valueType": "string",
+            "key": "sql",
+            "label": "sql",
+            "type": "hidden"
+          }
+        ]
+      },
+      {
+        "nodeId": "pluginOutput",
+        "name": "common:core.module.template.self_output",
+        "intro": "workflow:intro_custom_plugin_output",
+        "avatar": "core/workflow/template/pluginOutput",
+        "flowNodeType": "pluginOutput",
+        "showStatus": false,
+        "position": {
+          "x": 1788.4723692358186,
+          "y": -153.2313912808486
+        },
+        "version": "481",
+        "inputs": [
+          {
+            "renderTypeList": ["reference"],
+            "valueType": "object",
+            "canEdit": true,
+            "key": "result",
+            "label": "result",
+            "isToolOutput": true,
+            "description": "数据库连接结果",
+            "value": ["zBeXy7YZEiXe", "httpRawResponse"]
+          }
+        ],
+        "outputs": []
+      },
+      {
+        "nodeId": "zBeXy7YZEiXe",
+        "name": "数据库连接",
+        "intro": "可以发出一个 HTTP 请求，实现更为复杂的操作（联网搜索、数据库查询等）",
+        "avatar": "core/workflow/template/httpRequest",
+        "flowNodeType": "httpRequest468",
+        "showStatus": true,
+        "position": {
+          "x": 1035.92763304296,
+          "y": -498.57137296107504
+        },
+        "version": "481",
+        "inputs": [
+          {
+            "key": "system_addInputParam",
+            "renderTypeList": ["addInputParam"],
+            "valueType": "dynamic",
+            "label": "",
+            "required": false,
+            "description": "common:core.module.input.description.HTTP Dynamic Input",
+            "customInputConfig": {
+              "selectValueTypeList": [
+                "string",
+                "number",
+                "boolean",
+                "object",
+                "arrayString",
+                "arrayNumber",
+                "arrayBoolean",
+                "arrayObject",
+                "arrayAny",
+                "any",
+                "chatHistory",
+                "datasetQuote",
+                "dynamic",
+                "selectDataset",
+                "selectApp"
+              ],
+              "showDescription": false,
+              "showDefaultValue": true
+            },
+            "valueDesc": "",
+            "debugLabel": "",
+            "toolDescription": ""
+          },
+          {
+            "key": "system_httpMethod",
+            "renderTypeList": ["custom"],
+            "valueType": "string",
+            "label": "",
+            "value": "POST",
+            "required": true,
+            "valueDesc": "",
+            "description": "",
+            "debugLabel": "",
+            "toolDescription": ""
+          },
+          {
+            "key": "system_httpTimeout",
+            "renderTypeList": ["custom"],
+            "valueType": "number",
+            "label": "",
+            "value": 30,
+            "min": 5,
+            "max": 600,
+            "required": true,
+            "valueDesc": "",
+            "description": "",
+            "debugLabel": "",
+            "toolDescription": ""
+          },
+          {
+            "key": "system_httpReqUrl",
+            "renderTypeList": ["hidden"],
+            "valueType": "string",
+            "label": "",
+            "description": "common:core.module.input.description.Http Request Url",
+            "placeholder": "https://api.ai.com/getInventory",
+            "required": false,
+            "value": "databaseQuery",
+            "valueDesc": "",
+            "debugLabel": "",
+            "toolDescription": ""
+          },
+          {
+            "key": "system_httpHeader",
+            "renderTypeList": ["custom"],
+            "valueType": "any",
+            "value": [],
+            "label": "",
+            "description": "common:core.module.input.description.Http Request Header",
+            "placeholder": "common:core.module.input.description.Http Request Header",
+            "required": false,
+            "valueDesc": "",
+            "debugLabel": "",
+            "toolDescription": ""
+          },
+          {
+            "key": "system_httpParams",
+            "renderTypeList": ["hidden"],
+            "valueType": "any",
+            "value": [],
+            "label": "",
+            "required": false,
+            "valueDesc": "",
+            "description": "",
+            "debugLabel": "",
+            "toolDescription": ""
+          },
+          {
+            "key": "system_httpJsonBody",
+            "renderTypeList": ["hidden"],
+            "valueType": "any",
+            "value": "{\r\n  \"databaseType\":\"{{databaseType-H}}\",\r\n  \"connectionString\":\"{{connectionString-H}}\",\r\n  \"sql\":\"{{sql-H}}\"\r\n}",
+            "label": "",
+            "required": false,
+            "valueDesc": "",
+            "description": "",
+            "debugLabel": "",
+            "toolDescription": ""
+          },
+          {
+            "key": "system_httpFormBody",
+            "renderTypeList": ["hidden"],
+            "valueType": "any",
+            "value": [],
+            "label": "",
+            "required": false,
+            "valueDesc": "",
+            "description": "",
+            "debugLabel": "",
+            "toolDescription": ""
+          },
+          {
+            "key": "system_httpContentType",
+            "renderTypeList": ["hidden"],
+            "valueType": "string",
+            "value": "json",
+            "label": "",
+            "required": false,
+            "valueDesc": "",
+            "description": "",
+            "debugLabel": "",
+            "toolDescription": ""
+          },
+          {
+            "renderTypeList": ["reference"],
+            "valueType": "string",
+            "canEdit": true,
+            "key": "databaseType-H",
+            "label": "databaseType-H",
+            "customInputConfig": {
+              "selectValueTypeList": [
+                "string",
+                "number",
+                "boolean",
+                "object",
+                "arrayString",
+                "arrayNumber",
+                "arrayBoolean",
+                "arrayObject",
+                "arrayAny",
+                "any",
+                "chatHistory",
+                "datasetQuote",
+                "dynamic",
+                "selectDataset",
+                "selectApp"
+              ],
+              "showDescription": false,
+              "showDefaultValue": true
+            },
+            "required": true,
+            "value": ["pluginInput", "databaseType"]
+          },
+          {
+            "renderTypeList": ["reference"],
+            "valueType": "string",
+            "canEdit": true,
+            "key": "connectionString-H",
+            "label": "connectionString-H",
+            "customInputConfig": {
+              "selectValueTypeList": [
+                "string",
+                "number",
+                "boolean",
+                "object",
+                "arrayString",
+                "arrayNumber",
+                "arrayBoolean",
+                "arrayObject",
+                "arrayAny",
+                "any",
+                "chatHistory",
+                "datasetQuote",
+                "dynamic",
+                "selectDataset",
+                "selectApp"
+              ],
+              "showDescription": false,
+              "showDefaultValue": true
+            },
+            "required": true,
+            "value": ["pluginInput", "connectionString"]
+          },
+          {
+            "renderTypeList": ["reference"],
+            "valueType": "string",
+            "canEdit": true,
+            "key": "sql-H",
+            "label": "sql-H",
+            "customInputConfig": {
+              "selectValueTypeList": [
+                "string",
+                "number",
+                "boolean",
+                "object",
+                "arrayString",
+                "arrayNumber",
+                "arrayBoolean",
+                "arrayObject",
+                "arrayAny",
+                "any",
+                "chatHistory",
+                "datasetQuote",
+                "dynamic",
+                "selectDataset",
+                "selectApp"
+              ],
+              "showDescription": false,
+              "showDefaultValue": true
+            },
+            "required": true,
+            "value": ["pluginInput", "sql"]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "error",
+            "key": "error",
+            "label": "workflow:request_error",
+            "description": "HTTP请求错误信息，成功时返回空",
+            "valueType": "object",
+            "type": "static"
+          },
+          {
+            "id": "httpRawResponse",
+            "key": "httpRawResponse",
+            "required": true,
+            "label": "workflow:raw_response",
+            "description": "HTTP请求的原始响应。只能接受字符串或JSON类型响应数据。",
+            "valueType": "any",
+            "type": "static"
+          },
+          {
+            "id": "system_addOutputParam",
+            "key": "system_addOutputParam",
+            "type": "dynamic",
+            "valueType": "dynamic",
+            "label": "",
+            "customFieldConfig": {
+              "selectValueTypeList": [
+                "string",
+                "number",
+                "boolean",
+                "object",
+                "arrayString",
+                "arrayNumber",
+                "arrayBoolean",
+                "arrayObject",
+                "arrayAny",
+                "any",
+                "chatHistory",
+                "datasetQuote",
+                "dynamic",
+                "selectApp",
+                "selectDataset"
+              ],
+              "showDescription": false,
+              "showDefaultValue": false
+            },
+            "valueDesc": "",
+            "description": ""
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "source": "pluginInput",
+        "target": "zBeXy7YZEiXe",
+        "sourceHandle": "pluginInput-source-right",
+        "targetHandle": "zBeXy7YZEiXe-target-left"
+      },
+      {
+        "source": "zBeXy7YZEiXe",
+        "target": "pluginOutput",
+        "sourceHandle": "zBeXy7YZEiXe-source-right",
+        "targetHandle": "pluginOutput-target-left"
+      }
+    ],
+    "chatConfig": {
+      "welcomeText": "",
+      "variables": [],
+      "questionGuide": {
+        "open": false
+      },
+      "ttsConfig": {
+        "type": "web"
+      },
+      "whisperConfig": {
+        "open": false,
+        "autoSend": false,
+        "autoTTSResponse": false
+      },
+      "chatInputGuide": {
+        "open": false,
+        "textList": [],
+        "customUrl": ""
+      },
+      "instruction": "数据源配置，支持主流数据库配置",
+      "_id": "670a23b31957c5b9899b4a4d"
+    }
+  }
+}


### PR DESCRIPTION
参考数据库连接插件，但改用连接串来配置服务器地址等，便于根据各种不同数据库配各自的额外参数，例如mysql的时区、字符集，SQLServer加密。
考虑到直接修改数据库连接插件还要处理向前兼容的复杂问题，所以新建了一个插件，供参考