### PR TITLE
fix: update workflow to use ubuntu-24.04 for consistency across all jobs

### DIFF
--- a/.github/workflows/docs-deploy-cf.yml
+++ b/.github/workflows/docs-deploy-cf.yml
@@ -18,7 +18,7 @@ jobs:
       url: ${{ steps.vercel-action.outputs.preview-url }}
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: write

--- a/.github/workflows/docs-deploy-kubeconfig.yml
+++ b/.github/workflows/docs-deploy-kubeconfig.yml
@@ -73,7 +73,7 @@ jobs:
 
   update-docs-image:
     needs: build-fastgpt-docs-images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'labring/FastGPT'
     steps:
       - name: Checkout code

--- a/.github/workflows/docs-deploy-kubeconfig.yml
+++ b/.github/workflows/docs-deploy-kubeconfig.yml
@@ -73,7 +73,7 @@ jobs:
 
   update-docs-image:
     needs: build-fastgpt-docs-images
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.repository == 'labring/FastGPT'
     steps:
       - name: Checkout code

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -22,7 +22,7 @@ jobs:
       url: ${{ steps.vercel-action.outputs.preview-url }}
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     # Job outputs
     outputs:

--- a/.github/workflows/fastgpt-build-image-personal.yml
+++ b/.github/workflows/fastgpt-build-image-personal.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       attestations: write
       id-token: write
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.repository != 'labring/FastGPT'
     steps:
       - name: Checkout

--- a/.github/workflows/fastgpt-build-image-personal.yml
+++ b/.github/workflows/fastgpt-build-image-personal.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       attestations: write
       id-token: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository != 'labring/FastGPT'
     steps:
       - name: Checkout

--- a/.github/workflows/fastgpt-preview-image.yml
+++ b/.github/workflows/fastgpt-preview-image.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write
       pull-requests: write
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/fastgpt-preview-image.yml
+++ b/.github/workflows/fastgpt-preview-image.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write
       pull-requests: write
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -13,7 +13,7 @@ jobs:
       contents: read
       attestations: write
       id-token: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -13,7 +13,7 @@ jobs:
       contents: read
       attestations: write
       id-token: write
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101