### PR TITLE
fix: fix incomplete directory display when adding node team app with nested structure.

### DIFF
--- a/projects/app/src/components/common/folder/Path.tsx
+++ b/projects/app/src/components/common/folder/Path.tsx
@@ -38,7 +38,7 @@ const FolderPath = (props: {
   return paths.length === 0 && !!FirstPathDom ? (
     <>{FirstPathDom}</>
   ) : (
-    <Flex flex={1}>
+    <Flex flex={1} overflowX={'auto'}>
       {concatPaths.map((item, i) => {
         const clickStyles = {
           cursor: 'pointer',
@@ -57,7 +57,7 @@ const FolderPath = (props: {
               py={0.5}
               px={1.5}
               borderRadius={'md'}
-              maxW={'45vw'}
+              maxW={'164px'}
               className={'textEllipsis'}
               {...(i === concatPaths.length - 1 && concatPaths.length > 1
                 ? {


### PR DESCRIPTION
#5141
Fix incomplete directory display when adding node team app with nested structure.
(修复节点团队应用有目录时无法完整展示的问题)
优化点如下：
1. 对Path中的目录名称限制10个字宽度，以前的宽度为 45vw 不合理。
2. 对超出宽度的情况增加横线滚动条（改动最小的方式，因为观察到FolderPath组件用的地方挺多）
![image](https://github.com/user-attachments/assets/ce7fb563-d6bb-4c36-8825-1cbc3b65c178)
![image](https://github.com/user-attachments/assets/ea2717cd-9152-4cc1-b92f-5c7510101297)


