### PR TITLE
fix: Fixed the issue where anchor (`<a>`) tags in reply content could not properly open links in a new tab or window. 

### DIFF
--- a/projects/app/src/components/Markdown/codeBlock/iframe-html.tsx
+++ b/projects/app/src/components/Markdown/codeBlock/iframe-html.tsx
@@ -114,7 +114,7 @@ const IframeHtmlCodeBlock = ({
     () => (
       <iframe
         srcDoc={String(children)}
-        sandbox=""
+        sandbox="allow-popups"
         referrerPolicy="no-referrer"
         style={{
           width: '100%',


### PR DESCRIPTION
#4966 
Fixed the issue where anchor (`<a>`) tags in reply content could not properly open links in a new tab or window. For security reasons, it is recommended to add `rel="noopener"` when using `target="_blank"` in `<a>` tags.
