### PR TITLE
fix: 修复 MongoDB Change Streams 断连重连问题

### DIFF
--- a/packages/service/common/mongo/init.ts
+++ b/packages/service/common/mongo/init.ts
@@ -4,7 +4,7 @@ import type { Mongoose } from 'mongoose';
 
 const maxConnecting = Math.max(30, Number(process.env.DB_MAX_LINK || 20));
 
-/**
+w/**
  * connect MongoDB and init data
  */
 export async function connectMongo(db: Mongoose, url: string): Promise<Mongoose> {

--- a/projects/app/src/service/common/system/volumnMongoWatch.ts
+++ b/projects/app/src/service/common/system/volumnMongoWatch.ts
@@ -8,42 +8,138 @@ import { watchSystemModelUpdate } from '@fastgpt/service/core/ai/config/utils';
 import { SystemConfigsTypeEnum } from '@fastgpt/global/common/system/config/constants';
 
 export const startMongoWatch = async () => {
-  reloadConfigWatch();
-  createDatasetTrainingMongoWatch();
-  refetchAppTemplates();
-  watchSystemModelUpdate();
+  const cleanupFunctions: (() => void)[] = [];
+  
+  // 启动所有 Change Stream 监听器并收集清理函数
+  cleanupFunctions.push(reloadConfigWatch());
+  cleanupFunctions.push(createDatasetTrainingMongoWatch());
+  cleanupFunctions.push(refetchAppTemplates());
+  cleanupFunctions.push(watchSystemModelUpdate());
+  
+  console.log('All MongoDB change streams started');
+  
+  // 返回清理函数，用于关闭所有 Change Stream
+  return () => {
+    console.log('Closing all MongoDB change streams...');
+    cleanupFunctions.forEach(cleanup => {
+      try {
+        cleanup();
+      } catch (error) {
+        console.error('Error closing change stream:', error);
+      }
+    });
+    console.log('All MongoDB change streams closed');
+  };
 };
 
 const reloadConfigWatch = () => {
-  const changeStream = MongoSystemConfigs.watch();
-
-  changeStream.on('change', async (change) => {
+  let changeStream: any;
+  
+  const createWatch = () => {
     try {
-      if (
-        change.operationType === 'update' ||
-        (change.operationType === 'insert' &&
-          [SystemConfigsTypeEnum.fastgptPro, SystemConfigsTypeEnum.license].includes(
-            change.fullDocument.type
-          ))
-      ) {
-        await initSystemConfig();
-        console.log('refresh system config');
-      }
-    } catch (error) {}
-  });
+      changeStream = MongoSystemConfigs.watch();
+
+      changeStream.on('change', async (change) => {
+        try {
+          if (
+            change.operationType === 'update' ||
+            (change.operationType === 'insert' &&
+              [SystemConfigsTypeEnum.fastgptPro, SystemConfigsTypeEnum.license].includes(
+                change.fullDocument.type
+              ))
+          ) {
+            await initSystemConfig();
+            console.log('refresh system config');
+          }
+        } catch (error) {
+          console.error('System config change processing error:', error);
+        }
+      });
+
+      // 添加错误处理和重连机制
+      changeStream.on('error', (error) => {
+        console.error('System config change stream error:', error);
+        setTimeout(() => {
+          console.log('Attempting to reconnect system config change stream...');
+          createWatch();
+        }, 5000);
+      });
+
+      changeStream.on('close', () => {
+        console.log('System config change stream closed, attempting to reconnect...');
+        setTimeout(() => {
+          createWatch();
+        }, 1000);
+      });
+
+      console.log('System config change stream created');
+    } catch (error) {
+      console.error('Failed to create system config change stream:', error);
+      setTimeout(() => {
+        createWatch();
+      }, 5000);
+    }
+  };
+
+  createWatch();
+  
+  return () => {
+    if (changeStream) {
+      changeStream.close();
+    }
+  };
 };
 
 const refetchAppTemplates = () => {
-  const changeStream = MongoAppTemplate.watch();
+  let changeStream: any;
+  
+  const createWatch = () => {
+    try {
+      changeStream = MongoAppTemplate.watch();
 
-  changeStream.on(
-    'change',
-    debounce(async (change) => {
+      changeStream.on(
+        'change',
+        debounce(async (change) => {
+          setTimeout(() => {
+            try {
+              getAppTemplatesAndLoadThem(true);
+            } catch (error) {
+              console.error('App templates reload error:', error);
+            }
+          }, 5000);
+        }, 500)
+      );
+
+      // 添加错误处理和重连机制
+      changeStream.on('error', (error) => {
+        console.error('App templates change stream error:', error);
+        setTimeout(() => {
+          console.log('Attempting to reconnect app templates change stream...');
+          createWatch();
+        }, 5000);
+      });
+
+      changeStream.on('close', () => {
+        console.log('App templates change stream closed, attempting to reconnect...');
+        setTimeout(() => {
+          createWatch();
+        }, 1000);
+      });
+
+      console.log('App templates change stream created');
+    } catch (error) {
+      console.error('Failed to create app templates change stream:', error);
       setTimeout(() => {
-        try {
-          getAppTemplatesAndLoadThem(true);
-        } catch (error) {}
+        createWatch();
       }, 5000);
-    }, 500)
-  );
+    }
+  };
+
+  createWatch();
+  
+  return () => {
+    if (changeStream) {
+      changeStream.close();
+    }
+  };
 };

--- a/projects/app/src/service/core/dataset/training/utils.ts
+++ b/projects/app/src/service/core/dataset/training/utils.ts
@@ -6,23 +6,63 @@ import { MongoDatasetTraining } from '@fastgpt/service/core/dataset/training/sch
 import { datasetParseQueue } from '../queues/datasetParse';
 
 export const createDatasetTrainingMongoWatch = () => {
-  const changeStream = MongoDatasetTraining.watch();
-
-  changeStream.on('change', async (change) => {
+  let changeStream: any;
+  
+  const createWatch = () => {
     try {
-      if (change.operationType === 'insert') {
-        const fullDocument = change.fullDocument as DatasetTrainingSchemaType;
-        const { mode } = fullDocument;
-        if (mode === TrainingModeEnum.qa) {
-          generateQA();
-        } else if (mode === TrainingModeEnum.chunk) {
-          generateVector();
-        } else if (mode === TrainingModeEnum.parse) {
-          datasetParseQueue();
+      changeStream = MongoDatasetTraining.watch();
+
+      changeStream.on('change', async (change) => {
+        try {
+          if (change.operationType === 'insert') {
+            const fullDocument = change.fullDocument as DatasetTrainingSchemaType;
+            const { mode } = fullDocument;
+            if (mode === TrainingModeEnum.qa) {
+              generateQA();
+            } else if (mode === TrainingModeEnum.chunk) {
+              generateVector();
+            } else if (mode === TrainingModeEnum.parse) {
+              datasetParseQueue();
+            }
+          }
+        } catch (error) {
+          console.error('Change stream processing error:', error);
         }
-      }
-    } catch (error) {}
-  });
+      });
+
+      // 添加错误处理和重连机制
+      changeStream.on('error', (error) => {
+        console.error('Change stream error:', error);
+        setTimeout(() => {
+          console.log('Attempting to reconnect change stream...');
+          createWatch();
+        }, 5000); // 5秒后重连
+      });
+
+      changeStream.on('close', () => {
+        console.log('Change stream closed, attempting to reconnect...');
+        setTimeout(() => {
+          createWatch();
+        }, 1000); // 1秒后重连
+      });
+
+      console.log('Dataset training change stream created');
+    } catch (error) {
+      console.error('Failed to create change stream:', error);
+      setTimeout(() => {
+        createWatch();
+      }, 5000);
+    }
+  };
+
+  createWatch();
+  
+  // 返回清理函数
+  return () => {
+    if (changeStream) {
+      changeStream.close();
+    }
+  };
 };
 
 export const startTrainingQueue = (fast?: boolean) => {


### PR DESCRIPTION
- 问题描述：当大量推送数据到知识库时，MongoDB 主节点切换会导致 Change Streams 进程挂掉，数据消费变慢，需要重启服务
- 修复内容：
  1. 为所有 Change Stream 实现添加错误处理和自动重连机制
  2. 添加 error 和 close 事件监听器，实现延迟重连
  3. 增强日志记录，便于问题排查
  4. 提供清理函数，确保资源正确释放
- 影响文件：
  - packages/service/core/ai/config/utils.ts (watchSystemModelUpdate)
  - projects/app/src/service/common/system/volumnMongoWatch.ts (reloadConfigWatch, refetchAppTemplates, startMongoWatch)
  - projects/app/src/service/core/dataset/training/utils.ts (createDatasetTrainingMongoWatch)
- 解决场景：MongoDB 主节点切换时 Change Streams 自动重连，避免服务中断