### PR TITLE
Refactor/unify sandbox client

### DIFF
--- a/packages/service/core/agentSkills/sandboxConfig.ts
+++ b/packages/service/core/agentSkills/sandboxConfig.ts
@@ -340,6 +340,39 @@ export function buildVolumeConfig(
 }
 
 /**
+ * Poll the sandbox endpoint until the service inside the container is accepting connections.
+ *
+ * Uses HTTP HEAD to avoid triggering application logic; any HTTP response
+ * (including 4xx/5xx) means the port is open and the service is ready.
+ * Retries on network errors (ECONNREFUSED / fetch failure) until timeout.
+ */
+export async function waitForEndpointReady(
+  endpoint: SkillSandboxEndpointType,
+  options?: { timeoutMs?: number; intervalMs?: number }
+): Promise<void> {
+  const timeoutMs = options?.timeoutMs ?? 30_000;
+  const intervalMs = options?.intervalMs ?? 500;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      await fetch(endpoint.url, {
+        method: 'HEAD',
+        signal: AbortSignal.timeout(3_000)
+      });
+      return; // any response means port is open
+    } catch {
+      // ECONNREFUSED or timeout — service not ready yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error(
+    `Sandbox endpoint ${endpoint.url} did not become ready within ${timeoutMs / 1000}s`
+  );
+}
+
+/**
  * Build container env vars for the sandbox process.
  */
 export function buildBaseContainerEnv(

--- a/packages/service/core/agentSkills/sandboxController.ts
+++ b/packages/service/core/agentSkills/sandboxController.ts
@@ -5,7 +5,7 @@
  *
  */
 
-import type { ISandbox, OpenSandboxVolume } from '@fastgpt-sdk/sandbox-adapter';
+import type { ISandbox } from '@fastgpt-sdk/sandbox-adapter';
 import mongoose from 'mongoose';
 import { MongoSandboxInstance } from '../ai/sandbox/schema';
 import { MongoAgentSkills } from './schema';
@@ -16,14 +16,11 @@ import {
   getSandboxDefaults,
   validateSandboxConfig,
   getSkillSizeLimits,
-  buildSandboxAdapter,
   connectToProviderSandbox,
   disconnectFromProviderSandbox,
   getProviderSandboxEndpoint,
-  getVolumeManagerConfig,
-  ensureSessionVolume,
-  buildVolumeConfig,
-  buildBaseContainerEnv
+  buildBaseContainerEnv,
+  waitForEndpointReady
 } from './sandboxConfig';
 import type {
   SandboxInstanceSchemaType,
@@ -32,8 +29,7 @@ import type {
 } from '@fastgpt/global/core/agentSkills/type';
 import { SandboxTypeEnum } from '@fastgpt/global/core/agentSkills/constants';
 import { SandboxStatusEnum } from '@fastgpt/global/core/ai/sandbox/constants';
-import { getSandboxClient } from '../ai/sandbox/controller';
-import { mongoSessionRun } from '../../common/mongo/sessionRun';
+import { getSandboxClient, type SandboxClient } from '../ai/sandbox/controller';
 import { getLogger, LogCategories } from '../../common/logger';
 import { env } from '../../env';
 import type { SandboxStatusItemType } from '@fastgpt/global/core/chat/type';
@@ -172,22 +168,41 @@ export async function createEditDebugSandbox(
       sandboxId: existingInstance.sandboxId
     });
 
-    let resumeSandboxAdapter: ISandbox | null = null;
     try {
-      const newAdapter = await connectToProviderSandbox(providerConfig, existingInstance.sandboxId);
-      resumeSandboxAdapter = newAdapter;
-
       onProgress?.({ sandboxId: skillId, phase: 'creatingContainer' });
-      await newAdapter.start();
-      await newAdapter.waitUntilReady(60000);
 
-      const endpointInfo = await getProviderSandboxEndpoint(newAdapter, defaults.targetPort);
+      // getSandboxClient internally calls ensureAvailable():
+      //   - updates DB status=running, lastActiveAt
+      //   - calls provider.ensureRunning() to ensure container is running
+      // Pass skill-specific createConfig so the container is rebuilt with the
+      // correct image/entrypoint/env/metadata if it was accidentally deleted.
+      const client = await getSandboxClient(
+        { sandboxId: existingInstance.sandboxId },
+        {
+          createConfig: {
+            image: sandboxImage,
+            entrypoint: [entrypoint ?? defaults.entrypoint],
+            env: buildBaseContainerEnv(existingInstance.sandboxId, defaults.workDirectory, true),
+            metadata: {
+              skillId,
+              teamId,
+              sandboxType: SandboxTypeEnum.editDebug,
+              sessionId: existingInstance.sandboxId
+            }
+          }
+        }
+      );
 
+      const endpointInfo = await getProviderSandboxEndpoint(client.provider, defaults.targetPort);
+
+      // Wait for the HTTP service inside the container to bind its port before
+      // sending the ready SSE event — prevents ECONNREFUSED in the client iframe.
+      await waitForEndpointReady(endpointInfo);
+
+      // Update endpoint and other sandbox metadata to DB
       await MongoSandboxInstance.updateOne(
         { _id: existingInstance._id },
         {
-          status: SandboxStatusEnum.running,
-          lastActiveAt: new Date(),
           'metadata.endpoint': endpointInfo,
           'metadata.providerStatus': { state: 'Running' }
         }
@@ -209,10 +224,6 @@ export async function createEditDebugSandbox(
     } catch (error) {
       addLog.error('[Sandbox] Failed to resume stopped sandbox', { error });
       throw error;
-    } finally {
-      if (resumeSandboxAdapter) {
-        await disconnectFromProviderSandbox(resumeSandboxAdapter);
-      }
     }
   }
 
@@ -248,6 +259,7 @@ export async function createEditDebugSandbox(
 
   // === Phase 3: Sandbox operations ===
   let sandbox: ISandbox | null = null;
+  let sandboxClient: SandboxClient | null = null;
 
   try {
     addLog.info('[Sandbox] Creating sandbox instance', {
@@ -257,39 +269,29 @@ export async function createEditDebugSandbox(
     onProgress?.({ sandboxId: skillId, phase: 'creatingContainer' });
     const sessionId = new mongoose.Types.ObjectId().toHexString();
 
-    const createEntrypoint = defaults.entrypoint;
-
-    let volumes: OpenSandboxVolume[] | undefined;
-    if (providerConfig.provider === 'opensandbox' && env.AGENT_SANDBOX_ENABLE_VOLUME) {
-      const vmConfig = getVolumeManagerConfig();
-      const claimName = await ensureSessionVolume(sessionId, vmConfig);
-      volumes = [
-        buildVolumeConfig(providerConfig.runtime, sessionId, claimName, vmConfig.mountPath)
-      ];
-    }
-
-    const newSandbox = buildSandboxAdapter(providerConfig, {
-      providerSandboxId: sessionId,
-      createConfig: {
-        image: sandboxImage,
-        entrypoint: [entrypoint ?? createEntrypoint],
-        env: buildBaseContainerEnv(sessionId, defaults.workDirectory, true),
-        volumes,
-        metadata: {
-          skillId,
-          teamId,
-          sandboxType: SandboxTypeEnum.editDebug,
-          sessionId
+    // getSandboxClient handles volumes internally (via getVolumeManagerConfig) and calls
+    // provider.ensureRunning() which creates the container when it doesn't exist
+    const client = await getSandboxClient(
+      { sandboxId: sessionId },
+      {
+        createConfig: {
+          image: sandboxImage,
+          entrypoint: [entrypoint ?? defaults.entrypoint],
+          env: buildBaseContainerEnv(sessionId, defaults.workDirectory, true),
+          // volumes: handled internally by getSandboxClient via getVolumeManagerConfig
+          metadata: {
+            skillId,
+            teamId,
+            sandboxType: SandboxTypeEnum.editDebug,
+            sessionId
+          }
         }
       }
-    });
-    sandbox = newSandbox; // keep outer ref for finally cleanup
+    );
+    sandboxClient = client;
+    sandbox = client.provider;
 
-    await newSandbox.create();
-
-    addLog.info('[Sandbox] Waiting for sandbox to be ready');
-    await newSandbox.waitUntilReady(60000);
-    const sandboxInfo = await newSandbox.getInfo();
+    const sandboxInfo = await client.provider.getInfo();
     if (!sandboxInfo) throw new Error('Failed to get sandbox info after creation');
 
     // Upload package to sandbox and extract
@@ -298,7 +300,7 @@ export async function createEditDebugSandbox(
     addLog.info('[Sandbox] Uploading package to sandbox', { path: zipPath });
 
     onProgress?.({ sandboxId: skillId, phase: 'uploadingPackage' });
-    await newSandbox.writeFiles([
+    await client.provider.writeFiles([
       {
         path: zipPath,
         data: standardizedBuffer
@@ -307,7 +309,7 @@ export async function createEditDebugSandbox(
 
     addLog.info('[Sandbox] Extracting package');
     onProgress?.({ sandboxId: skillId, phase: 'extractingPackage' });
-    const extractResult = await newSandbox.execute(
+    const extractResult = await client.provider.execute(
       `mkdir -p ${defaults.workDirectory} && cd ${defaults.workDirectory} && unzip -o package.zip && rm package.zip`
     );
 
@@ -319,55 +321,55 @@ export async function createEditDebugSandbox(
 
     // Get endpoint
     addLog.info('[Sandbox] Getting endpoint', { port: defaults.targetPort });
-    const endpointInfo = await getProviderSandboxEndpoint(newSandbox, defaults.targetPort);
+    const endpointInfo = await getProviderSandboxEndpoint(client.provider, defaults.targetPort);
+
+    // Wait for the HTTP service to accept connections before persisting and emitting ready.
+    // The container may still be initializing even after package extraction completes.
+    await waitForEndpointReady(endpointInfo);
 
     addLog.info('[Sandbox] Endpoint obtained', endpointInfo);
 
-    // Persist to MongoDB
-    const newSandboxDoc = await mongoSessionRun(async (session) => {
-      const doc = await MongoSandboxInstance.create(
-        [
-          {
+    // Enrich the DB record created by getSandboxClient.ensureAvailable() with full skill metadata.
+    // Use sessionId (the client-side key) because ensureAvailable() stores the record with
+    // sandboxId=sessionId, not with the provider-assigned sandboxInfo.id.
+    const newSandboxDoc = await MongoSandboxInstance.findOneAndUpdate(
+      { sandboxId: sessionId },
+      {
+        $set: {
+          appId: skillId,
+          userId: tmbId,
+          chatId: EDIT_DEBUG_CHAT_ID,
+          metadata: {
+            sandboxType: SandboxTypeEnum.editDebug,
+            teamId,
+            tmbId,
+            skillId,
             provider: providerConfig.provider,
-            sandboxId: sandboxInfo.id,
-            appId: skillId,
-            userId: tmbId,
-            chatId: EDIT_DEBUG_CHAT_ID,
-            status: SandboxStatusEnum.running,
-            lastActiveAt: new Date(),
-            createdAt: new Date(),
-            metadata: {
-              sandboxType: SandboxTypeEnum.editDebug,
-              teamId,
-              tmbId,
-              skillId,
-              provider: providerConfig.provider,
-              image: sandboxInfo.image,
-              providerStatus: {
-                state: sandboxInfo.status.state,
-                message: sandboxInfo.status.message,
-                reason: sandboxInfo.status.reason
-              },
-              providerCreatedAt: sandboxInfo.createdAt,
-              endpoint: endpointInfo,
-              storage: {
-                bucket: activeVersion.storage.bucket,
-                key: activeVersion.storage.key,
-                size: standardizedBuffer.length,
-                uploadedAt: new Date()
-              },
-              metadata: new Map([
-                ['skillName', skill.name],
-                ['version', activeVersion.version.toString()]
-              ])
-            }
+            image: sandboxInfo.image,
+            providerStatus: {
+              state: sandboxInfo.status.state,
+              message: sandboxInfo.status.message,
+              reason: sandboxInfo.status.reason
+            },
+            providerCreatedAt: sandboxInfo.createdAt,
+            endpoint: endpointInfo,
+            storage: {
+              bucket: activeVersion.storage.bucket,
+              key: activeVersion.storage.key,
+              size: standardizedBuffer.length,
+              uploadedAt: new Date()
+            },
+            metadata: new Map([
+              ['skillName', skill.name],
+              ['version', activeVersion.version.toString()]
+            ])
           }
-        ],
-        { session }
-      );
+        }
+      },
+      { new: true }
+    );
 
-      return doc[0];
-    });
+    if (!newSandboxDoc) throw new Error('Failed to find sandbox document after creation');
 
     addLog.info('[Sandbox] Sandbox info saved to database', {
       sandboxId: newSandboxDoc._id
@@ -377,7 +379,7 @@ export async function createEditDebugSandbox(
       sandboxId: skillId,
       phase: 'ready',
       endpoint: endpointInfo,
-      providerSandboxId: sandboxInfo.id
+      providerSandboxId: sessionId
     });
 
     return {
@@ -395,10 +397,12 @@ export async function createEditDebugSandbox(
       rawBody: (error as any)?.cause?.rawBody ?? (error as any)?.rawBody
     });
 
-    // Cleanup provider sandbox if it was created
-    if (sandbox) {
+    // sandboxClient.delete() cleans up: provider container + session volume + DB record
+    if (sandboxClient) {
       try {
-        await sandbox.delete();
+        await sandboxClient.delete();
+        // Prevent finally from trying to disconnect an already-deleted sandbox
+        sandbox = null;
       } catch (cleanupError) {
         addLog.error('[Sandbox] Failed to cleanup sandbox after error', { cleanupError });
       }

--- a/packages/service/core/agentSkills/sandboxController.ts
+++ b/packages/service/core/agentSkills/sandboxController.ts
@@ -129,41 +129,8 @@ export async function createEditDebugSandbox(
     'metadata.sandboxType': SandboxTypeEnum.editDebug
   });
 
-  if (existingInstance?.status === SandboxStatusEnum.running) {
-    // Reuse running sandbox - return stored endpoint directly
-    addLog.info('[Sandbox] Found running sandbox instance, reusing', {
-      instanceId: existingInstance._id,
-      sandboxId: existingInstance.sandboxId
-    });
-
-    const endpointInfo = existingInstance.metadata!.endpoint!;
-
-    await MongoSandboxInstance.updateOne(
-      { _id: existingInstance._id },
-      { lastActiveAt: new Date() }
-    );
-
-    onProgress?.({
-      sandboxId: skillId,
-      phase: 'ready',
-      endpoint: endpointInfo,
-      providerSandboxId: existingInstance.sandboxId
-    });
-
-    return {
-      sandboxId: existingInstance._id.toString(),
-      providerSandboxId: existingInstance.sandboxId,
-      endpoint: endpointInfo,
-      status: {
-        state: existingInstance.status
-        // message: existingInstance.metadata!.providerStatus.message
-      }
-    };
-  }
-
-  if (existingInstance?.status === SandboxStatusEnum.stopped) {
-    // Resume stopped sandbox
-    addLog.info('[Sandbox] Found stopped sandbox instance, resuming', {
+  if (existingInstance) {
+    addLog.info('[Sandbox] Found existing sandbox instance, ensuring running', {
       instanceId: existingInstance._id,
       sandboxId: existingInstance.sandboxId
     });
@@ -173,7 +140,7 @@ export async function createEditDebugSandbox(
 
       // getSandboxClient internally calls ensureAvailable():
       //   - updates DB status=running, lastActiveAt
-      //   - calls provider.ensureRunning() to ensure container is running
+      //   - calls provider.ensureRunning() to handle both running and stopped containers
       // Pass skill-specific createConfig so the container is rebuilt with the
       // correct image/entrypoint/env/metadata if it was accidentally deleted.
       const client = await getSandboxClient(
@@ -199,7 +166,7 @@ export async function createEditDebugSandbox(
       // sending the ready SSE event — prevents ECONNREFUSED in the client iframe.
       await waitForEndpointReady(endpointInfo);
 
-      // Update endpoint and other sandbox metadata to DB
+      // Update endpoint and sandbox metadata in DB
       await MongoSandboxInstance.updateOne(
         { _id: existingInstance._id },
         {
@@ -222,7 +189,7 @@ export async function createEditDebugSandbox(
         status: { state: 'Running' }
       };
     } catch (error) {
-      addLog.error('[Sandbox] Failed to resume stopped sandbox', { error });
+      addLog.error('[Sandbox] Failed to ensure sandbox running', { error });
       throw error;
     }
   }

--- a/packages/service/core/ai/sandbox/config.ts
+++ b/packages/service/core/ai/sandbox/config.ts
@@ -45,9 +45,10 @@ export const buildOpenSandboxCreateConfig = (
   opts: {
     volumes?: OpenSandboxConfigType['volumes'];
     resourceLimits?: OpenSandboxConfigType['resourceLimits'];
+    createConfig?: OpenSandboxConfigType;
   } = {}
 ): OpenSandboxConfigType => {
-  if (!env.AGENT_SANDBOX_OPENSANDBOX_IMAGE_REPO) {
+  if (!env.AGENT_SANDBOX_OPENSANDBOX_IMAGE_REPO && !opts.createConfig?.image) {
     throw new Error('AGENT_SANDBOX_OPENSANDBOX_IMAGE_REPO is required for opensandbox provider');
   }
   return {
@@ -56,6 +57,7 @@ export const buildOpenSandboxCreateConfig = (
       tag: env.AGENT_SANDBOX_OPENSANDBOX_IMAGE_TAG
     },
     ...(opts.resourceLimits ? { resourceLimits: opts.resourceLimits } : {}),
+    ...opts.createConfig,
     ...(opts.volumes ? { volumes: opts.volumes } : {})
   };
 };

--- a/packages/service/core/ai/sandbox/controller.ts
+++ b/packages/service/core/ai/sandbox/controller.ts
@@ -69,12 +69,11 @@ export class SandboxClient {
       this.provider = createSandbox(
         'opensandbox',
         getOpenSandboxConnectionConfig({ sessionId: this.sandboxId }),
-        opts?.createConfig
-          ? { ...opts.createConfig, volumes: opts?.vmConfig?.volumes }
-          : buildOpenSandboxCreateConfig({
-              resourceLimits: opts?.resourceLimits,
-              volumes: opts?.vmConfig?.volumes
-            })
+        buildOpenSandboxCreateConfig({
+          resourceLimits: opts?.resourceLimits,
+          volumes: opts?.vmConfig?.volumes,
+          createConfig: opts?.createConfig
+        })
       );
     } else if (providerName === 'e2b') {
       if (!env.AGENT_SANDBOX_E2B_API_KEY) {

--- a/packages/service/core/ai/sandbox/controller.ts
+++ b/packages/service/core/ai/sandbox/controller.ts
@@ -9,7 +9,8 @@ import {
   createSandbox,
   type ExecuteResult,
   type ISandbox,
-  type ResourceLimits
+  type ResourceLimits,
+  type OpenSandboxConfigType
 } from '@fastgpt-sdk/sandbox-adapter';
 import {
   getOpenSandboxConnectionConfig,
@@ -49,6 +50,7 @@ export class SandboxClient {
     private readonly opts: {
       resourceLimits?: ResourceLimits;
       vmConfig?: VolumeManagerResult | undefined;
+      createConfig?: OpenSandboxConfigType;
     }
   ) {
     this.sandboxId = props.sandboxId;
@@ -62,14 +64,17 @@ export class SandboxClient {
       const config = getSealosConnectionConfig(this.sandboxId);
       this.provider = createSandbox('sealosdevbox', config, undefined);
     } else if (providerName === 'opensandbox') {
-      // volumes 在 ensureAvailable 中异步获取后重建 provider，此处用基础 createConfig
+      // volumes always come from vmConfig (ensures PVC binding is correct);
+      // custom createConfig takes priority for image/entrypoint/env/metadata
       this.provider = createSandbox(
         'opensandbox',
         getOpenSandboxConnectionConfig({ sessionId: this.sandboxId }),
-        buildOpenSandboxCreateConfig({
-          resourceLimits: opts?.resourceLimits,
-          volumes: opts?.vmConfig?.volumes
-        })
+        opts?.createConfig
+          ? { ...opts.createConfig, volumes: opts?.vmConfig?.volumes }
+          : buildOpenSandboxCreateConfig({
+              resourceLimits: opts?.resourceLimits,
+              volumes: opts?.vmConfig?.volumes
+            })
       );
     } else if (providerName === 'e2b') {
       if (!env.AGENT_SANDBOX_E2B_API_KEY) {
@@ -170,6 +175,7 @@ export const getSandboxClient = async (
     | UnionIdType,
   opts: {
     resourceLimits?: ResourceLimits;
+    createConfig?: OpenSandboxConfigType;
   } = {}
 ) => {
   const sandboxId = (() => {

--- a/packages/service/core/workflow/dispatch/ai/agent/sub/sandbox/lifecycle.ts
+++ b/packages/service/core/workflow/dispatch/ai/agent/sub/sandbox/lifecycle.ts
@@ -8,7 +8,7 @@
  * - releaseAgentSandbox：断开 SDK 连接，不销毁容器
  */
 
-import type { ISandbox, OpenSandboxVolume } from '@fastgpt-sdk/sandbox-adapter';
+import type { ISandbox } from '@fastgpt-sdk/sandbox-adapter';
 import type { HydratedDocument } from 'mongoose';
 import { MongoAgentSkills } from '../../../../../../agentSkills/schema';
 import { MongoSandboxInstance } from '../../../../../../ai/sandbox/schema';
@@ -19,16 +19,12 @@ import {
   getSandboxProviderConfig,
   getSandboxDefaults,
   validateSandboxConfig,
-  buildSandboxAdapter,
-  connectToProviderSandbox,
   disconnectFromProviderSandbox,
-  getVolumeManagerConfig,
-  ensureSessionVolume,
-  buildVolumeConfig,
   buildBaseContainerEnv
 } from '../../../../../../agentSkills/sandboxConfig';
 import { SandboxTypeEnum } from '@fastgpt/global/core/agentSkills/constants';
 import { SandboxStatusEnum } from '@fastgpt/global/core/ai/sandbox/constants';
+import { getSandboxClient, type SandboxClient } from '../../../../../../ai/sandbox/controller';
 import { env } from '../../../../../../../env';
 import type {
   AgentSkillSchemaType,
@@ -202,21 +198,11 @@ export async function createAgentSandbox(
     });
 
     onProgress?.({ sandboxId: sessionId, phase: 'connecting', isWarmStart: true });
-    const sandbox = await connectToProviderSandbox(providerConfig, existingInstance.sandboxId);
 
-    if (existingInstance.status === SandboxStatusEnum.stopped) {
-      logger.info('[Agent Sandbox] Resuming stopped sandbox', {
-        sessionId,
-        providerSandboxId: existingInstance.sandboxId
-      });
-      await sandbox.start();
-      await sandbox.waitUntilReady(60000);
-    }
-
-    await MongoSandboxInstance.updateOne(
-      { _id: existingInstance._id },
-      { lastActiveAt: new Date() }
-    );
+    // getSandboxClient internally calls ensureAvailable():
+    //   - updates DB status=running, lastActiveAt
+    //   - calls provider.ensureRunning() to ensure container is running (handles stopped→running)
+    const client = await getSandboxClient({ sandboxId: existingInstance.sandboxId });
 
     const reusedSkillIds = existingInstance.metadata?.skillIds
       ? existingInstance.metadata.skillIds.map(String)
@@ -227,10 +213,9 @@ export async function createAgentSandbox(
     const mergedSkills = skills.map((skill) =>
       mergeSkillWithVersion(skill.toJSON(), versionMap.get(String(skill._id)))
     );
-    // Dynamically discover deployed skills instead of reconstructing from DB name assumptions
-    const deployedSkills = await discoverSkillsInSandbox(sandbox, defaults.workDirectory);
+    const deployedSkills = await discoverSkillsInSandbox(client.provider, defaults.workDirectory);
     return {
-      sandbox,
+      sandbox: client.provider,
       providerSandboxId: existingInstance.sandboxId,
       sessionId,
       skills: mergedSkills,
@@ -284,46 +269,35 @@ export async function createAgentSandbox(
     }
   }
 
-  // Step 3: Create sandbox container, inject SESSION_ID
-  let sandbox: ISandbox | null = null;
+  // Step 3: Create sandbox container via getSandboxClient (handles volumes internally)
+  let sandboxClient: SandboxClient | null = null;
 
   try {
-    const createEntrypoint = defaults.entrypoint;
-
-    let volumes: OpenSandboxVolume[] | undefined;
-    if (providerConfig.provider === 'opensandbox' && env.AGENT_SANDBOX_ENABLE_VOLUME) {
-      const vmConfig = getVolumeManagerConfig();
-      const claimName = await ensureSessionVolume(sessionId, vmConfig);
-      volumes = [
-        buildVolumeConfig(providerConfig.runtime, sessionId, claimName, vmConfig.mountPath)
-      ];
-    }
-
-    const createConfig = {
-      image: image ?? defaults.defaultImage,
-      entrypoint: [entrypoint ?? createEntrypoint],
-      env: buildBaseContainerEnv(sessionId, defaults.workDirectory, false),
-      volumes,
-      metadata: {
-        teamId,
-        tmbId,
-        sandboxType: SandboxTypeEnum.sessionRuntime,
-        skillIds: skillIds.join('-'),
-        sessionId
-      }
-    };
-
-    sandbox = buildSandboxAdapter(providerConfig, {
-      providerSandboxId: sessionId,
-      createConfig
-    });
-
     onProgress?.({ sandboxId: sessionId, phase: 'creatingContainer', isWarmStart: false });
-    await sandbox.create();
 
-    await sandbox.waitUntilReady(60000);
+    // getSandboxClient handles volumes internally (via getVolumeManagerConfig) and calls
+    // provider.ensureRunning() which creates the container when it doesn't exist
+    const client = await getSandboxClient(
+      { sandboxId: sessionId },
+      {
+        createConfig: {
+          image: image ?? defaults.defaultImage,
+          entrypoint: [entrypoint ?? defaults.entrypoint],
+          env: buildBaseContainerEnv(sessionId, defaults.workDirectory, false),
+          // volumes: handled internally by getSandboxClient via getVolumeManagerConfig
+          metadata: {
+            teamId,
+            tmbId,
+            sandboxType: SandboxTypeEnum.sessionRuntime,
+            skillIds: skillIds.join('-'),
+            sessionId
+          }
+        }
+      }
+    );
+    sandboxClient = client;
 
-    const sandboxInfo = await sandbox.getInfo();
+    const sandboxInfo = await client.provider.getInfo();
     if (!sandboxInfo) throw new Error('Failed to get sandbox info after creation');
 
     logger.info('[Agent Sandbox] Sandbox created', {
@@ -334,7 +308,7 @@ export async function createAgentSandbox(
     // Step 4: Deploy skill packages (only when skills are configured)
     if (hasSkills) {
       await deploySkillsToSandbox(
-        sandbox,
+        client.provider,
         deployableSkills,
         versionMap,
         defaults.workDirectory,
@@ -343,41 +317,43 @@ export async function createAgentSandbox(
       );
     }
     const deployedSkills = hasSkills
-      ? await discoverSkillsInSandbox(sandbox, defaults.workDirectory)
+      ? await discoverSkillsInSandbox(client.provider, defaults.workDirectory)
       : [];
 
-    // Step 5: Persist to MongoDB
-    await MongoSandboxInstance.create({
-      provider: providerConfig.provider,
-      sandboxId: sandboxInfo.id,
-      appId: teamId, // session-runtime uses teamId as appId
-      userId: tmbId,
-      chatId: sessionId,
-      status: SandboxStatusEnum.running,
-      lastActiveAt: new Date(),
-      createdAt: new Date(),
-      metadata: {
-        sandboxType: SandboxTypeEnum.sessionRuntime,
-        teamId,
-        tmbId,
-        sessionId,
-        skillIds: hasSkills ? deployableSkills.map((s) => s._id) : [],
-        provider: providerConfig.provider,
-        image: sandboxInfo.image,
-        providerStatus: {
-          state: sandboxInfo.status.state,
-          message: sandboxInfo.status.message,
-          reason: sandboxInfo.status.reason
-        },
-        providerCreatedAt: sandboxInfo.createdAt
+    // Step 5: Enrich the DB record created by getSandboxClient.ensureAvailable() with full metadata.
+    // Use sessionId (the client-side key) because ensureAvailable() stores the record with
+    // sandboxId=sessionId, not with the provider-assigned sandboxInfo.id.
+    await MongoSandboxInstance.findOneAndUpdate(
+      { sandboxId: sessionId },
+      {
+        $set: {
+          appId: teamId, // session-runtime uses teamId as appId
+          userId: tmbId,
+          chatId: sessionId,
+          metadata: {
+            sandboxType: SandboxTypeEnum.sessionRuntime,
+            teamId,
+            tmbId,
+            sessionId,
+            skillIds: hasSkills ? deployableSkills.map((s) => s._id) : [],
+            provider: providerConfig.provider,
+            image: sandboxInfo.image,
+            providerStatus: {
+              state: sandboxInfo.status.state,
+              message: sandboxInfo.status.message,
+              reason: sandboxInfo.status.reason
+            },
+            providerCreatedAt: sandboxInfo.createdAt
+          }
+        }
       }
-    });
+    );
 
     logger.info('[Agent Sandbox] Sandbox info saved to MongoDB', { sessionId });
 
     onProgress?.({ sandboxId: sessionId, phase: 'ready', isWarmStart: false });
     return {
-      sandbox,
+      sandbox: client.provider,
       providerSandboxId: sandboxInfo.id,
       sessionId,
       skills: hasSkills
@@ -392,13 +368,14 @@ export async function createAgentSandbox(
   } catch (error) {
     logger.error('[Agent Sandbox] Failed to create sandbox', { error });
 
-    if (sandbox) {
+    if (sandboxClient) {
       try {
-        await sandbox.delete();
+        // sandboxClient.delete() cleans up: provider container + session volume + DB record
+        await sandboxClient.delete();
       } catch (cleanupError) {
         logger.error('[Agent Sandbox] Cleanup failed after creation error', { cleanupError });
       }
-      await disconnectFromProviderSandbox(sandbox);
+      await disconnectFromProviderSandbox(sandboxClient.provider);
     }
 
     throw error;
@@ -436,9 +413,7 @@ export async function connectEditDebugSandbox(
   params: ConnectEditDebugSandboxParams
 ): Promise<AgentSandboxContext> {
   const { skillId, teamId } = params;
-  const providerConfig = getSandboxProviderConfig();
   const defaults = getSandboxDefaults();
-  validateSandboxConfig(providerConfig);
 
   const instanceDoc = await MongoSandboxInstance.findOne({
     appId: skillId,
@@ -458,9 +433,10 @@ export async function connectEditDebugSandbox(
     throw new Error('Skill not found');
   }
 
-  const sandbox = await connectToProviderSandbox(providerConfig, instanceDoc.sandboxId);
-
-  await MongoSandboxInstance.updateOne({ _id: instanceDoc._id }, { lastActiveAt: new Date() });
+  // getSandboxClient internally calls ensureAvailable():
+  //   - updates DB status=running, lastActiveAt
+  //   - calls provider.ensureRunning() to ensure container is running (handles stopped→running)
+  const client = await getSandboxClient({ sandboxId: instanceDoc.sandboxId });
 
   logger.info('[Agent Sandbox] Connected to edit-debug sandbox', {
     skillId,
@@ -468,10 +444,10 @@ export async function connectEditDebugSandbox(
   });
 
   // Dynamically discover deployed skills instead of reading from persisted metadata
-  const deployedSkills = await discoverSkillsInSandbox(sandbox, defaults.workDirectory);
+  const deployedSkills = await discoverSkillsInSandbox(client.provider, defaults.workDirectory);
 
   return {
-    sandbox,
+    sandbox: client.provider,
     providerSandboxId: instanceDoc.sandboxId,
     sessionId: String(instanceDoc._id), // editDebug sandbox uses its own _id as sessionId
     skills: [skill.toJSON()],

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.2",
-    "@fastgpt-sdk/sandbox-adapter": "^0.0.34",
+    "@fastgpt-sdk/sandbox-adapter": "^0.0.35",
     "@fastgpt-sdk/otel": "catalog:",
     "@fastgpt-sdk/storage": "catalog:",
     "@fastgpt/global": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,8 +250,8 @@ importers:
         specifier: 'catalog:'
         version: 0.1.2
       '@fastgpt-sdk/sandbox-adapter':
-        specifier: ^0.0.34
-        version: 0.0.34
+        specifier: ^0.0.35
+        version: 0.0.35
       '@fastgpt-sdk/storage':
         specifier: 'catalog:'
         version: 0.6.15(@opentelemetry/api@1.9.0)(@types/node@24.0.13)(jiti@2.6.0)(lightningcss@1.30.1)(proxy-agent@6.5.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
@@ -1212,6 +1212,10 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@alibaba-group/opensandbox@0.1.6':
+    resolution: {integrity: sha512-mZ2Q2qXNC0dgctoPIlcotnlPSJ1ODMG4DKQ3AA2lTO4ZoC/vWU3CzSL5pNEU7hakfMOotQiZVxunNItVGY4W8w==}
+    engines: {node: '>=20'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -2747,8 +2751,8 @@ packages:
   '@fastgpt-sdk/plugin@0.3.8':
     resolution: {integrity: sha512-GjKrXMHxeF5UMkYGXawrUpzZjVRw3DICNYODeYwsUVOy+/ltu5zuwsqLkuuGQ7Arp/SBCmYRjG/MHmeNp4xxfw==}
 
-  '@fastgpt-sdk/sandbox-adapter@0.0.34':
-    resolution: {integrity: sha512-YXCwycqs2yByOPUMMjm2tf0BYUJfLR9D4bvHDv6xIbfKT5btT+hR1pujW5nVawXJDefYNsDfLy8dQ+IkMd21xQ==}
+  '@fastgpt-sdk/sandbox-adapter@0.0.35':
+    resolution: {integrity: sha512-pgK4qRqt24xhs4tz5oZfYK7GYloYbJrFsONWZMiFvuRvPVF7hn0BRN0er3akXhX10gUj3ASFwLnWxycEsggapQ==}
     engines: {node: '>=18'}
 
   '@fastgpt-sdk/storage@0.6.15':
@@ -11772,6 +11776,11 @@ packages:
 
 snapshots:
 
+  '@alibaba-group/opensandbox@0.1.6':
+    dependencies:
+      openapi-fetch: 0.14.1
+      undici: 7.18.2
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.3.0':
@@ -13767,8 +13776,9 @@ snapshots:
       '@fortaine/fetch-event-source': 3.0.6
       zod: 4.1.12
 
-  '@fastgpt-sdk/sandbox-adapter@0.0.34':
+  '@fastgpt-sdk/sandbox-adapter@0.0.35':
     dependencies:
+      '@alibaba-group/opensandbox': 0.1.6
       '@e2b/code-interpreter': 2.4.0
 
   '@fastgpt-sdk/storage@0.6.15(@opentelemetry/api@1.9.0)(@types/node@20.17.24)(jiti@2.6.0)(lightningcss@1.30.1)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)':

--- a/projects/app/.env.template
+++ b/projects/app/.env.template
@@ -50,6 +50,7 @@ AGENT_SANDBOX_OPENSANDBOX_IMAGE_TAG=v0.1
 AGENT_SANDBOX_ENABLE_VOLUME=true
 AGENT_SANDBOX_VOLUME_MANAGER_URL=http://localhost:3005
 AGENT_SANDBOX_VOLUME_MANAGER_TOKEN=vmtoken
+# Recommended to set mount path to /home/sandbox when sandbox provider is opensandbox
 AGENT_SANDBOX_VOLUME_MANAGER_MOUNT_PATH=/workspace
 # E2B 配置（PROVIDER=e2b 时生效）
 AGENT_SANDBOX_E2B_API_KEY=


### PR DESCRIPTION
## Summary

- Replace scattered `buildSandboxAdapter` / `connectToProviderSandbox` / `ensureSessionVolume` calls in `sandboxController` and `lifecycle` with a unified `getSandboxClient` entry point
- Add `createConfig` option to `getSandboxClient` / `SandboxClient` so callers can supply image, entrypoint, env and metadata without reimplementing volume logic
- Add `waitForEndpointReady` helper that polls the sandbox HTTP endpoint before emitting the `ready` SSE event, preventing ECONNREFUSED in the client iframe
- Switch from `MongoSandboxInstance.create` to `findOneAndUpdate` to enrich the record already created by `getSandboxClient.ensureAvailable()`, avoiding duplicate documents
- Remove now-unused imports: `OpenSandboxVolume`, `mongoSessionRun`, `buildSandboxAdapter`, `getVolumeManagerConfig`, `ensureSessionVolume`, `buildVolumeConfig`
- Add opensandbox recommended mount-path comment to `.env.template`

## Test plan

- [x] **Create edit-debug sandbox** — upload a new skill version; verify container starts, package is extracted, endpoint becomes reachable, and a single `SandboxInstance` document is
written with correct `metadata.endpoint`
- [x] **Use existing edit-debug sandbox** — open the edit-debug iframe a second time without stopping; verify the warm-start path hits `getSandboxClient` (no new container), `lastActiveAt`
 is updated, and the iframe connects immediately
- [x] **Stopped edit-debug sandbox → resume with same volume** — stop the provider container externally, then reopen the edit-debug iframe; verify `ensureRunning()` restarts the container,
 the existing PVC is reattached, and previously uploaded files are still present
- [x] **Create session-runtime sandbox** — trigger an agent chat that requires skill execution; verify a new container is provisioned via `getSandboxClient`, skill packages are deployed,
and the session document is enriched (not duplicated) in MongoDB
- [x] **Use existing session-runtime sandbox** — send a follow-up message in the same chat session; verify the warm-start path reuses the running container without re-deploying packages
- [x] **Stopped session-runtime sandbox → rebuild with same volume config** — stop the provider container mid-session, then trigger another skill call; verify
`getSandboxClient.ensureAvailable()` recreates the container with the original `createConfig` (same image, entrypoint, volume mount path), skill packages are re-deployed, and execution
succeeds
