### PR TITLE
fix: sanitize error objects to prevent BSON circular reference crash

### DIFF
--- a/packages/service/common/system/tools.ts
+++ b/packages/service/common/system/tools.ts
@@ -1,6 +1,7 @@
 import { type FastGPTConfigFileType } from '@fastgpt/global/common/system/types';
 import { isIPv6 } from 'net';
 import { getLogger, LogCategories } from '../logger';
+import { getErrText } from '@fastgpt/global/common/error/utils';
 
 const logger = getLogger(LogCategories.ERROR);
 
@@ -29,12 +30,12 @@ export const initFastGPTConfig = (config?: FastGPTConfigFileType) => {
 
 export const systemStartCb = () => {
   process.on('uncaughtException', (err) => {
-    logger.error('Uncaught exception', { error: err });
+    logger.error('Uncaught exception', { error: getErrText(err) });
     // process.exit(1); // 退出进程
   });
 
   process.on('unhandledRejection', (reason, promise) => {
-    logger.error('Unhandled promise rejection', { reason, promise });
+    logger.error('Unhandled promise rejection', { reason: getErrText(reason) });
     // process.exit(1); // 退出进程
   });
 };

--- a/packages/service/core/ai/llm/request.ts
+++ b/packages/service/core/ai/llm/request.ts
@@ -858,11 +858,11 @@ const createChatCompletion = async ({
       logger.warn('User AI API error', {
         baseUrl: userKey?.baseUrl,
         request: body,
-        error
+        error: getErrText(error)
       });
       return Promise.reject(`您的 OpenAI key 出错了: ${getErrText(error)}`);
     } else {
-      logger.error('LLM response error', { request: body, error });
+      logger.error('LLM response error', { request: body, error: getErrText(error) });
     }
     return Promise.reject(error);
   }

--- a/packages/service/core/ai/llm/utils.ts
+++ b/packages/service/core/ai/llm/utils.ts
@@ -212,7 +212,7 @@ export const loadRequestMessages = async ({
               if (error?.response?.status === 405 || error?.response?.status === 403) {
                 return item;
               }
-              logger.warn('Failed to validate image URL', { url: imgUrl, error });
+              logger.warn('Failed to validate image URL', { url: imgUrl, error: getErrText(error) });
               return;
             }
           }

--- a/packages/service/core/ai/record/controller.ts
+++ b/packages/service/core/ai/record/controller.ts
@@ -1,6 +1,48 @@
 import { MongoLLMRequestRecord } from './schema';
 import type { LLMRequestRecordSchemaType } from '@fastgpt/global/openapi/core/ai/api';
 import { getLogger, LogCategories } from '../../../common/logger';
+import { getErrText } from '@fastgpt/global/common/error/utils';
+
+/**
+ * Sanitize a value so it is safe for BSON serialization.
+ * Strips circular references (e.g. Axios error config/request) and
+ * non-serializable fields (functions, symbols).
+ */
+function sanitizeForBSON(value: unknown, seen = new WeakSet()): unknown {
+  if (value === null || value === undefined) return value;
+
+  if (typeof value === 'function' || typeof value === 'symbol') return undefined;
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+      ...(typeof (value as any).status === 'number' && { status: (value as any).status }),
+      ...(typeof (value as any).code === 'string' && { code: (value as any).code })
+    };
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value as object)) return '[Circular]';
+    seen.add(value as object);
+
+    if (Array.isArray(value)) {
+      return value.map((item) => sanitizeForBSON(item, seen));
+    }
+
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      const sanitized = sanitizeForBSON(val, seen);
+      if (sanitized !== undefined) {
+        result[key] = sanitized;
+      }
+    }
+    return result;
+  }
+
+  return value;
+}
 
 /**
  * 保存 LLM 请求追踪记录（异步，不阻塞主流程）
@@ -14,8 +56,8 @@ export const saveLLMRequestRecord = async (params: {
   try {
     await MongoLLMRequestRecord.create({
       requestId: params.requestId,
-      body: params.body,
-      response: params.response
+      body: sanitizeForBSON(params.body),
+      response: sanitizeForBSON(params.response)
     });
   } catch (error) {
     // 记录错误但不影响主流程


### PR DESCRIPTION
## Problem

Fixes #6300

When an Axios request fails (e.g., invalid image URL returns 401), the error object contains circular references (`config.transformRequest`, `config.transformResponse`, etc.) that cause:

```
BSONError: Cannot convert circular structure to BSON
```

This crashes the process with an unhandled rejection when the error is stored in MongoDB (via `saveLLMRequestRecord`) or passed to logger sinks.

## Changes

1. **`packages/service/core/ai/record/controller.ts`** — Add `sanitizeForBSON()` utility that recursively strips circular references, functions, and symbols. Applied to `body` and `response` before `MongoLLMRequestRecord.create()`.

2. **`packages/service/core/ai/llm/request.ts`** — Wrap error objects with `getErrText()` in logger calls to prevent circular refs in log sinks.

3. **`packages/service/core/ai/llm/utils.ts`** — Same treatment for image validation error logging.

4. **`packages/service/common/system/tools.ts`** — Sanitize `uncaughtException` and `unhandledRejection` handlers to prevent BSON issues in any downstream log storage.

## Root Cause

`saveLLMRequestRecord` stores request/response objects directly into MongoDB. When an Axios error is included in the response chain, its `config` property creates circular references that BSON serialization cannot handle.

## Testing

- Verified that `sanitizeForBSON` correctly handles: circular refs → `[Circular]`, Error objects → safe plain objects, functions/symbols → stripped, nested objects/arrays → recursively cleaned.