### PR TITLE
fix: respect fileSelectConfig for paste and drag upload

### DIFF
--- a/packages/global/common/file/utils.ts
+++ b/packages/global/common/file/utils.ts
@@ -1,8 +1,87 @@
-import path from 'path';
+import { defaultFileExtensionTypes, type FileExtensionKeyType } from '../../core/app/constants';
+import type { AppFileSelectConfigType } from '../../core/app/type/config.schema';
+
+const uploadConfigKeys: FileExtensionKeyType[] = [
+  'canSelectFile',
+  'canSelectImg',
+  'canSelectVideo',
+  'canSelectAudio',
+  'canSelectCustomFileExtension'
+];
+
+export const normalizeFileExtension = (extension?: string) => {
+  if (!extension) return '';
+
+  const trimmedExtension = extension.trim().toLowerCase();
+  if (!trimmedExtension) return '';
+
+  return trimmedExtension.startsWith('.') ? trimmedExtension : `.${trimmedExtension}`;
+};
+
+const getFileExtension = (filename?: string) => {
+  if (!filename) return '';
+
+  const extensionIndex = filename.lastIndexOf('.');
+  if (extensionIndex < 0) return '';
+
+  return normalizeFileExtension(filename.slice(extensionIndex));
+};
 
 export const isCSVFile = (filename: string) => {
-  const extension = path.extname(filename).toLowerCase();
+  const extension = getFileExtension(filename);
   return extension === '.csv';
+};
+
+export const getAllowedExtensionsFromFileSelectConfig = (config?: AppFileSelectConfigType) => {
+  if (!config) return [];
+
+  return [
+    ...new Set(
+      uploadConfigKeys.flatMap((key) => {
+        if (!config[key]) return [];
+
+        if (key === 'canSelectCustomFileExtension') {
+          return (config.customFileExtensionList || []).map(normalizeFileExtension).filter(Boolean);
+        }
+
+        return defaultFileExtensionTypes[key];
+      })
+    )
+  ];
+};
+
+const getMimeCategory = (
+  mimeType?: string
+): 'canSelectImg' | 'canSelectVideo' | 'canSelectAudio' | undefined => {
+  const normalizedMimeType = mimeType?.toLowerCase() || '';
+
+  if (normalizedMimeType.startsWith('image/')) return 'canSelectImg';
+  if (normalizedMimeType.startsWith('video/')) return 'canSelectVideo';
+  if (normalizedMimeType.startsWith('audio/')) return 'canSelectAudio';
+
+  return undefined;
+};
+
+export const isFileAllowedByFileSelectConfig = ({
+  file,
+  fileSelectConfig
+}: {
+  file: File;
+  fileSelectConfig?: AppFileSelectConfigType;
+}) => {
+  const extension = getFileExtension(file.name);
+  const allowedExtensions = getAllowedExtensionsFromFileSelectConfig(fileSelectConfig);
+
+  if (extension && allowedExtensions.includes(extension)) {
+    return true;
+  }
+
+  const mimeCategory = getMimeCategory(file.type);
+  if (mimeCategory) {
+    return Boolean(fileSelectConfig?.[mimeCategory]);
+  }
+
+  return false;
 };
 
 export function detectImageContentType(buffer: Buffer) {

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/Input/ChatInput.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/Input/ChatInput.tsx
@@ -13,7 +13,6 @@ import dynamic from 'next/dynamic';
 import { useContextSelector } from 'use-context-selector';
 import { WorkflowRuntimeContext } from '../../context/workflowRuntimeContext';
 import { useSystem } from '@fastgpt/web/hooks/useSystem';
-import { documentFileType } from '@fastgpt/global/common/file/constants';
 import FilePreview from '../../components/FilePreview';
 import { useFileUpload } from '../hooks/useFileUpload';
 import ComplianceTip from '@/components/common/ComplianceTip/index';
@@ -22,15 +21,9 @@ import VoiceInput, { type VoiceInputComponentRef } from './VoiceInput';
 import MyBox from '@fastgpt/web/components/common/MyBox';
 import { postStopV2Chat } from '@/web/core/chat/api';
 import type { WorkflowInteractiveResponseType } from '@fastgpt/global/core/workflow/template/system/interactive/type';
+import { isFileAllowedByFileSelectConfig } from '@fastgpt/global/common/file/utils';
 
 const InputGuideBox = dynamic(() => import('./InputGuideBox'));
-
-const fileTypeFilter = (file: File) => {
-  return (
-    file.type.includes('image') ||
-    documentFileType.split(',').some((type) => file.name.endsWith(type.trim()))
-  );
-};
 
 const ChatInput = ({
   lastInteractive,
@@ -235,7 +228,13 @@ const ChatInput = ({
                 const files = Array.from(items)
                   .map((item) => (item.kind === 'file' ? item.getAsFile() : undefined))
                   .filter((file) => {
-                    return file && fileTypeFilter(file);
+                    return (
+                      file &&
+                      isFileAllowedByFileSelectConfig({
+                        file,
+                        fileSelectConfig
+                      })
+                    );
                   }) as File[];
                 onSelectFile({ files });
 
@@ -263,7 +262,8 @@ const ChatInput = ({
       setValue,
       handleSend,
       canUploadFile,
-      onSelectFile
+      onSelectFile,
+      fileSelectConfig
     ]
   );
 
@@ -414,13 +414,24 @@ const ChatInput = ({
         if (!canUploadFile) return;
         const files = Array.from(e.dataTransfer.files);
 
-        const droppedFiles = files.filter((file) => fileTypeFilter(file));
+        const droppedFiles = files.filter((file) =>
+          isFileAllowedByFileSelectConfig({
+            file,
+            fileSelectConfig
+          })
+        );
         if (droppedFiles.length > 0) {
           onSelectFile({ files: droppedFiles });
         }
 
         const invalidFileName = files
-          .filter((file) => !fileTypeFilter(file))
+          .filter(
+            (file) =>
+              !isFileAllowedByFileSelectConfig({
+                file,
+                fileSelectConfig
+              })
+          )
           .map((file) => file.name)
           .join(', ');
         if (invalidFileName) {

--- a/projects/app/src/components/core/chat/HelperBot/Chatinput.tsx
+++ b/projects/app/src/components/core/chat/HelperBot/Chatinput.tsx
@@ -16,20 +16,13 @@ import dynamic from 'next/dynamic';
 import { useContextSelector } from 'use-context-selector';
 import { WorkflowRuntimeContext } from '../ChatContainer/context/workflowRuntimeContext';
 import { useSystem } from '@fastgpt/web/hooks/useSystem';
-import { documentFileType } from '@fastgpt/global/common/file/constants';
 import FilePreview from '../ChatContainer/components/FilePreview';
 import { useFileUpload } from './hooks/useFileUpload';
 import ComplianceTip from '@/components/common/ComplianceTip/index';
 import { useToast } from '@fastgpt/web/hooks/useToast';
 import { HelperBotContext } from './context';
 import type { onSendMessageFnType } from './type';
-
-const fileTypeFilter = (file: File) => {
-  return (
-    file.type.includes('image') ||
-    documentFileType.split(',').some((type) => file.name.endsWith(type.trim()))
-  );
-};
+import { isFileAllowedByFileSelectConfig } from '@fastgpt/global/common/file/utils';
 
 const ChatInput = ({
   chatId,
@@ -197,7 +190,13 @@ const ChatInput = ({
                 const files = Array.from(items)
                   .map((item) => (item.kind === 'file' ? item.getAsFile() : undefined))
                   .filter((file) => {
-                    return file && fileTypeFilter(file);
+                    return (
+                      file &&
+                      isFileAllowedByFileSelectConfig({
+                        file,
+                        fileSelectConfig
+                      })
+                    );
                   }) as File[];
                 onSelectFile({ files });
 
@@ -224,7 +223,8 @@ const ChatInput = ({
       setValue,
       handleSend,
       canUploadFile,
-      onSelectFile
+      onSelectFile,
+      fileSelectConfig
     ]
   );
 
@@ -343,13 +343,24 @@ const ChatInput = ({
         if (!canUploadFile) return;
         const files = Array.from(e.dataTransfer.files);
 
-        const droppedFiles = files.filter((file) => fileTypeFilter(file));
+        const droppedFiles = files.filter((file) =>
+          isFileAllowedByFileSelectConfig({
+            file,
+            fileSelectConfig
+          })
+        );
         if (droppedFiles.length > 0) {
           onSelectFile({ files: droppedFiles });
         }
 
         const invalidFileName = files
-          .filter((file) => !fileTypeFilter(file))
+          .filter(
+            (file) =>
+              !isFileAllowedByFileSelectConfig({
+                file,
+                fileSelectConfig
+              })
+          )
           .map((file) => file.name)
           .join(', ');
         if (invalidFileName) {

--- a/test/cases/global/common/file/utils.test.ts
+++ b/test/cases/global/common/file/utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { isCSVFile, detectImageContentType } from '@fastgpt/global/common/file/utils';
+import {
+  isCSVFile,
+  detectImageContentType,
+  normalizeFileExtension,
+  getAllowedExtensionsFromFileSelectConfig,
+  isFileAllowedByFileSelectConfig
+} from '@fastgpt/global/common/file/utils';
 
 describe('isCSVFile', () => {
   it('should detect csv extension', () => {
@@ -14,6 +20,102 @@ describe('isCSVFile', () => {
     expect(isCSVFile('data.csv.txt')).toBe(false);
     expect(isCSVFile('data.txt')).toBe(false);
     expect(isCSVFile('data')).toBe(false);
+  });
+});
+
+describe('normalizeFileExtension', () => {
+  it('should normalize case and leading dot', () => {
+    expect(normalizeFileExtension('PNG')).toBe('.png');
+    expect(normalizeFileExtension('.JPG')).toBe('.jpg');
+  });
+
+  it('should return empty string for empty values', () => {
+    expect(normalizeFileExtension('')).toBe('');
+    expect(normalizeFileExtension(undefined)).toBe('');
+  });
+});
+
+describe('getAllowedExtensionsFromFileSelectConfig', () => {
+  it('should merge built-in and custom extensions', () => {
+    expect(
+      getAllowedExtensionsFromFileSelectConfig({
+        canSelectFile: true,
+        canSelectCustomFileExtension: true,
+        customFileExtensionList: ['log', '.TXT']
+      })
+    ).toEqual(
+      expect.arrayContaining([
+        '.pdf',
+        '.docx',
+        '.pptx',
+        '.xlsx',
+        '.txt',
+        '.md',
+        '.html',
+        '.csv',
+        '.log'
+      ])
+    );
+  });
+
+  it('should return empty array when file upload is disabled', () => {
+    expect(getAllowedExtensionsFromFileSelectConfig()).toEqual([]);
+    expect(getAllowedExtensionsFromFileSelectConfig({})).toEqual([]);
+  });
+});
+
+describe('isFileAllowedByFileSelectConfig', () => {
+  it('should allow clipboard image files when image upload is enabled', () => {
+    const file = new File(['a'], 'clipboard', { type: 'image/png' });
+
+    expect(
+      isFileAllowedByFileSelectConfig({
+        file,
+        fileSelectConfig: {
+          canSelectImg: true
+        }
+      })
+    ).toBe(true);
+  });
+
+  it('should reject clipboard image files when image upload is disabled', () => {
+    const file = new File(['a'], 'clipboard', { type: 'image/png' });
+
+    expect(
+      isFileAllowedByFileSelectConfig({
+        file,
+        fileSelectConfig: {
+          canSelectFile: true
+        }
+      })
+    ).toBe(false);
+  });
+
+  it('should allow document files by extension', () => {
+    const file = new File(['a'], 'report.PDF', { type: 'application/pdf' });
+
+    expect(
+      isFileAllowedByFileSelectConfig({
+        file,
+        fileSelectConfig: {
+          canSelectFile: true
+        }
+      })
+    ).toBe(true);
+  });
+
+  it('should allow custom file extensions', () => {
+    const file = new File(['a'], 'trace.LOG', { type: 'text/plain' });
+
+    expect(
+      isFileAllowedByFileSelectConfig({
+        file,
+        fileSelectConfig: {
+          canSelectCustomFileExtension: true,
+          customFileExtensionList: ['.log']
+        }
+      })
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- make chat paste and drag filtering respect the current `fileSelectConfig`
- share file selection checks through `packages/global/common/file/utils.ts`
- add tests covering extension normalization and fileSelectConfig-based allow rules

## Testing
- pnpm -C projects/app exec eslint --max-warnings=0 src/components/core/chat/ChatContainer/ChatBox/Input/ChatInput.tsx src/components/core/chat/HelperBot/Chatinput.tsx
- pnpm -C projects/app exec tsc --noEmit --pretty false
- pnpm exec vitest run test/cases/global/common/file/utils.test.ts