### PR TITLE
fix: correct export config sensitive filter behavior

### DIFF
--- a/packages/web/i18n/en/common.json
+++ b/packages/web/i18n/en/common.json
@@ -782,6 +782,7 @@
   "failed": "Failed",
   "field_name": "Field Name",
   "filter_sensitive_info": "Filter sensitive information",
+  "filter_sensitive_info_tip": "Sensitive information includes temporary keys used by system tools (leaks may cause unexpected charges, so export carefully) and dataset information configured in dataset search nodes.",
   "folder.empty": "No More Items in This Directory",
   "folder.open_dataset": "Open Dataset",
   "folder_description": "Folder Description",

--- a/packages/web/i18n/zh-CN/common.json
+++ b/packages/web/i18n/zh-CN/common.json
@@ -782,6 +782,7 @@
   "failed": "失败",
   "field_name": "字段名",
   "filter_sensitive_info": "过滤敏感信息",
+  "filter_sensitive_info_tip": "敏感信息范围：【系统工具】使用的临时密钥（泄露可能导致意外扣费，请谨慎导出），以及【知识库搜索节点】配置的知识库信息",
   "folder.empty": "这个目录已经没东西可选了~",
   "folder.open_dataset": "打开知识库",
   "folder_description": "文件夹描述",

--- a/packages/web/i18n/zh-Hant/common.json
+++ b/packages/web/i18n/zh-Hant/common.json
@@ -776,6 +776,7 @@
   "failed": "失敗",
   "field_name": "欄位名稱",
   "filter_sensitive_info": "過濾敏感信息",
+  "filter_sensitive_info_tip": "敏感資訊範圍：【系統工具】使用的臨時密鑰（外洩可能導致意外扣費，請謹慎匯出），以及【知識庫搜尋節點】配置的知識庫資訊",
   "folder.empty": "此目錄中沒有更多項目了",
   "folder.open_dataset": "開啟知識庫",
   "folder_description": "資料夾描述",

--- a/projects/app/src/pageComponents/app/detail/Edit/FormComponent/AppCard.tsx
+++ b/projects/app/src/pageComponents/app/detail/Edit/FormComponent/AppCard.tsx
@@ -49,6 +49,7 @@ const AppCard = ({
   const appId = appDetail._id;
   const { feConfigs } = useSystemStore();
   const [TeamTagsSet, setTeamTagsSet] = useState<AppSchemaType>();
+  const [filterSensitiveInfo, setFilterSensitiveInfo] = useState(true);
 
   // transition to workflow
   const [transitionCreateNew, setTransitionCreateNew] = useState<boolean>();
@@ -148,6 +149,8 @@ const AppCard = ({
                                   appName={appDetail.name}
                                   appForm={appForm}
                                   chatConfig={appDetail.chatConfig}
+                                  filterSensitiveInfo={filterSensitiveInfo}
+                                  onFilterSensitiveInfoChange={setFilterSensitiveInfo}
                                 />
                               </Flex>
                             )

--- a/projects/app/src/pageComponents/app/detail/ExportConfigPopover.tsx
+++ b/projects/app/src/pageComponents/app/detail/ExportConfigPopover.tsx
@@ -13,16 +13,13 @@ import { filterSensitiveFormData } from '@/web/core/app/utils';
 import { type RequireOnlyOne } from '@fastgpt/global/common/type/utils';
 import { type StoreNodeItemType } from '@fastgpt/global/core/workflow/type/node';
 import { type StoreEdgeItemType } from '@fastgpt/global/core/workflow/type/edge';
+import QuestionTip from '@fastgpt/web/components/common/MyTooltip/QuestionTip';
 
-const ExportConfigPopover = ({
-  appForm,
-  getWorkflowData,
-
-  chatConfig,
-  appName
-}: {
+type ExportConfigPopoverProps = {
   appName: string;
   chatConfig?: AppChatConfigType;
+  filterSensitiveInfo?: boolean;
+  onFilterSensitiveInfoChange?: (value: boolean) => void;
 } & RequireOnlyOne<{
   getWorkflowData: () =>
     | {
@@ -31,11 +28,32 @@ const ExportConfigPopover = ({
       }
     | undefined;
   appForm: AppFormEditFormType;
-}>) => {
+}>;
+
+const ExportConfigPopover = ({
+  appForm,
+  getWorkflowData,
+  chatConfig,
+  appName,
+  filterSensitiveInfo: filterSensitiveInfoProp,
+  onFilterSensitiveInfoChange
+}: ExportConfigPopoverProps) => {
   const { t } = useTranslation();
   const { copyData } = useCopyData();
 
-  const [filterSensitiveInfo, setFilterSensitiveInfo] = useState<boolean>(true);
+  const [localFilterSensitiveInfo, setLocalFilterSensitiveInfo] = useState<boolean>(true);
+  const filterSensitiveInfo = filterSensitiveInfoProp ?? localFilterSensitiveInfo;
+
+  const setFilterSensitiveInfo = useCallback(
+    (value: boolean) => {
+      onFilterSensitiveInfoChange?.(value);
+
+      if (filterSensitiveInfoProp === undefined) {
+        setLocalFilterSensitiveInfo(value);
+      }
+    },
+    [filterSensitiveInfoProp, onFilterSensitiveInfoChange]
+  );
 
   const onExportWorkflow = useCallback(
     async (mode: 'copy' | 'json') => {
@@ -91,7 +109,7 @@ const ExportConfigPopover = ({
       offset={[0, 20]}
       hasArrow
       trigger={'hover'}
-      w={'8.6rem'}
+      w={'8.8rem'}
       Trigger={
         <MyBox display={'flex'} cursor={'pointer'} onClick={(e) => e.stopPropagation()}>
           <MyIcon name={'export'} w={'16px'} mr={2} />
@@ -137,6 +155,7 @@ const ExportConfigPopover = ({
           <Flex
             py={'0.38rem'}
             px={1}
+            alignItems={'center'}
             color={'myGray.600'}
             _hover={{
               bg: 'myGray.05',
@@ -147,6 +166,7 @@ const ExportConfigPopover = ({
             onClick={() => setFilterSensitiveInfo(!filterSensitiveInfo)}
           >
             <Checkbox
+              flex={1}
               size="sm"
               colorScheme="primary"
               isChecked={filterSensitiveInfo}
@@ -154,6 +174,20 @@ const ExportConfigPopover = ({
             >
               <Box fontSize={'mini'}>{t('common:filter_sensitive_info')}</Box>
             </Checkbox>
+            <Box
+              display={'flex'}
+              alignItems={'center'}
+              ml={1}
+              flexShrink={0}
+              onClick={(e) => e.stopPropagation()}
+              onMouseDown={(e) => e.stopPropagation()}
+            >
+              <QuestionTip
+                color={'inherit'}
+                maxW={'320px'}
+                label={t('common:filter_sensitive_info_tip')}
+              />
+            </Box>
           </Flex>
         </Box>
       )}

--- a/projects/app/src/web/core/app/utils.ts
+++ b/projects/app/src/web/core/app/utils.ts
@@ -14,7 +14,14 @@ export function filterSensitiveFormData(appForm: AppFormEditFormType) {
   const defaultAppForm = getDefaultAppForm();
   return {
     ...appForm,
-    dataset: defaultAppForm.dataset
+    dataset: defaultAppForm.dataset,
+    selectedTools: appForm.selectedTools.map((tool) => ({
+      ...tool,
+      inputs: tool.inputs.map((input) => ({
+        ...input,
+        value: input.key === NodeInputKeyEnum.systemInputConfig ? undefined : input.value
+      }))
+    }))
   };
 }
 

--- a/projects/app/test/web/core/app/utils.test.ts
+++ b/projects/app/test/web/core/app/utils.test.ts
@@ -96,6 +96,15 @@ describe('form2AppWorkflow', () => {
 
 describe('filterSensitiveFormData', () => {
   it('should filter sensitive data from app form', () => {
+    const toolSecretValue = {
+      type: 'manual',
+      value: {
+        apiKey: {
+          secret: '',
+          value: 'secret-key'
+        }
+      }
+    };
     const appForm: AppFormEditFormType = {
       aiSettings: {
         [NodeInputKeyEnum.aiModel]: 'gpt-4',
@@ -123,15 +132,49 @@ describe('filterSensitiveFormData', () => {
         datasetSearchExtensionModel: '',
         datasetSearchExtensionBg: ''
       },
-      selectedTools: [],
+      selectedTools: [
+        {
+          id: 'tool-1',
+          pluginId: 'plugin-1',
+          flowNodeType: FlowNodeTypeEnum.tool,
+          templateType: 'other',
+          name: 'Weather Tool',
+          avatar: '',
+          intro: '',
+          inputs: [
+            {
+              key: NodeInputKeyEnum.systemInputConfig,
+              value: toolSecretValue,
+              renderTypeList: [],
+              valueType: 'any'
+            },
+            {
+              key: NodeInputKeyEnum.history,
+              value: 5,
+              renderTypeList: [],
+              valueType: 'number'
+            }
+          ],
+          outputs: []
+        } as any
+      ],
       chatConfig: {}
     };
 
     const result = filterSensitiveFormData(appForm);
     const defaultForm = getDefaultAppForm();
+    const resultSecretInput = result.selectedTools[0].inputs.find(
+      (input) => input.key === NodeInputKeyEnum.systemInputConfig
+    );
+    const resultHistoryInput = result.selectedTools[0].inputs.find(
+      (input) => input.key === NodeInputKeyEnum.history
+    );
 
     expect(result.dataset).toEqual(defaultForm.dataset);
     expect(result.aiSettings).toEqual(appForm.aiSettings);
+    expect(resultSecretInput?.value).toBeUndefined();
+    expect(resultHistoryInput?.value).toBe(5);
+    expect(appForm.selectedTools[0].inputs[0].value).toEqual(toolSecretValue);
   });
 });
 


### PR DESCRIPTION
## Summary
- fix the simple app export popover so the sensitive-info toggle no longer gets stuck checked
- filter tool secret config from simple app exports to align with workflow export behavior
- add an i18n tooltip explaining the sensitive info scope in the export menu

## Testing
- pnpm vitest run projects/app/test/web/core/app/utils.test.ts
- pnpm --filter app typecheck