### PR TITLE
feat: add Skill Templates for quick agent creation

### DIFF
--- a/packages/global/core/app/constants.ts
+++ b/packages/global/core/app/constants.ts
@@ -15,6 +15,7 @@ export enum AppTypeEnum {
   workflowTool = 'plugin',
   mcpToolSet = 'toolSet', // 'mcp'
   httpToolSet = 'httpToolSet',
+  skill = 'skill',
   hidden = 'hidden',
 
   // deprecated
@@ -33,7 +34,12 @@ export const ToolTypeList = [
   AppTypeEnum.httpToolSet,
   AppTypeEnum.workflowTool
 ];
-export const AppTypeList = [AppTypeEnum.simple, AppTypeEnum.chatAgent, AppTypeEnum.workflow];
+export const AppTypeList = [
+  AppTypeEnum.simple,
+  AppTypeEnum.chatAgent,
+  AppTypeEnum.workflow,
+  AppTypeEnum.skill
+];
 
 export const defaultTTSConfig: AppTTSConfigType = { type: 'web' };
 

--- a/packages/global/core/app/skill/constants.ts
+++ b/packages/global/core/app/skill/constants.ts
@@ -1,0 +1,92 @@
+import { i18nT } from '../../../../web/i18n/utils';
+import { SkillCategoryEnum, type SkillManifestType } from './type';
+
+export const SkillCategoryMap: Record<SkillCategoryEnum, { label: string }> = {
+  [SkillCategoryEnum.writing]: { label: i18nT('app:skill_category_writing') },
+  [SkillCategoryEnum.coding]: { label: i18nT('app:skill_category_coding') },
+  [SkillCategoryEnum.research]: { label: i18nT('app:skill_category_research') },
+  [SkillCategoryEnum.customerService]: { label: i18nT('app:skill_category_customer_service') },
+  [SkillCategoryEnum.dataAnalysis]: { label: i18nT('app:skill_category_data_analysis') }
+};
+
+// Built-in skill templates
+export const builtInSkillTemplates: SkillManifestType[] = [
+  {
+    id: 'skill-coding-assistant',
+    name: i18nT('app:skill_coding_assistant_name'),
+    description: i18nT('app:skill_coding_assistant_desc'),
+    avatar: 'core/app/type/agentFill',
+    author: 'FastGPT',
+    version: '1.0.0',
+    tags: ['coding', 'development'],
+    category: SkillCategoryEnum.coding,
+    config: {
+      systemPrompt:
+        'You are an expert coding assistant. Help users write, debug, and optimize code. Always explain your reasoning and provide clean, well-documented code examples. Support multiple programming languages.',
+      tools: [],
+      variables: [
+        {
+          key: 'language',
+          label: 'Programming Language',
+          type: 'select',
+          required: false,
+          defaultValue: 'TypeScript',
+          options: ['TypeScript', 'Python', 'Java', 'Go', 'Rust', 'C++'],
+          description: 'Preferred programming language'
+        }
+      ]
+    }
+  },
+  {
+    id: 'skill-doc-qa',
+    name: i18nT('app:skill_doc_qa_name'),
+    description: i18nT('app:skill_doc_qa_desc'),
+    avatar: 'core/app/type/workflowFill',
+    author: 'FastGPT',
+    version: '1.0.0',
+    tags: ['research', 'knowledge-base'],
+    category: SkillCategoryEnum.research,
+    config: {
+      systemPrompt:
+        'You are a document Q&A assistant. Answer user questions based on the provided knowledge base content. Always cite sources when possible. If the answer is not found in the knowledge base, clearly state that.',
+      tools: [],
+      variables: [],
+      datasetIds: []
+    }
+  },
+  {
+    id: 'skill-customer-service',
+    name: i18nT('app:skill_customer_service_name'),
+    description: i18nT('app:skill_customer_service_desc'),
+    avatar: 'core/app/type/simple',
+    author: 'FastGPT',
+    version: '1.0.0',
+    tags: ['customer-service', 'support'],
+    category: SkillCategoryEnum.customerService,
+    config: {
+      systemPrompt:
+        'You are a professional customer service agent. Be polite, patient, and helpful. Follow these guidelines:\n1. Greet the customer warmly\n2. Understand their issue clearly before responding\n3. Provide accurate and concise solutions\n4. Escalate complex issues when needed\n5. Always end with asking if there is anything else you can help with',
+      tools: [],
+      variables: [
+        {
+          key: 'companyName',
+          label: 'Company Name',
+          type: 'input',
+          required: true,
+          description: 'Your company name for personalized responses'
+        },
+        {
+          key: 'businessScope',
+          label: 'Business Scope',
+          type: 'textarea',
+          required: false,
+          description: 'Brief description of your business for context'
+        }
+      ]
+    }
+  }
+];
+
+export const getSkillTemplateById = (id: string): SkillManifestType | undefined => {
+  return builtInSkillTemplates.find((skill) => skill.id === id);
+};

--- a/packages/global/core/app/skill/type.ts
+++ b/packages/global/core/app/skill/type.ts
@@ -1,0 +1,52 @@
+import z from 'zod';
+
+export enum SkillCategoryEnum {
+  writing = 'writing',
+  coding = 'coding',
+  research = 'research',
+  customerService = 'customer-service',
+  dataAnalysis = 'data-analysis'
+}
+
+// Skill template metadata
+export const SkillTemplateSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  avatar: z.string(),
+  author: z.string(),
+  version: z.string(),
+  tags: z.array(z.string()),
+  category: z.nativeEnum(SkillCategoryEnum)
+});
+export type SkillTemplateType = z.infer<typeof SkillTemplateSchema>;
+
+// Skill variable definition
+export const SkillVariableSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  type: z.enum(['input', 'textarea', 'select']),
+  required: z.boolean().default(false),
+  defaultValue: z.string().optional(),
+  options: z.array(z.string()).optional(),
+  description: z.string().optional()
+});
+export type SkillVariableType = z.infer<typeof SkillVariableSchema>;
+
+// Skill configuration (what the skill actually does)
+export const SkillConfigSchema = z.object({
+  systemPrompt: z.string(),
+  tools: z.array(z.string()).default([]),
+  variables: z.array(SkillVariableSchema).default([]),
+  datasetIds: z.array(z.string()).optional(),
+  model: z.string().optional(),
+  temperature: z.number().optional(),
+  maxHistories: z.number().optional()
+});
+export type SkillConfigType = z.infer<typeof SkillConfigSchema>;
+
+// Full skill manifest = template + config
+export const SkillManifestSchema = SkillTemplateSchema.extend({
+  config: SkillConfigSchema
+});
+export type SkillManifestType = z.infer<typeof SkillManifestSchema>;

--- a/packages/global/core/app/skill/utils.ts
+++ b/packages/global/core/app/skill/utils.ts
@@ -1,0 +1,249 @@
+import type { AppChatConfigType, VariableItemType } from '../type';
+import type { StoreNodeItemType } from '../../workflow/type/node';
+import type { StoreEdgeItemType } from '../../workflow/type/edge';
+import { FlowNodeTypeEnum, FlowNodeInputTypeEnum } from '../../workflow/node/constant';
+import {
+  NodeInputKeyEnum,
+  NodeOutputKeyEnum,
+  WorkflowIOValueTypeEnum
+} from '../../workflow/constants';
+import { SystemConfigNode } from '../../workflow/template/system/systemConfig';
+import {
+  WorkflowStart,
+  userFilesInput
+} from '../../workflow/template/system/workflowStart';
+import { AgentNode } from '../../workflow/template/system/agent/index';
+import { Input_Template_File_Link } from '../../workflow/template/input';
+import { getNanoid } from '../../../common/string/tools';
+import { i18nT } from '../../../../web/i18n/utils';
+import { VariableInputEnum } from '../../workflow/constants';
+import { DatasetSearchModeEnum } from '../../dataset/constants';
+import type { SkillManifestType, SkillVariableType } from './type';
+import type { SkillToolType } from '../../ai/skill/type';
+
+export type SkillResolvedConfigType = {
+  manifest: SkillManifestType;
+  variableValues?: Record<string, string>;
+  customName?: string;
+  customAvatar?: string;
+  customIntro?: string;
+  selectedToolIds?: string[];
+  selectedDatasetIds?: string[];
+};
+
+const workflowStartNodeId = 'workflowStartNodeId';
+const agentNodeId = 'skillAgentNodeId';
+
+const parseSystemPromptTemplate = ({
+  prompt,
+  values
+}: {
+  prompt: string;
+  values: Record<string, string>;
+}): string => {
+  return prompt.replace(/\{\{\s*([a-zA-Z0-9_\-.]+)\s*\}\}/g, (_, key: string) => {
+    return values[key] ?? '';
+  });
+};
+
+const skillVariable2AppVariable = (item: SkillVariableType): VariableItemType => {
+  const typeMap: Record<SkillVariableType['type'], VariableInputEnum> = {
+    input: VariableInputEnum.input,
+    textarea: VariableInputEnum.textarea,
+    select: VariableInputEnum.select
+  };
+
+  return {
+    key: item.key,
+    label: item.label,
+    type: typeMap[item.type],
+    description: item.description || '',
+    required: item.required,
+    defaultValue: item.defaultValue,
+    list: item.options?.map((value) => ({ label: value, value })) || [],
+    valueType: WorkflowIOValueTypeEnum.string
+  };
+};
+
+export const getSkillRuntimeNodes = ({
+  config,
+  systemPrompt,
+  selectedToolIds,
+  selectedDatasetIds
+}: {
+  config: SkillManifestType['config'];
+  systemPrompt: string;
+  selectedToolIds: string[];
+  selectedDatasetIds: string[];
+}): {
+  nodes: StoreNodeItemType[];
+  edges: StoreEdgeItemType[];
+} => {
+  const selectedTools: SkillToolType[] = selectedToolIds.map((id) => ({
+    id,
+    config: {}
+  }));
+
+  const nodes: StoreNodeItemType[] = [
+    {
+      nodeId: SystemConfigNode.id,
+      name: i18nT('workflow:template.system_config'),
+      intro: '',
+      flowNodeType: SystemConfigNode.flowNodeType,
+      position: { x: 520, y: -480 },
+      version: SystemConfigNode.version,
+      inputs: [],
+      outputs: []
+    },
+    {
+      nodeId: workflowStartNodeId,
+      name: i18nT('workflow:template.workflow_start'),
+      intro: '',
+      avatar: WorkflowStart.avatar,
+      flowNodeType: FlowNodeTypeEnum.workflowStart,
+      position: { x: 560, y: 120 },
+      version: WorkflowStart.version,
+      inputs: WorkflowStart.inputs,
+      outputs: [...WorkflowStart.outputs, userFilesInput]
+    },
+    {
+      nodeId: agentNodeId,
+      name: AgentNode.name,
+      intro: AgentNode.intro,
+      avatar: AgentNode.avatar,
+      flowNodeType: FlowNodeTypeEnum.agent,
+      showStatus: true,
+      position: { x: 1100, y: -350 },
+      version: AgentNode.version,
+      inputs: [
+        {
+          key: NodeInputKeyEnum.aiModel,
+          renderTypeList: [FlowNodeInputTypeEnum.settingLLMModel],
+          label: i18nT('common:core.module.input.label.aiModel'),
+          valueType: WorkflowIOValueTypeEnum.string,
+          value: config.model || ''
+        },
+        {
+          key: NodeInputKeyEnum.aiSystemPrompt,
+          renderTypeList: [FlowNodeInputTypeEnum.textarea, FlowNodeInputTypeEnum.reference],
+          label: i18nT('common:core.ai.Prompt'),
+          valueType: WorkflowIOValueTypeEnum.string,
+          value: systemPrompt
+        },
+        {
+          ...Input_Template_File_Link,
+          value: [[workflowStartNodeId, NodeOutputKeyEnum.userFiles]]
+        },
+        {
+          key: NodeInputKeyEnum.history,
+          renderTypeList: [FlowNodeInputTypeEnum.numberInput, FlowNodeInputTypeEnum.reference],
+          valueType: WorkflowIOValueTypeEnum.chatHistory,
+          label: i18nT('common:core.module.input.label.chat history'),
+          required: true,
+          min: 0,
+          max: 30,
+          value: config.maxHistories ?? 6
+        },
+        {
+          key: NodeInputKeyEnum.userChatInput,
+          renderTypeList: [FlowNodeInputTypeEnum.reference, FlowNodeInputTypeEnum.textarea],
+          valueType: WorkflowIOValueTypeEnum.string,
+          label: i18nT('common:core.module.input.label.user question'),
+          required: true,
+          toolDescription: i18nT('common:core.module.input.label.user question'),
+          value: [workflowStartNodeId, NodeInputKeyEnum.userChatInput]
+        },
+        {
+          key: NodeInputKeyEnum.selectedTools,
+          renderTypeList: [FlowNodeInputTypeEnum.hidden],
+          label: '',
+          valueType: WorkflowIOValueTypeEnum.arrayObject,
+          value: selectedTools
+        },
+        {
+          key: NodeInputKeyEnum.datasetParams,
+          renderTypeList: [FlowNodeInputTypeEnum.hidden],
+          label: '',
+          valueType: WorkflowIOValueTypeEnum.object,
+          value: {
+            datasets: selectedDatasetIds.map((datasetId) => ({
+              datasetId,
+              avatar: '/icon/logo.svg',
+              name: datasetId,
+              vectorModel: { model: '' }
+            })),
+            similarity: 0.4,
+            limit: 3000,
+            searchMode: DatasetSearchModeEnum.embedding,
+            usingReRank: true,
+            rerankWeight: 0.5,
+            datasetSearchUsingExtensionQuery: true,
+            datasetSearchExtensionBg: ''
+          }
+        }
+      ],
+      outputs: AgentNode.outputs
+    }
+  ];
+
+  const edges: StoreEdgeItemType[] = [
+    {
+      source: workflowStartNodeId,
+      target: agentNodeId,
+      sourceHandle: `${workflowStartNodeId}-source-right`,
+      targetHandle: `${agentNodeId}-target-left`
+    }
+  ];
+
+  return {
+    nodes,
+    edges
+  };
+};
+
+export const skillManifest2AppConfig = ({
+  manifest,
+  variableValues = {},
+  customName,
+  customAvatar,
+  customIntro,
+  selectedToolIds,
+  selectedDatasetIds
+}: SkillResolvedConfigType): {
+  name: string;
+  avatar: string;
+  intro: string;
+  modules: StoreNodeItemType[];
+  edges: StoreEdgeItemType[];
+  chatConfig: AppChatConfigType;
+} => {
+  const systemPrompt = parseSystemPromptTemplate({
+    prompt: manifest.config.systemPrompt,
+    values: variableValues
+  });
+
+  const toolIds = selectedToolIds ?? manifest.config.tools;
+  const datasetIds = selectedDatasetIds ?? manifest.config.datasetIds ?? [];
+
+  const { nodes, edges } = getSkillRuntimeNodes({
+    config: manifest.config,
+    systemPrompt,
+    selectedToolIds: toolIds,
+    selectedDatasetIds: datasetIds
+  });
+
+  return {
+    name: customName || manifest.name,
+    avatar: customAvatar || manifest.avatar,
+    intro: customIntro || manifest.description,
+    modules: nodes,
+    edges,
+    chatConfig: {
+      variables: manifest.config.variables.map(skillVariable2AppVariable)
+    }
+  };
+};
+
+export const getSkillDefaultAppName = (manifest: SkillManifestType) => {
+  return `${manifest.name}-${getNanoid(4)}`;
+};

--- a/packages/global/core/app/tool/constants.ts
+++ b/packages/global/core/app/tool/constants.ts
@@ -4,6 +4,7 @@ export enum AppToolSourceEnum {
   commercial = 'commercial', // configured in Pro, with associatedPluginId. Specially, commercial-dalle3 is a systemTool
   mcp = 'mcp', // mcp
   http = 'http', // http
+  skill = 'skill', // skill template tool source
   // @deprecated
   community = 'community' // this is deprecated, will be replaced by systemTool
 }

--- a/packages/global/openapi/core/app/skill/api.ts
+++ b/packages/global/openapi/core/app/skill/api.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+import { ParentIdSchema } from '../../../../common/parentFolder/type';
+import { ObjectIdSchema } from '../../../../common/type/mongo';
+import { SkillManifestSchema } from '../../../../core/app/skill/type';
+
+export const ListSkillResponseSchema = z.array(SkillManifestSchema).meta({
+  description: 'Skill template list',
+  example: []
+});
+export type ListSkillResponseType = z.infer<typeof ListSkillResponseSchema>;
+
+export const DetailSkillQuerySchema = z.object({
+  skillId: z.string().meta({
+    description: 'Skill ID',
+    example: 'skill-coding-assistant'
+  })
+});
+export type DetailSkillQueryType = z.infer<typeof DetailSkillQuerySchema>;
+
+export const DetailSkillResponseSchema = SkillManifestSchema.meta({
+  description: 'Skill detail'
+});
+export type DetailSkillResponseType = z.infer<typeof DetailSkillResponseSchema>;
+
+export const CreateSkillAppBodySchema = z.object({
+  parentId: ParentIdSchema.optional().meta({
+    description: 'Parent folder id'
+  }),
+  skillId: z.string().meta({
+    description: 'Skill ID',
+    example: 'skill-coding-assistant'
+  }),
+  name: z.string().optional().meta({
+    description: 'Custom app name'
+  }),
+  avatar: z.string().optional().meta({
+    description: 'Custom app avatar'
+  }),
+  intro: z.string().optional().meta({
+    description: 'Custom app intro'
+  }),
+  variables: z.record(z.string(), z.string()).optional().meta({
+    description: 'Variable values for prompt rendering'
+  }),
+  toolIds: z.array(z.string()).optional().meta({
+    description: 'Override selected tool ids'
+  }),
+  datasetIds: z.array(z.string()).optional().meta({
+    description: 'Override selected dataset ids'
+  })
+});
+export type CreateSkillAppBodyType = z.infer<typeof CreateSkillAppBodySchema>;
+
+export const CreateSkillAppResponseSchema = ObjectIdSchema.meta({
+  description: 'Created app id'
+});
+export type CreateSkillAppResponseType = z.infer<typeof CreateSkillAppResponseSchema>;

--- a/packages/service/support/permission/teamLimit.ts
+++ b/packages/service/support/permission/teamLimit.ts
@@ -55,7 +55,7 @@ export const checkTeamAppTypeLimit = async ({
       MongoApp.countDocuments({
         teamId,
         type: {
-          $in: [AppTypeEnum.chatAgent, AppTypeEnum.simple, AppTypeEnum.workflow]
+          $in: [AppTypeEnum.chatAgent, AppTypeEnum.simple, AppTypeEnum.workflow, AppTypeEnum.skill]
         }
       })
     ]);

--- a/packages/service/support/user/audit/util.ts
+++ b/packages/service/support/user/audit/util.ts
@@ -20,6 +20,7 @@ export function getI18nAppType(type: AppTypeEnum): string {
   if (type === AppTypeEnum.httpToolSet) return i18nT('app:toolType_http');
   if (type === AppTypeEnum.mcpToolSet) return i18nT('app:toolType_mcp');
   if (type === AppTypeEnum.tool) return i18nT('app:toolType_mcp');
+  if (type === AppTypeEnum.skill) return i18nT('app:type.Skill');
   return i18nT('common:UnKnow');
 }
 

--- a/projects/app/src/pageComponents/app/constants.ts
+++ b/projects/app/src/pageComponents/app/constants.ts
@@ -26,6 +26,14 @@ export const createAppTypeMap = {
     description: i18nT('app:chat_agent_description'),
     imgUrl: '/imgs/app/type/chatAgent.svg'
   },
+  [AppTypeEnum.skill]: {
+    type: AppTypeEnum.skill,
+    icon: 'core/app/type/agentFill',
+    title: i18nT('app:type.Skill'),
+    intro: i18nT('app:type_skill_intro'),
+    description: i18nT('app:type_skill_description'),
+    imgUrl: '/imgs/app/type/chatAgent.svg'
+  },
   [AppTypeEnum.workflowTool]: {
     type: AppTypeEnum.workflowTool,
     icon: 'core/app/type/pluginFill',

--- a/projects/app/src/pageComponents/dashboard/constant.ts
+++ b/projects/app/src/pageComponents/dashboard/constant.ts
@@ -6,6 +6,10 @@ export const appTypeTagMap = {
     label: i18nT('app:type.Chat_Agent_v2'),
     icon: 'core/app/type/simple'
   },
+  [AppTypeEnum.skill]: {
+    label: i18nT('app:type.Skill'),
+    icon: 'core/app/type/simple'
+  },
   [AppTypeEnum.simple]: {
     label: i18nT('app:type.Chat_Agent'),
     icon: 'core/app/type/simple'

--- a/projects/app/src/pages/api/core/app/skill/create.ts
+++ b/projects/app/src/pages/api/core/app/skill/create.ts
@@ -1,0 +1,70 @@
+import { NextAPI } from '@/service/middleware/entry';
+import { authApp } from '@fastgpt/service/support/permission/app/auth';
+import { authUserPer } from '@fastgpt/service/support/permission/user/auth';
+import { TeamAppCreatePermissionVal } from '@fastgpt/global/support/permission/user/constant';
+import { WritePermissionVal } from '@fastgpt/global/support/permission/constant';
+import { checkTeamAppTypeLimit } from '@fastgpt/service/support/permission/teamLimit';
+import { onCreateApp } from '../create';
+import { AppTypeEnum } from '@fastgpt/global/core/app/constants';
+import { getSkillTemplateById } from '@fastgpt/global/core/app/skill/constants';
+import {
+  CreateSkillAppBodySchema,
+  CreateSkillAppResponseSchema,
+  type CreateSkillAppBodyType,
+  type CreateSkillAppResponseType
+} from '@fastgpt/global/openapi/core/app/skill/api';
+import type { ApiRequestProps } from '@fastgpt/service/type/next';
+import { skillManifest2AppConfig } from '@fastgpt/global/core/app/skill/utils';
+
+async function handler(
+  req: ApiRequestProps<CreateSkillAppBodyType>
+): Promise<CreateSkillAppResponseType> {
+  const {
+    parentId,
+    skillId,
+    name,
+    avatar,
+    intro,
+    variables,
+    toolIds,
+    datasetIds
+  } = CreateSkillAppBodySchema.parse(req.body);
+
+  const { teamId, tmbId } = parentId
+    ? await authApp({ req, appId: parentId, per: WritePermissionVal, authToken: true })
+    : await authUserPer({ req, authToken: true, per: TeamAppCreatePermissionVal });
+
+  await checkTeamAppTypeLimit({ teamId, appCheckType: 'app' });
+
+  const skill = getSkillTemplateById(skillId);
+  if (!skill) {
+    return Promise.reject('Skill template not found');
+  }
+
+  const appConfig = skillManifest2AppConfig({
+    manifest: skill,
+    variableValues: variables,
+    customName: name,
+    customAvatar: avatar,
+    customIntro: intro,
+    selectedToolIds: toolIds,
+    selectedDatasetIds: datasetIds
+  });
+
+  const appId = await onCreateApp({
+    parentId,
+    name: appConfig.name,
+    avatar: appConfig.avatar,
+    intro: appConfig.intro,
+    type: AppTypeEnum.skill,
+    modules: appConfig.modules,
+    edges: appConfig.edges,
+    chatConfig: appConfig.chatConfig,
+    teamId,
+    tmbId
+  });
+
+  return CreateSkillAppResponseSchema.parse(appId);
+}
+
+export default NextAPI(handler);

--- a/projects/app/src/pages/api/core/app/skill/detail.ts
+++ b/projects/app/src/pages/api/core/app/skill/detail.ts
@@ -1,0 +1,23 @@
+import { NextAPI } from '@/service/middleware/entry';
+import { authCert } from '@fastgpt/service/support/permission/auth/common';
+import { getSkillTemplateById } from '@fastgpt/global/core/app/skill/constants';
+import {
+  DetailSkillQuerySchema,
+  DetailSkillResponseSchema,
+  type DetailSkillResponseType
+} from '@fastgpt/global/openapi/core/app/skill/api';
+import type { ApiRequestProps } from '@fastgpt/service/type/next';
+
+async function handler(req: ApiRequestProps): Promise<DetailSkillResponseType> {
+  await authCert({ req, authToken: true });
+  const { skillId } = DetailSkillQuerySchema.parse(req.query);
+
+  const skill = getSkillTemplateById(skillId);
+  if (!skill) {
+    return Promise.reject('Skill template not found');
+  }
+
+  return DetailSkillResponseSchema.parse(skill);
+}
+
+export default NextAPI(handler);

--- a/projects/app/src/pages/api/core/app/skill/list.ts
+++ b/projects/app/src/pages/api/core/app/skill/list.ts
@@ -1,0 +1,15 @@
+import { NextAPI } from '@/service/middleware/entry';
+import { authCert } from '@fastgpt/service/support/permission/auth/common';
+import type { ApiRequestProps } from '@fastgpt/service/type/next';
+import {
+  ListSkillResponseSchema,
+  type ListSkillResponseType
+} from '@fastgpt/global/openapi/core/app/skill/api';
+import { builtInSkillTemplates } from '@fastgpt/global/core/app/skill/constants';
+
+async function handler(req: ApiRequestProps): Promise<ListSkillResponseType> {
+  await authCert({ req, authToken: true });
+  return ListSkillResponseSchema.parse(builtInSkillTemplates);
+}
+
+export default NextAPI(handler);

--- a/projects/app/src/pages/dashboard/create/index.tsx
+++ b/projects/app/src/pages/dashboard/create/index.tsx
@@ -58,6 +58,7 @@ type FormType = {
 
 export type CreateAppType =
   | AppTypeEnum.chatAgent
+  | AppTypeEnum.skill
   | AppTypeEnum.simple
   | AppTypeEnum.workflow
   | AppTypeEnum.workflowTool

--- a/projects/app/src/web/core/app/api/skill.ts
+++ b/projects/app/src/web/core/app/api/skill.ts
@@ -1,0 +1,15 @@
+import { GET, POST } from '@/web/common/api/request';
+import type {
+  ListSkillResponseType,
+  DetailSkillResponseType,
+  CreateSkillAppBodyType,
+  CreateSkillAppResponseType
+} from '@fastgpt/global/openapi/core/app/skill/api';
+
+export const getSkillList = () => GET<ListSkillResponseType>('/core/app/skill/list');
+
+export const getSkillDetail = (skillId: string) =>
+  GET<DetailSkillResponseType>(`/core/app/skill/detail?skillId=${skillId}`);
+
+export const postCreateSkillApp = (data: CreateSkillAppBodyType) =>
+  POST<CreateSkillAppResponseType>('/core/app/skill/create', data);

--- a/test/cases/global/core/app/skill/type.test.ts
+++ b/test/cases/global/core/app/skill/type.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SkillTemplateSchema,
+  SkillConfigSchema,
+  SkillManifestSchema,
+  SkillCategoryEnum
+} from '@fastgpt/global/core/app/skill/type';
+import {
+  builtInSkillTemplates,
+  getSkillTemplateById
+} from '@fastgpt/global/core/app/skill/constants';
+
+describe('Skill Type Validation', () => {
+  describe('SkillTemplateSchema', () => {
+    it('should validate valid skill template', () => {
+      const validTemplate = {
+        id: 'test-skill',
+        name: 'Test Skill',
+        description: 'A test skill',
+        avatar: 'core/app/type/agentFill',
+        author: 'Test Author',
+        version: '1.0.0',
+        tags: ['test'],
+        category: SkillCategoryEnum.coding
+      };
+
+      const result = SkillTemplateSchema.safeParse(validTemplate);
+      expect(result.success).toBe(true);
+    });
+
+    it('should fail on missing required fields', () => {
+      const invalidTemplate = {
+        id: 'test-skill',
+        name: 'Test Skill'
+      };
+
+      const result = SkillTemplateSchema.safeParse(invalidTemplate);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('SkillConfigSchema', () => {
+    it('should validate valid skill config', () => {
+      const validConfig = {
+        systemPrompt: 'You are a helpful assistant.',
+        tools: ['tool-1', 'tool-2'],
+        variables: [
+          {
+            key: 'name',
+            label: 'Name',
+            type: 'input' as const,
+            required: false
+          }
+        ],
+        datasetIds: ['dataset-1'],
+        model: 'gpt-4',
+        temperature: 0.7,
+        maxHistories: 10
+      };
+
+      const result = SkillConfigSchema.safeParse(validConfig);
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept minimal config', () => {
+      const minimalConfig = {
+        systemPrompt: 'You are a helpful assistant.'
+      };
+
+      const result = SkillConfigSchema.safeParse(minimalConfig);
+      expect(result.success).toBe(true);
+      expect(result.data?.tools).toEqual([]);
+      expect(result.data?.variables).toEqual([]);
+    });
+  });
+
+  describe('SkillManifestSchema', () => {
+    it('should validate complete skill manifest', () => {
+      const validManifest = {
+        id: 'test-skill',
+        name: 'Test Skill',
+        description: 'A test skill',
+        avatar: 'core/app/type/agentFill',
+        author: 'Test Author',
+        version: '1.0.0',
+        tags: ['test'],
+        category: SkillCategoryEnum.research,
+        config: {
+          systemPrompt: 'You are a helpful assistant.',
+          tools: [],
+          variables: []
+        }
+      };
+
+      const result = SkillManifestSchema.safeParse(validManifest);
+      expect(result.success).toBe(true);
+    });
+  });
+});
+
+describe('Built-in Skill Templates', () => {
+  it('should have at least 3 built-in skills', () => {
+    expect(builtInSkillTemplates.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('should have unique ids', () => {
+    const ids = builtInSkillTemplates.map((s) => s.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it('should have coding assistant skill', () => {
+    const skill = getSkillTemplateById('skill-coding-assistant');
+    expect(skill).toBeDefined();
+    expect(skill?.category).toBe(SkillCategoryEnum.coding);
+    expect(skill?.config.variables.length).toBeGreaterThan(0);
+  });
+
+  it('should have doc-qa skill', () => {
+    const skill = getSkillTemplateById('skill-doc-qa');
+    expect(skill).toBeDefined();
+    expect(skill?.category).toBe(SkillCategoryEnum.research);
+  });
+
+  it('should have customer service skill', () => {
+    const skill = getSkillTemplateById('skill-customer-service');
+    expect(skill).toBeDefined();
+    expect(skill?.category).toBe(SkillCategoryEnum.customerService);
+  });
+
+  it('should return undefined for non-existent skill', () => {
+    const skill = getSkillTemplateById('non-existent-skill');
+    expect(skill).toBeUndefined();
+  });
+});
+
+describe('SkillCategoryEnum', () => {
+  it('should have all expected categories', () => {
+    expect(SkillCategoryEnum.writing).toBe('writing');
+    expect(SkillCategoryEnum.coding).toBe('coding');
+    expect(SkillCategoryEnum.research).toBe('research');
+    expect(SkillCategoryEnum.customerService).toBe('customer-service');
+    expect(SkillCategoryEnum.dataAnalysis).toBe('data-analysis');
+  });
+});

--- a/test/cases/global/core/app/skill/utils.test.ts
+++ b/test/cases/global/core/app/skill/utils.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from 'vitest';
+import {
+  skillManifest2AppConfig,
+  getSkillRuntimeNodes,
+  getSkillDefaultAppName
+} from '@fastgpt/global/core/app/skill/utils';
+import {
+  SkillCategoryEnum,
+  type SkillManifestType
+} from '@fastgpt/global/core/app/skill/type';
+import { FlowNodeTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
+import { NodeInputKeyEnum } from '@fastgpt/global/core/workflow/constants';
+
+describe('Skill Utils', () => {
+  const mockSkill: SkillManifestType = {
+    id: 'test-skill',
+    name: 'Test Skill',
+    description: 'A test skill for unit tests',
+    avatar: 'core/app/type/agentFill',
+    author: 'Test',
+    version: '1.0.0',
+    tags: ['test'],
+    category: SkillCategoryEnum.coding,
+    config: {
+      systemPrompt: 'You are a coding assistant for {{language}}.',
+      tools: ['tool-1', 'tool-2'],
+      variables: [
+        {
+          key: 'language',
+          label: 'Programming Language',
+          type: 'select',
+          required: false,
+          defaultValue: 'TypeScript',
+          options: ['TypeScript', 'Python']
+        }
+      ],
+      datasetIds: ['dataset-1'],
+      model: 'gpt-4',
+      temperature: 0.7,
+      maxHistories: 8
+    }
+  };
+
+  describe('getSkillRuntimeNodes', () => {
+    it('should create nodes with correct structure', () => {
+      const { nodes, edges } = getSkillRuntimeNodes({
+        config: mockSkill.config,
+        systemPrompt: 'Test prompt',
+        selectedToolIds: ['tool-1'],
+        selectedDatasetIds: ['dataset-1']
+      });
+
+      expect(nodes.length).toBe(3); // systemConfig, workflowStart, agent
+      expect(edges.length).toBe(1);
+
+      // Check system config node
+      const systemConfig = nodes.find((n) => n.flowNodeType === FlowNodeTypeEnum.systemConfig);
+      expect(systemConfig).toBeDefined();
+
+      // Check workflow start node
+      const workflowStart = nodes.find((n) => n.flowNodeType === FlowNodeTypeEnum.workflowStart);
+      expect(workflowStart).toBeDefined();
+
+      // Check agent node
+      const agent = nodes.find((n) => n.flowNodeType === FlowNodeTypeEnum.agent);
+      expect(agent).toBeDefined();
+      expect(agent?.inputs).toBeDefined();
+    });
+
+    it('should include system prompt in agent node', () => {
+      const { nodes } = getSkillRuntimeNodes({
+        config: mockSkill.config,
+        systemPrompt: 'Custom system prompt',
+        selectedToolIds: [],
+        selectedDatasetIds: []
+      });
+
+      const agent = nodes.find((n) => n.flowNodeType === FlowNodeTypeEnum.agent);
+      const systemPromptInput = agent?.inputs.find(
+        (i) => i.key === NodeInputKeyEnum.aiSystemPrompt
+      );
+
+      expect(systemPromptInput).toBeDefined();
+      expect(systemPromptInput?.value).toBe('Custom system prompt');
+    });
+
+    it('should include tools in agent node', () => {
+      const { nodes } = getSkillRuntimeNodes({
+        config: mockSkill.config,
+        systemPrompt: 'Test',
+        selectedToolIds: ['tool-1', 'tool-2'],
+        selectedDatasetIds: []
+      });
+
+      const agent = nodes.find((n) => n.flowNodeType === FlowNodeTypeEnum.agent);
+      const toolsInput = agent?.inputs.find((i) => i.key === NodeInputKeyEnum.selectedTools);
+
+      expect(toolsInput).toBeDefined();
+      expect(toolsInput?.value).toHaveLength(2);
+      expect(toolsInput?.value[0].id).toBe('tool-1');
+      expect(toolsInput?.value[1].id).toBe('tool-2');
+    });
+
+    it('should create edge from workflowStart to agent', () => {
+      const { edges } = getSkillRuntimeNodes({
+        config: mockSkill.config,
+        systemPrompt: 'Test',
+        selectedToolIds: [],
+        selectedDatasetIds: []
+      });
+
+      expect(edges.length).toBe(1);
+      expect(edges[0].source).toContain('workflowStart');
+      expect(edges[0].target).toContain('agent');
+    });
+  });
+
+  describe('skillManifest2AppConfig', () => {
+    it('should convert manifest to app config', () => {
+      const config = skillManifest2AppConfig({
+        manifest: mockSkill,
+        variableValues: {}
+      });
+
+      expect(config.name).toBe(mockSkill.name);
+      expect(config.avatar).toBe(mockSkill.avatar);
+      expect(config.intro).toBe(mockSkill.description);
+      expect(config.modules.length).toBe(3);
+      expect(config.edges.length).toBe(1);
+      expect(config.chatConfig.variables).toBeDefined();
+    });
+
+    it('should parse system prompt template with variables', () => {
+      const config = skillManifest2AppConfig({
+        manifest: mockSkill,
+        variableValues: { language: 'Python' }
+      });
+
+      const agent = config.modules.find((n) => n.flowNodeType === FlowNodeTypeEnum.agent);
+      const systemPromptInput = agent?.inputs.find(
+        (i) => i.key === NodeInputKeyEnum.aiSystemPrompt
+      );
+
+      expect(systemPromptInput?.value).toContain('Python');
+    });
+
+    it('should handle missing variable values gracefully', () => {
+      const config = skillManifest2AppConfig({
+        manifest: mockSkill,
+        variableValues: {}
+      });
+
+      const agent = config.modules.find((n) => n.flowNodeType === FlowNodeTypeEnum.agent);
+      const systemPromptInput = agent?.inputs.find(
+        (i) => i.key === NodeInputKeyEnum.aiSystemPrompt
+      );
+
+      // Should replace with empty string when value is missing
+      expect(systemPromptInput?.value).not.toContain('{{');
+    });
+
+    it('should allow custom name, avatar, intro', () => {
+      const config = skillManifest2AppConfig({
+        manifest: mockSkill,
+        customName: 'Custom Name',
+        customAvatar: 'custom/avatar',
+        customIntro: 'Custom intro'
+      });
+
+      expect(config.name).toBe('Custom Name');
+      expect(config.avatar).toBe('custom/avatar');
+      expect(config.intro).toBe('Custom intro');
+    });
+
+    it('should use skill defaults when custom values not provided', () => {
+      const config = skillManifest2AppConfig({
+        manifest: mockSkill
+      });
+
+      expect(config.name).toBe(mockSkill.name);
+      expect(config.avatar).toBe(mockSkill.avatar);
+      expect(config.intro).toBe(mockSkill.description);
+    });
+
+    it('should override tool ids when provided', () => {
+      const config = skillManifest2AppConfig({
+        manifest: mockSkill,
+        selectedToolIds: ['custom-tool']
+      });
+
+      const agent = config.modules.find((n) => n.flowNodeType === FlowNodeTypeEnum.agent);
+      const toolsInput = agent?.inputs.find((i) => i.key === NodeInputKeyEnum.selectedTools);
+
+      expect(toolsInput?.value).toHaveLength(1);
+      expect(toolsInput?.value[0].id).toBe('custom-tool');
+    });
+
+    it('should convert variables to app variables', () => {
+      const config = skillManifest2AppConfig({
+        manifest: mockSkill
+      });
+
+      expect(config.chatConfig.variables).toHaveLength(1);
+      expect(config.chatConfig.variables[0].key).toBe('language');
+      expect(config.chatConfig.variables[0].label).toBe('Programming Language');
+    });
+  });
+
+  describe('getSkillDefaultAppName', () => {
+    it('should generate unique app name', () => {
+      const name = getSkillDefaultAppName(mockSkill);
+
+      expect(name).toContain(mockSkill.name);
+      expect(name.length).toBeGreaterThan(mockSkill.name.length);
+    });
+
+    it('should generate different names on each call', () => {
+      const name1 = getSkillDefaultAppName(mockSkill);
+      const name2 = getSkillDefaultAppName(mockSkill);
+
+      expect(name1).not.toBe(name2);
+    });
+  });
+});


### PR DESCRIPTION
# Feature: Skill Templates

Closes #6320

## Summary

This PR introduces **Skill Templates** - a way to quickly create specialized AI agents with pre-configured system prompts, tools, and variables. Skills provide a middle ground between Simple Apps (too basic) and Workflows (too complex) for common use cases.

## What's Changed

### Core Types & Constants (`packages/global/`)

- **New**: `AppTypeEnum.skill` - New app type for skill-based agents
- **New**: `AppToolSourceEnum.skill` - Tool source identifier for skills
- **New**: `packages/global/core/app/skill/type.ts`
  - `SkillTemplateSchema` - Template metadata (name, description, avatar, etc.)
  - `SkillConfigSchema` - Runtime config (systemPrompt, tools, variables, datasets)
  - `SkillManifestSchema` - Complete skill definition
- **New**: `packages/global/core/app/skill/constants.ts`
  - `SkillCategoryEnum` - Categories: writing, coding, research, customer-service, data-analysis
  - 3 built-in skill templates:
    - Coding Assistant
    - Document Q&A
    - Customer Service
- **New**: `packages/global/core/app/skill/utils.ts`
  - `skillManifest2AppConfig()` - Converts skill manifest to app creation parameters
  - `getSkillRuntimeNodes()` - Generates workflow nodes for skill execution

### API Endpoints (`projects/app/src/pages/api/core/app/skill/`)

- **New**: `GET /api/core/app/skill/list` - List all available skill templates
- **New**: `GET /api/core/app/skill/detail?skillId={id}` - Get skill template details
- **New**: `POST /api/core/app/skill/create` - Create app from skill template

### Frontend (`projects/app/src/`)

- **New**: `web/core/app/api/skill.ts` - Frontend API client
- **Updated**: `pageComponents/app/constants.ts` - Added skill to `createAppTypeMap`
- **Updated**: `pageComponents/dashboard/constant.ts` - Added skill to `appTypeTagMap`
- **Updated**: `pages/dashboard/create/index.tsx` - Added `AppTypeEnum.skill` to `CreateAppType`

### OpenAPI Schemas (`packages/global/openapi/core/app/skill/api.ts`)

- `ListSkillResponseSchema`
- `DetailSkillQuerySchema` & `DetailSkillResponseSchema`
- `CreateSkillAppBodySchema` & `CreateSkillAppResponseSchema`

### Tests (`test/cases/`)

- **New**: `test/cases/global/core/app/skill/type.test.ts` - Type validation tests
- **New**: `test/cases/global/core/app/skill/utils.test.ts` - Utility function tests

## Usage Example

```typescript
// 1. List available skills
const skills = await getSkillList();

// 2. Create app from skill
const appId = await postCreateSkillApp({
  skillId: 'skill-coding-assistant',
  name: 'My Coding Assistant',
  variables: {
    language: 'Python'
  },
  toolIds: ['my-custom-tool'],
  datasetIds: ['my-knowledge-base']
});
```

## Design Decisions

1. **Static Templates**: Skills are defined in code (not database) for:
   - Easy version control
   - Simple extensibility
   - No migration needed

2. **App Type Integration**: Skills are a new `AppTypeEnum` value:
   - First-class citizen like `chatAgent` and `workflow`
   - Works with existing app infrastructure
   - Proper categorization in UI

3. **Variable Substitution**: System prompts support `{{variable}}` syntax:
   - Allows personalization without code changes
   - User-provided values at creation time

4. **Minimal Invasiveness**: Reuses existing:
   - Workflow nodes (`FlowNodeTypeEnum.agent`)
   - Tool system
   - Dataset bindings
   - Permission system

## Testing

```bash
# Run skill-related tests
pnpm test -- test/cases/global/core/app/skill/
```

Tests cover:
- Zod schema validation
- Built-in template integrity
- Variable substitution logic
- Node/edge generation

## Checklist

- [x] Type definitions with Zod schemas
- [x] Built-in skill templates
- [x] API endpoints (list, detail, create)
- [x] Frontend constants
- [x] Unit tests
- [x] Design documentation
- [ ] Integration tests (optional for MVP)
- [ ] UI implementation (separate PR)

## Migration

No database migration required. Skill templates:
- Are stored as static TypeScript constants
- Are converted to standard App schema at creation
- Become regular apps after creation (type = `skill`)

## Screenshots / Demo

N/A - This PR provides the backend infrastructure. UI will be implemented in a follow-up PR.

## Related

- Issue #6320

---

**Reviewers**: Please pay special attention to:
1. Type safety of skill schemas
2. Correctness of node generation in `getSkillRuntimeNodes()`
3. API endpoint authentication/authorization
