### PR TITLE
fix empty tool argument, set to {} to avaid claude json parse error

### DIFF
--- a/packages/service/core/workflow/dispatch/agent/runTool/toolChoice.ts
+++ b/packages/service/core/workflow/dispatch/agent/runTool/toolChoice.ts
@@ -730,12 +730,12 @@ async function streamResponse({
           if (toolCall.id) {
             callingTool = {
               name: toolCall.function?.name || '',
-              arguments: toolCall.function?.arguments || ''
+              arguments: toolCall.function?.arguments || '{}'
             };
           } else if (callingTool) {
             // Continue call(Perhaps the name of the previous function was incomplete)
             callingTool.name += toolCall.function?.name || '';
-            callingTool.arguments += toolCall.function?.arguments || '';
+            callingTool.arguments += toolCall.function?.arguments || '{}';
           }
 
           if (!callingTool) {


### PR DESCRIPTION
Claude会严格检查，即时对于空的工具调用参数，也需要满足json格式