### PR TITLE
fix: avoid client abort close false positives

### DIFF
--- a/packages/service/core/workflow/dispatch/utils/clientAbort.ts
+++ b/packages/service/core/workflow/dispatch/utils/clientAbort.ts
@@ -13,8 +13,10 @@ export const createClientAbortTracker = ({
   res?: NextApiResponse;
 }) => {
   let clientAborted = false;
+  let responseCompleted = !!(res?.writableEnded || res?.writableFinished);
 
-  const responseFinished = () => !!(res?.writableEnded || res?.writableFinished);
+  const responseFinished = () =>
+    responseCompleted || !!(res?.writableEnded || res?.writableFinished);
   const responseWritableAborted = () =>
     !!(res as ResponseWithWritableAborted | undefined)?.writableAborted;
   const isAbortedSnapshot = () => {
@@ -22,12 +24,14 @@ export const createClientAbortTracker = ({
 
     return !!(
       req?.aborted ||
-      req?.socket?.destroyed ||
       res?.closed ||
       res?.destroyed ||
       responseWritableAborted() ||
       res?.errored
     );
+  };
+  const markResponseCompleted = () => {
+    responseCompleted = true;
   };
   const markClientAborted = () => {
     if (!responseFinished()) {
@@ -36,7 +40,9 @@ export const createClientAbortTracker = ({
   };
 
   req?.on('aborted', markClientAborted);
-  req?.socket?.on('close', markClientAborted);
+  // Socket close is connection-level and can outlive the current response lifecycle.
+  // Use response close/error plus request aborted to avoid stopping workflow on connection churn.
+  res?.on('finish', markResponseCompleted);
   res?.on('close', markClientAborted);
   res?.on('error', markClientAborted);
 
@@ -44,7 +50,7 @@ export const createClientAbortTracker = ({
     isClientAborted: () => clientAborted || isAbortedSnapshot(),
     cleanup: () => {
       req?.off('aborted', markClientAborted);
-      req?.socket?.off('close', markClientAborted);
+      res?.off('finish', markResponseCompleted);
       res?.off('close', markClientAborted);
       res?.off('error', markClientAborted);
     }

--- a/packages/service/core/workflow/dispatch/utils/clientAbort.ts
+++ b/packages/service/core/workflow/dispatch/utils/clientAbort.ts
@@ -19,16 +19,12 @@ export const createClientAbortTracker = ({
     responseCompleted || !!(res?.writableEnded || res?.writableFinished);
   const responseWritableAborted = () =>
     !!(res as ResponseWithWritableAborted | undefined)?.writableAborted;
+  const hasExplicitAbort = () => !!(req?.aborted || responseWritableAborted());
+  const hasBrokenConnection = () => !!(req?.socket?.destroyed || res?.destroyed || res?.errored);
   const isAbortedSnapshot = () => {
     if (responseFinished()) return false;
 
-    return !!(
-      req?.aborted ||
-      res?.closed ||
-      res?.destroyed ||
-      responseWritableAborted() ||
-      res?.errored
-    );
+    return hasExplicitAbort() || hasBrokenConnection();
   };
   const markResponseCompleted = () => {
     responseCompleted = true;
@@ -38,20 +34,26 @@ export const createClientAbortTracker = ({
       clientAborted = true;
     }
   };
+  const markClientAbortedIfConnectionBroken = () => {
+    if (!responseFinished() && (hasExplicitAbort() || hasBrokenConnection())) {
+      clientAborted = true;
+    }
+  };
 
   req?.on('aborted', markClientAborted);
-  // Socket close is connection-level and can outlive the current response lifecycle.
-  // Use response close/error plus request aborted to avoid stopping workflow on connection churn.
+  // close itself is too broad; only stop when paired with explicit abort or a broken connection.
+  req?.socket?.on('close', markClientAbortedIfConnectionBroken);
   res?.on('finish', markResponseCompleted);
-  res?.on('close', markClientAborted);
+  res?.on('close', markClientAbortedIfConnectionBroken);
   res?.on('error', markClientAborted);
 
   return {
     isClientAborted: () => clientAborted || isAbortedSnapshot(),
     cleanup: () => {
       req?.off('aborted', markClientAborted);
+      req?.socket?.off('close', markClientAbortedIfConnectionBroken);
       res?.off('finish', markResponseCompleted);
-      res?.off('close', markClientAborted);
+      res?.off('close', markClientAbortedIfConnectionBroken);
       res?.off('error', markClientAborted);
     }
   };

--- a/packages/service/test/core/workflow/dispatch/index.test.ts
+++ b/packages/service/test/core/workflow/dispatch/index.test.ts
@@ -40,11 +40,35 @@ describe('createClientAbortTracker', () => {
     tracker.cleanup();
   });
 
-  it('响应未结束时 close，应判定为客户端 abort', () => {
+  it('响应未结束但只有 close，不应判定为客户端 abort', () => {
     const req = mockReq();
     const res = mockRes();
     const tracker = createClientAbortTracker({ req, res });
 
+    res.emit('close');
+
+    expect(tracker.isClientAborted()).toBe(false);
+    tracker.cleanup();
+  });
+
+  it('响应未结束且连接已断开时 close，应判定为客户端 abort', () => {
+    const req = mockReq();
+    const res = mockRes();
+    const tracker = createClientAbortTracker({ req, res });
+
+    req.socket.destroyed = true;
+    res.emit('close');
+
+    expect(tracker.isClientAborted()).toBe(true);
+    tracker.cleanup();
+  });
+
+  it('响应 writableAborted 时 close，应判定为客户端 abort', () => {
+    const req = mockReq();
+    const res = mockRes();
+    const tracker = createClientAbortTracker({ req, res });
+
+    res.writableAborted = true;
     res.emit('close');
 
     expect(tracker.isClientAborted()).toBe(true);
@@ -86,8 +110,18 @@ describe('createClientAbortTracker', () => {
     tracker.cleanup();
   });
 
-  it('创建 tracker 前响应已经异常关闭，应通过快照判定为客户端 abort', () => {
+  it('创建 tracker 前只有 closed，不应通过快照判定为客户端 abort', () => {
     const req = mockReq();
+    const res = mockRes({ closed: true });
+    const tracker = createClientAbortTracker({ req, res });
+
+    expect(tracker.isClientAborted()).toBe(false);
+    tracker.cleanup();
+  });
+
+  it('创建 tracker 前连接已经断开，应通过快照判定为客户端 abort', () => {
+    const req = mockReq();
+    req.socket.destroyed = true;
     const res = mockRes({ closed: true });
     const tracker = createClientAbortTracker({ req, res });
 

--- a/packages/service/test/core/workflow/dispatch/index.test.ts
+++ b/packages/service/test/core/workflow/dispatch/index.test.ts
@@ -51,14 +51,38 @@ describe('createClientAbortTracker', () => {
     tracker.cleanup();
   });
 
-  it('socket 在响应结束前关闭，应判定为客户端 abort', () => {
+  it('socket 单独关闭不应判定为当前请求 abort', () => {
     const req = mockReq();
     const res = mockRes();
     const tracker = createClientAbortTracker({ req, res });
 
     req.socket.emit('close');
 
+    expect(tracker.isClientAborted()).toBe(false);
+    tracker.cleanup();
+  });
+
+  it('请求 aborted 时应判定为客户端 abort', () => {
+    const req = mockReq();
+    const res = mockRes();
+    const tracker = createClientAbortTracker({ req, res });
+
+    req.emit('aborted');
+
     expect(tracker.isClientAborted()).toBe(true);
+    tracker.cleanup();
+  });
+
+  it('响应 finish 后 close，不应受 closed 状态误判', () => {
+    const req = mockReq();
+    const res = mockRes();
+    const tracker = createClientAbortTracker({ req, res });
+
+    res.emit('finish');
+    res.closed = true;
+    res.emit('close');
+
+    expect(tracker.isClientAborted()).toBe(false);
     tracker.cleanup();
   });
 


### PR DESCRIPTION
## Summary
- narrow v1 client abort tracking so close alone does not stop workflow execution
- only treat close as abort when paired with explicit abort or a broken connection
- cover socket close, writableAborted, finish+close, and pre-existing closed snapshots in tests

## Tests
- Not run: this worktree has no installed node_modules; Vitest fails during dependency resolution before running tests.