### PR TITLE
修复表单单选选中长文本时，文字溢出选择框的问题；修复表单单选下拉选项在移动端界面上触发自动换行时部分文字位于屏幕之外的问题

### DIFF
--- a/packages/web/components/common/MySelect/index.tsx
+++ b/packages/web/components/common/MySelect/index.tsx
@@ -191,6 +191,9 @@ const MySelect = <T = any,>(
           size={'md'}
           fontSize={'sm'}
           textAlign={'left'}
+          h={'100%'}
+          whiteSpace={'pre-wrap'}
+          wordBreak={'break-word'}
           _active={{
             transform: 'none'
           }}

--- a/packages/web/components/common/MySelect/index.tsx
+++ b/packages/web/components/common/MySelect/index.tsx
@@ -169,6 +169,7 @@ const MySelect = <T = any,>(
     <Box
       css={css({
         '& div': {
+          maxWidth: '100%',
           width: 'auto !important'
         }
       })}


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Fixes text overflow issues in the MySelect component by adding proper text wrapping and container sizing properties.

- Added `maxWidth: '100%'` to the container div to prevent content from overflowing its parent.
- Added `h: '100%'`, `whiteSpace: 'pre-wrap'`, and `wordBreak: 'break-word'` to the MenuButton to properly handle long text content.
- These changes fix two issues: long text overflowing selection boxes and dropdown options being partially off-screen on mobile devices.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->