### PR TITLE
[security] fix(app): validate stored MCP tool URLs

### DIFF
--- a/packages/service/core/app/mcp.ts
+++ b/packages/service/core/app/mcp.ts
@@ -10,8 +10,15 @@ import type { McpToolDataType } from '@fastgpt/global/core/app/tool/mcpTool/type
 import { UserError } from '@fastgpt/global/common/error/utils';
 import $RefParser from '@apidevtools/json-schema-ref-parser';
 import { getLogger, LogCategories } from '../../common/logger';
+import { isInternalAddress, PRIVATE_URL_TEXT } from '../../common/system/utils';
 
 const logger = getLogger(LogCategories.MODULE.APP.MCP_TOOLS);
+
+export const assertMCPUrlNotInternal = async (url: string) => {
+  if (await isInternalAddress(url)) {
+    return Promise.reject(PRIVATE_URL_TEXT);
+  }
+};
 
 export class MCPClient {
   private client: Client;

--- a/packages/service/core/workflow/dispatch/ai/agent/sub/tool/index.ts
+++ b/packages/service/core/workflow/dispatch/ai/agent/sub/tool/index.ts
@@ -16,7 +16,7 @@ import { NodeOutputKeyEnum } from '@fastgpt/global/core/workflow/constants';
 import { pushTrack } from '../../../../../../../common/middle/tracks/utils';
 import { getErrText } from '@fastgpt/global/common/error/utils';
 import { getAppVersionById } from '../../../../../../app/version/controller';
-import { MCPClient } from '../../../../../../app/mcp';
+import { assertMCPUrlNotInternal, MCPClient } from '../../../../../../app/mcp';
 import { runHTTPTool } from '../../../../../../app/http';
 import { getS3ChatSource } from '../../../../../../../common/s3/sources/chat';
 import { parseToolId } from '../../../../child/runTool';
@@ -197,6 +197,9 @@ export const dispatchTool = async ({
 
       const { headerSecret, url } =
         tool.nodes[0].toolConfig?.mcpToolSet ?? tool.nodes[0].inputs[0].value;
+
+      await assertMCPUrlNotInternal(url);
+
       const mcpClient = new MCPClient({
         url,
         headers: getSecretValue({

--- a/packages/service/core/workflow/dispatch/child/runTool.ts
+++ b/packages/service/core/workflow/dispatch/child/runTool.ts
@@ -7,7 +7,7 @@ import {
   type ModuleDispatchProps
 } from '@fastgpt/global/core/workflow/runtime/type';
 import { NodeInputKeyEnum } from '@fastgpt/global/core/workflow/constants';
-import { MCPClient } from '../../../app/mcp';
+import { assertMCPUrlNotInternal, MCPClient } from '../../../app/mcp';
 import { getSecretValue } from '../../../../common/secret/utils';
 import type { McpToolDataType } from '@fastgpt/global/core/app/tool/mcpTool/type';
 import type { HttpToolConfigType } from '@fastgpt/global/core/app/tool/httpTool/type';
@@ -214,6 +214,8 @@ export const dispatchRunTool = async (props: RunToolProps): Promise<RunToolRespo
       const { headerSecret, url } =
         tool.nodes[0].toolConfig?.mcpToolSet ?? tool.nodes[0].inputs[0].value;
 
+      await assertMCPUrlNotInternal(url);
+
       const context = getWorkflowContext();
       // Buffer mcpClient in this workflow
       const mcpClient =
@@ -300,6 +302,8 @@ export const dispatchRunTool = async (props: RunToolProps): Promise<RunToolRespo
       // mcp tool (old version compatible)
       const { toolData, system_toolData, ...restParams } = params;
       const { name: toolName, url, headerSecret } = toolData || system_toolData;
+
+      await assertMCPUrlNotInternal(url);
 
       const mcpClient = new MCPClient({
         url,

--- a/packages/service/test/core/app/mcp.test.ts
+++ b/packages/service/test/core/app/mcp.test.ts
@@ -18,7 +18,7 @@ vi.mock('@fastgpt/service/core/app/schema', () => ({
   }
 }));
 
-import { MCPClient, getMCPChildren } from '@fastgpt/service/core/app/mcp';
+import { MCPClient, assertMCPUrlNotInternal, getMCPChildren } from '@fastgpt/service/core/app/mcp';
 import type { AppSchemaType } from '@fastgpt/global/core/app/type';
 
 // Access private client via prototype for spying
@@ -37,6 +37,18 @@ beforeEach(() => {
 
 describe('MCPClient', () => {
   const config = { url: 'http://localhost:3000/mcp', headers: { Authorization: 'Bearer test' } };
+
+  describe('assertMCPUrlNotInternal', () => {
+    it('should reject localhost MCP endpoints', async () => {
+      await expect(assertMCPUrlNotInternal('http://localhost:3000/mcp')).rejects.toBe(
+        'Request to private network not allowed'
+      );
+    });
+
+    it('should allow public MCP endpoints', async () => {
+      await expect(assertMCPUrlNotInternal('https://example.com/mcp')).resolves.toBeUndefined();
+    });
+  });
 
   // Helper: stub getConnection to avoid real network calls
   const stubConnection = (mcpClient: MCPClient) => {

--- a/projects/app/src/pages/api/core/app/mcpTools/create.ts
+++ b/projects/app/src/pages/api/core/app/mcpTools/create.ts
@@ -17,6 +17,7 @@ import {
   type CreateMcpToolsBodyType,
   type CreateMcpToolsResponseType
 } from '@fastgpt/global/openapi/core/app/mcpTools/api';
+import { assertMCPUrlNotInternal } from '@fastgpt/service/core/app/mcp';
 
 export type createMCPToolsQuery = {};
 
@@ -36,6 +37,8 @@ async function handler(
   const { teamId, tmbId, userId } = parentId
     ? await authApp({ req, appId: parentId, per: WritePermissionVal, authToken: true })
     : await authUserPer({ req, authToken: true, per: TeamAppCreatePermissionVal });
+
+  await assertMCPUrlNotInternal(url);
 
   await checkTeamAppTypeLimit({ teamId, appCheckType: 'tool' });
 

--- a/projects/app/src/pages/api/core/app/mcpTools/getTools.ts
+++ b/projects/app/src/pages/api/core/app/mcpTools/getTools.ts
@@ -1,6 +1,6 @@
 import { NextAPI } from '@/service/middleware/entry';
 import type { ApiRequestProps, ApiResponseType } from '@fastgpt/service/type/next';
-import { MCPClient } from '@fastgpt/service/core/app/mcp';
+import { assertMCPUrlNotInternal, MCPClient } from '@fastgpt/service/core/app/mcp';
 import { getSecretValue } from '@fastgpt/service/common/secret/utils';
 import {
   GetMcpToolsBodySchema,
@@ -8,7 +8,6 @@ import {
   type GetMcpToolsBodyType,
   type GetMcpToolsResponseType
 } from '@fastgpt/global/openapi/core/app/mcpTools/api';
-import { isInternalAddress, PRIVATE_URL_TEXT } from '@fastgpt/service/common/system/utils';
 import { authCert } from '@fastgpt/service/support/permission/auth/common';
 
 async function handler(
@@ -19,9 +18,7 @@ async function handler(
 
   const { url, headerSecret } = GetMcpToolsBodySchema.parse(req.body);
 
-  if (await isInternalAddress(url)) {
-    return Promise.reject(PRIVATE_URL_TEXT);
-  }
+  await assertMCPUrlNotInternal(url);
 
   const mcpClient = new MCPClient({
     url,

--- a/projects/app/src/pages/api/core/app/mcpTools/runTool.ts
+++ b/projects/app/src/pages/api/core/app/mcpTools/runTool.ts
@@ -1,13 +1,12 @@
 import { NextAPI } from '@/service/middleware/entry';
 import type { ApiRequestProps, ApiResponseType } from '@fastgpt/service/type/next';
-import { MCPClient } from '@fastgpt/service/core/app/mcp';
+import { assertMCPUrlNotInternal, MCPClient } from '@fastgpt/service/core/app/mcp';
 import { getSecretValue } from '@fastgpt/service/common/secret/utils';
 import {
   RunMcpToolBodySchema,
   type RunMcpToolBodyType,
   type RunMcpToolResponseType
 } from '@fastgpt/global/openapi/core/app/mcpTools/api';
-import { isInternalAddress, PRIVATE_URL_TEXT } from '@fastgpt/service/common/system/utils';
 import { authCert } from '@fastgpt/service/support/permission/auth/common';
 
 async function handler(
@@ -18,9 +17,7 @@ async function handler(
 
   const { url, toolName, headerSecret, params } = RunMcpToolBodySchema.parse(req.body);
 
-  if (await isInternalAddress(url)) {
-    return Promise.reject(PRIVATE_URL_TEXT);
-  }
+  await assertMCPUrlNotInternal(url);
 
   const mcpClient = new MCPClient({
     url,

--- a/projects/app/src/pages/api/core/app/mcpTools/update.ts
+++ b/projects/app/src/pages/api/core/app/mcpTools/update.ts
@@ -13,12 +13,15 @@ import {
   UpdateMcpToolsBodySchema,
   type UpdateMcpToolsBodyType
 } from '@fastgpt/global/openapi/core/app/mcpTools/api';
+import { assertMCPUrlNotInternal } from '@fastgpt/service/core/app/mcp';
 
 export type updateMCPToolsQuery = {};
 
 async function handler(req: ApiRequestProps<UpdateMcpToolsBodyType>, res: ApiResponseType) {
   const { appId, url, toolList, headerSecret } = UpdateMcpToolsBodySchema.parse(req.body);
   const { app } = await authApp({ req, authToken: true, appId, per: ManagePermissionVal });
+
+  await assertMCPUrlNotInternal(url);
 
   const formatedHeaderAuth = storeSecretValue(headerSecret);
 


### PR DESCRIPTION
## Summary

This PR hardens the MCP tool URL boundary so the same internal-address validation is enforced when MCP URLs are saved and when stored MCP tools are executed from workflows.

- Adds a shared MCP URL guard around the existing `isInternalAddress()` policy.
- Reuses that guard on direct MCP preview/run endpoints.
- Adds missing validation to MCP tool create/update paths before URLs are persisted.
- Adds runtime defense-in-depth before workflow execution connects to stored MCP URLs.
- Adds focused tests for blocking localhost MCP endpoints while allowing public endpoints.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Stored MCP tool URLs were not validated consistently before persistence and workflow execution | An authenticated user with MCP toolset permissions could persist an internal MCP endpoint and later cause the backend workflow runner to connect to it | Medium |

## Before this PR

- Direct MCP preview/run API paths checked `isInternalAddress(url)` before connecting to a user-supplied MCP server.
- MCP tool create/update paths accepted and stored `url` without the same internal-address validation.
- Workflow execution loaded stored MCP toolset URLs and constructed `MCPClient` instances without re-checking the stored URL.
- The direct-call SSRF guard and stored workflow execution path could drift apart.

## After this PR

- MCP URL validation lives behind a shared `assertMCPUrlNotInternal()` helper.
- Direct MCP preview/run endpoints continue to enforce the existing internal-address policy through that shared helper.
- MCP tool create/update endpoints reject internal URLs before storing toolset configuration.
- Workflow MCP execution paths revalidate stored URLs before connecting, covering pre-existing or indirectly inserted stored data.
- Tests lock in localhost rejection and public endpoint allowance for the shared guard.

## Why this matters

MCP server URLs are server-side network destinations. If a stored MCP URL is allowed to point at localhost, metadata services, or other blocked internal destinations, a later workflow run can make the FastGPT backend connect across a network boundary that the direct MCP preview/run endpoints already attempted to protect.

This patch keeps the existing FastGPT SSRF policy consistent across both admission-time and runtime MCP paths.

## How this differs from #6640

PR #6640 added SSRF checks to the direct MCP and HTTP tool run/preview API paths.

This PR addresses the remaining stored-configuration and workflow-runtime variant:

- #6640 guarded direct MCP requests in `mcpTools/getTools.ts` and `mcpTools/runTool.ts`.
- This PR also validates MCP URLs before create/update persistence.
- This PR also validates stored MCP URLs immediately before workflow execution constructs an `MCPClient`.

Both layers matter because saved tool configuration can outlive the original request path and can be executed later by workflow dispatch code.

## Attack flow

```text
Authenticated user with MCP toolset write permission
    -> creates or updates an MCP toolset with an internal URL
        -> workflow execution loads the stored toolset URL
            -> backend MCP client connects to the internal destination
```

## Affected code

| Issue | Files |
|-------|-------|
| Inconsistent MCP URL validation | `projects/app/src/pages/api/core/app/mcpTools/create.ts`, `projects/app/src/pages/api/core/app/mcpTools/update.ts`, `packages/service/core/workflow/dispatch/child/runTool.ts`, `packages/service/core/workflow/dispatch/ai/agent/sub/tool/index.ts` |
| Shared validation helper | `packages/service/core/app/mcp.ts` |
| Regression coverage | `test/cases/service/core/app/mcp.test.ts` |

## Root cause

Stored MCP URL validation drift:

- The direct MCP request endpoints used the internal-address check, but the stored MCP configuration write paths did not.
- Workflow execution trusted stored MCP URLs without applying the same network-boundary policy at runtime.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Stored MCP URL internal-address bypass | 6.5 Medium | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L` |

Rationale:

- The issue requires authenticated access with permission to create or manage an MCP toolset.
- The impact depends on what internal services are reachable from the FastGPT backend and what the MCP response path exposes.
- The patch is intentionally scoped to enforcing the existing internal-address policy consistently rather than introducing a new network policy.

## Safe reproduction steps

1. Run a FastGPT instance before this patch.
2. Authenticate as a user who can create or manage MCP toolsets.
3. Submit an MCP toolset create or update request with a URL such as `http://localhost:3000/mcp` or another destination that `isInternalAddress()` would reject.
4. Observe that the create/update path can store the URL even though direct MCP preview/run paths reject the same URL.
5. Add that stored MCP tool to a workflow and execute the workflow.
6. Observe that workflow execution reaches `MCPClient` construction for the stored URL.

After this patch, the create/update request is rejected and workflow execution also re-checks stored MCP URLs before connecting.

## Expected vulnerable behavior

- The direct MCP preview/run endpoints reject internal URLs.
- The MCP create/update endpoints do not apply the same validation before storing the URL.
- The workflow runtime later attempts to connect to the stored URL through `MCPClient`.

## Changes in this PR

- Adds `assertMCPUrlNotInternal()` in the MCP service module.
- Refactors direct MCP preview/run endpoints to use the shared helper.
- Adds MCP URL validation before create/update persistence.
- Adds runtime validation before new and legacy MCP workflow tool execution paths connect to stored URLs.
- Adds regression tests for localhost rejection and public endpoint allowance.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Shared guard | `packages/service/core/app/mcp.ts` | Adds `assertMCPUrlNotInternal()` using the existing `isInternalAddress()` / `PRIVATE_URL_TEXT` policy |
| Direct MCP endpoints | `projects/app/src/pages/api/core/app/mcpTools/getTools.ts`, `projects/app/src/pages/api/core/app/mcpTools/runTool.ts` | Reuses the shared guard |
| MCP persistence | `projects/app/src/pages/api/core/app/mcpTools/create.ts`, `projects/app/src/pages/api/core/app/mcpTools/update.ts` | Rejects internal MCP URLs before storing toolset configuration |
| Workflow runtime | `packages/service/core/workflow/dispatch/child/runTool.ts`, `packages/service/core/workflow/dispatch/ai/agent/sub/tool/index.ts` | Revalidates stored MCP URLs before constructing `MCPClient` |
| Tests | `test/cases/service/core/app/mcp.test.ts` | Adds focused guard coverage |

## Maintainer impact

- The patch is narrow and reuses the existing SSRF policy helper.
- Existing public MCP destinations remain allowed.
- Internal destinations that were already blocked on direct MCP preview/run paths are now blocked consistently when saved and executed from workflows.
- Runtime checks add defense-in-depth for older stored configuration or data inserted through alternate paths.

## Fix rationale

The safest durable boundary is to validate MCP URLs both:

1. before persistence, so new unsafe toolset configuration is not saved; and
2. before runtime use, so old or alternate-path stored data cannot bypass the policy.

Centralizing this behind `assertMCPUrlNotInternal()` keeps future MCP entrypoints aligned with the existing FastGPT internal-address policy.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused MCP service test passes.
- [x] Prettier check passes on touched files.
- [x] ESLint passes on touched files.

Executed with:

- `corepack pnpm@9.15.9 vitest run test/cases/service/core/app/mcp.test.ts`
- `corepack pnpm@9.15.9 prettier --config ./.prettierrc.js --check packages/service/core/app/mcp.ts projects/app/src/pages/api/core/app/mcpTools/getTools.ts projects/app/src/pages/api/core/app/mcpTools/runTool.ts projects/app/src/pages/api/core/app/mcpTools/create.ts projects/app/src/pages/api/core/app/mcpTools/update.ts packages/service/core/workflow/dispatch/child/runTool.ts packages/service/core/workflow/dispatch/ai/agent/sub/tool/index.ts test/cases/service/core/app/mcp.test.ts`
- `corepack pnpm@9.15.9 eslint --ignore-path .eslintignore packages/service/core/app/mcp.ts projects/app/src/pages/api/core/app/mcpTools/getTools.ts projects/app/src/pages/api/core/app/mcpTools/runTool.ts projects/app/src/pages/api/core/app/mcpTools/create.ts projects/app/src/pages/api/core/app/mcpTools/update.ts packages/service/core/workflow/dispatch/child/runTool.ts packages/service/core/workflow/dispatch/ai/agent/sub/tool/index.ts test/cases/service/core/app/mcp.test.ts`

## Token usage

- discovery tokens: partial/unknown
- validation tokens: partial/unknown
- duplicate-check tokens: partial/unknown
- PR/writeup tokens: partial/unknown
- total tokens: partial/unknown
- notes: exact token telemetry was not available in this session.

## Disclosure notes

- This PR is intentionally bounded to a stored MCP URL validation variant adjacent to the already-public MCP SSRF hardening in #6640.
- It does not claim unauthenticated access or account takeover.
- It reuses the existing FastGPT internal-address policy rather than changing the policy itself.
- No unrelated files are changed.
