### PR TITLE
修复 SSE响应内存泄露以及chat item数据超过mongo限制的问题

### DIFF
--- a/packages/global/core/chat/type.d.ts
+++ b/packages/global/core/chat/type.d.ts
@@ -1,4 +1,3 @@
-import { ClassifyQuestionAgentItemType } from '../workflow/template/system/classifyQuestion/type';
 import type { SearchDataResponseItemType } from '../dataset/type';
 import type {
   ChatFileTypeEnum,
@@ -11,9 +10,7 @@ import type { FlowNodeTypeEnum } from '../workflow/node/constant';
 import type { NodeOutputKeyEnum } from '../workflow/constants';
 import type { DispatchNodeResponseKeyEnum } from '../workflow/runtime/constants';
 import type { AppSchema, VariableItemType } from '../app/type';
-import { AppChatConfigType } from '../app/type';
 import type { AppSchema as AppType } from '@fastgpt/global/core/app/type.d';
-import { DatasetSearchModeEnum } from '../dataset/constants';
 import type { DispatchNodeResponseType } from '../workflow/runtime/type.d';
 import type { ChatBoxInputType } from '../../../../projects/app/src/components/core/chat/ChatContainer/ChatBox/type';
 import type { WorkflowInteractiveResponseType } from '../workflow/template/system/interactive/type';
@@ -116,7 +113,17 @@ export type ChatItemSchema = (UserChatItemType | SystemChatItemType | AIChatItem
   durationSeconds?: number;
   errorMsg?: string;
 };
-
+export type ChatItemResDataSchema = {
+  dataId: string;
+  chatId: string;
+  userId: string;
+  teamId: string;
+  tmbId: string;
+  appId: string;
+  itemId: string;
+  dataSort: number;
+  [DispatchNodeResponseKeyEnum.nodeResponse]: ChatHistoryItemResType
+};
 export type AdminFbkType = {
   feedbackDataId: string;
   datasetId: string;
@@ -175,6 +182,7 @@ export type ChatHistoryItemResType = DispatchNodeResponseType & {
   id: string;
   moduleType: FlowNodeTypeEnum;
   moduleName: string;
+  quoteList: SearchDataResponseItemType
 };
 
 /* ---------- node outputs ------------ */

--- a/packages/service/common/response/index.ts
+++ b/packages/service/common/response/index.ts
@@ -137,13 +137,25 @@ export function responseWrite({
   event?: string;
   data: string;
 }) {
+  // break if closed
+  if (res?.closed || res?.destroyed) return;
+
+
   const Write = write || res?.write;
 
   if (!Write) return;
 
-  event && Write(`event: ${event}\n`);
-  Write(`data: ${data}\n\n`);
+  // event && Write(`event: ${event}\n`);
+  // Write(`data: ${data}\n\n`);
+  const text = event ? `event: ${event}\ndata: ${data}\n\n` : `data: ${data}\n\n`;
+  Write(text);
+  // flush immediately
+  if (res && typeof (res as any).flush === 'function') {
+    (res as any).flush();
+  }
+
 }
+
 
 export const responseWriteNodeStatus = ({
   res,

--- a/packages/service/core/app/controller.ts
+++ b/packages/service/core/app/controller.ts
@@ -11,6 +11,8 @@ import { removeEvaluationJob } from './evaluation/mq';
 import { deleteChatFiles } from '../chat/controller';
 import { MongoChatItem } from '../chat/chatItemSchema';
 import { MongoChat } from '../chat/chatSchema';
+import { MongoChatItemResData } from "../chat/chatItemResDataSchema";
+
 import { MongoOutLink } from '../../support/outLink/schema';
 import { MongoOpenApi } from '../../support/openapi/schema';
 import { MongoAppVersion } from './version/schema';
@@ -167,6 +169,12 @@ export const onDelOneApp = async ({
         { session }
       );
 
+      await MongoChatItemResData.deleteMany(
+        {
+          appId
+        },
+        { session }
+      );
       // 删除分享链接
       await MongoOutLink.deleteMany({
         appId

--- a/packages/service/core/chat/chatItemResDataSchema.ts
+++ b/packages/service/core/chat/chatItemResDataSchema.ts
@@ -1,0 +1,71 @@
+import { connectionMongo, getMongoModel } from '../../common/mongo';
+import { type ChatItemResDataSchema } from '@fastgpt/global/core/chat/type';
+import { getNanoid } from '@fastgpt/global/common/string/tools';
+import {
+  TeamCollectionName,
+  TeamMemberCollectionName
+} from '@fastgpt/global/support/user/team/constant';
+import { AppCollectionName } from '../app/schema';
+import { ChatItemCollectionName } from './chatItemSchema';
+import { userCollectionName } from '../../support/user/schema';
+import { DispatchNodeResponseKeyEnum } from '@fastgpt/global/core/workflow/runtime/constants';
+
+const { Schema } = connectionMongo;
+
+export const CollectionName = 'chat_item_res_data';
+
+const ChatItemResDataSchema = new Schema({
+  teamId: {
+    type: Schema.Types.ObjectId,
+    ref: TeamCollectionName,
+    required: true
+  },
+  tmbId: {
+    type: Schema.Types.ObjectId,
+    ref: TeamMemberCollectionName,
+    required: true
+  },
+  userId: {
+    type: Schema.Types.ObjectId,
+    ref: userCollectionName
+  },
+  chatId: {
+    type: String,
+    require: true
+  },
+  dataId: {
+    type: String,
+    require: true,
+    default: () => getNanoid(22)
+  },
+  appId: {
+    type: Schema.Types.ObjectId,
+    ref: AppCollectionName,
+    required: true
+  },
+  itemId: {
+    type: Schema.Types.ObjectId,
+    ref: ChatItemCollectionName,
+    required: true
+  },
+  [DispatchNodeResponseKeyEnum.nodeResponse]: {
+    type: Object,
+    default: {}
+  },
+  dataSort:{
+    type: Number,
+    default: 0,
+    required: true
+  }
+});
+
+try {
+  ChatItemResDataSchema.index({ dataId: 1 });
+  ChatItemResDataSchema.index({ dataId: 1,itemId:1 });
+  ChatItemResDataSchema.index({ appId: 1, chatId: 1, dataId: 1 });
+  ChatItemResDataSchema.index({ teamId: 1});
+} catch (error) {
+  console.log(error);
+}
+
+export const MongoChatItemResData = getMongoModel<ChatItemResDataSchema>(CollectionName, ChatItemResDataSchema);

--- a/packages/service/core/chat/chatItemSchema.ts
+++ b/packages/service/core/chat/chatItemSchema.ts
@@ -1,6 +1,5 @@
 import { connectionMongo, getMongoModel } from '../../common/mongo';
-const { Schema } = connectionMongo;
-import { type ChatItemSchema as ChatItemType } from '@fastgpt/global/core/chat/type';
+import { type ChatItemSchema } from '@fastgpt/global/core/chat/type';
 import { ChatRoleMap } from '@fastgpt/global/core/chat/constants';
 import { getNanoid } from '@fastgpt/global/common/string/tools';
 import {
@@ -10,6 +9,8 @@ import {
 import { AppCollectionName } from '../app/schema';
 import { userCollectionName } from '../../support/user/schema';
 import { DispatchNodeResponseKeyEnum } from '@fastgpt/global/core/workflow/runtime/constants';
+
+const { Schema } = connectionMongo;
 
 export const ChatItemCollectionName = 'chatitems';
 
@@ -100,4 +101,4 @@ try {
   console.log(error);
 }
 
-export const MongoChatItem = getMongoModel<ChatItemType>(ChatItemCollectionName, ChatItemSchema);
+export const MongoChatItem = getMongoModel<ChatItemSchema>(ChatItemCollectionName, ChatItemSchema);

--- a/projects/app/src/pages/api/core/chat/clearHistories.ts
+++ b/projects/app/src/pages/api/core/chat/clearHistories.ts
@@ -8,6 +8,7 @@ import { deleteChatFiles } from '@fastgpt/service/core/chat/controller';
 import { mongoSessionRun } from '@fastgpt/service/common/mongo/sessionRun';
 import { type ApiRequestProps } from '@fastgpt/service/type/next';
 import { authChatCrud } from '@/service/support/permission/auth/chat';
+import {MongoChatItemResData} from "@fastgpt/service/core/chat/chatItemResDataSchema";
 
 /* clear chat history */
 async function handler(req: ApiRequestProps<{}, ClearHistoriesProps>, res: NextApiResponse) {
@@ -66,6 +67,13 @@ async function handler(req: ApiRequestProps<{}, ClearHistoriesProps>, res: NextA
   await deleteChatFiles({ chatIdList: idList });
 
   return mongoSessionRun(async (session) => {
+    await MongoChatItemResData.deleteMany(
+      {
+        appId,
+        chatId: { $in: idList }
+      },
+      { session }
+    );
     await MongoChatItem.deleteMany(
       {
         appId,

--- a/projects/app/src/pages/api/core/chat/delHistory.ts
+++ b/projects/app/src/pages/api/core/chat/delHistory.ts
@@ -8,6 +8,7 @@ import { mongoSessionRun } from '@fastgpt/service/common/mongo/sessionRun';
 import { NextAPI } from '@/service/middleware/entry';
 import { type ApiRequestProps } from '@fastgpt/service/type/next';
 import { deleteChatFiles } from '@fastgpt/service/core/chat/controller';
+import { MongoChatItemResData } from '@fastgpt/service/core/chat/chatItemResDataSchema';
 
 /* clear chat history */
 async function handler(req: ApiRequestProps<{}, DelHistoryProps>, res: NextApiResponse) {
@@ -22,6 +23,13 @@ async function handler(req: ApiRequestProps<{}, DelHistoryProps>, res: NextApiRe
 
   await deleteChatFiles({ chatIdList: [chatId] });
   await mongoSessionRun(async (session) => {
+    await MongoChatItemResData.deleteMany(
+      {
+        appId,
+        chatId
+      },
+      { session }
+    );
     await MongoChatItem.deleteMany(
       {
         appId,

--- a/projects/app/src/pages/api/core/chat/getResData.ts
+++ b/projects/app/src/pages/api/core/chat/getResData.ts
@@ -1,11 +1,13 @@
 import { authChatCrud } from '@/service/support/permission/auth/chat';
 import { MongoChatItem } from '@fastgpt/service/core/chat/chatItemSchema';
+import { MongoChatItemResData } from '@fastgpt/service/core/chat/chatItemResDataSchema';
 import { ChatRoleEnum } from '@fastgpt/global/core/chat/constants';
 import type { ApiRequestProps, ApiResponseType } from '@fastgpt/service/type/next';
 import { NextAPI } from '@/service/middleware/entry';
 import { type ChatHistoryItemResType } from '@fastgpt/global/core/chat/type';
 import { type OutLinkChatAuthProps } from '@fastgpt/global/support/permission/chat';
 import { filterPublicNodeResponseData } from '@fastgpt/global/core/chat/utils';
+import { DispatchNodeResponseKeyEnum } from '@fastgpt/global/core/workflow/runtime/constants';
 
 export type getResDataQuery = OutLinkChatAuthProps & {
   chatId?: string;
@@ -47,13 +49,36 @@ async function handler(
     return [];
   }
 
-  const flowResponses = chatData.responseData ?? [];
-  return req.query.shareId
-    ? filterPublicNodeResponseData({
-        responseDetail,
-        flowResponses: chatData.responseData
-      })
-    : flowResponses;
+  let nodeResponseData: ChatHistoryItemResType[] = [];
+
+  //AI节点的详情从item表迁移到了resData表，做个判断，兼容新老数据
+  const archiveItemResponseData = chatData?.[DispatchNodeResponseKeyEnum.nodeResponse];
+  // 判断是否为空：undefined / null / 非数组 / 空数组
+  const itemResponseDataExist =
+    Array.isArray(archiveItemResponseData) && archiveItemResponseData.length > 0;
+  if (chatData?.obj === ChatRoleEnum.AI && itemResponseDataExist === false) {
+    const resDataList = await MongoChatItemResData.find(
+      {
+        itemId: chatData._id // 所有属于该 chatItem 的子数据
+      },
+      { [DispatchNodeResponseKeyEnum.nodeResponse]: 1, _id: 0 } // 只取 nodeResponse 字段
+    )
+      .sort({ dataSort: 1 }) // 确保顺序一致（可按插入顺序）
+      .lean();
+    return req.query.shareId
+      ? filterPublicNodeResponseData({
+          responseDetail,
+          flowResponses: nodeResponseData
+        })
+      : resDataList.flatMap((item) => item[DispatchNodeResponseKeyEnum.nodeResponse] || []);
+  } else {
+    return req.query.shareId
+      ? filterPublicNodeResponseData({
+          responseDetail,
+          flowResponses: nodeResponseData
+        })
+      : chatData?.[DispatchNodeResponseKeyEnum.nodeResponse] ?? [];
+  }
 }
 
 export default NextAPI(handler);


### PR DESCRIPTION
<img width="3531" height="1791" alt="image" src="https://github.com/user-attachments/assets/ed7d405b-33c1-40c5-865a-bfb7b27b72e4" />
<img width="3809" height="1464" alt="image" src="https://github.com/user-attachments/assets/efeb1dcd-1c9a-4d75-aafc-f151bfa79ee1" />
在深度使用的过程中发现，一次对话流式输出内容很长时会出现两个问题
1. 保存的对话历史记录，AI类的responseData过长，写入chatitems表时超出mongo限制
2. API response for /api/core/chat/chatTest exceeds 20MB.  超过了next js的响应限制，多次出现后发生OOM
做出了两个改动
1. 加入chat_item_res_datas，一对多的存储item下的responseData，查询时兼容新老数据结构。
2. sse输出时，即时flush缓冲区，避免出现”API response for /api/core/chat/chatTest exceeds 20MB“问题，测试几天后没有复现OOM问题。