### PR TITLE
fix: app copy api

### DIFF
--- a/projects/app/src/pages/api/core/app/copy.ts
+++ b/projects/app/src/pages/api/core/app/copy.ts
@@ -1,10 +1,10 @@
-import type { ApiRequestProps, ApiResponseType } from '@fastgpt/service/type/next';
 import { NextAPI } from '@/service/middleware/entry';
-import { authApp } from '@fastgpt/service/support/permission/app/auth';
 import { WritePermissionVal } from '@fastgpt/global/support/permission/constant';
-import { authUserPer } from '@fastgpt/service/support/permission/user/auth';
-import { onCreateApp } from './create';
 import { TeamAppCreatePermissionVal } from '@fastgpt/global/support/permission/user/constant';
+import { authApp } from '@fastgpt/service/support/permission/app/auth';
+import { authUserPer } from '@fastgpt/service/support/permission/user/auth';
+import type { ApiRequestProps, ApiResponseType } from '@fastgpt/service/type/next';
+import { onCreateApp } from './create';
 
 export type copyAppQuery = {};
 
@@ -26,7 +26,7 @@ async function handler(
   });
 
   const { tmbId } = app.parentId
-    ? await authApp({ req, appId: app.parentId, per: TeamAppCreatePermissionVal, authToken: true })
+    ? await authApp({ req, appId: app.parentId, per: WritePermissionVal, authToken: true })
     : await authUserPer({ req, authToken: true, per: TeamAppCreatePermissionVal });
 
   const appId = await onCreateApp({

--- a/projects/app/test/api/core/app/copy.test.ts
+++ b/projects/app/test/api/core/app/copy.test.ts
@@ -1,0 +1,74 @@
+import * as copyapi from '@/pages/api/core/app/copy';
+import * as createapi from '@/pages/api/core/app/create';
+import { AppErrEnum } from '@fastgpt/global/common/error/code/app';
+import { AppTypeEnum } from '@fastgpt/global/core/app/constants';
+import { WritePermissionVal } from '@fastgpt/global/support/permission/constant';
+import { TeamAppCreatePermissionVal } from '@fastgpt/global/support/permission/user/constant';
+import { MongoResourcePermission } from '@fastgpt/service/support/permission/schema';
+import { getFakeUsers } from '@test/datas/users';
+import { Call } from '@test/utils/request';
+import { describe, expect, it } from 'vitest';
+
+describe('Copy', () => {
+  it('should return success', async () => {
+    const users = await getFakeUsers(2);
+    await MongoResourcePermission.create({
+      resourceType: 'team',
+      teamId: users.members[0].teamId,
+      resourceId: null,
+      tmbId: users.members[0].tmbId,
+      permission: TeamAppCreatePermissionVal
+    });
+
+    const res = await Call<createapi.CreateAppBody, {}, {}>(createapi.default, {
+      auth: users.members[0],
+      body: {
+        modules: [],
+        name: 'testfolder',
+        type: AppTypeEnum.folder
+      }
+    });
+    expect(res.error).toBeUndefined();
+    expect(res.code).toBe(200);
+    const folderId = res.data as string;
+
+    const res2 = await Call<createapi.CreateAppBody, {}, {}>(createapi.default, {
+      auth: users.members[0],
+      body: {
+        modules: [],
+        parentId: folderId,
+        name: 'simple app',
+        type: AppTypeEnum.simple
+      }
+    });
+    expect(res2.error).toBeUndefined();
+    expect(res2.code).toBe(200);
+    const appId = res2.data as string;
+
+    const res3 = await Call<copyapi.copyAppBody, {}, {}>(copyapi.default, {
+      auth: users.members[1],
+      body: {
+        appId
+      }
+    });
+    expect(res3.error).toBe(AppErrEnum.unAuthApp);
+    expect(res3.code).toBe(500);
+
+    await MongoResourcePermission.create({
+      resourceType: 'app',
+      teamId: users.members[1].teamId,
+      resourceId: String(folderId),
+      tmbId: users.members[1].tmbId,
+      permission: WritePermissionVal
+    });
+
+    const res4 = await Call<copyapi.copyAppBody, {}, {}>(copyapi.default, {
+      auth: users.members[1],
+      body: {
+        appId
+      }
+    });
+    expect(res4.error).toBeUndefined();
+    expect(res4.code).toBe(200);
+  });
+});

--- a/projects/app/test/api/core/app/create.test.ts
+++ b/projects/app/test/api/core/app/create.test.ts
@@ -1,12 +1,12 @@
 import * as createapi from '@/pages/api/core/app/create';
 import { AppErrEnum } from '@fastgpt/global/common/error/code/app';
-import { delay } from '@fastgpt/global/common/system/utils';
 import { AppTypeEnum } from '@fastgpt/global/core/app/constants';
+import { WritePermissionVal } from '@fastgpt/global/support/permission/constant';
 import { TeamAppCreatePermissionVal } from '@fastgpt/global/support/permission/user/constant';
 import { MongoResourcePermission } from '@fastgpt/service/support/permission/schema';
 import { getFakeUsers } from '@test/datas/users';
 import { Call } from '@test/utils/request';
-import { expect, it, describe } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 describe('create api', () => {
   it('should return 200 when create app success', async () => {
@@ -18,7 +18,7 @@ describe('create api', () => {
       tmbId: users.members[0].tmbId,
       permission: TeamAppCreatePermissionVal
     });
-    await delay(100);
+
     const res = await Call<createapi.CreateAppBody, {}, {}>(createapi.default, {
       auth: users.members[0],
       body: {
@@ -40,7 +40,6 @@ describe('create api', () => {
         parentId: String(folderId)
       }
     });
-    await delay(500);
     expect(res2.error).toBeUndefined();
     expect(res2.code).toBe(200);
     expect(res2.data).toBeDefined();
@@ -56,5 +55,26 @@ describe('create api', () => {
     });
     expect(res3.error).toBe(AppErrEnum.unAuthApp);
     expect(res3.code).toBe(500);
+
+    await MongoResourcePermission.create({
+      resourceType: 'app',
+      teamId: users.members[1].teamId,
+      resourceId: String(folderId),
+      tmbId: users.members[1].tmbId,
+      permission: WritePermissionVal
+    });
+
+    const res4 = await Call<createapi.CreateAppBody, {}, {}>(createapi.default, {
+      auth: users.members[1],
+      body: {
+        modules: [],
+        name: 'testapp',
+        type: AppTypeEnum.simple,
+        parentId: String(folderId)
+      }
+    });
+    expect(res4.error).toBeUndefined();
+    expect(res4.code).toBe(200);
+    expect(res4.data).toBeDefined();
   });
 });


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Fixed the app copy API by changing the required permission level from TeamAppCreatePermissionVal to WritePermissionVal for parent app access.

- Changed the permission requirement in `copy.ts` from TeamAppCreatePermissionVal to WritePermissionVal, allowing users with write access to copy apps.
- Added comprehensive test cases in `copy.test.ts` to verify the app copying functionality works correctly with the new permission model.
- Updated `create.test.ts` to include additional test cases for app creation with write permissions and removed unnecessary delay calls.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

- **fix: app copy**
- **test: add app copy test case**
