### PR TITLE
feat: add sitemap and robots.txt support for FastGPT

### DIFF
--- a/projects/app/src/pages/robots.txt.tsx
+++ b/projects/app/src/pages/robots.txt.tsx
@@ -1,0 +1,32 @@
+import { GetServerSideProps } from 'next';
+import { RobotsGenerator } from '@/web/common/seo/robots';
+
+const Robots = () => {
+  // This component is never actually rendered because we serve text directly
+  return null;
+};
+
+export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL || process.env.VERCEL_URL || 'http://localhost:3000';
+  const protocol = req.headers['x-forwarded-proto'] || 'https';
+  const domain = `${protocol}://${baseUrl.replace(/^https?:\/\//, '')}`;
+
+  // Get default robots configuration for FastGPT
+  const robotsConfig = RobotsGenerator.getDefaultConfig(domain);
+
+  // Generate robots.txt content
+  const robotsTxt = RobotsGenerator.generateRobots(robotsConfig);
+
+  // Set appropriate headers
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.setHeader('Cache-Control', 'public, s-maxage=86400, stale-while-revalidate=43200'); // Cache for 24 hours
+  res.write(robotsTxt);
+  res.end();
+
+  return {
+    props: {}
+  };
+};
+
+export default Robots;

--- a/projects/app/src/pages/sitemap.xml.tsx
+++ b/projects/app/src/pages/sitemap.xml.tsx
@@ -1,0 +1,42 @@
+import { GetServerSideProps } from 'next';
+import { SitemapGenerator } from '@/web/common/seo/sitemap';
+
+const Sitemap = () => {
+  // This component is never actually rendered because we serve XML directly
+  return null;
+};
+
+export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL || process.env.VERCEL_URL || 'http://localhost:3000';
+  const protocol = req.headers['x-forwarded-proto'] || 'https';
+  const domain = `${protocol}://${baseUrl.replace(/^https?:\/\//, '')}`;
+
+  // Configure sitemap generator with FastGPT's i18n settings
+  const locales = ['en', 'zh-CN', 'zh-Hant'];
+  const defaultLocale = 'en';
+
+  const sitemapGenerator = new SitemapGenerator({
+    baseUrl: domain,
+    locales,
+    defaultLocale
+  });
+
+  // Get default pages for FastGPT
+  const pages = SitemapGenerator.getDefaultPages();
+
+  // Generate sitemap XML
+  const sitemap = sitemapGenerator.generateSitemap(pages);
+
+  // Set appropriate headers
+  res.setHeader('Content-Type', 'text/xml; charset=utf-8');
+  res.setHeader('Cache-Control', 'public, s-maxage=86400, stale-while-revalidate=43200'); // Cache for 24 hours
+  res.write(sitemap);
+  res.end();
+
+  return {
+    props: {}
+  };
+};
+
+export default Sitemap;

--- a/projects/app/src/web/common/seo/robots.ts
+++ b/projects/app/src/web/common/seo/robots.ts
@@ -1,0 +1,45 @@
+import { RobotsConfig } from './types';
+
+export class RobotsGenerator {
+  /**
+   * Generate robots.txt content
+   */
+  static generateRobots(config: RobotsConfig): string {
+    const { userAgent, allow, disallow, sitemap } = config;
+
+    let content = `User-agent: ${userAgent}\n`;
+
+    // Add allowed paths
+    if (allow.length > 0) {
+      allow.forEach((path) => {
+        content += `Allow: ${path}\n`;
+      });
+    }
+
+    // Add disallowed paths
+    if (disallow.length > 0) {
+      disallow.forEach((path) => {
+        content += `Disallow: ${path}\n`;
+      });
+    }
+
+    // Add sitemap if provided
+    if (sitemap) {
+      content += `\nSitemap: ${sitemap}\n`;
+    }
+
+    return content;
+  }
+
+  /**
+   * Get default robots configuration for FastGPT
+   */
+  static getDefaultConfig(baseUrl: string): RobotsConfig {
+    return {
+      userAgent: '*',
+      allow: ['/'],
+      disallow: ['/api/', '/admin/', '/account/', '/_next/', '/favicon.ico'],
+      sitemap: `${baseUrl}/sitemap.xml`
+    };
+  }
+}

--- a/projects/app/src/web/common/seo/sitemap.ts
+++ b/projects/app/src/web/common/seo/sitemap.ts
@@ -1,0 +1,75 @@
+import { SitemapPage } from './types';
+
+export interface SitemapConfig {
+  baseUrl: string;
+  locales: string[];
+  defaultLocale: string;
+}
+
+export class SitemapGenerator {
+  private config: SitemapConfig;
+
+  constructor(config: SitemapConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Generate sitemap XML string
+   */
+  generateSitemap(pages: SitemapPage[]): string {
+    const currentDate = new Date().toISOString();
+
+    const urlElements = pages.map((page) => this.generateUrlElement(page, currentDate)).join('');
+
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+${urlElements}
+</urlset>`;
+  }
+
+  /**
+   * Generate URL element for a single page
+   */
+  private generateUrlElement(page: SitemapPage, lastmod: string): string {
+    const defaultUrl = `${this.config.baseUrl}${page.path}`;
+    const alternateLinks = this.generateAlternateLinks(page.path);
+
+    return `  <url>
+    <loc>${defaultUrl}</loc>
+    <lastmod>${page.lastmod || lastmod}</lastmod>
+    <changefreq>${page.changefreq}</changefreq>
+    <priority>${page.priority}</priority>
+${alternateLinks}
+  </url>`;
+  }
+
+  /**
+   * Generate alternate language links for a page
+   */
+  private generateAlternateLinks(path: string): string {
+    return this.config.locales
+      .filter((locale) => locale !== this.config.defaultLocale)
+      .map((locale) => {
+        const localePath = locale === this.config.defaultLocale ? path : `/${locale}${path}`;
+        return `    <xhtml:link rel="alternate" hreflang="${locale}" href="${this.config.baseUrl}${localePath}" />`;
+      })
+      .join('\n');
+  }
+
+  /**
+   * Get default static pages for FastGPT
+   */
+  static getDefaultPages(): SitemapPage[] {
+    return [
+      { path: '', priority: '1.0', changefreq: 'daily' },
+      { path: '/app/list', priority: '0.9', changefreq: 'weekly' },
+      { path: '/chat', priority: '0.9', changefreq: 'daily' },
+      { path: '/dataset/list', priority: '0.8', changefreq: 'weekly' },
+      { path: '/login', priority: '0.7', changefreq: 'monthly' },
+      { path: '/more', priority: '0.6', changefreq: 'monthly' },
+      { path: '/price', priority: '0.6', changefreq: 'monthly' },
+      { path: '/toolkit', priority: '0.6', changefreq: 'monthly' }
+    ];
+  }
+}

--- a/projects/app/src/web/common/seo/types.ts
+++ b/projects/app/src/web/common/seo/types.ts
@@ -1,0 +1,13 @@
+export interface SitemapPage {
+  path: string;
+  priority: string;
+  changefreq: 'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
+  lastmod?: string;
+}
+
+export interface RobotsConfig {
+  userAgent: string;
+  allow: string[];
+  disallow: string[];
+  sitemap?: string;
+}


### PR DESCRIPTION
## Summary
- Add dynamic sitemap.xml generation with i18n support for FastGPT
- Add dynamic robots.txt generation
- Create SEO utility classes for scalable sitemap and robots management
- Support multiple locales (en, zh-CN, zh-Hant)
- Include proper caching headers for performance

## Changes
- **Sitemap Generation**: Dynamic sitemap.xml that automatically includes all main pages
- **Robots.txt**: Dynamic robots.txt with proper crawling directives
- **SEO Utils**: Reusable utility classes for sitemap and robots generation
- **Internationalization**: Full support for FastGPT's multi-language setup
- **Caching**: Performance optimized with proper cache headers

## Test plan
- [ ] Verify sitemap.xml is accessible at `/sitemap.xml`
- [ ] Verify robots.txt is accessible at `/robots.txt`
- [ ] Test sitemap includes all main pages with correct priorities
- [ ] Test internationalization links are properly generated
- [ ] Verify cache headers are working correctly

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)