### PR TITLE
变量更新组件处理字符串数组错误修复

### DIFF
--- a/packages/service/core/workflow/dispatch/utils.ts
+++ b/packages/service/core/workflow/dispatch/utils.ts
@@ -106,44 +106,97 @@ export const getHistories = (history?: ChatItemType[] | number, histories: ChatI
 
 /* value type format */
 export const valueTypeFormat = (value: any, type?: WorkflowIOValueTypeEnum) => {
-  if (value === undefined) return;
+  // 1. 基础条件检查
+  if (value === undefined || value === null) return;
   if (!type || type === WorkflowIOValueTypeEnum.any) return value;
 
-  if (type === 'string') {
-    if (typeof value !== 'object') return String(value);
-    return JSON.stringify(value);
-  }
-  if (type === 'number') return Number(value);
-  if (type === 'boolean') {
-    if (typeof value === 'string') return value === 'true';
-    return Boolean(value);
-  }
-  try {
-    if (type === WorkflowIOValueTypeEnum.arrayString && typeof value === 'string') {
-      return [value];
-    }
-    if (
-      type &&
-      [
-        WorkflowIOValueTypeEnum.object,
-        WorkflowIOValueTypeEnum.chatHistory,
-        WorkflowIOValueTypeEnum.datasetQuote,
-        WorkflowIOValueTypeEnum.selectApp,
-        WorkflowIOValueTypeEnum.selectDataset,
-        WorkflowIOValueTypeEnum.arrayString,
-        WorkflowIOValueTypeEnum.arrayNumber,
-        WorkflowIOValueTypeEnum.arrayBoolean,
-        WorkflowIOValueTypeEnum.arrayObject,
-        WorkflowIOValueTypeEnum.arrayAny
-      ].includes(type) &&
-      typeof value !== 'object'
-    ) {
-      return json5.parse(value);
-    }
-  } catch (error) {
+  // 2. 如果值已经符合目标类型，直接返回
+  if (
+    (type === WorkflowIOValueTypeEnum.string && typeof value === 'string') ||
+    (type === WorkflowIOValueTypeEnum.number && typeof value === 'number') ||
+    (type === WorkflowIOValueTypeEnum.boolean && typeof value === 'boolean') ||
+    (type === WorkflowIOValueTypeEnum.object &&
+      typeof value === 'object' &&
+      !Array.isArray(value)) ||
+    (type.startsWith('array') && Array.isArray(value))
+  ) {
     return value;
   }
 
+  // 3. 处理JSON字符串
+  if (type === WorkflowIOValueTypeEnum.object || type.startsWith('array')) {
+    if (typeof value === 'string' && value.trim()) {
+      const trimmedValue = value.trim();
+      const isJsonLike =
+        (trimmedValue.startsWith('{') && trimmedValue.endsWith('}')) ||
+        (trimmedValue.startsWith('[') && trimmedValue.endsWith(']'));
+
+      if (isJsonLike) {
+        try {
+          const parsed = json5.parse(trimmedValue);
+
+          // 解析结果与目标类型匹配时使用解析后的值
+          if (
+            (Array.isArray(parsed) && type.startsWith('array')) ||
+            (type === WorkflowIOValueTypeEnum.object &&
+              typeof parsed === 'object' &&
+              !Array.isArray(parsed))
+          ) {
+            return parsed;
+          }
+        } catch (error) {
+          // 解析失败时继续使用原始值
+        }
+      }
+    }
+  }
+
+  // 4. 按类型处理
+  // 4.1 数组类型
+  if (type.startsWith('array')) {
+    // 数组类型的特殊处理：字符串转为单元素数组
+    if (type === WorkflowIOValueTypeEnum.arrayString && typeof value === 'string') {
+      return [value];
+    }
+    // 其他值包装为数组
+    return [value];
+  }
+
+  // 4.2 基本类型转换
+  if (type === WorkflowIOValueTypeEnum.string) {
+    return typeof value === 'object' ? JSON.stringify(value) : String(value);
+  }
+
+  if (type === WorkflowIOValueTypeEnum.number) {
+    return Number(value);
+  }
+
+  if (type === WorkflowIOValueTypeEnum.boolean) {
+    if (typeof value === 'string') {
+      return value.toLowerCase() === 'true';
+    }
+    return Boolean(value);
+  }
+
+  // 4.3 复杂对象类型处理
+  if (
+    [
+      WorkflowIOValueTypeEnum.object,
+      WorkflowIOValueTypeEnum.chatHistory,
+      WorkflowIOValueTypeEnum.datasetQuote,
+      WorkflowIOValueTypeEnum.selectApp,
+      WorkflowIOValueTypeEnum.selectDataset
+    ].includes(type) &&
+    typeof value !== 'object'
+  ) {
+    try {
+      return json5.parse(value);
+    } catch (error) {
+      return value;
+    }
+  }
+
+  // 5. 默认返回原值
   return value;
 };
 


### PR DESCRIPTION
1，字符串数组的值可能包含转义斜杠会导致typeof value为string，结果变量更新后的值变形为多层数组嵌套而无法使用（[[]]）。这个修复解决了这个问题。 
2，另外对整体的逻辑做了梳理和整理，更加清晰易懂