### PR TITLE
fix: merge ECharts toolbox options instead of overwriting (#6269)

### DIFF
--- a/projects/app/src/components/Markdown/img/EChartsCodeBlock.tsx
+++ b/projects/app/src/components/Markdown/img/EChartsCodeBlock.tsx
@@ -36,12 +36,18 @@ const EChartsCodeBlock = ({ code }: { code: string }) => {
   useLayoutEffect(() => {
     const option = (() => {
       try {
+        const userOption = json5.parse(code.trim());
+        const userToolbox = userOption.toolbox || {};
+        const userFeature = userToolbox.feature || {};
+
         const parse = {
-          ...json5.parse(code.trim()),
+          ...userOption,
           toolbox: {
+            ...userToolbox,
             // show: true,
             feature: {
-              saveAsImage: {}
+              saveAsImage: {},
+              ...userFeature
             }
           }
         };


### PR DESCRIPTION
修改内容：保持原有逻辑，saveAsImage 作为兜底配置始终存在，其余的使用用户配置。
| 场景 | toolbox | feature | saveAsImage |
|---|---|---|---|
| 用户什么都没写 | 自动创建 | 自动创建 | 默认 `{}` 兜底 |
| 只写了 toolbox 属性 | 保留用户属性 | 自动创建 | 默认 `{}` 兜底 |
| 写了完整 feature | 保留用户属性 | 保留用户所有功能 | 默认 `{}` 兜底 |
| 自定义了 saveAsImage | 保留用户属性 | 保留用户所有功能 | 用户配置覆盖|


修改前：
<img width="1718" height="645" alt="image" src="https://github.com/user-attachments/assets/31770ec7-fab2-4909-9365-ad42c4d7aaf8" />


修改后：
<img width="1697" height="643" alt="image" src="https://github.com/user-attachments/assets/5616a4ec-ea28-46ca-8e12-65e099289d66" />
<img width="1661" height="575" alt="image" src="https://github.com/user-attachments/assets/eacb3dbd-e471-4266-bd08-6b97427bace2" />

