### PR TITLE
fix: remove duplicate Bearer token in MCP SSE transport headers

### DIFF
--- a/packages/service/core/app/mcp.ts
+++ b/packages/service/core/app/mcp.ts
@@ -41,28 +41,6 @@ export class MCPClient {
         new SSEClientTransport(new URL(this.url), {
           requestInit: {
             headers: this.headers
-          },
-          eventSourceInit: {
-            fetch: (url, init) => {
-              const mergedHeaders: Record<string, string> = {
-                ...this.headers
-              };
-
-              if (init?.headers) {
-                if (init.headers instanceof Headers) {
-                  init.headers.forEach((value, key) => {
-                    mergedHeaders[key] = value;
-                  });
-                } else if (typeof init.headers === 'object') {
-                  Object.assign(mergedHeaders, init.headers);
-                }
-              }
-
-              return fetch(url, {
-                ...init,
-                headers: mergedHeaders
-              });
-            }
           }
         })
       );


### PR DESCRIPTION
## Problem

Fixes #6375

When adding MCP tools with Bearer authentication, the Authorization header is sent twice (e.g. `Bearer xxx, Bearer xxx`).

## Root Cause

In `packages/service/core/app/mcp.ts`, the SSE fallback path had a custom `eventSourceInit.fetch` that manually merged `this.headers` (containing `Authorization: Bearer xxx`) with `init.headers` from the MCP SDK's `_commonHeaders()`.

The SDK's `_commonHeaders()` already includes headers from `requestInit.headers` and returns a `Headers` object, which normalizes keys to lowercase (`authorization`). The custom fetch then spread `this.headers` (with original case `Authorization`) and iterated the `Headers` object (yielding lowercase `authorization`), resulting in both keys coexisting in the plain object — causing duplicate Bearer tokens.

## Fix

Remove the redundant `eventSourceInit.fetch` override. The MCP SDK (v1.26.0) already properly merges `requestInit.headers` into SSE connection requests via its internal `_commonHeaders()` method, so the custom fetch wrapper is unnecessary.

## Changes

- `packages/service/core/app/mcp.ts`: Removed `eventSourceInit` block from `SSEClientTransport` constructor call (22 lines deleted)