### PR TITLE
feat(seo): add sitemap, robots.txt, and enhanced metadata

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -30,20 +30,11 @@ jobs:
 
       - name: Sync images
         run: |
-          # Create imgs directory if it doesn't exist
           mkdir -p fastgpt-img
-
-          # Copy all images from document/public/imgs to the target repository
           cp -r document/public/imgs/* fastgpt-img
-
-          # Navigate to target repository
           cd fastgpt-img
-
-          # Configure git
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Add, commit and push changes
           git add .
           if ! git diff --cached --quiet; then
             git commit -m "Sync images from FastGPT document at $(date)"
@@ -52,7 +43,7 @@ jobs:
           else
             echo "No changes to sync"
           fi
-  # Add a new job to generate unified timestamp
+
   generate-timestamp:
     needs: sync-images
     runs-on: ubuntu-latest
@@ -63,29 +54,20 @@ jobs:
         id: datetime
         run: echo "datetime=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
 
-  build-images:
+  build-cn:
     needs: generate-timestamp
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        domain_config:
-          - domain: 'https://fastgpt.io'
-            suffix: 'io'
-          - domain: 'https://fastgpt.cn'
-            suffix: 'cn'
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Rewrite image paths
-        if: matrix.domain_config.suffix == 'io'
         run: |
           find document/content/docs -name "*.mdx" -type f | while read file; do
             sed -i 's|](/imgs/|](https://cdn.jsdelivr.net/gh/labring/fastgpt-img@main/|g' "$file"
           done
+
       - name: Rewrite domain links for CN
-        if: matrix.domain_config.suffix == 'cn'
         run: |
           find document/content/docs -name "*.mdx" -type f | while read file; do
             sed -i 's|doc\.fastgpt\.io|doc.fastgpt.cn|g' "$file"
@@ -95,11 +77,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          # list of Docker images to use as base name for tags
-          images: |
-            ${{ secrets.ALI_IMAGE_NAME }}/fastgpt-docs
+          images: ${{ secrets.ALI_IMAGE_NAME }}/fastgpt-docs
           tags: |
-            ${{ matrix.domain_config.suffix }}-${{ needs.generate-timestamp.outputs.datetime }}
+            cn-${{ needs.generate-timestamp.outputs.datetime }}
           flavor: latest=false
 
       - name: Login to Aliyun
@@ -109,8 +89,7 @@ jobs:
           username: ${{ secrets.ALI_HUB_USERNAME }}
           password: ${{ secrets.ALI_HUB_PASSWORD }}
 
-      - name: Build and push Docker images (CN)
-        if: matrix.domain_config.suffix == 'cn'
+      - name: Build and push CN
         uses: docker/build-push-action@v5
         with:
           context: ./document
@@ -120,12 +99,41 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
           build-args: |
-            FASTGPT_HOME_DOMAIN=${{ matrix.domain_config.domain }}
+            FASTGPT_HOME_DOMAIN=https://fastgpt.cn
             DOC_TRACK_SRC=${{ secrets.DOC_TRACK_SRC }}
             DOC_TRACK_SITE_ID=${{ secrets.DOC_TRACK_CN }}
+            NEXT_PUBLIC_DOC_DOMAIN=doc.fastgpt.cn
 
-      - name: Build and push Docker images (IO)
-        if: matrix.domain_config.suffix == 'io'
+  build-io:
+    needs: generate-timestamp
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Rewrite image paths
+        run: |
+          find document/content/docs -name "*.mdx" -type f | while read file; do
+            sed -i 's|](/imgs/|](https://cdn.jsdelivr.net/gh/labring/fastgpt-img@main/|g' "$file"
+          done
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.ALI_IMAGE_NAME }}/fastgpt-docs
+          tags: |
+            io-${{ needs.generate-timestamp.outputs.datetime }}
+          flavor: latest=false
+
+      - name: Login to Aliyun
+        uses: docker/login-action@v3
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ secrets.ALI_HUB_USERNAME }}
+          password: ${{ secrets.ALI_HUB_PASSWORD }}
+
+      - name: Build and push IO
         uses: docker/build-push-action@v5
         with:
           context: ./document
@@ -135,39 +143,49 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
           build-args: |
-            FASTGPT_HOME_DOMAIN=${{ matrix.domain_config.domain }}
+            FASTGPT_HOME_DOMAIN=https://fastgpt.io
             DOC_TRACK_SRC=${{ secrets.DOC_TRACK_SRC }}
             DOC_TRACK_SITE_ID=${{ secrets.DOC_TRACK_IO }}
+            NEXT_PUBLIC_DOC_DOMAIN=doc.fastgpt.io
 
-  update-images:
-    needs: [generate-timestamp, build-images]
+  update-cn:
+    needs: [generate-timestamp, build-cn]
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        domain_config:
-          - domain: 'https://fastgpt.io'
-            suffix: 'io'
-            deployment: 'fastgpt-docs'
-            kube_config: 'KUBE_CONFIG_IO'
-          - domain: 'https://fastgpt.cn'
-            suffix: 'cn'
-            deployment: 'fastgpt-docs'
-            kube_config: 'KUBE_CONFIG_CN'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Add kubeconfig setup step to handle encoding issues
       - name: Setup kubeconfig
         run: |
           mkdir -p $HOME/.kube
-          echo "${{ secrets[matrix.domain_config.kube_config] }}" > $HOME/.kube/config
+          echo "${{ secrets.KUBE_CONFIG_CN }}" > $HOME/.kube/config
           chmod 600 $HOME/.kube/config
 
       - name: Update deployment image
         run: |
-          kubectl set image deployment/${{ matrix.domain_config.deployment }} ${{ matrix.domain_config.deployment }}=${{ secrets.ALI_IMAGE_NAME }}/fastgpt-docs:${{ matrix.domain_config.suffix }}-${{ needs.generate-timestamp.outputs.datetime }}
+          kubectl set image deployment/fastgpt-docs fastgpt-docs=${{ secrets.ALI_IMAGE_NAME }}/fastgpt-docs:cn-${{ needs.generate-timestamp.outputs.datetime }}
 
       - name: Annotate deployment
         run: |
-          kubectl annotate deployment/${{ matrix.domain_config.deployment }} originImageName="${{ secrets.ALI_IMAGE_NAME }}/fastgpt-docs:${{ matrix.domain_config.suffix }}-${{ needs.generate-timestamp.outputs.datetime }}" --overwrite
+          kubectl annotate deployment/fastgpt-docs originImageName="${{ secrets.ALI_IMAGE_NAME }}/fastgpt-docs:cn-${{ needs.generate-timestamp.outputs.datetime }}" --overwrite
+
+  update-io:
+    needs: [generate-timestamp, build-io]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup kubeconfig
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBE_CONFIG_IO }}" > $HOME/.kube/config
+          chmod 600 $HOME/.kube/config
+
+      - name: Update deployment image
+        run: |
+          kubectl set image deployment/fastgpt-docs fastgpt-docs=${{ secrets.ALI_IMAGE_NAME }}/fastgpt-docs:io-${{ needs.generate-timestamp.outputs.datetime }}
+
+      - name: Annotate deployment
+        run: |
+          kubectl annotate deployment/fastgpt-docs originImageName="${{ secrets.ALI_IMAGE_NAME }}/fastgpt-docs:io-${{ needs.generate-timestamp.outputs.datetime }}" --overwrite

--- a/document/app/sitemap.ts
+++ b/document/app/sitemap.ts
@@ -1,0 +1,54 @@
+import { MetadataRoute } from 'next';
+import { source } from '@/lib/source';
+import { i18n } from '@/lib/i18n';
+
+// 由 CI/CD 构建参数传入: doc.fastgpt.cn 或 doc.fastgpt.io
+const baseUrl = process.env.NEXT_PUBLIC_DOC_DOMAIN
+  ? `https://${process.env.NEXT_PUBLIC_DOC_DOMAIN}`
+  : 'https://doc.fastgpt.io';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const entries: MetadataRoute.Sitemap = [];
+
+  for (const lang of i18n.languages) {
+    const pages = source.getPages(lang);
+
+    // 首页
+    entries.push({
+      url: `${baseUrl}/${lang}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1.0,
+      alternates: {
+        languages: Object.fromEntries(
+          i18n.languages.map((l) => [l, `${baseUrl}/${l}`])
+        )
+      }
+    });
+
+    // 所有文档页面
+    for (const page of pages) {
+      const slug = page.slugs?.join('/') || '';
+      const url = `${baseUrl}/${lang}/docs/${slug}`;
+
+      const alternates: Record<string, string> = {};
+      for (const altLang of i18n.languages) {
+        alternates[altLang] = `${baseUrl}/${altLang}/docs/${slug}`;
+      }
+
+      entries.push({
+        url,
+        lastModified: page.data.lastModified
+          ? new Date(page.data.lastModified)
+          : new Date(),
+        changeFrequency: 'weekly',
+        priority: 0.8,
+        alternates: {
+          languages: alternates
+        }
+      });
+    }
+  }
+
+  return entries;
+}

--- a/document/public/robots.txt
+++ b/document/public/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+
+# Sitemaps
+Sitemap: https://doc.fastgpt.cn/sitemap.xml
+Sitemap: https://doc.fastgpt.io/sitemap.xml


### PR DESCRIPTION
## 变更内容

### 新增
- `document/app/sitemap.ts` — 动态生成所有文档页面的 sitemap，包含中英文 hreflang alternates
- `document/public/robots.txt` — 允许爬虫访问，指向 doc.fastgpt.cn 和 doc.fastgpt.io 的 sitemap

### 优化
- `generateMetadata` 增强：
  - hreflang alternates（zh-CN ↔ en 互相标注）
  - OpenGraph 标签（社交分享）
  - Twitter Card 标签
  - Canonical URL
  - description 兜底（frontmatter 没写时自动生成）

## 背景

通过流量分析发现 doc.fastgpt.cn 和 doc.fastgpt.io 缺少 sitemap 和完整的 meta 标签，影响搜索引擎收录效率。