### PR TITLE
fix: 修复添加 MCP 工具时 Bearer 鉴权重复添加前缀的问题

### DIFF
--- a/packages/service/common/secret/utils.ts
+++ b/packages/service/common/secret/utils.ts
@@ -45,9 +45,9 @@ export const getSecretValue = ({
     }
 
     if (key === HeaderSecretTypeEnum.Bearer) {
-      acc['Authorization'] = `Bearer ${actualValue}`;
+      acc['Authorization'] = actualValue.startsWith('Bearer ') ? actualValue : `Bearer ${actualValue}`;
     } else if (key === HeaderSecretTypeEnum.Basic) {
-      acc['Authorization'] = `Basic ${actualValue}`;
+      acc['Authorization'] = actualValue.startsWith('Basic ') ? actualValue : `Basic ${actualValue}`;
     } else {
       acc[key] = actualValue;
     }

--- a/test/cases/service/common/secret/utils.test.ts
+++ b/test/cases/service/common/secret/utils.test.ts
@@ -148,6 +148,28 @@ describe('getSecretValue', () => {
     expect(result).toEqual({ Authorization: 'Bearer my-token' });
   });
 
+  it('should not duplicate Bearer prefix when value already contains it', () => {
+    const encrypted = encryptSecret('Bearer my-token');
+    const result = getSecretValue({
+      storeSecret: {
+        [HeaderSecretTypeEnum.Bearer]: { value: '', secret: encrypted }
+      }
+    });
+
+    expect(result).toEqual({ Authorization: 'Bearer my-token' });
+  });
+
+  it('should not duplicate Basic prefix when value already contains it', () => {
+    const encrypted = encryptSecret('Basic dXNlcjpwYXNz');
+    const result = getSecretValue({
+      storeSecret: {
+        [HeaderSecretTypeEnum.Basic]: { value: '', secret: encrypted }
+      }
+    });
+
+    expect(result).toEqual({ Authorization: 'Basic dXNlcjpwYXNz' });
+  });
+
   it('should convert Basic type to Authorization header', () => {
     const encrypted = encryptSecret('dXNlcjpwYXNz');
     const result = getSecretValue({


### PR DESCRIPTION
Fixes #6375

## 问题描述

添加 MCP 工具时，鉴权类型选择 Bearer 时，如果用户输入的 token 已经包含 `Bearer ` 前缀，`getSecretValue` 函数会再次拼接前缀，导致 Authorization header 变成 `Bearer Bearer xxx`。Basic 鉴权同理。

## 修复方案

在 `packages/service/common/secret/utils.ts` 的 `getSecretValue` 函数中，拼接 `Bearer ` / `Basic ` 前缀前先检查 `actualValue` 是否已包含对应前缀，避免重复。

## 改动文件

- `packages/service/common/secret/utils.ts` — 添加前缀重复检查
- `test/cases/service/common/secret/utils.test.ts` — 添加对应测试用例（已通过）