### PR TITLE
fix: reset stale generating chats by stream activity

### DIFF
--- a/.codex/design/bug/stream-resume-stale-reset.md
+++ b/.codex/design/bug/stream-resume-stale-reset.md
@@ -1,0 +1,96 @@
+# 流恢复服务重启生成态快速重置设计
+
+## 背景
+
+服务崩溃或重启时，正在生成的对话可能来不及把 `chatGenerateStatus` 从 `generating` 写回 `done`。如果只依赖历史的 30 分钟清理，侧栏和恢复逻辑会在较长时间内继续认为该会话还在生成，用户需要等待很久才能恢复正常状态。
+
+流恢复的 stream 模式会持续向 Redis stream 写入数据，并通过心跳维持连接。因此可以把 Redis stream 的最近活动时间作为更精确的“服务是否还在持续生成”的依据。
+
+## 问题分析
+
+1. 旧清理逻辑只看 `MongoChat.updateTime` 是否超过 30 分钟，修正速度慢。
+2. 服务重启后，Mongo 里的 `generating` 状态可能残留，但 Redis stream 不再有新数据或心跳。
+3. 如果直接把 cron 改成频繁扫描 Mongo updateTime，仍然无法区分“正常长耗时生成”和“异常中断”。
+4. Redis 可能短暂异常，不能因为 Redis 读失败就误把正在生成的会话改成 done。
+
+## 最终方案
+
+### 1. Redis 记录 stream activity
+
+流恢复写入 Redis stream 时，同步刷新 `stream:resume:active:{teamId}:{appId}:{chatId}`。
+
+activity key 记录：
+
+- `updatedAt`
+
+写入策略跟 stream TTL touch 绑定，不对每个 chunk 都强制写 Redis，而是按既有 touch 间隔刷新，避免额外压力。
+
+### 2. 2 分钟无活动视为异常中断
+
+新增 `STREAM_RESUME_INACTIVE_MS = 2 * 60 * 1000`。
+
+`cleanStaleGeneratingChats` 先筛选生成态且 `updateTime` 早于 2 分钟前的会话，再读取 Redis activity：
+
+- activity 不存在：视为 stale。
+- activity 存在但 `now - updatedAt > 2min`：视为 stale。
+- activity 仍新鲜：跳过，认为生成仍活跃。
+
+这里的 2 分钟基于 stream 模式每分钟会推送心跳的前提，给一次心跳延迟留出缓冲。
+
+### 3. 保留 30 分钟 Mongo 兜底
+
+当会话 `updateTime` 已超过 30 分钟时，直接按旧逻辑修正为 done。
+
+兜底作用：
+
+- Redis activity key 被提前清理或不存在时，长期异常仍能被修正。
+- Redis 读异常时，不会立刻误判短时生成会话。
+
+### 4. Redis 异常时跳过快速修正
+
+如果读取 Redis activity 抛错，本轮清理记录 warn，并停止依赖 Redis 的快速判定；只保留 30 分钟兜底修正。
+
+这样 Redis 短暂不可用时，不会把真实仍在生成的会话误改成 done。
+
+### 5. cron 调整为每分钟
+
+清理任务从每 5 分钟调整为每 1 分钟，锁时间同步缩短为 1 分钟。
+
+由于候选查询先限制 `generating` 且 `updateTime < now - 2min`，再按候选逐个检查 Redis activity，频率提升主要用于缩短异常恢复时间，不是全量高频扫描。
+
+## 涉及文件
+
+- `packages/service/core/chat/resume.ts`
+  - 增加 `keyOfActive`。
+  - 增加 `STREAM_RESUME_INACTIVE_MS`。
+  - stream 写入时刷新 active state。
+  - stream 完成后同步缩短 stream key 和 active key TTL。
+  - 清理 mirror key 时删除 active key。
+  - 暴露 `getStreamResumeActiveState` 与 `isStreamResumeActiveStale`。
+- `packages/service/core/chat/cleanStaleGeneratingChats.ts`
+  - 从 30 分钟 updateTime 单条件清理，改为 Redis activity 快速判定 + 30 分钟兜底。
+  - 返回 `modifiedCount`、`inactiveCount`、`fallbackCount`，便于观察修正来源。
+- `projects/app/src/service/common/system/cron.ts`
+  - 清理任务执行频率从 5 分钟改为 1 分钟。
+  - 定时锁从 4 分钟改为 1 分钟。
+- `projects/app/test/api/core/chat/resume.test.ts`
+  - 覆盖 stream mirror active key 刷新。
+- `projects/app/test/service/core/chat/cleanStaleGeneratingChats.test.ts`
+  - 覆盖 active stale、active fresh、Redis 异常、30 分钟兜底等分支。
+
+## 验证点
+
+1. stream 写入会刷新 active key。
+2. active 超过 2 分钟未更新时，`generating` 会话被修正为 `done`。
+3. active 仍新鲜时，不修正生成态。
+4. Redis 读取异常时，不执行 2 分钟快速修正。
+5. 超过 30 分钟的旧会话仍能通过兜底逻辑修正。
+
+## TODO
+
+- [x] stream resume 写入时刷新 Redis activity
+- [x] stale cleaner 使用 activity 判断 2 分钟无更新
+- [x] Redis 异常时保留 30 分钟兜底
+- [x] cron 调整为每分钟执行
+- [x] 增加 resume active key 测试
+- [x] 增加 stale cleaner 分支测试

--- a/packages/service/core/chat/cleanStaleGeneratingChats.ts
+++ b/packages/service/core/chat/cleanStaleGeneratingChats.ts
@@ -1,25 +1,37 @@
-import { subMinutes } from 'date-fns';
+import { subMilliseconds, subMinutes } from 'date-fns';
 import { ChatGenerateStatusEnum } from '@fastgpt/global/core/chat/constants';
 import { getLogger, LogCategories } from '../../common/logger';
 import { MongoChat } from './chatSchema';
+import {
+  getStreamResumeActiveState,
+  isStreamResumeActiveStale,
+  STREAM_RESUME_INACTIVE_MS
+} from './resume';
 
 const logger = getLogger(LogCategories.MODULE.CHAT.HISTORY);
 
 /** 超过该时间仍停留在 generating 的会话视为异常中断，需纠正状态（分钟） */
 export const STALE_GENERATING_CHAT_MINUTES = 30;
 
-/**
- * 定时将长时间卡在 generating 的对话标记为 done，避免侧栏/恢复逻辑永久认为「生成中」。
- * 依赖 MongoChat.updateTime：进入 generating 时会更新；若进程崩溃未写 done/error，则时间停留在发起时刻。
- */
-export const cleanStaleGeneratingChats = async (): Promise<{ modifiedCount: number }> => {
-  const threshold = subMinutes(new Date(), STALE_GENERATING_CHAT_MINUTES);
-  const now = new Date();
+type GeneratingChat = {
+  _id: unknown;
+  teamId: { toString: () => string } | string;
+  appId: { toString: () => string } | string;
+  chatId: string;
+  updateTime?: Date;
+};
 
-  const result = await MongoChat.updateMany(
+type CleanStaleGeneratingChatsResult = {
+  modifiedCount: number;
+  inactiveCount: number;
+  fallbackCount: number;
+};
+
+const markChatAsDone = async (chat: GeneratingChat, now: Date) => {
+  const result = await MongoChat.updateOne(
     {
-      chatGenerateStatus: ChatGenerateStatusEnum.generating,
-      updateTime: { $lt: threshold }
+      _id: chat._id,
+      chatGenerateStatus: ChatGenerateStatusEnum.generating
     },
     {
       $set: {
@@ -30,13 +42,87 @@ export const cleanStaleGeneratingChats = async (): Promise<{ modifiedCount: numb
     }
   );
 
-  if (result.modifiedCount > 0) {
+  return result.modifiedCount ?? 0;
+};
+
+/**
+ * 定时将卡在 generating 的对话标记为 done，避免侧栏/恢复逻辑永久认为「生成中」。
+ * 优先依赖 Redis stream activity：stream 模式会持续推送心跳，activity 超过 2 分钟未刷新视为异常中断。
+ * Redis 异常时保留 30 分钟 updateTime 兜底，避免短暂 Redis 故障误改正在生成的会话。
+ */
+export const cleanStaleGeneratingChats = async (): Promise<CleanStaleGeneratingChatsResult> => {
+  const now = new Date();
+  const fallbackThreshold = subMinutes(now, STALE_GENERATING_CHAT_MINUTES);
+  const inactiveThreshold = subMilliseconds(now, STREAM_RESUME_INACTIVE_MS);
+  let modifiedCount = 0;
+  let inactiveCount = 0;
+  let fallbackCount = 0;
+  let redisFailed = false;
+
+  const generatingChats = (await MongoChat.find(
+    {
+      chatGenerateStatus: ChatGenerateStatusEnum.generating,
+      updateTime: { $lt: inactiveThreshold }
+    },
+    {
+      _id: 1,
+      teamId: 1,
+      appId: 1,
+      chatId: 1,
+      updateTime: 1
+    }
+  )
+    .lean()
+    .exec()) as GeneratingChat[];
+
+  for (const chat of generatingChats) {
+    const shouldUseFallback = !!chat.updateTime && chat.updateTime < fallbackThreshold;
+
+    if (shouldUseFallback) {
+      const currentModifiedCount = await markChatAsDone(chat, now);
+      modifiedCount += currentModifiedCount;
+      fallbackCount += currentModifiedCount;
+      continue;
+    }
+
+    if (redisFailed) {
+      continue;
+    }
+
+    try {
+      const activeState = await getStreamResumeActiveState({
+        teamId: chat.teamId.toString(),
+        appId: chat.appId.toString(),
+        chatId: chat.chatId
+      });
+
+      if (isStreamResumeActiveStale(activeState, now.getTime())) {
+        const currentModifiedCount = await markChatAsDone(chat, now);
+        modifiedCount += currentModifiedCount;
+        inactiveCount += currentModifiedCount;
+      }
+    } catch (error) {
+      redisFailed = true;
+      logger.warn('cleanStaleGeneratingChats: failed to inspect stream resume activity', {
+        error
+      });
+    }
+  }
+
+  if (modifiedCount > 0) {
     logger.info('cleanStaleGeneratingChats: corrected stuck generating chats', {
-      modifiedCount: result.modifiedCount,
-      threshold,
+      modifiedCount,
+      inactiveCount,
+      fallbackCount,
+      inactiveMs: STREAM_RESUME_INACTIVE_MS,
+      fallbackThreshold,
       staleMinutes: STALE_GENERATING_CHAT_MINUTES
     });
   }
 
-  return { modifiedCount: result.modifiedCount };
+  return {
+    modifiedCount,
+    inactiveCount,
+    fallbackCount
+  };
 };

--- a/packages/service/core/chat/resume.ts
+++ b/packages/service/core/chat/resume.ts
@@ -22,6 +22,7 @@ export const STREAM_RESUME_REDIS_MEMORY_CHECK_INTERVAL_MS =
  */
 export const STREAM_RESUME_BLOCK_MS = 30000;
 export const STREAM_RESUME_TTL_TOUCH_INTERVAL_MS = 1000;
+export const STREAM_RESUME_INACTIVE_MS = 2 * 60 * 1000;
 
 type ResumeRequestHeaderValue = string | string[] | undefined;
 type RedisMemoryPressureCache = {
@@ -47,7 +48,8 @@ export const getStreamResumeRedisKeys = ({
   chatId
 }: StreamResumeRedisKeysParams) => ({
   keyOfStream: `stream:resume:data:${teamId}:${appId}:${chatId}`,
-  keyOfUnavailable: `stream:resume:unavailable:${teamId}:${appId}:${chatId}`
+  keyOfUnavailable: `stream:resume:unavailable:${teamId}:${appId}:${chatId}`,
+  keyOfActive: `stream:resume:active:${teamId}:${appId}:${chatId}`
 });
 
 type StreamResumeKeys = ReturnType<typeof getStreamResumeRedisKeys>;
@@ -60,6 +62,10 @@ const getStreamResumeRedisRawKeys = (keys: StreamResumeKeys) => ({
 
 export type StreamResumeUnavailableState = {
   reason: `${StreamResumeUnavailableReasonEnum}`;
+};
+
+export type StreamResumeActiveState = {
+  updatedAt: number;
 };
 
 const resumeRequestEnabledValues = new Set(['1', 'true', 'yes', 'on']);
@@ -183,9 +189,26 @@ const touchStreamResumeTTL = async ({ keyOfStream }: StreamResumeKeys) => {
   await redis.expire(keyOfStream, STREAM_RESUME_TTL_SECONDS);
 };
 
-const shrinkStreamResumeTTL = async ({ keyOfStream }: StreamResumeKeys) => {
+const touchStreamResumeActiveState = async (keys: StreamResumeKeys) => {
   const redis = getGlobalRedisConnection();
-  await redis.expire(keyOfStream, STREAM_RESUME_POST_COMPLETE_TTL_SECONDS);
+  await redis.set(
+    keys.keyOfActive,
+    JSON.stringify({ updatedAt: Date.now() } satisfies StreamResumeActiveState),
+    'EX',
+    STREAM_RESUME_TTL_SECONDS
+  );
+};
+
+const touchStreamResumeState = async (keys: StreamResumeKeys) => {
+  await Promise.all([touchStreamResumeTTL(keys), touchStreamResumeActiveState(keys)]);
+};
+
+const shrinkStreamResumeTTL = async ({ keyOfStream, keyOfActive }: StreamResumeKeys) => {
+  const redis = getGlobalRedisConnection();
+  await Promise.all([
+    redis.expire(keyOfStream, STREAM_RESUME_POST_COMPLETE_TTL_SECONDS),
+    redis.expire(keyOfActive, STREAM_RESUME_POST_COMPLETE_TTL_SECONDS)
+  ]);
 };
 
 const setStreamResumeUnavailableState = async (
@@ -217,6 +240,27 @@ export const getStreamResumeUnavailableState = async (params: StreamResumeRedisK
   }
 };
 
+export const getStreamResumeActiveState = async (params: StreamResumeRedisKeysParams) => {
+  const redis = getGlobalRedisConnection();
+  const keys = getStreamResumeRedisKeys(params);
+  const state = await redis.get(keys.keyOfActive);
+
+  if (!state) return;
+
+  try {
+    const parsed = JSON.parse(state) as StreamResumeActiveState;
+    if (!Number.isFinite(parsed?.updatedAt)) return;
+    return parsed;
+  } catch {
+    return;
+  }
+};
+
+export const isStreamResumeActiveStale = (
+  state: StreamResumeActiveState | undefined,
+  now = Date.now()
+) => !state || now - state.updatedAt > STREAM_RESUME_INACTIVE_MS;
+
 const chunkToString = (chunk: string | Buffer | Uint8Array, encoding?: BufferEncoding) => {
   if (typeof chunk === 'string') return chunk;
   if (Buffer.isBuffer(chunk)) return chunk.toString(encoding || 'utf8');
@@ -227,7 +271,8 @@ const chunkToString = (chunk: string | Buffer | Uint8Array, encoding?: BufferEnc
 const clearStreamResumeMirrorKeys = async (keys: StreamResumeKeys) => {
   await Promise.all([
     clearStreamResumeUnavailableState(keys),
-    getGlobalRedisConnection().del(keys.keyOfStream)
+    getGlobalRedisConnection().del(keys.keyOfStream),
+    getGlobalRedisConnection().del(keys.keyOfActive)
   ]);
 };
 
@@ -247,7 +292,7 @@ export const mirrorChatStream = (params: StreamResumeRedisKeysParams) => {
         await redis.call('XADD', rawKeys.rawKeyOfStream, '*', 'raw', chunk);
         const now = Date.now();
         if (lastTouchedAt === 0 || now - lastTouchedAt >= STREAM_RESUME_TTL_TOUCH_INTERVAL_MS) {
-          await touchStreamResumeTTL(keys);
+          await touchStreamResumeState(keys);
           lastTouchedAt = now;
         }
       })

--- a/projects/app/src/service/common/system/cron.ts
+++ b/projects/app/src/service/common/system/cron.ts
@@ -65,13 +65,13 @@ const scheduleTriggerAppCron = () => {
   getScheduleTriggerApp();
 };
 
-/** 超过 30 分钟仍为 generating 的会话纠正为 done（与 cleanStaleGeneratingChats 阈值一致） */
+/** 基于 Redis stream activity 快速纠正异常中断的 generating 会话，保留 30 分钟兜底 */
 const cleanStaleGeneratingChatCron = () => {
-  setCron('*/5 * * * *', async () => {
+  setCron('*/1 * * * *', async () => {
     if (
       await checkTimerLock({
         timerId: TimerIdEnum.cleanStaleGeneratingChat,
-        lockMinuted: 4
+        lockMinuted: 1
       })
     ) {
       await cleanStaleGeneratingChats();

--- a/projects/app/test/api/core/chat/resume.test.ts
+++ b/projects/app/test/api/core/chat/resume.test.ts
@@ -20,6 +20,9 @@ import {
   mirrorChatStream,
   resetStreamResumeMirrorGuardForTest,
   getStreamResumeRedisKeys,
+  getStreamResumeActiveState,
+  isStreamResumeActiveStale,
+  STREAM_RESUME_INACTIVE_MS,
   STREAM_RESUME_POST_COMPLETE_TTL_SECONDS,
   STREAM_RESUME_REDIS_MAXMEMORY_RATIO,
   STREAM_RESUME_TTL_SECONDS,
@@ -763,6 +766,7 @@ describe('stream resume helpers', () => {
 
       expect(redis.del).toHaveBeenCalledWith(keys.keyOfUnavailable);
       expect(redis.del).toHaveBeenCalledWith(keys.keyOfStream);
+      expect(redis.del).toHaveBeenCalledWith(keys.keyOfActive);
       expect(redis.call).toHaveBeenNthCalledWith(
         1,
         'XADD',
@@ -782,12 +786,22 @@ describe('stream resume helpers', () => {
 
       expect(redis.expire).toHaveBeenCalledWith(keys.keyOfStream, STREAM_RESUME_TTL_SECONDS);
       expect(redis.expire).toHaveBeenCalledTimes(1);
+      expect(redis.set).toHaveBeenCalledWith(
+        keys.keyOfActive,
+        expect.stringMatching(/^\{"updatedAt":\d+\}$/),
+        'EX',
+        STREAM_RESUME_TTL_SECONDS
+      );
+      expect(await getStreamResumeActiveState({ teamId, appId, chatId })).toEqual({
+        updatedAt: expect.any(Number)
+      });
 
       vi.advanceTimersByTime(STREAM_RESUME_TTL_TOUCH_INTERVAL_MS);
       await mirror.enqueueRaw('event: done\ndata: [DONE]\n\n');
       await mirror.flush();
 
       expect(redis.expire).toHaveBeenCalledTimes(2);
+      expect(redis.set).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }
@@ -805,7 +819,11 @@ describe('stream resume helpers', () => {
       keys.keyOfStream,
       STREAM_RESUME_POST_COMPLETE_TTL_SECONDS
     );
-    expect(redis.expire).toHaveBeenCalledTimes(1);
+    expect(redis.expire).toHaveBeenCalledWith(
+      keys.keyOfActive,
+      STREAM_RESUME_POST_COMPLETE_TTL_SECONDS
+    );
+    expect(redis.expire).toHaveBeenCalledTimes(2);
   });
 
   it('should clear old redis mirror when mirror starts (before first chunk)', async () => {
@@ -828,6 +846,13 @@ describe('stream resume helpers', () => {
     await mirror.flush();
 
     expect(redis.del).toHaveBeenCalledWith(keyOfStream);
+    expect(redis.del).toHaveBeenCalledWith(
+      getStreamResumeRedisKeys({
+        teamId,
+        appId,
+        chatId
+      }).keyOfActive
+    );
     expect(await redis.get(keyOfStream)).toBeFalsy();
   });
 
@@ -851,6 +876,7 @@ describe('stream resume helpers', () => {
 
     expect(redis.del).toHaveBeenCalledWith(keys.keyOfUnavailable);
     expect(redis.del).toHaveBeenCalledWith(keys.keyOfStream);
+    expect(redis.del).toHaveBeenCalledWith(keys.keyOfActive);
     expect(redis.call).toHaveBeenNthCalledWith(1, 'XADD', rawStream, '*', 'raw', 'event: answer\n');
     expect(redis.call).toHaveBeenNthCalledWith(2, 'XADD', rawStream, '*', 'raw', 'data: hello\n\n');
   });
@@ -905,5 +931,27 @@ describe('stream resume helpers', () => {
   it('should parse truthy stream resume request headers', () => {
     expect(isStreamResumeMirrorRequested('YES')).toBe(true);
     expect(isStreamResumeMirrorRequested('0')).toBe(false);
+  });
+
+  it('should detect stale stream resume activity states', () => {
+    const now = Date.now();
+
+    expect(isStreamResumeActiveStale(undefined, now)).toBe(true);
+    expect(
+      isStreamResumeActiveStale(
+        {
+          updatedAt: now - STREAM_RESUME_INACTIVE_MS + 1
+        },
+        now
+      )
+    ).toBe(false);
+    expect(
+      isStreamResumeActiveStale(
+        {
+          updatedAt: now - STREAM_RESUME_INACTIVE_MS - 1
+        },
+        now
+      )
+    ).toBe(true);
   });
 });

--- a/projects/app/test/service/core/chat/cleanStaleGeneratingChats.test.ts
+++ b/projects/app/test/service/core/chat/cleanStaleGeneratingChats.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatGenerateStatusEnum } from '@fastgpt/global/core/chat/constants';
+import { MongoChat } from '@fastgpt/service/core/chat/chatSchema';
+import {
+  cleanStaleGeneratingChats,
+  STALE_GENERATING_CHAT_MINUTES
+} from '@fastgpt/service/core/chat/cleanStaleGeneratingChats';
+import {
+  getStreamResumeRedisKeys,
+  STREAM_RESUME_INACTIVE_MS
+} from '@fastgpt/service/core/chat/resume';
+import { getGlobalRedisConnection } from '@fastgpt/service/common/redis';
+
+vi.mock('@fastgpt/service/core/chat/chatSchema', () => ({
+  MongoChat: {
+    find: vi.fn(),
+    updateOne: vi.fn()
+  }
+}));
+
+const teamId = '507f1f77bcf86cd799439011';
+const appId = '507f1f77bcf86cd799439012';
+const baseNow = new Date('2026-05-13T08:00:00.000Z');
+
+const mockGeneratingChats = (chats: any[]) => {
+  vi.mocked(MongoChat.find).mockReturnValue({
+    lean: () => ({
+      exec: () => Promise.resolve(chats)
+    })
+  } as any);
+};
+
+describe('cleanStaleGeneratingChats', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(baseNow);
+    vi.clearAllMocks();
+
+    const redis = getGlobalRedisConnection() as any;
+    await redis.flushdb();
+    redis.get.mockClear?.();
+    vi.mocked(MongoChat.updateOne).mockResolvedValue({ modifiedCount: 1 } as any);
+  });
+
+  it('should correct generating chats when stream resume activity is stale or missing', async () => {
+    const activeChat = {
+      _id: 'active-chat',
+      teamId,
+      appId,
+      chatId: 'active',
+      updateTime: new Date(baseNow.getTime() - STREAM_RESUME_INACTIVE_MS - 1000)
+    };
+    const staleChat = {
+      _id: 'stale-chat',
+      teamId,
+      appId,
+      chatId: 'stale',
+      updateTime: new Date(baseNow.getTime() - STREAM_RESUME_INACTIVE_MS - 1000)
+    };
+    const missingChat = {
+      _id: 'missing-chat',
+      teamId,
+      appId,
+      chatId: 'missing',
+      updateTime: new Date(baseNow.getTime() - STREAM_RESUME_INACTIVE_MS - 1000)
+    };
+    mockGeneratingChats([activeChat, staleChat, missingChat]);
+
+    const redis = getGlobalRedisConnection() as any;
+    await redis.set(
+      getStreamResumeRedisKeys({ teamId, appId, chatId: activeChat.chatId }).keyOfActive,
+      JSON.stringify({ updatedAt: baseNow.getTime() - STREAM_RESUME_INACTIVE_MS + 1000 }),
+      'EX',
+      1800
+    );
+    await redis.set(
+      getStreamResumeRedisKeys({ teamId, appId, chatId: staleChat.chatId }).keyOfActive,
+      JSON.stringify({ updatedAt: baseNow.getTime() - STREAM_RESUME_INACTIVE_MS - 1000 }),
+      'EX',
+      1800
+    );
+
+    const result = await cleanStaleGeneratingChats();
+
+    expect(MongoChat.find).toHaveBeenCalledWith(
+      {
+        chatGenerateStatus: ChatGenerateStatusEnum.generating,
+        updateTime: { $lt: new Date(baseNow.getTime() - STREAM_RESUME_INACTIVE_MS) }
+      },
+      {
+        _id: 1,
+        teamId: 1,
+        appId: 1,
+        chatId: 1,
+        updateTime: 1
+      }
+    );
+    expect(MongoChat.updateOne).toHaveBeenCalledTimes(2);
+    expect(MongoChat.updateOne).toHaveBeenCalledWith(
+      {
+        _id: staleChat._id,
+        chatGenerateStatus: ChatGenerateStatusEnum.generating
+      },
+      {
+        $set: {
+          chatGenerateStatus: ChatGenerateStatusEnum.done,
+          updateTime: baseNow,
+          hasBeenRead: false
+        }
+      }
+    );
+    expect(MongoChat.updateOne).toHaveBeenCalledWith(
+      {
+        _id: missingChat._id,
+        chatGenerateStatus: ChatGenerateStatusEnum.generating
+      },
+      {
+        $set: {
+          chatGenerateStatus: ChatGenerateStatusEnum.done,
+          updateTime: baseNow,
+          hasBeenRead: false
+        }
+      }
+    );
+    expect(result).toEqual({
+      modifiedCount: 2,
+      inactiveCount: 2,
+      fallbackCount: 0
+    });
+  });
+
+  it('should keep the 30 minute fallback when redis activity lookup fails', async () => {
+    const inactiveOnlyChat = {
+      _id: 'inactive-only-chat',
+      teamId,
+      appId,
+      chatId: 'inactive-only',
+      updateTime: new Date(baseNow.getTime() - STREAM_RESUME_INACTIVE_MS - 1000)
+    };
+    const fallbackChat = {
+      _id: 'fallback-chat',
+      teamId,
+      appId,
+      chatId: 'fallback',
+      updateTime: new Date(baseNow.getTime() - STALE_GENERATING_CHAT_MINUTES * 60 * 1000 - 1000)
+    };
+    mockGeneratingChats([inactiveOnlyChat, fallbackChat]);
+
+    const redis = getGlobalRedisConnection() as any;
+    redis.get.mockRejectedValueOnce(new Error('redis down'));
+
+    const result = await cleanStaleGeneratingChats();
+
+    expect(MongoChat.updateOne).toHaveBeenCalledTimes(1);
+    expect(MongoChat.updateOne).toHaveBeenCalledWith(
+      {
+        _id: fallbackChat._id,
+        chatGenerateStatus: ChatGenerateStatusEnum.generating
+      },
+      {
+        $set: {
+          chatGenerateStatus: ChatGenerateStatusEnum.done,
+          updateTime: baseNow,
+          hasBeenRead: false
+        }
+      }
+    );
+    expect(result).toEqual({
+      modifiedCount: 1,
+      inactiveCount: 0,
+      fallbackCount: 1
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- refresh a Redis stream resume activity key while mirroring chat stream chunks
- reset generating chats after stream activity is missing or stale for 2 minutes
- keep the 30 minute Mongo updateTime fallback when Redis activity lookup fails
- run the stale generating chat cron every minute

## Tests
- pnpm --filter @fastgpt/app test test/service/core/chat/cleanStaleGeneratingChats.test.ts
- pnpm --filter @fastgpt/app test test/api/core/chat/resume.test.ts
- pnpm --filter @fastgpt/app typecheck