### PR TITLE
chore: update FastGPT image tag to v4.14.7.1

### DIFF
--- a/deploy/docker/cn/docker-compose.milvus.yml
+++ b/deploy/docker/cn/docker-compose.milvus.yml
@@ -185,7 +185,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7 # git
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/deploy/docker/cn/docker-compose.oceanbase.yml
+++ b/deploy/docker/cn/docker-compose.oceanbase.yml
@@ -162,7 +162,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7 # git
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/deploy/docker/cn/docker-compose.pg.yml
+++ b/deploy/docker/cn/docker-compose.pg.yml
@@ -143,7 +143,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7 # git
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/deploy/docker/cn/docker-compose.seekdb.yml
+++ b/deploy/docker/cn/docker-compose.seekdb.yml
@@ -149,7 +149,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7 # git
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/deploy/docker/cn/docker-compose.zilliz.yml
+++ b/deploy/docker/cn/docker-compose.zilliz.yml
@@ -127,7 +127,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7 # git
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/deploy/docker/global/docker-compose.milvus.yml
+++ b/deploy/docker/global/docker-compose.milvus.yml
@@ -185,7 +185,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: ghcr.io/labring/fastgpt:v4.14.7 # git
+    image: ghcr.io/labring/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/deploy/docker/global/docker-compose.oceanbase.yml
+++ b/deploy/docker/global/docker-compose.oceanbase.yml
@@ -162,7 +162,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: ghcr.io/labring/fastgpt:v4.14.7 # git
+    image: ghcr.io/labring/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/deploy/docker/global/docker-compose.pg.yml
+++ b/deploy/docker/global/docker-compose.pg.yml
@@ -143,7 +143,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: ghcr.io/labring/fastgpt:v4.14.7 # git
+    image: ghcr.io/labring/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/deploy/docker/global/docker-compose.seekdb.yml
+++ b/deploy/docker/global/docker-compose.seekdb.yml
@@ -149,7 +149,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: ghcr.io/labring/fastgpt:v4.14.7 # git
+    image: ghcr.io/labring/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/deploy/docker/global/docker-compose.ziliiz.yml
+++ b/deploy/docker/global/docker-compose.ziliiz.yml
@@ -127,7 +127,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: ghcr.io/labring/fastgpt:v4.14.7 # git
+    image: ghcr.io/labring/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/document/content/docs/upgrading/4-14/4147.mdx
+++ b/document/content/docs/upgrading/4-14/4147.mdx
@@ -7,8 +7,8 @@ description: 'FastGPT V4.14.7 更新说明'
 
 ### 1. 更新镜像
 
-- 更新 FastGPT 镜像 tag: v4.14.7
-- 更新 FastGPT 商业版镜像 tag: v4.14.7
+- 更新 FastGPT 镜像 tag: v4.14.7.1
+- 更新 FastGPT 商业版镜像 tag: v4.14.7.1
 - 更新 fastgpt-plugin 镜像 tag: v0.5.4
 - mcp_server 无需更新（4.14.7 镜像不可用，可用旧的）
 - sandbox 无需更新

--- a/document/public/deploy/docker/cn/docker-compose.milvus.yml
+++ b/document/public/deploy/docker/cn/docker-compose.milvus.yml
@@ -185,7 +185,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7 # git
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/document/public/deploy/docker/cn/docker-compose.oceanbase.yml
+++ b/document/public/deploy/docker/cn/docker-compose.oceanbase.yml
@@ -162,7 +162,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7 # git
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/document/public/deploy/docker/cn/docker-compose.pg.yml
+++ b/document/public/deploy/docker/cn/docker-compose.pg.yml
@@ -143,7 +143,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7 # git
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/document/public/deploy/docker/cn/docker-compose.seekdb.yml
+++ b/document/public/deploy/docker/cn/docker-compose.seekdb.yml
@@ -149,7 +149,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7 # git
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/document/public/deploy/docker/cn/docker-compose.zilliz.yml
+++ b/document/public/deploy/docker/cn/docker-compose.zilliz.yml
@@ -127,7 +127,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7 # git
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/document/public/deploy/docker/global/docker-compose.milvus.yml
+++ b/document/public/deploy/docker/global/docker-compose.milvus.yml
@@ -185,7 +185,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: ghcr.io/labring/fastgpt:v4.14.7 # git
+    image: ghcr.io/labring/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/document/public/deploy/docker/global/docker-compose.oceanbase.yml
+++ b/document/public/deploy/docker/global/docker-compose.oceanbase.yml
@@ -162,7 +162,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: ghcr.io/labring/fastgpt:v4.14.7 # git
+    image: ghcr.io/labring/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/document/public/deploy/docker/global/docker-compose.pg.yml
+++ b/document/public/deploy/docker/global/docker-compose.pg.yml
@@ -143,7 +143,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: ghcr.io/labring/fastgpt:v4.14.7 # git
+    image: ghcr.io/labring/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/document/public/deploy/docker/global/docker-compose.seekdb.yml
+++ b/document/public/deploy/docker/global/docker-compose.seekdb.yml
@@ -149,7 +149,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: ghcr.io/labring/fastgpt:v4.14.7 # git
+    image: ghcr.io/labring/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:

--- a/document/public/deploy/docker/global/docker-compose.ziliiz.yml
+++ b/document/public/deploy/docker/global/docker-compose.ziliiz.yml
@@ -127,7 +127,7 @@ services:
 
   fastgpt:
     container_name: fastgpt
-    image: ghcr.io/labring/fastgpt:v4.14.7 # git
+    image: ghcr.io/labring/fastgpt:v4.14.7.1 # git
     ports:
       - 3000:3000
     networks:


### PR DESCRIPTION
更新 FastGPT 镜像 tag 为 v4.14.7.1

- 更新 4.14.7 版本文档中的镜像 tag（开源版 + 商业版）
- 更新 deploy/docker 下所有 docker-compose yml（cn + global，共 10 个文件）
- 同步更新 document/public/deploy/docker 下对应的 yml 文件