### PR TITLE
fix: initv4141

### DIFF
--- a/projects/app/src/pages/api/admin/initv4141.ts
+++ b/projects/app/src/pages/api/admin/initv4141.ts
@@ -92,6 +92,10 @@ async function appSplitMigration(teamId: string) {
 
       for (const folder of allFolders) {
         const obj = appMap.get(folder._id)!;
+        const newParentId = obj?.parentId ? appMap.get(obj!.parentId)?.newId : null;
+        if (!newParentId) {
+          continue;
+        }
 
         const oldRp = RPMap.get(folder._id)!;
         rpOps.push({
@@ -112,7 +116,7 @@ async function appSplitMigration(teamId: string) {
               teamId
             },
             update: {
-              parentId: obj.parentId
+              parentId: newParentId
             }
           }
         });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensure migrated folders/apps use new parent folder IDs and replicate resource permissions, skipping updates when parent mapping is missing.
> 
> - **Backend (migration)**:
>   - Update `projects/app/src/pages/api/admin/initv4141.ts` to remap `parentId` to the corresponding `newId` of migrated folders.
>     - Skip updates when no mapped `newParentId` exists.
>     - For tool-type apps, set `parentId` to `newParentId` similarly.
>   - Duplicate resource permissions for new folders by inserting RP documents with `resourceId` set to the new folder IDs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94bb6b70ad9690b3d798940fc879f4cb0af04043. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->