### PR TITLE
fix(docker): copy Pi Agent runtime deps into runner image

### DIFF
--- a/projects/app/Dockerfile
+++ b/projects/app/Dockerfile
@@ -103,6 +103,9 @@ COPY --from=builder --chown=nextjs:nodejs /app/projects/app/worker /app/worker
 COPY --from=maindeps /app/node_modules/tiktoken ./node_modules/tiktoken
 RUN rm -rf ./node_modules/tiktoken/encoders
 COPY --from=maindeps /app/node_modules/@zilliz/milvus2-sdk-node ./node_modules/@zilliz/milvus2-sdk-node
+# Pi Agent runtime deps (listed in serverExternalPackages but not traced by standalone output)
+# Docker COPY resolves symlinks, so this copies actual files from pnpm's symlinked structure.
+COPY --from=maindeps /app/node_modules/@mariozechner ./node_modules/@mariozechner
 
 # copy package.json to version file
 COPY --from=builder /app/projects/app/package.json ./package.json


### PR DESCRIPTION
## Summary

Copy `@mariozechner/pi-ai` and `@mariozechner/pi-agent-core` into the Docker runner stage so that Pi Agent (`AGENT_ENGINE=pi`) works out of the box.

## Problem

Both packages are listed in `serverExternalPackages` in `next.config.ts`, but the runner stage of the Dockerfile does not copy them from the `maindeps` build stage. Next.js standalone output tracing fails to pick them up because pnpm's symlink structure (`node_modules/@mariozechner/pi-ai` → `.pnpm/@mariozechner+pi-ai@x.x.x/node_modules/@mariozechner/pi-ai`) is not resolved by the file tracer.

This causes `MODULE_NOT_FOUND` at runtime when Pi Agent dispatch runs `require('@mariozechner/pi-agent-core')`, resulting in empty AI responses with no error logged.

## Fix

Add one `COPY` line to the runner stage, following the same pattern already used for `tiktoken` and `@zilliz/milvus2-sdk-node`:

```dockerfile
COPY --from=maindeps /app/node_modules/@mariozechner ./node_modules/@mariozechner
```

Docker's `COPY` instruction resolves symlinks, so this correctly copies the actual package files from pnpm's `.pnpm` store.

## Testing

- Verified on `ghcr.io/labring/fastgpt:v4.14.17` that the packages are missing by default
- Verified that adding this COPY line resolves the issue in our custom Dockerfile
- Pi Agent works correctly after the fix (Agent class, agentLoop, streamProxy all functional)

Related issue: #6865

🤖 Generated with [Claude Code](https://claude.com/claude-code)