### PR TITLE
fix: preserve user-defined ECharts toolbox config (closes #6269)

### DIFF
--- a/projects/app/src/components/Markdown/img/EChartsCodeBlock.tsx
+++ b/projects/app/src/components/Markdown/img/EChartsCodeBlock.tsx
@@ -36,12 +36,17 @@ const EChartsCodeBlock = ({ code }: { code: string }) => {
   useLayoutEffect(() => {
     const option = (() => {
       try {
+        const userOption = json5.parse(code.trim());
+        const userToolbox = userOption.toolbox || {};
+        const userFeature = userToolbox.feature || {};
+
         const parse = {
-          ...json5.parse(code.trim()),
+          ...userOption,
           toolbox: {
-            // show: true,
+            ...userToolbox,
             feature: {
-              saveAsImage: {}
+              saveAsImage: {},
+              ...userFeature
             }
           }
         };


### PR DESCRIPTION
## 问题

在 `EChartsCodeBlock.tsx` 中，toolbox 被硬编码覆盖，用户在 ECharts JSON 中自定义的 `toolbox` 配置（如 `dataView`、`magicType`、`restore` 等）会被完全丢弃，只保留 `saveAsImage`。

**修复前：**
```ts
const parse = {
  ...json5.parse(code.trim()),
  toolbox: {
    feature: {
      saveAsImage: {}  // 硬编码覆盖，用户配置丢失
    }
  }
};
```

## 修复方案

改为深度合并：先展开用户的 `toolbox` 和 `feature`，以 `saveAsImage` 作为默认值，用户配置优先。

**修复后：**
```ts
const userOption = json5.parse(code.trim());
const userToolbox = userOption.toolbox || {};
const userFeature = userToolbox.feature || {};

const parse = {
  ...userOption,
  toolbox: {
    ...userToolbox,          // 保留用户的 show、orient 等设置
    feature: {
      saveAsImage: {},       // 默认提供 saveAsImage
      ...userFeature         // 用户自定义 feature 优先（含 dataView、magicType、restore 等）
    }
  }
};
```

## 效果

- 用户未配置 toolbox → 默认显示 saveAsImage（行为不变）
- 用户配置了 toolbox → 完整保留用户配置，saveAsImage 作为兜底
- 用户配置了自定义 saveAsImage → 用户配置优先

Closes #6269