### PR TITLE
fix empty tool argument, set to {} to avaid claude json parse error

### DIFF
--- a/packages/service/core/workflow/dispatch/agent/runTool/toolChoice.ts
+++ b/packages/service/core/workflow/dispatch/agent/runTool/toolChoice.ts
@@ -764,7 +764,7 @@ async function streamResponse({
                   toolName: toolNode.name,
                   toolAvatar: toolNode.avatar,
                   functionName: callingTool.name,
-                  params: callingTool?.arguments ?? '',
+                  params: callingTool?.arguments ?? '{}',
                   response: ''
                 }
               }


### PR DESCRIPTION
claude在空参数的工具调用的时候会报错json parse error，即时参数为空也要填一下{}