### PR TITLE
solve unsafe usage

### DIFF
--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useWorkflow.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useWorkflow.tsx
@@ -302,8 +302,12 @@ export const useWorkflow = () => {
   const [helperLineVertical, setHelperLineVertical] = useState<THelperLine>();
 
   const checkNodeHelpLine = useMemoizedFn((change: NodeChange, nodes: Node[]) => {
-    const positionChange = change.type === 'position' && change.dragging ? change : undefined;
+    let positionChange: NodePositionChange | undefined
 
+    if(change.type === 'position'){
+      positionChange = change.dragging ? change :undefined
+    }
+    
     if (positionChange?.position) {
       // 只判断，3000px 内的 nodes，并按从近到远的顺序排序
       const filterNodes = nodes


### PR DESCRIPTION
参数change是NodeChange类型，Nodechange是6个类型的联合类型。只有当6个类型同时拥有同一属性时，TS才能找到这一属性。6个类型只有NodePositionChange有dragging属性，在使用change.dragging之前需要使用条件语句类型收缩。