### PR TITLE
fix: 修复Plugin代理服务在处理通过nginx转发部署的Plugin服务时，req.headers中的host会导致返回404.

### DIFF
--- a/projects/app/src/pages/api/system/plugin/[...path].ts
+++ b/projects/app/src/pages/api/system/plugin/[...path].ts
@@ -17,6 +17,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const parsedUrl = new URL(FastGPTPluginUrl);
     delete req.headers?.rootkey;
+    delete req.headers?.cookie;
+    delete req.headers?.host;
+    delete req.headers?.origin;
 
     const requestResult = request({
       protocol: parsedUrl.protocol,


### PR DESCRIPTION
问题场景：
当Plugin服务不是直接通过ip\docker内路由直接访问，而是通过nginx做域名转发的方式部署时，30行headers: req.headers会直接将host（此时host=fastgpt主项目的域名）带入，nginx会使用host值判断转发路由，而导致请求无法被正确转发到plugin项目中。 此次修改参照了projects/app/src/pages/api/lafApi/[...path].ts中的做法，同时删除了cookie\host\origin三个header