### PR TITLE
feature: add password as form input

### DIFF
--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeFormInput/InputFormEditModal.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeFormInput/InputFormEditModal.tsx
@@ -54,6 +54,12 @@ const InputFormEditModal = ({
       defaultValueType: WorkflowIOValueTypeEnum.string
     },
     {
+      icon: 'core/workflow/inputType/password',
+      label: t('common:core.workflow.inputType.password'),
+      value: FlowNodeInputTypeEnum.password,
+      defaultValueType: WorkflowIOValueTypeEnum.string
+    },
+    {
       icon: 'core/workflow/inputType/numberInput',
       label: t('common:core.workflow.inputType.number input'),
       value: FlowNodeInputTypeEnum.numberInput,


### PR DESCRIPTION
<img width="1033" height="496" alt="Screenshot 2025-11-20 at 00 23 53" src="https://github.com/user-attachments/assets/6b8352d4-5110-44e6-86ed-dce25c92505a" />

Fixed issue: [5785](https://github.com/labring/FastGPT/issues/5785)
added password as form input