### PR TITLE
fix: MCP tool call fails with toolName undefined

### DIFF
--- a/packages/service/core/workflow/dispatch/ai/agent/sub/tool/index.ts
+++ b/packages/service/core/workflow/dispatch/ai/agent/sub/tool/index.ts
@@ -176,7 +176,7 @@ export const dispatchTool = async ({
       };
     } else if (toolConfig?.mcpTool?.toolId) {
       const { pluginId } = splitCombineToolId(toolConfig.mcpTool.toolId);
-      const [parentId, toolSetName, toolName] = pluginId.split('/');
+      const [parentId, toolName] = pluginId.split('/');
       const tool = await getAppVersionById({
         appId: parentId,
         versionId: version

--- a/packages/service/core/workflow/dispatch/child/runTool.ts
+++ b/packages/service/core/workflow/dispatch/child/runTool.ts
@@ -206,9 +206,9 @@ export const dispatchRunTool = async (props: RunToolProps): Promise<RunToolRespo
         ]
       };
     } else if (toolConfig?.mcpTool?.toolId) {
-      // pluginId: toolSetAppId/toolsetName/toolName
+      // pluginId: parentId/toolName
       const { pluginId } = splitCombineToolId(toolConfig.mcpTool.toolId);
-      const [parentId, toolSetName, toolName] = pluginId.split('/');
+      const [parentId, toolName] = pluginId.split('/');
       const tool = await getAppVersionById({
         appId: parentId,
         versionId: version


### PR DESCRIPTION
## Problem

MCP tool calls fail with `toolName: undefined` since v4.14.7.1 (reported in #6456).

## Root Cause

The MCP tool ID format is `mcp-parentId/toolName` (2 segments when split by `/`), but the code destructures with 3 segments:

```ts
const [parentId, toolSetName, toolName] = pluginId.split('/');
```

This causes `toolName` to always be `undefined`, which is then passed to `mcpClient.toolCall()`, resulting in the MCP error:

```
MCP error -32603: Invalid input: expected string, received undefined
```

This was likely introduced when HTTP tool support (which uses a 3-segment format `parentId/toolSetName/toolName`) was added, and the MCP path was incorrectly updated to match.

## Fix

Changed the destructuring to match the actual MCP tool ID format:

```ts
const [parentId, toolName] = pluginId.split('/');
```

Fixed in both dispatch paths:
- `packages/service/core/workflow/dispatch/child/runTool.ts`
- `packages/service/core/workflow/dispatch/ai/agent/sub/tool/index.ts`

Fixes #6456