### PR TITLE
feat: 将对话内容上方的交互按钮移动到对话内容下方

### DIFF
--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/ChatItem.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/ChatItem.tsx
@@ -288,23 +288,20 @@ const ChatItem = (props: Props) => {
     >
       {/* control icon */}
       <Flex w={'100%'} alignItems={'center'} gap={2} justifyContent={styleMap.justifyContent}>
-        {isChatting && type === ChatRoleEnum.AI && isLastChild ? null : (
+        {chat.time && (isPc || isChatLog) && (
           <Flex order={styleMap.order} ml={styleMap.ml} align={'center'} gap={'0.62rem'}>
-            {chat.time && (isPc || isChatLog) && (
-              <Box
-                order={type === ChatRoleEnum.AI ? 2 : 0}
-                className={'time-label'}
-                fontSize={styleMap.fontSize}
-                color={styleMap.color}
-                fontWeight={styleMap.fontWeight}
-                display={isChatLog ? 'block' : 'none'}
-              >
-                {t(formatTimeToChatItemTime(chat.time) as any, {
-                  time: dayjs(chat.time).format('HH:mm')
-                }).replace('#', ':')}
-              </Box>
-            )}
-            <ChatController {...props} isLastChild={isLastChild} />
+            <Box
+              order={type === ChatRoleEnum.AI ? 2 : 0}
+              className={'time-label'}
+              fontSize={styleMap.fontSize}
+              color={styleMap.color}
+              fontWeight={styleMap.fontWeight}
+              display={isChatLog ? 'block' : 'none'}
+            >
+              {t(formatTimeToChatItemTime(chat.time) as any, {
+                time: dayjs(chat.time).format('HH:mm')
+              }).replace('#', ':')}
+            </Box>
           </Flex>
         )}
         <ChatAvatar src={avatar} type={type} />
@@ -340,11 +337,6 @@ const ChatItem = (props: Props) => {
           mt={['6px', 2]}
           className="chat-box-card"
           textAlign={styleMap.textAlign}
-          _hover={{
-            '& .footer-copy': {
-              display: 'block'
-            }
-          }}
         >
           <Card
             {...MessageCardStyle}
@@ -384,36 +376,22 @@ const ChatItem = (props: Props) => {
                     </Box>
                   </Box>
                 )}
-                {children}
               </>
             )}
-            {/* 对话框底部的复制按钮 */}
-            {type == ChatRoleEnum.AI &&
-              value[0]?.type !== 'interactive' &&
-              (!isChatting || (isChatting && !isLastChild)) && (
-                <Box
-                  className="footer-copy"
-                  display={['block', 'none']}
-                  position={'absolute'}
-                  bottom={0}
-                  right={0}
-                  transform={'translateX(100%)'}
-                >
-                  <MyTooltip label={t('common:Copy')}>
-                    <MyIcon
-                      w={'1rem'}
-                      cursor="pointer"
-                      p="5px"
-                      bg="white"
-                      name={'copy'}
-                      color={'myGray.500'}
-                      _hover={{ color: 'primary.600' }}
-                      onClick={() => copyData(formatChatValue2InputType(value).text ?? '')}
-                    />
-                  </MyTooltip>
-                </Box>
+            </Card>
+          {/* 在Card外部添加控制按钮 */}
+          {i === splitAiResponseResults.length - 1 && (
+            <Flex
+              mt={2}
+              w="100%"
+              justifyContent={type === ChatRoleEnum.Human ? 'flex-end' : 'flex-start'}
+            >
+              {/* 只有在非聊天中，或不是AI最后一条消息时才显示ChatController */}
+              {!(isChatting && type === ChatRoleEnum.AI && isLastChild) && (
+                <ChatController {...props} isLastChild={isLastChild} />
               )}
-          </Card>
+            </Flex>
+          )}
         </Box>
       ))}
     </Box>


### PR DESCRIPTION
现在虽然对话框右下角有复制按钮，但是其他交互（点赞、朗读等）都在对话内容上方，每次返回大量文字，都需要滑动页面到对话框上方才能交互。此项修改旨在将原来复制&点赞/点踩等按钮移动到对话框下方。由于右下方的按钮有重复作用，因此做了删除处理。

<img width="588" height="351" alt="image" src="https://github.com/user-attachments/assets/867af08f-7de3-446d-87e8-56c0fbd23c29" />
