### PR TITLE
修复同一域名下的多个 iframe 共享相同的缓存，可能导致页面展示混乱问题

### DIFF
--- a/projects/app/src/web/core/chat/context/useChatStore.ts
+++ b/projects/app/src/web/core/chat/context/useChatStore.ts
@@ -23,13 +23,25 @@ type State = {
 const createCustomStorage = () => {
   const sessionKeys = ['source', 'chatId', 'appId'];
 
+  // 从 URL 中获取 appId 作为存储键的一部分
+  const getStorageKey = (name: string) => {
+    let appId = '';
+    if (typeof window !== 'undefined') {
+      const urlParams = new URLSearchParams(window.location.search);
+      appId = urlParams.get('appId') || '';
+    }
+    return appId ? `${name}_${appId}` : name;
+  };
+
   return {
     getItem: (name: string) => {
-      const sessionData = JSON.parse(sessionStorage.getItem(name) || '{}');
-      const localData = JSON.parse(localStorage.getItem(name) || '{}');
+      const storageKey = getStorageKey(name);
+      const sessionData = JSON.parse(sessionStorage.getItem(storageKey) || '{}');
+      const localData = JSON.parse(localStorage.getItem(storageKey) || '{}');
       return JSON.stringify({ ...localData, ...sessionData });
     },
     setItem: (name: string, value: string) => {
+      const storageKey = getStorageKey(name);
       const data = JSON.parse(value);
 
       // 分离 session 和 local 数据
@@ -42,15 +54,16 @@ const createCustomStorage = () => {
 
       // 分别存储
       if (Object.keys(sessionData).length > 0) {
-        sessionStorage.setItem(name, JSON.stringify({ state: sessionData, version: 0 }));
+        sessionStorage.setItem(storageKey, JSON.stringify({ state: sessionData, version: 0 }));
       }
       if (Object.keys(localData).length > 0) {
-        localStorage.setItem(name, JSON.stringify({ state: localData, version: 0 }));
+        localStorage.setItem(storageKey, JSON.stringify({ state: localData, version: 0 }));
       }
     },
     removeItem: (name: string) => {
-      sessionStorage.removeItem(name);
-      localStorage.removeItem(name);
+      const storageKey = getStorageKey(name);
+      sessionStorage.removeItem(storageKey);
+      localStorage.removeItem(storageKey);
     }
   };
 };


### PR DESCRIPTION
1、**appld 和 chatld 的存储方式:** 在 usechatStore.ts 中，appld、chatld 和 source 被存储在 sessionStorage中，而其他状态被存储在 localstorage 中。
2、**iframe 共享存储:** 同一域名下的多个 iframe 共享相同的 sessionStorage 和 localStorage，这可能导致状态混乱。
3、**状态恢复逻辑:** 当页面加载时，FastGPT 会尝试从存储中恢复状态，但这个恢复逻辑可能在多个 iframe 快速切换时出现问题。