### PR TITLE
fix: node template bugs

### DIFF
--- a/packages/global/core/workflow/utils.ts
+++ b/packages/global/core/workflow/utils.ts
@@ -276,7 +276,7 @@ export const appData2FlowNodeIO = ({
           description: '',
           valueType: WorkflowIOValueTypeEnum.any,
           required: item.required,
-          list: item.enums?.map((enumItem) => ({
+          list: (item.list || item.enums)?.map((enumItem) => ({
             label: enumItem.value,
             value: enumItem.value
           }))

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/components/NodeTemplates/list.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/components/NodeTemplates/list.tsx
@@ -275,6 +275,13 @@ const NodeTemplateList = ({
         });
 
         const currentNode = nodeList.find((node) => node.nodeId === handleParams?.nodeId);
+        if (templateNode.flowNodeType === FlowNodeTypeEnum.loop && !!currentNode?.parentNodeId) {
+          toast({
+            status: 'warning',
+            title: t('workflow:can_not_loop')
+          });
+          return;
+        }
 
         const newNode = nodeTemplate2FlowNode({
           template: {

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeFormInput/InputFormEditModal.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeFormInput/InputFormEditModal.tsx
@@ -166,6 +166,7 @@ const InputFormEditModal = ({
                     }}
                     onClick={() => {
                       setValue('type', item.value);
+                      setValue('defaultValue', '');
                     }}
                   >
                     <MyIcon

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodePluginIO/InputEditModal.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodePluginIO/InputEditModal.tsx
@@ -296,6 +296,7 @@ const FieldEditModal = ({
                           }}
                           onClick={() => {
                             setValue('renderTypeList', item.value);
+                            setValue('defaultValue', '');
                           }}
                         >
                           <MyIcon

--- a/projects/app/src/web/core/workflow/utils.ts
+++ b/projects/app/src/web/core/workflow/utils.ts
@@ -87,7 +87,9 @@ export const storeNode2FlowNode = ({
     moduleTemplatesFlat.find((template) => template.flowNodeType === storeNode.flowNodeType) ||
     EmptyNode;
 
-  const templateInputs = template.inputs.filter((input) => !input.canEdit);
+  const templateInputs = template.inputs.filter(
+    (input) => !input.canEdit && input.deprecated !== true
+  );
   const templateOutputs = template.outputs.filter(
     (output) => output.type !== FlowNodeOutputTypeEnum.dynamic
   );


### PR DESCRIPTION
1. 工作流调用应用，单选的全局变量无法显示
2. 批量运行节点内部，未过滤批量运行节点的创建
3. 表单输入节点的输入，切换类型时重置默认值
4. 复制http节点，会渲染出废弃的输入