### PR TITLE
fix full text recall without question optim

### DIFF
--- a/packages/service/core/dataset/search/controller.ts
+++ b/packages/service/core/dataset/search/controller.ts
@@ -544,7 +544,7 @@ export async function searchDatasetData(
       };
     }
 
-    const searchResults = (
+    const rawSearchResults = (
       await Promise.all(
         datasetIds.map(async (id) => {
           return MongoDatasetDataText.aggregate(
@@ -594,6 +594,7 @@ export async function searchDatasetData(
         })
       )
     ).flat() as (DatasetDataTextSchemaType & { score: number })[];
+    const searchResults = rawSearchResults.sort((a, b) => b.score - a.score);
 
     // Get data and collections
     const [dataList, collections] = await Promise.all([


### PR DESCRIPTION
#4835
写成datasetId: { $in: datasetIds.map((id) => new Types.ObjectId(id)) }之后直接排序就是一个query总的排序结果了，不知道这样会不会引起性能问题