### PR TITLE
docs: add FuturMix provider integration guide

### DIFF
--- a/document/content/self-host/config/model/futurmix.en.mdx
+++ b/document/content/self-host/config/model/futurmix.en.mdx
@@ -1,0 +1,44 @@
+---
+title: FuturMix Integration Example
+description: FuturMix integration example for FastGPT
+---
+
+[FuturMix](https://futurmix.ai) is a unified AI gateway that provides access to 22+ models (GPT-4o, Claude, Gemini, etc.) through a single OpenAI-compatible API endpoint. Instead of obtaining separate API keys from OpenAI, Anthropic, and Google, you can use a single FuturMix API key to access all major models in FastGPT.
+
+Before reading this guide, make sure you've read the [Model Configuration Guide](./intro.en.mdx).
+
+## 1. Get an API Key
+
+1. Visit [FuturMix](https://futurmix.ai), register and log in.
+2. Go to the console and create an API Key.
+
+## 2. Add Models
+
+On the `Model Configuration` page, search and add the models you need. FuturMix supports models including but not limited to:
+
+- **OpenAI**: gpt-4o, gpt-4o-mini, o3-mini, etc.
+- **Anthropic**: claude-sonnet-4-20250514, claude-3.5-haiku, etc.
+- **Google**: gemini-2.5-pro, gemini-2.0-flash, etc.
+
+If the model you need is not in the built-in model list, you can [add it manually](./intro.en.mdx#add-a-custom-model).
+
+## 3. Add a Model Channel
+
+On the Model Channels page, add a new FuturMix channel:
+
+- Protocol type: Select **OpenAI**
+- Proxy URL: `https://futurmix.ai/v1`
+- Enter your FuturMix API Key
+- Select the models you just enabled
+
+Since FuturMix is OpenAI-compatible, all models provided through FuturMix (including Claude, Gemini, etc.) can be accessed using the OpenAI protocol type. There is no need to create separate channels for different providers.
+
+## 4. Test Models
+
+After configuration, click the test button in the channel list to verify the models are working properly.
+
+## Advantages
+
+- **Unified Access**: One API key for 22+ models — no need to configure separate channels for OpenAI, Anthropic, Google, etc.
+- **OpenAI Compatible**: Fully compatible with the OpenAI protocol for simple configuration
+- **High Availability**: 99.99% SLA with built-in failover and load balancing

--- a/document/content/self-host/config/model/futurmix.mdx
+++ b/document/content/self-host/config/model/futurmix.mdx
@@ -1,0 +1,44 @@
+---
+title: FuturMix 接入示例
+description: FuturMix 接入示例
+---
+
+[FuturMix](https://futurmix.ai) 是一个统一 AI 网关，提供 22+ 模型（GPT-4o、Claude、Gemini 等）的统一访问，兼容 OpenAI 协议。用户无需分别在 OpenAI、Anthropic、Google 等平台申请 API Key，只需一个 FuturMix API Key 即可在 FastGPT 中访问所有主流模型。
+
+在阅读该章之前，请先确保你阅读了[模型配置说明](./intro.mdx)。
+
+## 1. 获取 API Key
+
+1. 访问 [FuturMix](https://futurmix.ai)，注册并登录账号。
+2. 进入控制台，创建 API Key。
+
+## 2. 新增模型
+
+在`模型配置`页面，搜索并添加您需要使用的模型。FuturMix 支持的模型包括但不限于：
+
+- **OpenAI**：gpt-4o、gpt-4o-mini、o3-mini 等
+- **Anthropic**：claude-sonnet-4-20250514、claude-3.5-haiku 等
+- **Google**：gemini-2.5-pro、gemini-2.0-flash 等
+
+如果系统内置模型列表中没有您需要的模型，可以[手动添加](./intro.mdx#新增自定义模型)。
+
+## 3. 新增模型渠道
+
+在模型渠道页，新增一个 FuturMix 的渠道：
+
+- 协议类型选择 **OpenAI**
+- 代理地址填写：`https://futurmix.ai/v1`
+- 填写 FuturMix 的 API Key
+- 选择刚刚启用的模型
+
+由于 FuturMix 兼容 OpenAI 协议，所有通过 FuturMix 提供的模型（包括 Claude、Gemini 等）均可使用 OpenAI 协议类型接入，无需为不同厂商的模型分别创建渠道。
+
+## 4. 测试模型
+
+配置完成后，可以在渠道列表中点击测试按钮，验证模型是否正常工作。
+
+## 优势
+
+- **统一接入**：一个 API Key 访问 22+ 模型，无需分别配置 OpenAI、Anthropic、Google 等渠道
+- **OpenAI 兼容**：完全兼容 OpenAI 协议，配置简单
+- **高可用**：99.99% SLA，内置故障转移和负载均衡

--- a/document/content/self-host/config/model/meta.en.json
+++ b/document/content/self-host/config/model/meta.en.json
@@ -1,4 +1,4 @@
 {
   "title": "Model Configuration",
-  "pages": ["intro", "siliconCloud", "minimax"]
+  "pages": ["intro", "futurmix", "minimax", "siliconCloud"]
 }

--- a/document/content/self-host/config/model/meta.json
+++ b/document/content/self-host/config/model/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "模型配置方案",
-  "pages": ["intro", "siliconCloud", "minimax"]
+  "pages": ["intro", "futurmix", "minimax", "siliconCloud"]
 }


### PR DESCRIPTION
## Summary

Add documentation for configuring [FuturMix](https://futurmix.ai) as an AI provider in FastGPT.

FuturMix is an enterprise AI agent platform that provides access to 22+ models (GPT-4o, Claude, Gemini, etc.) . Instead of configuring separate channels for OpenAI, Anthropic, and Google, users can use FuturMix as a single channel to access all models.

## Changes

- Added `futurmix.mdx` (Chinese) and `futurmix.en.mdx` (English) provider integration guides
- Updated `meta.json` and `meta.en.json` to include FuturMix in the model provider docs navigation

## 变更说明

新增 FuturMix 企业级 AI 智能体平台的接入文档。FuturMix 提供 22+ 模型（GPT-4o、Claude、Gemini 等）的统一访问，兼容 OpenAI 协议。用户无需分别配置多个渠道，一个 API Key 即可访问所有模型。