### PR TITLE
fix: 避免日志记录触发递归日志风暴，排除日志模型的性能监控中间件

### DIFF
--- a/packages/service/common/mongo/index.ts
+++ b/packages/service/common/mongo/index.ts
@@ -112,7 +112,7 @@ export const getMongoModel = <T>(name: string, schema: mongoose.Schema) => {
 export const getMongoLogModel = <T>(name: string, schema: mongoose.Schema) => {
   if (connectionLogMongo.models[name]) return connectionLogMongo.models[name] as Model<T>;
   console.log('Load model======', name);
-  addCommonMiddleware(schema);
+  // addCommonMiddleware(schema); 
 
   const model = connectionLogMongo.model<T>(name, schema);
 


### PR DESCRIPTION
高并发业务流量期间，DB负载过高变缓部分操作触发慢日志写入。

慢日志写入本身也会因处于高并发下DB负载过高处理变缓，触发自身的慢日志写入。

这种递归产生的日志写入会在高并发业务流量期间慢慢累计形成新的高并发日志流量。
即使初始高并发业务流量期已经结束，但新的高并发日志流量已经成形。且会随着递归无限持续产生耗尽系统资源，直至服务崩溃。

修复方案：
- 对日志模型（Log）跳过 addCommonMiddleware 中间件注册
- 避免日志写入操作被自身监控逻辑拦截，从源头切断循环触发条件
- 不影响业务模型的慢操作监控功能，仅豁免日志自身的性能统计