### PR TITLE
fix: sync temporary chat history title

### DIFF
--- a/.codex/design/bug/stream-resume-history-title.md
+++ b/.codex/design/bug/stream-resume-history-title.md
@@ -1,0 +1,81 @@
+# 流恢复历史记录名称修复设计
+
+## 背景
+
+新对话发起后，侧栏会先展示一个临时历史项。旧逻辑在服务端历史记录尚未落库或尚未拉取回来时，容易显示固定的“新对话”。流恢复场景下，这个临时标题更容易停留在默认文案，导致用户在历史列表中无法通过刚输入的问题识别会话。
+
+本 PR 目标是让临时历史项先使用用户输入生成的标题，服务端标题回来后再覆盖。
+
+## 问题分析
+
+1. 侧栏临时项默认标题固定为“新对话”，没有优先使用当前轮用户输入。
+2. `onUpdateHistoryTitle` 发现本地 histories 没有目标 chatId 时，会直接触发拉取服务端历史；如果服务端还没落库，本地仍然没有可展示标题。
+3. 当前会话 `chatBoxData.title` 与侧栏临时项标题没有在新对话开始时同步。
+4. 生成完成后仍需要尊重服务端最终标题，不能让临时标题永久覆盖服务端标题。
+
+## 最终方案
+
+### 1. 新对话开始时生成临时标题
+
+在 `ChatBox` 发起新一轮对话时，通过 `getChatTitleFromChatMessage(currentHumanChat)` 从用户输入生成临时标题。
+
+该标题同步写入：
+
+- 当前会话 `chatBoxData.title`
+- 侧栏临时历史项
+
+这样服务端历史未返回前，侧栏也能展示用户可识别的标题。
+
+### 2. 侧栏展示标题统一走 display helper
+
+新增 `getDisplayHistoryTitle`：
+
+- 有非空标题时展示标题。
+- 标题为空时回退到“新对话”。
+
+侧栏临时项不再无条件展示固定“新对话”，而是优先使用 `chatBoxData.title`。
+
+### 3. `onUpdateHistoryTitle` 支持本地 upsert
+
+新增 `upsertHistoryTitle`：
+
+- 如果 histories 中已有目标会话，直接本地替换标题。
+- 如果还没有目标会话，先插入一个临时历史项。
+- 插入临时项时标记为 `generating` 且 `hasBeenRead=false`。
+
+随后仍然调用 `loadHistories({ init: true })` 拉取服务端数据。这样既保证即时展示，又能在服务端落库后回到真实历史记录。
+
+### 4. 服务端标题回来后覆盖临时标题
+
+本 PR 不改变服务端标题生成逻辑。拉取历史成功后，服务端返回的历史项会覆盖本地临时项，从而把临时标题替换成最终落库标题。
+
+## 涉及文件
+
+- `projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx`
+  - 新对话开始时根据用户输入生成临时标题。
+  - 同步更新当前会话标题和侧栏临时历史项标题。
+- `projects/app/src/pageComponents/chat/slider/ChatSliderList.tsx`
+  - 临时历史项展示时优先使用 `chatBoxData.title`。
+  - 接入 `getDisplayHistoryTitle` 处理空标题回退。
+- `projects/app/src/web/core/chat/context/chatContext.tsx`
+  - `onUpdateHistoryTitle` 改为先本地 upsert，再拉取服务端历史。
+  - 使用 ref effect 同步 histories，避免直接渲染期赋值。
+- `projects/app/src/web/core/chat/context/historyTitleUtils.ts`
+  - 新增 `getDisplayHistoryTitle` 和 `upsertHistoryTitle`。
+- `projects/app/test/web/core/chat/context/historyTitleUtils.test.ts`
+  - 覆盖标题回退、已存在历史替换、不存在历史插入等场景。
+
+## 验证点
+
+1. 新会话刚开始时，侧栏展示用户输入生成的标题，而不是固定“新对话”。
+2. `onUpdateHistoryTitle` 在 histories 尚未包含目标 chatId 时，也能先插入临时项。
+3. 标题为空时仍回退到“新对话”。
+4. 服务端历史拉取回来后，可以用服务端标题覆盖临时标题。
+
+## TODO
+
+- [x] 新对话开始时生成并同步临时标题
+- [x] 侧栏临时项优先展示当前会话标题
+- [x] `onUpdateHistoryTitle` 支持本地 upsert
+- [x] 保留服务端历史刷新覆盖最终标题
+- [x] 增加 history title 工具函数测试

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx
@@ -59,7 +59,10 @@ import { useContextSelector } from 'use-context-selector';
 import { useSystem } from '@fastgpt/web/hooks/useSystem';
 import { useCreation, useDebounceEffect, useMemoizedFn, useThrottleFn } from 'ahooks';
 import MyIcon from '@fastgpt/web/components/common/Icon';
-import { mergeChatResponseData } from '@fastgpt/global/core/chat/utils';
+import {
+  getChatTitleFromChatMessage,
+  mergeChatResponseData
+} from '@fastgpt/global/core/chat/utils';
 import { getWebReqUrl } from '@fastgpt/web/common/system/utils';
 import { ChatRecordContext } from '@/web/core/chat/context/chatRecordContext';
 import { ChatContext } from '@/web/core/chat/context/chatContext';
@@ -201,7 +204,12 @@ const ChatBox = ({
   const syncSidebarChatGenerateStatus = useMemoizedFn(
     (
       status: ChatGenerateStatusEnum,
-      options?: { hasBeenRead?: boolean; targetAppId?: string; targetChatId?: string }
+      options?: {
+        hasBeenRead?: boolean;
+        targetAppId?: string;
+        targetChatId?: string;
+        title?: string;
+      }
     ) => {
       const targetAppId = options?.targetAppId ?? appId;
       if (targetAppId !== appId) return;
@@ -216,7 +224,7 @@ const ChatBox = ({
             {
               chatId: targetChatId,
               appId: targetAppId,
-              title: chatBoxData.title || t('common:core.chat.New Chat'),
+              title: options?.title || chatBoxData.title || t('common:core.chat.New Chat'),
               customTitle: '',
               top: false,
               updateTime: new Date(),
@@ -840,6 +848,7 @@ const ChatBox = ({
               status: ChatStatusEnum.loading
             }
           ];
+          const temporaryHistoryTitle = getChatTitleFromChatMessage(currentHumanChat);
 
           resumedChatTargetRef.current = `${appId}:${chatId}`;
 
@@ -847,12 +856,16 @@ const ChatBox = ({
             state.chatId === chatId
               ? {
                   ...state,
+                  title: temporaryHistoryTitle,
                   chatGenerateStatus: ChatGenerateStatusEnum.generating,
                   hasBeenRead: false
                 }
               : state
           );
-          syncSidebarChatGenerateStatus(ChatGenerateStatusEnum.generating, { hasBeenRead: false });
+          syncSidebarChatGenerateStatus(ChatGenerateStatusEnum.generating, {
+            hasBeenRead: false,
+            title: temporaryHistoryTitle
+          });
 
           // Update histories(Interactive input does not require new session rounds)
           setChatRecords(

--- a/projects/app/src/pageComponents/chat/slider/ChatSliderList.tsx
+++ b/projects/app/src/pageComponents/chat/slider/ChatSliderList.tsx
@@ -12,6 +12,7 @@ import { useSystem } from '@fastgpt/web/hooks/useSystem';
 import { formatTimeToChatTime } from '@fastgpt/global/common/string/time';
 import { ChatItemContext } from '@/web/core/chat/context/chatItemContext';
 import { ChatGenerateStatusEnum } from '@fastgpt/global/core/chat/constants';
+import { getDisplayHistoryTitle } from '@/web/core/chat/context/historyTitleUtils';
 
 const ChatSliderList = () => {
   const { isPc } = useSystem();
@@ -47,9 +48,9 @@ const ChatSliderList = () => {
         top: item.top,
         updateTime: item.updateTime,
         chatGenerateStatus: isActiveChat
-          ? chatBoxData.chatGenerateStatus ?? item.chatGenerateStatus
+          ? (chatBoxData.chatGenerateStatus ?? item.chatGenerateStatus)
           : item.chatGenerateStatus,
-        hasBeenRead: isActiveChat ? chatBoxData.hasBeenRead ?? item.hasBeenRead : item.hasBeenRead
+        hasBeenRead: isActiveChat ? (chatBoxData.hasBeenRead ?? item.hasBeenRead) : item.hasBeenRead
       };
     });
 
@@ -63,7 +64,10 @@ const ChatSliderList = () => {
       hasBeenRead?: boolean;
     } = {
       id: activeChatId,
-      title: t('common:core.chat.New Chat'),
+      title: getDisplayHistoryTitle({
+        title: chatBoxData.chatId === activeChatId ? chatBoxData.title : undefined,
+        fallbackTitle: t('common:core.chat.New Chat')
+      }),
       updateTime: new Date(),
       chatGenerateStatus:
         chatBoxData.chatId === activeChatId ? chatBoxData.chatGenerateStatus : undefined,
@@ -77,6 +81,7 @@ const ChatSliderList = () => {
     histories,
     t,
     chatBoxData.chatId,
+    chatBoxData.title,
     chatBoxData.chatGenerateStatus,
     chatBoxData.hasBeenRead
   ]);
@@ -89,6 +94,7 @@ const ChatSliderList = () => {
 
   return (
     <>
+      {/* eslint-disable-next-line react-hooks/static-components -- ScrollData is supplied by useScrollPagination. */}
       <ScrollData flex={'1 0 0'} h={0} px={[2, 5]} overflow={'overlay'}>
         {concatHistory.map((item, i) => (
           <Flex

--- a/projects/app/src/web/core/chat/context/chatContext.tsx
+++ b/projects/app/src/web/core/chat/context/chatContext.tsx
@@ -16,6 +16,7 @@ import { getNanoid } from '@fastgpt/global/common/string/tools';
 import { useScrollPagination } from '@fastgpt/web/hooks/useScrollPagination';
 import type { UpdateHistoryBodyType } from '@fastgpt/global/openapi/core/chat/history/api';
 import { ChatGenerateStatusEnum } from '@fastgpt/global/core/chat/constants';
+import { upsertHistoryTitle } from './historyTitleUtils';
 
 type UpdateHistoryParams = Pick<UpdateHistoryBodyType, 'chatId' | 'customTitle' | 'top'>;
 
@@ -204,22 +205,26 @@ const ChatContextProvider = ({
 
   const onUpdateHistoryTitle = useCallback(
     ({ chatId, newTitle }: { chatId: string; newTitle: string }) => {
-      // Chat history exists
-      if (histories.find((item) => item.chatId === chatId)) {
-        setHistories((state) =>
-          state.map((item) => (item.chatId === chatId ? { ...item, title: newTitle } : item))
-        );
-      } else {
-        // Chat history not exists
-        loadHistories({ init: true });
-      }
+      setHistories((state) =>
+        upsertHistoryTitle({
+          histories: state,
+          appId,
+          chatId,
+          title: newTitle,
+          fallbackTitle: '新对话'
+        })
+      );
+      loadHistories({ init: true });
     },
-    [histories, loadHistories, setHistories]
+    [appId, loadHistories, setHistories]
   );
 
   const historyChatIdsKey = useMemo(() => histories.map((h) => h.chatId).join(','), [histories]);
   const historiesRef = useRef(histories);
-  historiesRef.current = histories;
+
+  useEffect(() => {
+    historiesRef.current = histories;
+  }, [histories]);
 
   /** 侧栏是否仍有「思考中」：仅此时需要定时轮询；无则只依赖单次 poll / 可见性拉取，避免一直打接口。 */
   const hasGeneratingInSidebar = useMemo(
@@ -249,7 +254,7 @@ const ChatContextProvider = ({
               const nextRead =
                 nextGen === ChatGenerateStatusEnum.generating
                   ? false
-                  : s.hasBeenRead ?? item.hasBeenRead;
+                  : (s.hasBeenRead ?? item.hasBeenRead);
               return {
                 ...item,
                 chatGenerateStatus: nextGen,

--- a/projects/app/src/web/core/chat/context/historyTitleUtils.ts
+++ b/projects/app/src/web/core/chat/context/historyTitleUtils.ts
@@ -1,0 +1,60 @@
+import { ChatGenerateStatusEnum } from '@fastgpt/global/core/chat/constants';
+import type { ChatHistoryItemType } from '@fastgpt/global/core/chat/type';
+
+export const getDisplayHistoryTitle = ({
+  title,
+  fallbackTitle
+}: {
+  title?: string;
+  fallbackTitle: string;
+}) => {
+  const normalizedTitle = title?.trim();
+  return normalizedTitle || fallbackTitle;
+};
+
+export const upsertHistoryTitle = ({
+  histories,
+  appId,
+  chatId,
+  title,
+  fallbackTitle,
+  now = new Date()
+}: {
+  histories: ChatHistoryItemType[];
+  appId: string;
+  chatId: string;
+  title?: string;
+  fallbackTitle: string;
+  now?: Date;
+}) => {
+  const nextTitle = getDisplayHistoryTitle({ title, fallbackTitle });
+  const existingIndex = histories.findIndex(
+    (item) => item.chatId === chatId && item.appId === appId
+  );
+
+  if (existingIndex >= 0) {
+    return histories.map((item, index) =>
+      index === existingIndex
+        ? {
+            ...item,
+            title: nextTitle,
+            updateTime: now
+          }
+        : item
+    );
+  }
+
+  return [
+    {
+      chatId,
+      appId,
+      title: nextTitle,
+      customTitle: '',
+      top: false,
+      updateTime: now,
+      chatGenerateStatus: ChatGenerateStatusEnum.generating,
+      hasBeenRead: false
+    },
+    ...histories
+  ];
+};

--- a/projects/app/test/web/core/chat/context/historyTitleUtils.test.ts
+++ b/projects/app/test/web/core/chat/context/historyTitleUtils.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { ChatGenerateStatusEnum } from '@fastgpt/global/core/chat/constants';
+import type { ChatHistoryItemType } from '@fastgpt/global/core/chat/type';
+import {
+  getDisplayHistoryTitle,
+  upsertHistoryTitle
+} from '@/web/core/chat/context/historyTitleUtils';
+
+const appId = 'app-1';
+const chatId = 'chat-1';
+const now = new Date('2026-05-13T08:00:00.000Z');
+
+const createHistory = (override: Partial<ChatHistoryItemType> = {}): ChatHistoryItemType => ({
+  appId,
+  chatId,
+  title: 'old title',
+  customTitle: '',
+  top: false,
+  updateTime: new Date('2026-05-13T07:00:00.000Z'),
+  chatGenerateStatus: ChatGenerateStatusEnum.done,
+  hasBeenRead: true,
+  ...override
+});
+
+describe('historyTitleUtils', () => {
+  it('should prefer non-empty title and fallback when title is blank', () => {
+    expect(
+      getDisplayHistoryTitle({
+        title: ' user question ',
+        fallbackTitle: '新对话'
+      })
+    ).toBe('user question');
+    expect(
+      getDisplayHistoryTitle({
+        title: '   ',
+        fallbackTitle: '新对话'
+      })
+    ).toBe('新对话');
+  });
+
+  it('should insert a temporary history with user input title', () => {
+    const result = upsertHistoryTitle({
+      histories: [],
+      appId,
+      chatId,
+      title: 'What is FastGPT?',
+      fallbackTitle: '新对话',
+      now
+    });
+
+    expect(result).toEqual([
+      {
+        appId,
+        chatId,
+        title: 'What is FastGPT?',
+        customTitle: '',
+        top: false,
+        updateTime: now,
+        chatGenerateStatus: ChatGenerateStatusEnum.generating,
+        hasBeenRead: false
+      }
+    ]);
+  });
+
+  it('should replace existing temporary title with server title without duplicating history', () => {
+    const otherHistory = createHistory({
+      chatId: 'chat-2',
+      title: 'other title'
+    });
+    const result = upsertHistoryTitle({
+      histories: [
+        createHistory({
+          title: '新对话',
+          chatGenerateStatus: ChatGenerateStatusEnum.generating,
+          hasBeenRead: false
+        }),
+        otherHistory
+      ],
+      appId,
+      chatId,
+      title: 'server generated title',
+      fallbackTitle: '新对话',
+      now
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      ...createHistory({
+        title: 'server generated title',
+        chatGenerateStatus: ChatGenerateStatusEnum.generating,
+        hasBeenRead: false
+      }),
+      updateTime: now
+    });
+    expect(result[1]).toBe(otherHistory);
+  });
+});


### PR DESCRIPTION
## Summary
- use the user input title for the temporary active chat history item instead of always showing New Chat
- upsert a local history title before refreshing server histories so the sidebar updates immediately
- allow the completed/server history title to replace the temporary title after persistence
- add helper coverage for fallback, insert, and replace behavior

## Tests
- pnpm --filter @fastgpt/app test test/web/core/chat/context/historyTitleUtils.test.ts
- pnpm --filter @fastgpt/app typecheck
- pnpm exec eslint --fix "projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx" "projects/app/src/pageComponents/chat/slider/ChatSliderList.tsx" "projects/app/src/web/core/chat/context/chatContext.tsx" "projects/app/src/web/core/chat/context/historyTitleUtils.ts" "projects/app/test/web/core/chat/context/historyTitleUtils.test.ts"