### PR TITLE
fix(dockerfile): include server-proxy.js in standalone output for run…

### DIFF
--- a/projects/app/Dockerfile
+++ b/projects/app/Dockerfile
@@ -59,6 +59,8 @@ RUN cd projects/app && ./node_modules/.bin/esbuild server.ts \
     --external:next \
     '--banner:js=process.chdir(__dirname);try{const d=require("./.next/required-server-files.json");process.env.__NEXT_PRIVATE_STANDALONE_CONFIG=JSON.stringify(d.config);}catch(e){}'
 
+RUN cp /app/projects/app/server-proxy.js /app/projects/app/.next/standalone/projects/app/server-proxy.js
+
 # Remove build-time-only packages from standalone output before copying to runner.
 # These are traced into standalone by mistake (rspack bindings, gnu platform binaries, etc.)
 RUN rm -rf projects/app/.next/standalone/node_modules/.pnpm/@next+rspack-binding-*/ \


### PR DESCRIPTION
  ## Summary
  - Fix `server-proxy.js` missing from the runner stage, causing
    `MODULE_NOT_FOUND` when `SHOW_SKILL=true`

  ## Problem
  The builder stage uses esbuild to bundle `server.ts` into `server-proxy.js` (line 54-60), and the ENTRYPOINT runs it when `SHOW_SKILL=true` (line 125):

  ENTRYPOINT ["sh","-c","if [ "$SHOW_SKILL" = "true" ]; then
    node ./projects/app/server-proxy.js;
  else node ./projects/app/server.js; fi"]

  However, the runner stage only copies the `.next/standalone/` directory tree, which does not include `server-proxy.js`. There is no COPY instruction for it, so when `SHOW_SKILL=true`, the server crashes:

  Error: Cannot find module '/app/projects/app/server-proxy.js'
    code: 'MODULE_NOT_FOUND'

  ## Fix
  Add a `RUN cp` in the builder stage to place `server-proxy.js` into the `.next/standalone/projects/app/` directory (alongside the existing `server.js`). This way it is automatically included when the runner stage copies the standalone output to the final image.