### PR TITLE
fix: sync chat stop state

### DIFF
--- a/.codex/design/bug/stream-resume-stop-state.md
+++ b/.codex/design/bug/stream-resume-stop-state.md
@@ -1,0 +1,91 @@
+# 流恢复暂停状态与禁发保护设计
+
+## 背景
+
+流式对话暂停时，前端原本只把 stop 请求当作一次本地 abort 处理。若后端工作流尚未真正完成，用户立刻发送下一轮消息，会出现上一轮仍在写入、下一轮已经开始的并发状态，进而导致上下文混乱、侧栏生成态和输入框状态不一致。
+
+本 PR 目标是让“暂停”从单纯的前端中断动作，升级为前后端共同确认的生成态切换：后端返回真实完成情况，前端在未完成时继续保持禁发。
+
+## 问题分析
+
+1. `/api/v2/chat/stop` 只返回 `success`，前端不知道工作流是否已经结束。
+2. 前端 stop 后会立即执行本地 abort，输入区可能恢复可发送状态。
+3. `sendPrompt` 只依赖局部 `isChatting` 判断，不能覆盖服务端仍为 `generating` 或最后一条 AI 记录未 finish 的情况。
+4. 侧栏生成态、输入按钮状态和当前会话 `chatGenerateStatus` 没有在 stop 结果返回后统一同步。
+
+## 最终方案
+
+### 1. stop 接口返回生成态
+
+`/api/v2/chat/stop` 在触发 `finishWorkflow` 并最多等待工作流完成后，重新读取 `MongoChat.chatGenerateStatus`，返回：
+
+- `success`
+- `completed`
+- `chatGenerateStatus`
+
+其中 `completed = chatGenerateStatus !== generating`。这样前端能区分“停止完成”和“停止请求已发出但后台还没完全收尾”。
+
+### 2. 前端 stop 等待结果并同步状态
+
+`ChatInput` 调用 `postStopV2Chat` 后，把 `chatGenerateStatus` 和 `completed` 回传给 `ChatBox`。
+
+`ChatBox` 统一处理 stop settle：
+
+- `completed=true` 时使用后端返回的状态。
+- `completed=false` 时继续保持 `generating`。
+- 同步 `chatBoxData` 和侧栏历史项生成态。
+- 未完成时提示“停止中”，避免用户误以为可以马上开始下一轮。
+
+### 3. 抽象下一轮禁发判断
+
+新增 `isChatRoundPending`，统一判断本轮是否仍处于未完成状态：
+
+- 本地 `isChatting=true`
+- 当前会话 `chatGenerateStatus=generating`
+- 最后一条 AI 记录存在但 `status !== finish`
+
+只要任一条件成立，`sendPrompt` 和输入按钮都进入禁发状态。
+
+### 4. 补齐提示文案和接口 schema
+
+OpenAPI schema 增加 stop response 字段定义，前端 API 类型跟随 schema 更新。
+
+新增 `chat:stopping_chat` 国际化文案，用于 stop 未真正完成时的提示。
+
+## 涉及文件
+
+- `projects/app/src/pages/api/v2/chat/stop.ts`
+  - stop 后读取当前 `chatGenerateStatus`，返回 `completed` 与生成态。
+- `packages/global/openapi/core/chat/controler/api.ts`
+  - 更新 stop response schema。
+- `projects/app/src/web/core/chat/api.ts`
+  - 更新前端 stop API 返回类型。
+- `projects/app/src/components/core/chat/ChatContainer/ChatBox/chatStatus.ts`
+  - 新增 `isChatRoundPending`，集中维护禁发判断。
+- `projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx`
+  - 使用 `isChatRoundPending` 禁止下一轮发送，并处理 stop settle 后的状态同步。
+- `projects/app/src/components/core/chat/ChatContainer/ChatBox/Input/ChatInput.tsx`
+  - stop 请求等待后端结果；输入发送受 `disableSend` 控制。
+- `packages/web/i18n/en/chat.json`
+- `packages/web/i18n/zh-CN/chat.json`
+- `packages/web/i18n/zh-Hant/chat.json`
+  - 新增“停止中”提示文案。
+- `packages/global/test/core/chat/controler.test.ts`
+  - 覆盖 stop response schema。
+- `projects/app/test/components/core/chat/ChatContainer/ChatBox/chatStatus.test.ts`
+  - 覆盖禁发判断。
+
+## 验证点
+
+1. stop response schema 支持 `completed` 与 `chatGenerateStatus`。
+2. stop 未完成时，前端仍视为生成中并禁止继续发送。
+3. 本地 `isChatting=false` 但服务端生成态仍为 `generating` 时，不能发起下一轮。
+4. 最后一条 AI 记录未 finish 时，不能发起下一轮。
+
+## TODO
+
+- [x] stop 接口返回 `completed` 和 `chatGenerateStatus`
+- [x] 前端 stop settle 后同步当前会话和侧栏生成态
+- [x] 抽象并接入统一禁发判断
+- [x] 增加 stop response schema 测试
+- [x] 增加禁发判断单元测试

--- a/packages/global/openapi/core/chat/controler/api.ts
+++ b/packages/global/openapi/core/chat/controler/api.ts
@@ -76,11 +76,15 @@ export type StopV2ChatParams = z.infer<typeof StopV2ChatSchema>;
 
 export const StopV2ChatResponseSchema = z
   .object({
-    success: z.boolean().describe('是否成功停止')
+    success: z.boolean().describe('是否成功发送停止信号'),
+    completed: z.boolean().describe('工作流是否已在本次请求等待窗口内完成停止'),
+    chatGenerateStatus: z.enum(ChatGenerateStatusEnum).optional().describe('当前对话生成状态')
   })
   .meta({
     example: {
-      success: true
+      success: true,
+      completed: true,
+      chatGenerateStatus: ChatGenerateStatusEnum.done
     }
   });
 export type StopV2ChatResponse = z.infer<typeof StopV2ChatResponseSchema>;

--- a/packages/global/test/core/chat/controler.test.ts
+++ b/packages/global/test/core/chat/controler.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { ChatGenerateStatusEnum } from '@fastgpt/global/core/chat/constants';
+import { StopV2ChatResponseSchema } from '@fastgpt/global/openapi/core/chat/controler/api';
+
+describe('StopV2ChatResponseSchema', () => {
+  it('parses completed stop response with chat generate status', () => {
+    const result = StopV2ChatResponseSchema.parse({
+      success: true,
+      completed: true,
+      chatGenerateStatus: ChatGenerateStatusEnum.done
+    });
+
+    expect(result).toEqual({
+      success: true,
+      completed: true,
+      chatGenerateStatus: ChatGenerateStatusEnum.done
+    });
+  });
+
+  it('requires completed flag', () => {
+    expect(() =>
+      StopV2ChatResponseSchema.parse({
+        success: true
+      })
+    ).toThrow();
+  });
+});

--- a/packages/web/i18n/en/chat.json
+++ b/packages/web/i18n/en/chat.json
@@ -66,6 +66,7 @@
   "invalid_share_url": "Invalid sharing link",
   "is_chatting": "Chatting in progress... please wait until it finishes",
   "resume_placeholder_generating": "Generating",
+  "stopping_chat": "Stopping the previous chat turn. Please wait.",
   "resume_unavailable": "The current streaming response cannot be restored right now. Please check back later for the final answer.",
   "resume_unavailable_memory_pressure": "The service is currently under resource pressure, so stream resume is temporarily unavailable. Please check back later for the final answer.",
   "llm_request_detail": "LLM Request Detail",

--- a/packages/web/i18n/zh-CN/chat.json
+++ b/packages/web/i18n/zh-CN/chat.json
@@ -66,6 +66,7 @@
   "invalid_share_url": "无效的分享链接",
   "is_chatting": "正在聊天中...请等待结束",
   "resume_placeholder_generating": "生成中",
+  "stopping_chat": "正在停止上一轮对话，请稍候",
   "resume_unavailable": "当前无法恢复正在生成的流式内容，请稍后查看最终回答。",
   "resume_unavailable_memory_pressure": "当前服务资源紧张，暂不提供流式恢复。请稍后查看最终回答。",
   "llm_request_detail": "LLM 请求详情",

--- a/packages/web/i18n/zh-Hant/chat.json
+++ b/packages/web/i18n/zh-Hant/chat.json
@@ -66,6 +66,7 @@
   "invalid_share_url": "無效的分享鏈接",
   "is_chatting": "對話進行中...請稍候",
   "resume_placeholder_generating": "生成中",
+  "stopping_chat": "正在停止上一輪對話，請稍候",
   "resume_unavailable": "目前無法恢復正在產生的串流內容，請稍後再查看最終回答。",
   "resume_unavailable_memory_pressure": "目前服務資源緊張，暫時不提供串流恢復。請稍後再查看最終回答。",
   "llm_request_ids": "LLM 請求詳情",

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/Input/ChatInput.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/Input/ChatInput.tsx
@@ -22,6 +22,7 @@ import VoiceInput, { type VoiceInputComponentRef } from './VoiceInput';
 import MyBox from '@fastgpt/web/components/common/MyBox';
 import { postStopV2Chat } from '@/web/core/chat/api';
 import type { WorkflowInteractiveResponseType } from '@fastgpt/global/core/workflow/template/system/interactive/type';
+import { ChatGenerateStatusEnum } from '@fastgpt/global/core/chat/constants';
 
 const InputGuideBox = dynamic(() => import('./InputGuideBox'));
 
@@ -36,6 +37,8 @@ const ChatInput = ({
   lastInteractive,
   onSendMessage,
   onStop,
+  onStopSettled,
+  disableSend,
   TextareaDom,
   resetInputVal,
   chatForm
@@ -43,6 +46,8 @@ const ChatInput = ({
   lastInteractive?: WorkflowInteractiveResponseType;
   onSendMessage: SendPromptFnType;
   onStop: () => void;
+  onStopSettled?: (status: ChatGenerateStatusEnum, completed: boolean) => void;
+  disableSend?: boolean;
   TextareaDom: React.MutableRefObject<HTMLTextAreaElement | null>;
   resetInputVal: (val: ChatBoxInputType) => void;
   chatForm: UseFormReturn<ChatBoxInputFormType>;
@@ -100,7 +105,7 @@ const ChatInput = ({
     chatId
   });
   const havInput = !!inputValue || fileList.length > 0;
-  const canSendMessage = havInput && !hasFileUploading;
+  const canSendMessage = havInput && !hasFileUploading && !disableSend;
   const canUploadFile =
     showSelectFile ||
     showSelectImg ||
@@ -117,28 +122,30 @@ const ChatInput = ({
 
   /* on send */
   const handleSend = useCallback(
-    async (val?: string) => {
+    async (val: string = inputValue) => {
       if (!canSendMessage) return;
-      const textareaValue = val || TextareaDom.current?.value || '';
 
       onSendMessage({
-        text: textareaValue.trim(),
+        text: val.trim(),
         files: fileList,
         interactive: lastInteractive
       });
       replaceFiles([]);
     },
-    [TextareaDom, lastInteractive, canSendMessage, fileList, onSendMessage, replaceFiles]
+    [inputValue, lastInteractive, canSendMessage, fileList, onSendMessage, replaceFiles]
   );
   const { runAsync: handleStop, loading: isStopping } = useRequest(async () => {
     try {
       if (isChatting) {
-        await postStopV2Chat({
+        const result = await postStopV2Chat({
           appId,
           chatId,
           outLinkAuthData
-        }).catch();
+        });
+        onStopSettled?.(result.chatGenerateStatus ?? ChatGenerateStatusEnum.done, result.completed);
       }
+    } catch {
+      onStopSettled?.(ChatGenerateStatusEnum.generating, false);
     } finally {
       onStop();
     }
@@ -205,26 +212,28 @@ const ChatInput = ({
             onKeyDown={(e) => {
               // enter send.(pc or iframe && enter and unPress shift)
               const isEnter = e.key === 'Enter';
-              if (isEnter && TextareaDom.current && (e.ctrlKey || e.altKey)) {
+              const textarea = e.currentTarget;
+              if (isEnter && (e.ctrlKey || e.altKey)) {
                 // Add a new line
-                const index = TextareaDom.current.selectionStart;
-                const val = TextareaDom.current.value;
-                TextareaDom.current.value = `${val.slice(0, index)}\n${val.slice(index)}`;
-                TextareaDom.current.selectionStart = index + 1;
-                TextareaDom.current.selectionEnd = index + 1;
+                const index = textarea.selectionStart;
+                const val = textarea.value;
+                textarea.value = `${val.slice(0, index)}\n${val.slice(index)}`;
+                textarea.selectionStart = index + 1;
+                textarea.selectionEnd = index + 1;
 
-                TextareaDom.current.style.height = textareaMinH;
-                TextareaDom.current.style.height = `${TextareaDom.current.scrollHeight}px`;
+                textarea.style.height = textareaMinH;
+                textarea.style.height = `${textarea.scrollHeight}px`;
 
                 return;
               }
 
               // Select all content
-              // @ts-ignore
-              e.key === 'a' && e.ctrlKey && e.target?.select();
+              if (e.key === 'a' && e.ctrlKey) {
+                textarea.select();
+              }
 
               if ((isPc || window !== parent) && e.keyCode === 13 && !e.shiftKey) {
-                handleSend();
+                handleSend(textarea.value);
                 e.preventDefault();
               }
             }}
@@ -366,7 +375,7 @@ const ChatInput = ({
                 if (isChatting) {
                   return handleStop();
                 }
-                return handleSend();
+                return void handleSend(inputValue);
               }}
             >
               {isChatting ? (
@@ -394,10 +403,12 @@ const ChatInput = ({
     isStopping,
     isChatting,
     canSendMessage,
+    disableSend,
     onOpenSelectFile,
     onSelectFile,
     handleSend,
-    handleStop
+    handleStop,
+    onStopSettled
   ]);
 
   const activeStyles: FlexProps = {

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/chatStatus.ts
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/chatStatus.ts
@@ -1,0 +1,18 @@
+import { ChatGenerateStatusEnum, ChatRoleEnum } from '@fastgpt/global/core/chat/constants';
+import type { ChatSiteItemType } from './type';
+
+type ChatRoundStatusItem = Pick<ChatSiteItemType, 'obj' | 'status'>;
+
+export const isChatRoundPending = ({
+  isChatting,
+  chatGenerateStatus,
+  lastChat
+}: {
+  isChatting: boolean;
+  chatGenerateStatus?: ChatGenerateStatusEnum;
+  lastChat?: ChatRoundStatusItem;
+}) => {
+  if (isChatting) return true;
+  if (chatGenerateStatus === ChatGenerateStatusEnum.generating) return true;
+  return !!lastChat && lastChat.obj === ChatRoleEnum.AI && lastChat.status !== 'finish';
+};

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx
@@ -73,6 +73,7 @@ import { TeamErrEnum } from '@fastgpt/global/common/error/code/team';
 import { useMemoEnhance } from '@fastgpt/web/hooks/useMemoEnhance';
 import { cloneDeep } from 'lodash';
 import { ChatGenerateStatusEnum } from '@fastgpt/global/core/chat/constants';
+import { isChatRoundPending } from './chatStatus';
 
 const FeedbackModal = dynamic(() => import('./components/FeedbackModal'));
 const SelectMarkCollection = dynamic(() => import('./components/SelectMarkCollection'));
@@ -194,6 +195,14 @@ const ChatBox = ({
   const setAudioPlayingChatId = useContextSelector(ChatBoxContext, (v) => v.setAudioPlayingChatId);
   const splitText2Audio = useContextSelector(ChatBoxContext, (v) => v.splitText2Audio);
   const isChatting = useContextSelector(ChatBoxContext, (v) => v.isChatting);
+  const isRoundPending = isChatRoundPending({
+    isChatting,
+    chatGenerateStatus:
+      chatBoxData.appId === appId && chatBoxData.chatId === chatId
+        ? chatBoxData.chatGenerateStatus
+        : undefined,
+    lastChat: chatRecords[chatRecords.length - 1]
+  });
 
   const setHistories = useContextSelector(ChatContext, (v) => v.setHistories);
   const loadHistories = useContextSelector(ChatContext, (v) => v.loadHistories);
@@ -746,7 +755,7 @@ const ChatBox = ({
       variablesForm.handleSubmit(
         async ({ variables = {} }) => {
           if (!onStartChat) return;
-          if (isChatting) {
+          if (isRoundPending) {
             !hideInUI &&
               toast({
                 title: t('chat:is_chatting'),
@@ -1042,6 +1051,26 @@ const ChatBox = ({
       )();
     }
   );
+
+  const handleStopSettled = useMemoizedFn((status: ChatGenerateStatusEnum, completed: boolean) => {
+    const nextStatus = completed ? status : ChatGenerateStatusEnum.generating;
+    setChatBoxData((state) =>
+      state.chatId === chatId && state.appId === appId
+        ? {
+            ...state,
+            chatGenerateStatus: nextStatus,
+            hasBeenRead: false
+          }
+        : state
+    );
+    syncSidebarChatGenerateStatus(nextStatus, { hasBeenRead: false });
+    if (!completed) {
+      toast({
+        title: t('chat:stopping_chat'),
+        status: 'warning'
+      });
+    }
+  });
 
   // retry input
   const onDelMessage = useCallback(
@@ -1499,7 +1528,8 @@ const ChatBox = ({
     toast
   ]);
 
-  const canSendPrompt = onStartChat && chatStarted && active && canSendQuery;
+  const canRenderChatInput = onStartChat && chatStarted && active && canSendQuery;
+  const canSendPrompt = canRenderChatInput && !isRoundPending;
 
   // Add listener
   useEffect(() => {
@@ -1908,6 +1938,8 @@ const ChatBox = ({
               <ChatInput
                 onSendMessage={sendPrompt}
                 onStop={() => abortRequest('stop')}
+                onStopSettled={handleStopSettled}
+                disableSend={isRoundPending}
                 TextareaDom={TextareaDom}
                 resetInputVal={resetInputVal}
                 chatForm={chatForm}
@@ -1918,7 +1950,7 @@ const ChatBox = ({
       ) : (
         <>
           {AppChatRenderBox}
-          {canSendPrompt && (
+          {canRenderChatInput && (
             <Box
               px={[3, 5]}
               m={['0 auto 10px', '10px auto']}
@@ -1931,6 +1963,8 @@ const ChatBox = ({
                 onSendMessage={sendPrompt}
                 lastInteractive={lastInteractive}
                 onStop={() => abortRequest('stop')}
+                onStopSettled={handleStopSettled}
+                disableSend={isRoundPending}
                 TextareaDom={TextareaDom}
                 resetInputVal={resetInputVal}
                 chatForm={chatForm}

--- a/projects/app/src/pages/api/v2/chat/stop.ts
+++ b/projects/app/src/pages/api/v2/chat/stop.ts
@@ -7,8 +7,11 @@ import {
 } from '@fastgpt/service/core/workflow/dispatch/workflowStatus';
 import {
   StopV2ChatSchema,
+  StopV2ChatResponseSchema,
   type StopV2ChatResponse
 } from '@fastgpt/global/openapi/core/chat/controler/api';
+import { MongoChat } from '@fastgpt/service/core/chat/chatSchema';
+import { ChatGenerateStatusEnum } from '@fastgpt/global/core/chat/constants';
 
 async function handler(req: NextApiRequest, res: NextApiResponse): Promise<StopV2ChatResponse> {
   const { appId, chatId, outLinkAuthData } = StopV2ChatSchema.parse(req.body);
@@ -31,9 +34,14 @@ async function handler(req: NextApiRequest, res: NextApiResponse): Promise<StopV
   // 等待工作流完成 (最多等待 5 秒)
   await waitForWorkflowComplete({ appId, chatId, timeout: 5000 });
 
-  return {
-    success: true
-  };
+  const chat = await MongoChat.findOne({ appId, chatId }, 'chatGenerateStatus').lean();
+  const chatGenerateStatus = chat?.chatGenerateStatus ?? ChatGenerateStatusEnum.done;
+
+  return StopV2ChatResponseSchema.parse({
+    success: true,
+    completed: chatGenerateStatus !== ChatGenerateStatusEnum.generating,
+    chatGenerateStatus
+  });
 }
 
 export default NextAPI(handler);

--- a/projects/app/src/web/core/chat/api.ts
+++ b/projects/app/src/web/core/chat/api.ts
@@ -10,7 +10,8 @@ import type {
   InitChatQueryType,
   InitChatResponseType,
   InitTeamChatQueryType,
-  StopV2ChatParams
+  StopV2ChatParams,
+  StopV2ChatResponse
 } from '@fastgpt/global/openapi/core/chat/controler/api';
 import type { GetRecentlyUsedAppsResponseType } from '@fastgpt/global/openapi/core/chat/api';
 
@@ -49,4 +50,5 @@ export const deleteFavouriteApp = (data: { id: string }) =>
   DELETE<null>('/proApi/core/chat/setting/favourite/delete', data);
 
 /* Chat controller */
-export const postStopV2Chat = (data: StopV2ChatParams) => POST('/v2/chat/stop', data);
+export const postStopV2Chat = (data: StopV2ChatParams) =>
+  POST<StopV2ChatResponse>('/v2/chat/stop', data);

--- a/projects/app/test/components/core/chat/ChatContainer/ChatBox/chatStatus.test.ts
+++ b/projects/app/test/components/core/chat/ChatContainer/ChatBox/chatStatus.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { ChatGenerateStatusEnum, ChatRoleEnum } from '@fastgpt/global/core/chat/constants';
+import { isChatRoundPending } from '@/components/core/chat/ChatContainer/ChatBox/chatStatus';
+
+describe('isChatRoundPending', () => {
+  it('returns true while the local chat is streaming', () => {
+    expect(
+      isChatRoundPending({
+        isChatting: true,
+        chatGenerateStatus: ChatGenerateStatusEnum.done
+      })
+    ).toBe(true);
+  });
+
+  it('returns true while the server status is generating', () => {
+    expect(
+      isChatRoundPending({
+        isChatting: false,
+        chatGenerateStatus: ChatGenerateStatusEnum.generating
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when the latest AI item has not finished', () => {
+    expect(
+      isChatRoundPending({
+        isChatting: false,
+        chatGenerateStatus: ChatGenerateStatusEnum.done,
+        lastChat: {
+          obj: ChatRoleEnum.AI,
+          status: 'loading'
+        }
+      })
+    ).toBe(true);
+  });
+
+  it('returns false when there is no running signal', () => {
+    expect(
+      isChatRoundPending({
+        isChatting: false,
+        chatGenerateStatus: ChatGenerateStatusEnum.done,
+        lastChat: {
+          obj: ChatRoleEnum.AI,
+          status: 'finish'
+        }
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- return stop completion status and chat generate status from /api/v2/chat/stop
- keep the chat input visible while stopping but block new sends until the current turn is truly settled
- update sidebar/chat box state from stop response and add a stopping warning

## Tests
- pnpm --filter @fastgpt/global test test/core/chat/controler.test.ts
- pnpm --filter @fastgpt/app test test/components/core/chat/ChatContainer/ChatBox/chatStatus.test.ts
- pnpm --filter @fastgpt/app typecheck