### PR TITLE
ci: Add OceanBase integration tests (Issue #6194)

### DIFF
--- a/.github/workflows/vector-db-tests.yml
+++ b/.github/workflows/vector-db-tests.yml
@@ -1,0 +1,50 @@
+name: Vector DB Integration Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test-oceanbase:
+    runs-on: ubuntu-latest
+
+    services:
+      oceanbase:
+        image: oceanbase/oceanbase-ce:latest
+        env:
+          MODE: mini
+          OB_root_PASSWORD: root_password
+        ports:
+          - 2881:2881
+        options: >-
+          --health-cmd "mysql -h 127.0.0.1 -P 2881 -u root@test -proot_password -e 'SELECT 1'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 30
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: pnpm/action-setup@v2
+      with:
+        version: 8
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18
+        cache: 'pnpm'
+
+    - name: Install Dependencies
+      run: pnpm install
+
+    - name: Run OceanBase Connection Test
+      env:
+        DB_HOST: 127.0.0.1
+        DB_PORT: 2881
+        DB_USER: root@test
+        DB_PASSWORD: root_password
+        DB_NAME: test
+      run: npx tsx scripts/test-oceanbase.ts

--- a/scripts/test-oceanbase.ts
+++ b/scripts/test-oceanbase.ts
@@ -1,0 +1,39 @@
+import mysql from 'mysql2/promise';
+
+async function testConnection() {
+  console.log('Connecting to OceanBase...');
+  try {
+    const connection = await mysql.createConnection({
+      host: process.env.DB_HOST || '127.0.0.1',
+      port: Number(process.env.DB_PORT) || 2881,
+      user: process.env.DB_USER || 'root@test',
+      password: process.env.DB_PASSWORD || '',
+      database: process.env.DB_NAME || 'test'
+    });
+
+    console.log('✅ Connected to OceanBase!');
+    const [rows] = await connection.execute('SELECT VERSION() as version');
+    console.log('Version:', (rows as any)[0].version);
+
+    // Create a test table to verify write permissions
+    await connection.execute('CREATE TABLE IF NOT EXISTS ci_test_table (id INT PRIMARY KEY, name VARCHAR(255))');
+    console.log('✅ Table created');
+
+    await connection.execute('INSERT INTO ci_test_table (id, name) VALUES (1, "ci_test") ON DUPLICATE KEY UPDATE name="ci_test"');
+    console.log('✅ Data inserted');
+
+    const [results] = await connection.execute('SELECT * FROM ci_test_table WHERE id = 1');
+    console.log('✅ Data retrieved:', (results as any)[0]);
+
+    await connection.execute('DROP TABLE ci_test_table');
+    console.log('✅ Cleanup successful');
+
+    await connection.end();
+    process.exit(0);
+  } catch (error) {
+    console.error('❌ Connection failed:', error);
+    process.exit(1);
+  }
+}
+
+testConnection();


### PR DESCRIPTION
This PR introduces a CI/CD workflow to validate OceanBase vector database integration, addressing [Issue #6194](https://github.com/labring/FastGPT/issues/6194).

This contribution is part of the [OceanBase AI Coding Event](https://github.com/oceanbase/seekdb/issues/123).

## 🛠 Changes

*   **New Workflow**: Added `.github/workflows/vector-db-tests.yml` which spins up an `oceanbase/oceanbase-ce` Docker container.
*   **Test Script**: Added `scripts/test-oceanbase.ts` to verify database connectivity and basic table operations (Create/Insert/Select/Drop).

## ✅ Verification

The workflow is configured to:
1.  Start OceanBase service with health checks.
2.  Install project dependencies via pnpm.
3.  Execute the TypeScript verification script.

This ensures that the FastGPT environment can successfully connect to and interact with OceanBase, paving the way for full integration testing.