### PR TITLE
Change the default MongoDB image source to Docker Hub.

### DIFF
--- a/deploy/docker/docker-compose-milvus.yml
+++ b/deploy/docker/docker-compose-milvus.yml
@@ -67,7 +67,8 @@ services:
       - 'minio'
 
   mongo:
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/mongo:5.0.18 # 阿里云
+    image: mongo:5.0.18 # dockerhub
+    # image: registry.cn-hangzhou.aliyuncs.com/fastgpt/mongo:5.0.18 # 阿里云
     container_name: mongo
     restart: always
     ports:


### PR DESCRIPTION
修复默认使用aliyuncs阿里云docker镜像部署报错的问题，现默认使用dockerhub官方源。


![fastgpt_error_img](https://github.com/user-attachments/assets/680288a4-88f5-4e7b-a6c9-40fd7555b039)
