### PR TITLE
docs: add MiniMax model provider integration guide

### DIFF
--- a/document/content/docs/self-host/config/model/meta.en.json
+++ b/document/content/docs/self-host/config/model/meta.en.json
@@ -1,4 +1,4 @@
 {
   "title": "Model Configuration",
-  "pages": ["intro", "siliconCloud"]
+  "pages": ["intro", "siliconCloud", "minimax"]
 }

--- a/document/content/docs/self-host/config/model/meta.json
+++ b/document/content/docs/self-host/config/model/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "模型配置方案",
-  "pages": ["intro", "siliconCloud"]
+  "pages": ["intro", "siliconCloud", "minimax"]
 }

--- a/document/content/docs/self-host/config/model/minimax.en.mdx
+++ b/document/content/docs/self-host/config/model/minimax.en.mdx
@@ -1,0 +1,30 @@
+---
+title: MiniMax Integration Example
+description: MiniMax integration example for FastGPT
+---
+
+[MiniMax](https://www.minimaxi.com) is an AI technology company that provides high-performance large language model API services. MiniMax's API is compatible with the OpenAI format, making it easy to integrate with FastGPT.
+
+Before reading this guide, make sure you've read the [Model Configuration Guide](/docs/self-host/config/model/intro).
+
+## 1. Get an API Key
+
+1. Visit [MiniMax Platform](https://platform.minimaxi.com), register and log in.
+2. Go to the console and create an API Key.
+
+## 2. Add Models
+
+The system includes built-in MiniMax models. Simply search for `MiniMax` on the `Model Configuration` page and enable the models you need. If you need additional models, you can [add them manually](/docs/self-host/config/model/intro/#add-a-custom-model).
+
+## 3. Add a Model Channel
+
+On the Model Channels page, add a new MiniMax channel:
+
+- Protocol type: Select **MiniMax**
+- Proxy URL: `https://api.minimax.io/v1`
+- Enter your MiniMax API Key
+- Select the models you just enabled
+
+## 4. Test Models
+
+After configuration, click the test button in the channel list to verify the models are working properly.

--- a/document/content/docs/self-host/config/model/minimax.mdx
+++ b/document/content/docs/self-host/config/model/minimax.mdx
@@ -1,0 +1,30 @@
+---
+title: MiniMax 接入示例
+description: MiniMax 接入示例
+---
+
+[MiniMax](https://www.minimaxi.com) 是一家通用人工智能科技公司，提供高性能的大语言模型 API 服务。MiniMax 的 API 兼容 OpenAI 格式，可以方便地接入 FastGPT。
+
+在阅读该章之前，请先确保你阅读了[模型配置说明](/docs/self-host/config/model/intro)。
+
+## 1. 获取 API Key
+
+1. 访问 [MiniMax 开放平台](https://platform.minimaxi.com)，注册并登录账号。
+2. 进入控制台，创建 API Key。
+
+## 2. 新增模型
+
+系统内置了 MiniMax 的模型，直接在`模型配置`页面搜索 `MiniMax` 并启用即可。如果需要其他模型，可以[手动添加](/docs/self-host/config/model/intro/#新增自定义模型)。
+
+## 3. 新增模型渠道
+
+在模型渠道页，新增一个 MiniMax 的渠道：
+
+- 协议类型选择 **MiniMax**
+- 代理地址填写：`https://api.minimax.io/v1`
+- 填写 MiniMax 的 API Key
+- 选择刚刚启用的模型
+
+## 4. 测试模型
+
+配置完成后，可以在渠道列表中点击测试按钮，验证模型是否正常工作。


### PR DESCRIPTION
## Summary

- Add MiniMax model provider integration documentation (Chinese + English)
- Add MiniMax entry to model configuration navigation (meta.json)
- Documentation follows the standard siliconCloud example format

## Changes

- `document/content/docs/self-host/config/model/minimax.mdx` - Chinese documentation
- `document/content/docs/self-host/config/model/minimax.en.mdx` - English documentation
- `document/content/docs/self-host/config/model/meta.json` - Add minimax to pages list
- `document/content/docs/self-host/config/model/meta.en.json` - Add minimax to pages list