### PR TITLE
fix: fix left-aligned list marker styling in chat welcome guide

### DIFF
--- a/projects/app/src/components/Markdown/chat/Guide.tsx
+++ b/projects/app/src/components/Markdown/chat/Guide.tsx
@@ -20,7 +20,13 @@ function MyLink(e: any) {
       {text}
     </Link>
   ) : (
-    <Box as={'li'} mb={1}>
+    <Box
+      as={'li'}
+      mb={1}
+      sx={{
+        listStylePosition: 'inside'
+      }}
+    >
       <Box
         as={'span'}
         color={'primary.700'}


### PR DESCRIPTION
### Summary
This PR fixes an issue where the bullet point marker (`●`) for suggested questions in the chat welcome message was rendered too close to the left edge, making it appear misaligned or cramped.
### Issue
In the chat welcome guide, the default styling for the list item (`<li>`) caused the bullet point to be positioned too far to the left, which negatively impacted readability and visual aesthetics.
### Root Cause
The problem occurred in `projects/app/src/components/Markdown/chat/Guide.tsx`. The component renders suggested questions using a `<Box as="li">`, but the default `list-style-position` is `outside`. This causes the bullet to be placed outside the content flow, leading to the alignment issue.
### Solution
Modified the `<Box as="li">` element in the `MyLink` function within `Guide.tsx` to include the `sx` prop with `listStylePosition: 'inside'`.
This change moves the list marker (the bullet point) into the content flow of the list item, ensuring it aligns properly with the text content and appears less cramped against the left edge.