### PR TITLE
fix(workflow): clarify multi-select tooltip copy

### DIFF
--- a/packages/web/i18n/en/workflow.json
+++ b/packages/web/i18n/en/workflow.json
@@ -170,7 +170,7 @@
   "current_iteration_desc": "1-based iteration counter in conditional mode.",
   "max_dialog_rounds": "Maximum Number of Dialog Rounds",
   "max_tokens": "Maximum Tokens",
-  "mouse_priority": "Mouse first\n- Press the left button to drag the canvas\n- Hold down shift and left click to select batches",
+  "mouse_priority": "Mouse first\n- Press the left button to drag the canvas\n- Hold down Shift and drag to box-select multiple nodes",
   "new_context": "New Context",
   "next": "Next",
   "no_edit_permission": "No editing rights",

--- a/packages/web/i18n/zh-CN/workflow.json
+++ b/packages/web/i18n/zh-CN/workflow.json
@@ -170,7 +170,7 @@
   "current_iteration_desc": "条件循环模式下的 1-based 迭代次数。",
   "max_dialog_rounds": "最多携带多少轮对话记录",
   "max_tokens": "最大 Tokens",
-  "mouse_priority": "鼠标优先\n- 左键按下后可拖动画布\n- 按住 shift 后左键可批量选择",
+  "mouse_priority": "鼠标优先\n- 左键按下后可拖动画布\n- 按住 Shift 并拖动可框选多个节点",
   "new_context": "新的上下文",
   "next": "下一个",
   "no_edit_permission": "没有编辑权限",

--- a/packages/web/i18n/zh-Hant/workflow.json
+++ b/packages/web/i18n/zh-Hant/workflow.json
@@ -170,7 +170,7 @@
   "current_iteration_desc": "條件迴圈模式下的 1-based 迭代次數。",
   "max_dialog_rounds": "最多攜帶幾輪對話紀錄",
   "max_tokens": "最大 Token 數",
-  "mouse_priority": "滑鼠優先\n- 按下左鍵拖曳畫布\n- 按住 Shift 鍵並點選左鍵可批次選取",
+  "mouse_priority": "滑鼠優先\n- 按下左鍵拖曳畫布\n- 按住 Shift 並拖曳可框選多個節點",
   "new_context": "新的脈絡",
   "next": "下一個",
   "no_edit_permission": "沒有編輯權限",


### PR DESCRIPTION
## 变更说明
- 优化工作流画布右下角操作提示文案
- 将“按住 shift 后左键可批量选择”改为“按住 Shift 并拖动可框选多个节点”
- 同步更新 en / zh-Hant 文案，保持多语言一致

## 验证
- 文案修改，无逻辑变更