### PR TITLE
fix: support formatter functions in ECharts code blocks

### DIFF
--- a/projects/app/src/components/Markdown/img/EChartsCodeBlock.tsx
+++ b/projects/app/src/components/Markdown/img/EChartsCodeBlock.tsx
@@ -34,26 +34,37 @@ const EChartsCodeBlock = ({ code }: { code: string }) => {
   });
 
   useLayoutEffect(() => {
+    const buildOption = (userOption: any) => {
+      const userToolbox = userOption.toolbox || {};
+      const userFeature = userToolbox.feature || {};
+      return {
+        ...userOption,
+        toolbox: {
+          ...userToolbox,
+          // show: true,
+          feature: {
+            saveAsImage: {},
+            ...userFeature
+          }
+        }
+      };
+    };
+
     const option = (() => {
+      // First try json5 parse (safe, handles JSON5 syntax like comments/trailing commas)
       try {
         const userOption = json5.parse(code.trim());
-        const userToolbox = userOption.toolbox || {};
-        const userFeature = userToolbox.feature || {};
+        return buildOption(userOption);
+      } catch (_e) {}
 
-        const parse = {
-          ...userOption,
-          toolbox: {
-            ...userToolbox,
-            // show: true,
-            feature: {
-              saveAsImage: {},
-              ...userFeature
-            }
-          }
-        };
-
-        return parse;
-      } catch (error) {}
+      // Fallback: evaluate as JS expression to support formatter functions and other JS values
+      try {
+        // eslint-disable-next-line no-new-func
+        const userOption = new Function(`return (${code.trim()})`)();
+        if (userOption && typeof userOption === 'object') {
+          return buildOption(userOption);
+        }
+      } catch (_e) {}
     })();
 
     setOption(option ?? {});


### PR DESCRIPTION
Fixes #6536

## Problem

When an ECharts configuration contains `formatter` (or other function-valued properties), `json5.parse()` throws a `SyntaxError` because function literals are not valid JSON5. The error is silently caught, `option` becomes `undefined`, and `setOption({})` is called — the chart renders as a blank white box with no error shown.

## Solution

Add a fallback parser that evaluates the ECharts config as a JavaScript expression using the `Function` constructor. This allows formatter callbacks and other JS function values to work correctly.

- `json5.parse()` is still tried first (safer, handles comments/trailing commas)
- Only if that fails, the `Function` constructor fallback is used
- The `buildOption` helper is extracted to avoid duplication between the two paths

## Testing

Using an ECharts code block with a `formatter` function (as in the issue report) now renders the chart correctly instead of showing a blank box.