### PR TITLE
fix: chat agent template create (#5912)

### DIFF
--- a/projects/app/src/pageComponents/dashboard/agent/TemplateCreatePanel.tsx
+++ b/projects/app/src/pageComponents/dashboard/agent/TemplateCreatePanel.tsx
@@ -11,7 +11,7 @@ import {
   SkeletonCircle,
   useBreakpointValue
 } from '@chakra-ui/react';
-import type { AppTypeEnum } from '@fastgpt/global/core/app/constants';
+import { AppTypeEnum } from '@fastgpt/global/core/app/constants';
 import Avatar from '@fastgpt/web/components/common/Avatar';
 import { useRequest2 } from '@fastgpt/web/hooks/useRequest';
 import MyIcon from '@fastgpt/web/components/common/Icon';
@@ -22,6 +22,8 @@ import MyBox from '@fastgpt/web/components/common/MyBox';
 import { useLocalStorageState } from 'ahooks';
 import { useState } from 'react';
 import { getWebReqUrl } from '@fastgpt/web/common/system/utils';
+import { form2AppWorkflow } from '@/web/core/app/utils';
+import { webPushTrack } from '@/web/common/middle/tracks/utils';
 
 const TemplateCreatePanel = ({ type }: { type: AppTypeEnum | 'all' }) => {
   const { t } = useTranslation();
@@ -62,6 +64,11 @@ const TemplateCreatePanel = ({ type }: { type: AppTypeEnum | 'all' }) => {
       setCreatingTemplateId(templateId);
       const templateDetail = await getTemplateMarketItemDetail(templateId);
 
+      if (templateDetail.type === AppTypeEnum.simple) {
+        const completeWorkflow = form2AppWorkflow(templateDetail.workflow, t);
+        templateDetail.workflow = completeWorkflow;
+      }
+
       return postCreateApp({
         avatar: templateDetail.avatar,
         name: templateDetail.name,
@@ -70,6 +77,13 @@ const TemplateCreatePanel = ({ type }: { type: AppTypeEnum | 'all' }) => {
         edges: templateDetail.workflow.edges || [],
         chatConfig: templateDetail.workflow.chatConfig || {},
         templateId: templateDetail.templateId
+      }).then((res) => {
+        webPushTrack.useAppTemplate({
+          id: res,
+          name: templateDetail.name
+        });
+
+        return res;
       });
     },
     {

--- a/projects/app/src/pages/api/core/app/template/list.ts
+++ b/projects/app/src/pages/api/core/app/template/list.ts
@@ -30,7 +30,8 @@ async function handler(
 
   let filteredItems = templateMarketItems.filter((item) => {
     if (!item.isActive) return false;
-    if (type === 'all' && !ToolTypeList.includes(item.type as AppTypeEnum)) return true;
+    if (type === 'all' && !(ToolTypeList.includes(item.type as AppTypeEnum) && randomNumber > 0))
+      return true;
     if (item.type === type) return true;
     return false;
   });

--- a/projects/app/src/pages/dashboard/templateMarket/index.tsx
+++ b/projects/app/src/pages/dashboard/templateMarket/index.tsx
@@ -12,6 +12,8 @@ import {
   type AppTemplateSchemaType,
   type TemplateTypeSchemaType
 } from '@fastgpt/global/core/app/type';
+import { appWorkflow2Form } from '@fastgpt/global/core/app/utils';
+import { form2AppWorkflow } from '@/web/core/app/utils';
 import MyBox from '@fastgpt/web/components/common/MyBox';
 import { useRequest2 } from '@fastgpt/web/hooks/useRequest';
 import { getTemplateMarketItemDetail } from '@/web/core/app/api/template';
@@ -66,6 +68,11 @@ const TemplateMarket = ({
   const { runAsync: onUseTemplate, loading: isCreating } = useRequest2(
     async (template: AppTemplateSchemaType) => {
       const templateDetail = await getTemplateMarketItemDetail(template.templateId);
+
+      if (template.type === AppTypeEnum.simple) {
+        const completeWorkflow = form2AppWorkflow(templateDetail.workflow, t);
+        templateDetail.workflow = completeWorkflow;
+      }
 
       return postCreateApp({
         parentId,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Convert simple templates to complete workflows before creation, add usage tracking, and tweak 'all' template filtering logic based on randomNumber/tool types.
> 
> - **Frontend**
>   - `TemplateCreatePanel.tsx`
>     - Convert `AppTypeEnum.simple` templates using `form2AppWorkflow` before `postCreateApp`.
>     - Track template usage via `webPushTrack.useAppTemplate` after creation.
>     - Import `AppTypeEnum` as a runtime enum (not type-only).
>   - `pages/dashboard/templateMarket/index.tsx`
>     - Convert `AppTypeEnum.simple` templates with `form2AppWorkflow` before creating apps.
> - **API**
>   - `pages/api/core/app/template/list.ts`
>     - Modify `'all'` filtering: factor `ToolTypeList` with `randomNumber` to determine inclusion before sampling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dddf85e3a6a0cd342399718bc2a44480d4629c4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->