### PR TITLE
fix: page /404 translator not working bug

### DIFF
--- a/projects/app/src/pages/404.tsx
+++ b/projects/app/src/pages/404.tsx
@@ -1,3 +1,4 @@
+import { serviceSideProps } from '@/web/common/i18n/utils';
 import React, { useEffect } from 'react';
 import { useRouter } from 'next/router';
 
@@ -9,5 +10,13 @@ const NonePage = () => {
 
   return <div></div>;
 };
+
+export async function getStaticProps(content: any) {
+  return {
+    props: {
+      ...(await serviceSideProps(content))
+    }
+  };
+}
 
 export default NonePage;


### PR DESCRIPTION
### desc
`/404` page translator failure causes navigation bar text flickering on redirected page load.