### PR TITLE
fix(workflow): 恢复循环开始节点的数组元素输出

### DIFF
--- a/packages/global/core/workflow/template/system/loop/loopStart.ts
+++ b/packages/global/core/workflow/template/system/loop/loopStart.ts
@@ -43,6 +43,13 @@ export const LoopStartNode: FlowNodeTemplateType = {
   ],
   outputs: [
     {
+      id: NodeOutputKeyEnum.loopStartInput,
+      key: NodeOutputKeyEnum.loopStartInput,
+      label: i18nT('workflow:Array_element'),
+      type: FlowNodeOutputTypeEnum.static,
+      valueType: WorkflowIOValueTypeEnum.any
+    },
+    {
       id: NodeOutputKeyEnum.loopStartIndex,
       key: NodeOutputKeyEnum.loopStartIndex,
       label: i18nT('workflow:Array_element_index'),


### PR DESCRIPTION
## 背景
修复 #6482：批量执行（循环）时，循环开始节点无法将当前数组元素继续传递到后续节点，导致循环体内依赖该元素的节点取值失败。

## 根因
`LoopStartNode` 模板中仅暴露了 `loopStartIndex` 输出，没有暴露 `loopStartInput` 输出。
虽然运行时 `dispatchLoopStart` 已写入了 `loopStartInput`，但由于节点模板缺少对应 output 定义，前端/编排层无法正确建立对该值的后续引用。

## 修复
在 `packages/global/core/workflow/template/system/loop/loopStart.ts` 的 `outputs` 中补充：
- `loopStartInput`（label: `Array_element`，type: static，valueType: any）

## 影响
- 循环体内可以正常引用当前数组元素并向后续节点传递。
- 不改变原有执行流程，仅补齐缺失的输出声明，兼容性风险低。

## 变更文件
- `packages/global/core/workflow/template/system/loop/loopStart.ts`
