### PR TITLE
fix: MCP tools parsing regression in v4.14.7 (closes #6451)

### DIFF
--- a/packages/global/openapi/core/app/mcpTools/api.ts
+++ b/packages/global/openapi/core/app/mcpTools/api.ts
@@ -116,10 +116,21 @@ export const GetMcpToolsBodySchema = z
   });
 export type GetMcpToolsBodyType = z.infer<typeof GetMcpToolsBodySchema>;
 
-export const GetMcpToolsResponseSchema = z.array(McpToolConfigSchema).meta({
-  example: [],
-  description: 'MCP 工具配置列表'
-});
+// Use a permissive schema for MCP tools response since remote MCP servers can
+// return arbitrary JSON Schema structures (anyOf, oneOf, allOf, $ref, etc.)
+// that don't conform to the strict JSONSchemaInputTypeSchema after dereferencing.
+export const GetMcpToolsResponseSchema = z
+  .array(
+    z.object({
+      name: z.string(),
+      description: z.string(),
+      inputSchema: z.record(z.string(), z.any())
+    })
+  )
+  .meta({
+    example: [],
+    description: 'MCP 工具配置列表'
+  });
 export type GetMcpToolsResponseType = z.infer<typeof GetMcpToolsResponseSchema>;
 
 // Run MCP tool


### PR DESCRIPTION
## 问题描述

v4.14.7 中 `POST /api/core/app/mcpTools/getTools` 返回 500 错误，日志显示 "MCP client connection closed" 后 "Request validation failed"。v4.14.6 正常。

## 回归原因

v4.14.7 中有两个相关变更叠加导致了此问题：

1. **`mcp.ts` 新增了 `$RefParser.dereference()`**：用于解析 MCP 工具 JSON Schema 中的 `$ref` 引用。解引用后，属性可能包含 `anyOf`/`oneOf`/`allOf` 等复合类型结构，而不再有 `type` 字段。

2. **`getTools.ts` API 新增了 Zod 响应校验**：`GetMcpToolsResponseSchema.parse(result)` 使用 `McpToolConfigSchema` → `JSONSchemaInputTypeSchema` → `JsonSchemaPropertiesItemSchema` 进行校验。`JsonSchemaPropertiesItemSchema` 要求每个属性必须有 `type` 字段且值为 `string|number|integer|boolean|array|object` 之一。

当远程 MCP 服务器返回包含 `$ref` 或复合类型的工具 schema 时，解引用后的属性缺少 `type` 字段，Zod 校验失败 → 500。

## 修复方案

将 `GetMcpToolsResponseSchema` 的 `inputSchema` 字段改为宽松的 `z.record(z.string(), z.any())`，因为远程 MCP 服务器可以返回任意合法的 JSON Schema 结构，不应在响应校验层做严格的 schema 结构限制。

存储侧的 `McpToolConfigSchema`（用于 toolList 持久化）保持不变。