### PR TITLE
修复当大模型回复内容较短时 ai 对话报 LLM_model_response_empty 的问题

### DIFF
--- a/packages/service/core/ai/utils.ts
+++ b/packages/service/core/ai/utils.ts
@@ -279,7 +279,7 @@ export const parseLLMStreamResponse = () => {
         return { reasoningContent, content };
       }
 
-      if (!content) {
+      if (!content && !isStreamEnd) {
         return {
           reasoningContent: '',
           content: ''


### PR DESCRIPTION
修复bug: 
[4840](https://github.com/labring/FastGPT/issues/4840)