### PR TITLE
fix(api): 修复二级路由下的页面判断逻辑

### DIFF
--- a/projects/app/src/web/common/api/request.ts
+++ b/projects/app/src/web/common/api/request.ts
@@ -109,10 +109,13 @@ function checkRes(data: ResponseDataType) {
  */
 function responseError(err: any) {
   console.log('error->', '请求错误', err);
+  // 获取二级路由
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || '';
+  // 拼接二级路由
   const isOutlinkPage = {
-    '/chat/share': true,
-    '/chat': true,
-    '/login': true
+    [`${baseUrl}/chat/share`]: true,
+    [`${baseUrl}/chat`]: true,
+    [`${baseUrl}/login`]: true
   }[window.location.pathname];
 
   const data = err?.response?.data || err;


### PR DESCRIPTION
在请求错误处理中，添加基础URL前缀以正确判断当前是否为外部链接页面。