### PR TITLE
feat(vectordb): add OceanBase HNSW quantization (HNSW_SQ/HNSW_BQ)

### DIFF
--- a/packages/service/common/vectorDB/constants.ts
+++ b/packages/service/common/vectorDB/constants.ts
@@ -24,3 +24,58 @@ export const VectorVQ = (() => {
   }
   return 32;
 })();
+
+/**
+ * OceanBase HNSW Index Configuration
+ *
+ * VECTOR_VQ_LEVEL mapping:
+ * - 32 (default): hnsw + inner_product
+ * - 8: hnsw_sq + inner_product
+ * - 1: hnsw_bq + cosine
+ *
+ * See https://www.oceanbase.com/docs/common-oceanbase-database-cn-1000000004920602
+ * for the recommended way of choosing parameters (`m`, `ef_construction`, `ef_search`). It varies for data volume.
+ *
+ * HNSW_BQ requires cosine or l2 distance. inner_product is not supported up until V4.3.5 BP5 (current lts version until Jan 2026).
+ * See https://www.oceanbase.com/docs/common-oceanbase-database-cn-1000000004920603
+ * `HNSW_BQ distance 参数支持 l2 和 cosine。cosine 从 V4.3.5 BP4 版本开始支持。` and section `距离函数使用规则`.
+ *
+ * Tested on OceanBase 4.3.5-lts:
+ * ```sql
+ * -- HNSW_BQ + cosine: VECTOR INDEX SCAN ✓
+ * CREATE VECTOR INDEX idx ON t(vec) WITH (distance=cosine, type=hnsw_bq, m=16, ef_construction=200);
+ * EXPLAIN SELECT id, cosine_distance(vec, '[...]') AS score FROM t ORDER BY score ASC APPROXIMATE LIMIT 10;
+ * -- |1 |└─VECTOR INDEX SCAN|t(idx)|
+ * ```
+ */
+export const OceanBaseIndexConfig = (() => {
+  const level = process.env.VECTOR_VQ_LEVEL;
+
+  if (level === '1') {
+    return {
+      type: 'hnsw_bq' as const,
+      distance: 'cosine' as const,
+      distanceFunc: 'cosine_distance',
+      orderDirection: 'ASC' as const,
+      scoreTransform: (score: number) => 1 - score / 2
+    };
+  }
+
+  if (level === '8') {
+    return {
+      type: 'hnsw_sq' as const,
+      distance: 'inner_product' as const,
+      distanceFunc: 'inner_product',
+      orderDirection: 'DESC' as const,
+      scoreTransform: (score: number) => score
+    };
+  }
+
+  return {
+    type: 'hnsw' as const,
+    distance: 'inner_product' as const,
+    distanceFunc: 'inner_product',
+    orderDirection: 'DESC' as const,
+    scoreTransform: (score: number) => score
+  };
+})();

--- a/projects/app/.env.template
+++ b/projects/app/.env.template
@@ -54,8 +54,9 @@ MONGODB_URI="mongodb://myusername:mypassword@localhost:27017/fastgpt?authSource=
 # 日志库
 MONGODB_LOG_URI="mongodb://myusername:mypassword@localhost:27017/fastgpt?authSource=admin&directConnection=true"
 # 向量库优先级: pg > oceanbase > milvus
+# 向量量化等级: PG支持32/16, OceanBase支持32/8/1
+VECTOR_VQ_LEVEL=32
 # PG 向量库连接参数
-VECTOR_VQ_LEVEL=16 # 向量量化等级（目前支持 PG：32,16， 其他数据库未支持）
 PG_URL=postgresql://username:password@localhost:5432/postgres
 # OceanBase 向量库连接参数
 # OCEANBASE_URL=


### PR DESCRIPTION
Support OceanBase vector index quantization via VECTOR_VQ_LEVEL:
`32` (default): hnsw + inner_product
`8`: hnsw_sq + inner_product (2-3x memory savings)
`1`: hnsw_bq + cosine (~15x memory savings)

HNSW_BQ requires cosine distance per OceanBase docs. Tested on OceanBase 4.3.5-lts.

Tests passed. 
`pnpm run test` gives:
`Test Files  75 passed (75)
Tests  1061 passed (1061)`

Closes #6202