### PR TITLE
fix(oss): use list() instead of getBucketInfo() in ensureBucket to avoid bundling issue

### DIFF
--- a/sdk/storage/src/adapters/oss.adapter.ts
+++ b/sdk/storage/src/adapters/oss.adapter.ts
@@ -107,7 +107,11 @@ export class OssStorageAdapter implements IStorage {
   }
 
   async ensureBucket(): Promise<EnsureBucketResult> {
-    await this.client.getBucketInfo(this.options.bucket);
+    // Use list() instead of getBucketInfo() to verify bucket access.
+    // getBucketInfo() references a variable named `name` internally which conflicts
+    // with JavaScript's global `name` property in bundled environments (e.g. Next.js),
+    // causing "ReferenceError: name is not defined".
+    await this.client.list({ 'max-keys': 1 }, {});
 
     return {
       exists: true,


### PR DESCRIPTION
Fixes #6552

## Problem

When OSS storage is configured, the application logs the following error on startup:

```
ReferenceError: name is not defined
    at b.createRequest (.next/server/chunks/55042.js:1:4872)
    at b.getBucketInfo (...)
    at y.ensureBucket (...)
```

This happens because ali-oss's getBucketInfo() internally references a variable named `name` in its createRequest() function. In bundled environments (Next.js webpack), this conflicts with JavaScript's implicit global `name` property — resulting in a ReferenceError every time the application starts with OSS configured.

The error is non-fatal (caught and logged), but confusing: users see an alarming error even though their OSS bucket exists and uploads work fine.

## Solution

Replace getBucketInfo() with list({ 'max-keys': 1 }) in the ensureBucket() method of the OSS adapter. The list() call:

- Verifies the bucket is accessible (throws on invalid credentials or missing bucket)
- Does not trigger the name is not defined code path
- Is already used successfully elsewhere in the OSS adapter

## Testing

- OSS configuration with valid credentials: list() returns successfully, no error logged
- OSS configuration with invalid bucket name: list() throws an OSS NoSuchBucket error, correctly caught and logged