### PR TITLE
fix: 修复Markdown渲染加粗链接时显示[object Object]的问题

### DIFF
--- a/projects/app/src/components/Markdown/A.tsx
+++ b/projects/app/src/components/Markdown/A.tsx
@@ -202,7 +202,7 @@ const A = ({
     );
   }
 
-  return <Link {...props}>{content || props?.href}</Link>;
+  return <Link {...props}>{children || props?.href}</Link>;
 };
 
 export default React.memo(A);


### PR DESCRIPTION
Qwen3等模型有时会输出这样的加粗的网址，在大多数markdown编辑器都显示正常，但是fastgpt没法正常显示
```
[**显示不正常的格式**](https://www.baidu.com/)
**[这样则正常](https://www.baidu.com/)**
```
显示不正常的格式会显示成
[[object Object]]

例如
https://cloud.fastgpt.cn/chat/share?shareId=tHAa3EFBJJAQcDaUSjbxWIAK