### PR TITLE
fix(s3): use Buffer instead of string for health check body

### DIFF
--- a/packages/service/common/s3/buckets/base.ts
+++ b/packages/service/common/s3/buckets/base.ts
@@ -73,7 +73,7 @@ export class S3BaseBucket {
 
     await this.client.uploadObject({
       key,
-      body: 'ok',
+      body: Buffer.from('ok'),
       contentType: 'text/plain',
       metadata: {
         contentDisposition: getContentDisposition({ filename, type: 'attachment' }),


### PR DESCRIPTION
  ## Summary
  - Fix `checkBucketHealth()` passing a plain string as upload body, which
    crashes the server at startup when `STORAGE_VENDOR=oss`

  ## Problem
  When using Aliyun OSS (`STORAGE_VENDOR=oss`), the `checkBucketHealth()`
  method in `S3BaseBucket` uploads `body: 'ok'` as a health check. The
  ali-oss SDK's `put(name, file, options)` method treats string arguments
  as file paths, calling `fs.statSync('ok')`, which throws:

  ENOENT: no such file or directory, stat 'ok'

  This causes the `instrumentation-check` initialization step to fail and
  the server cannot start.

  ## Fix
  Change `body: 'ok'` to `Buffer.from('ok')`. Buffer is correctly
  recognized as content by all storage adapters (aws-s3, minio, cos, oss).