### PR TITLE
feat:优化全文索引，增加datasetId作为联合索引

### DIFF
--- a/packages/service/core/dataset/data/dataTextSchema.ts
+++ b/packages/service/core/dataset/data/dataTextSchema.ts
@@ -34,9 +34,9 @@ const DatasetDataTextSchema = new Schema({
 
 try {
   DatasetDataTextSchema.index(
-    { teamId: 1, fullTextToken: 'text' },
+    { teamId: 1, datasetId: 1, fullTextToken: 'text' },
     {
-      name: 'teamId_1_fullTextToken_text',
+      name: 'teamId_1_datasetId_1_fullTextToken_text',
       default_language: 'none'
     }
   );


### PR DESCRIPTION
我这边的应用，在执行的时候发现问题：每次查询时，扫描的数据数量几乎为整个知识库（整个DB）的文本数量，而不是单个DataSet的文本数量。进一步查询发现，此处的索引未针对datasetID字段做联合索引，导致所有的全文检索扫描都会对比所有文本。
通过将datasetId字段加入联合索引，并在本地进行测试后，测试结论如下：

以下是针对10w左右数据量的一个dataset进行查询的前后对比。
增加DatasetID作为联合索引的字段，用于优化全文索引效率。优化效果如下：
![优化前耗时](https://github.com/user-attachments/assets/b8f207bb-770e-4700-97fb-1a8242989991)
![优化后耗时](https://github.com/user-attachments/assets/79d7370e-6617-410c-8f71-b31150fd5b88)

以下是索引优化前后，慢SQL日志对比
![image](https://github.com/user-attachments/assets/19884926-510b-4c35-95b4-b06fcab27a42)

经过上述对比，可见文档扫描数量和数据检索数量都有大幅下降。
该优化对于1个TeamID下有很多知识库，但是目标查询知识库占总知识库文本数量较低的查询优化效果更明显。