### PR TITLE
Fix the issue where the original page number was not preserved when returning to the knowledge base dataset file list after viewing file details.

### DIFF
--- a/packages/web/hooks/usePagination.tsx
+++ b/packages/web/hooks/usePagination.tsx
@@ -27,7 +27,8 @@ export function usePagination<DataT, ResT = {}>(
     onChange,
     refreshDeps,
     scrollLoadType = 'bottom',
-    EmptyTip
+    EmptyTip,
+    defaultPageNum = 1
   }: {
     pageSize?: number;
     params?: DataT;
@@ -38,6 +39,7 @@ export function usePagination<DataT, ResT = {}>(
     throttleWait?: number;
     scrollLoadType?: 'top' | 'bottom';
     EmptyTip?: React.JSX.Element;
+    defaultPageNum?: number;
   }
 ) {
   const { toast } = useToast();
@@ -55,7 +57,7 @@ export function usePagination<DataT, ResT = {}>(
 
   const fetchData = useMemoizedFn(
     async (num: number = pageNum, ScrollContainerRef?: RefObject<HTMLDivElement>) => {
-      if (noMore && num !== 1) return;
+      if (noMore && num !== defaultPageNum) return;
       setTrue();
 
       try {
@@ -247,7 +249,7 @@ export function usePagination<DataT, ResT = {}>(
   // Reload data
   const { runAsync: refresh } = useRequest(
     async () => {
-      defaultRequest && fetchData(1);
+      defaultRequest && fetchData(defaultPageNum || 1);
     },
     {
       manual: false,

--- a/projects/app/src/components/Markdown/codeBlock/iframe-html.tsx
+++ b/projects/app/src/components/Markdown/codeBlock/iframe-html.tsx
@@ -114,7 +114,7 @@ const IframeHtmlCodeBlock = ({
     () => (
       <iframe
         srcDoc={String(children)}
-        sandbox=""
+        sandbox="allow-popups"
         referrerPolicy="no-referrer"
         style={{
           width: '100%',

--- a/projects/app/src/pageComponents/dataset/detail/CollectionCard/Context.tsx
+++ b/projects/app/src/pageComponents/dataset/detail/CollectionCard/Context.tsx
@@ -32,6 +32,8 @@ type CollectionPageContextType = {
   setFilterTags: Dispatch<SetStateAction<string[]>>;
 };
 
+let defaultPageNum = 1;
+
 export const CollectionPageContext = createContext<CollectionPageContextType>({
   openWebSyncConfirm: function (): () => void {
     throw new Error('Function not implemented.');
@@ -114,6 +116,7 @@ const CollectionPageContextProvider = ({ children }: { children: ReactNode }) =>
     pageSize
   } = usePagination(getDatasetCollections, {
     pageSize: 20,
+    defaultPageNum,
     params: {
       datasetId,
       parentId,
@@ -123,6 +126,7 @@ const CollectionPageContextProvider = ({ children }: { children: ReactNode }) =>
     // defaultRequest: false,
     refreshDeps: [parentId, searchText, filterTags]
   });
+  defaultPageNum = pageNum;
 
   const contextValue: CollectionPageContextType = {
     openWebSyncConfirm: openWebSyncConfirm(syncWebsite),


### PR DESCRIPTION
#5067
Fix the issue where the original page number was not preserved when returning to the knowledge base dataset file list after viewing file details.
(修复查看知识库数据集文件详情后返回列表时未保留原页码的问题)