### PR TITLE
fix(auth): prevent ended mongoose session use in pre-login code cleanup

### DIFF
--- a/packages/service/support/user/auth/controller.ts
+++ b/packages/service/support/user/auth/controller.ts
@@ -57,10 +57,13 @@ export const authCode = async ({
       return Promise.reject(new UserError(i18nT('common:error.code_error')));
     }
 
+    const authId = result._id;
+
     setTimeout(async () => {
-      await result.deleteOne({ session }).catch();
+      await MongoUserAuth.deleteOne({ _id: authId }).catch();
     }, 60000);
 
     return 'SUCCESS';
   });
 };
+


### PR DESCRIPTION
## Summary
- fix `authCode` delayed cleanup to avoid reusing a transaction-bound document/session after `mongoSessionRun` has ended
- store the auth record `_id` and run cleanup via `MongoUserAuth.deleteOne({ _id })` in the timeout callback
- this removes the `Cannot set a document's session to a session that has ended` runtime error seen in `/api/support/user/account/preLogin` flow

## Root cause
`result` is loaded inside `mongoSessionRun` with an active mongoose session.
A delayed `setTimeout` later called `result.deleteOne({ session })` after the transaction finished and session was ended, which triggers mongoose session-ended error.

## Validation
- code path inspection confirms delayed deletion no longer depends on ended session/document-bound session

Fixes #6476
