### PR TITLE
chore: update admin release workflow

### DIFF
--- a/.github/workflows/build-admin.yml
+++ b/.github/workflows/build-admin.yml
@@ -1,0 +1,164 @@
+name: Build FastGPT Admin images
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-fastgpt-admin-images:
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    strategy:
+      matrix:
+        sub_routes:
+          - repo: fastgpt-pro
+            base_url: ""
+          - repo: fastgpt-pro-sub-route
+            base_url: "/fastaipro"
+          - repo: fastgpt-pro-sub-route-gchat
+            base_url: "/gchat-admin"
+        archs:
+          - arch: amd64
+          - arch: arm64
+            runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.archs.runs-on || 'ubuntu-24.04' }}
+    steps:
+      # install env
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Update submodules
+        env:
+          PRO_SUBMODULE_TOKEN: ${{ secrets.PRO_SUBMODULE_TOKEN }}
+        run: |
+          if [ -f .gitmodules ]; then
+            if [ -z "${PRO_SUBMODULE_TOKEN}" ]; then
+              echo "::error::PRO_SUBMODULE_TOKEN is required to clone the private pro submodule. Add it to this repository's Actions secrets, or run this workflow from a repository that has the secret configured."
+              exit 1
+            fi
+            git config --global url."https://x-access-token:${PRO_SUBMODULE_TOKEN}@github.com/".insteadOf "https://github.com/"
+            git submodule update --init --recursive
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-${{ matrix.archs.arch }}-${{ matrix.sub_routes.repo
+            }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.archs.arch }}-${{ matrix.sub_routes.repo }}-buildx-
+
+      # login docker (GHCR only; Ali tags are pushed in release job via imagetools)
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build for ${{ matrix.archs.arch }}
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: pro/admin/Dockerfile
+          platforms: linux/${{ matrix.archs.arch }}
+          build-args: |
+            ${{ matrix.sub_routes.base_url && format('base_url={0}', matrix.sub_routes.base_url) || '' }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=${{ matrix.sub_routes.repo }} image
+          outputs: type=image,"name=ghcr.io/${{ github.repository_owner }}/${{
+            matrix.sub_routes.repo }}",push-by-digest=true,push=true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.sub_routes.repo }}-${{ github.sha }}-${{
+            matrix.archs.arch }}
+          path: ${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}/*
+          if-no-files-found: error
+          retention-days: 1
+
+  release-fastgpt-images:
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    needs: build-fastgpt-admin-images
+    strategy:
+      matrix:
+        sub_routes:
+          - repo: fastgpt-pro
+          - repo: fastgpt-pro-sub-route
+          - repo: fastgpt-pro-sub-route-gchat
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to Ali Hub
+        uses: docker/login-action@v3
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
+          password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-${{ matrix.sub_routes.repo }}-${{ github.sha }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set image name and tag
+        run: |
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
+            echo "Git_Tag=ghcr.io/${{ github.repository_owner }}/${{ matrix.sub_routes.repo }}:latest" >> $GITHUB_ENV
+            echo "Git_Latest=ghcr.io/${{ github.repository_owner }}/${{ matrix.sub_routes.repo }}:latest" >> $GITHUB_ENV
+            echo "Ali_Tag=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/${{ matrix.sub_routes.repo }}:latest" >> $GITHUB_ENV
+            echo "Ali_Latest=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/${{ matrix.sub_routes.repo }}:latest" >> $GITHUB_ENV
+          else
+            echo "Git_Tag=ghcr.io/${{ github.repository_owner }}/${{ matrix.sub_routes.repo }}:${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "Git_Latest=ghcr.io/${{ github.repository_owner }}/${{ matrix.sub_routes.repo }}:latest" >> $GITHUB_ENV
+            echo "Ali_Tag=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/${{ matrix.sub_routes.repo }}:${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "Ali_Latest=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/${{ matrix.sub_routes.repo }}:latest" >> $GITHUB_ENV
+          fi
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          TAGS="$(echo -e "${Git_Tag}\n${Git_Latest}\n${Ali_Tag}\n${Ali_Latest}")"
+          for TAG in $TAGS; do
+            docker buildx imagetools create -t $TAG \
+              $(printf 'ghcr.io/${{ github.repository_owner }}/${{ matrix.sub_routes.repo }}@sha256:%s ' *)
+            sleep 5
+          done

--- a/.github/workflows/preview-admin-build.yml
+++ b/.github/workflows/preview-admin-build.yml
@@ -1,8 +1,9 @@
 name: Preview Admin Image - Build
 
 on:
-  pull_request_target:
-    types: [ opened, synchronize, reopened ]
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: ['*']
     paths:
       - "pro"
       - "pro/**"
@@ -14,10 +15,9 @@ on:
       - ".gitmodules"
       - ".github/workflows/preview-admin-build.yml"
       - ".github/workflows/preview-admin-push.yml"
-  workflow_dispatch:
 
 concurrency:
-  group: "preview-admin-build-${{ github.event.pull_request.number || github.ref }}"
+  group: 'preview-admin-build-${{ github.head_ref || github.ref }}'
   cancel-in-progress: true
 
 permissions:
@@ -31,11 +31,8 @@ jobs:
       - name: Checkout PR code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request_target' &&
-            github.event.pull_request.head.sha || github.ref }}
-          repository: ${{ github.event_name == 'pull_request_target' &&
-            github.event.pull_request.head.repo.full_name || github.repository
-            }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 1
 
       - name: Update submodules
@@ -63,20 +60,19 @@ jobs:
           file: pro/admin/Dockerfile
           platforms: linux/amd64
           push: false
-          tags: fastgpt-pro-pr:${{ github.event_name == 'pull_request_target' &&
-            github.event.pull_request.head.sha || github.sha }}
+          tags: fastgpt-pro-pr:${{ github.event.pull_request.head.sha }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/FastGPT
             org.opencontainers.image.description=fastgpt-pro admin image
-            org.opencontainers.image.revision=${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
           outputs: type=docker,dest=/tmp/fastgpt-pro-image.tar
           cache-from: type=gha,scope=fastgpt-pro
           cache-to: type=gha,mode=max,scope=fastgpt-pro
 
       - name: Save PR metadata
         run: |
-          echo "${{ github.event.pull_request.number || '' }}" > /tmp/pr-number.txt
-          echo "${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}" > /tmp/pr-sha.txt
+          echo "${{ github.event.pull_request.number }}" > /tmp/pr-number.txt
+          echo "${{ github.event.pull_request.head.sha }}" > /tmp/pr-sha.txt
 
       - name: Upload Docker image artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What changed
- Add the admin release image workflow.
- Build admin images from the current FastGPT checkout plus the `pro` submodule.
- Align the release Docker context and Dockerfile with the preview admin build flow.
- Include the updated `pro` submodule pointer.

## Why
The admin release workflow was still shaped around cloning `labring/fastgpt-pro` and building the app Dockerfile directly. The preview workflow now builds from this repository with `pro/admin/Dockerfile`, so release should follow the same source layout.

## Validation
- Parsed `.github/workflows/build-admin.yml` as YAML.
- Ran `actionlint .github/workflows/build-admin.yml`.
