### PR TITLE
fix: validate chat data ids before run

### DIFF
--- a/.codex/design/bug/stream-resume-dataid-validation.md
+++ b/.codex/design/bug/stream-resume-dataid-validation.md
@@ -1,0 +1,103 @@
+# Chat dataId 前置去重校验设计
+
+## 背景
+
+流恢复依赖 `appId + chatId + obj + dataId` 定位和合并对话记录。历史上入口没有统一校验 `dataId` 唯一性，调用方如果重复传入 `dataId`，可能导致对话项、响应项或恢复合并时定位错误。
+
+本 PR 目标是在工作流执行前发现重复 `dataId`，直接抛业务错误，避免脏数据继续进入工作流和持久化链路。
+
+## 约束
+
+本 PR 不采用 human 和 AI 共用同一个 `dataId` 的方案。
+
+当前选择是保持 human/AI 各自拥有独立 `dataId`，但要求同一 `appId + chatId` 下新一轮要写入的 `dataId` 不与请求内或库内已有记录重复。
+
+## 问题分析
+
+1. v1、v2、chatTest 三个入口都可以创建新一轮对话，但此前没有统一的 dataId 前置校验。
+2. 如果用户请求里 `userContent.dataId` 和 `responseChatItemId` 相同，会在同一轮内产生重复。
+3. 如果用户传入的 `dataId` 已存在于当前会话历史中，会导致后续查找、恢复、合并逻辑产生歧义。
+4. 校验必须发生在工作流执行前，否则即使后续发现重复，也可能已经触发模型调用或工作流副作用。
+
+## 最终方案
+
+### 1. 抽象统一校验模块
+
+新增 `packages/service/core/chat/dataIdValidation.ts`，提供：
+
+- `assertNoDuplicateChatDataIdsInRequest`
+- `assertNoExistingChatDataIds`
+- `validateChatRoundDataIds`
+
+统一错误信息为 `Chat dataId already exists: {dataId}`，并通过 `UserError` 抛出业务错误。
+
+### 2. 校验请求内重复
+
+每一轮新写入的 dataId 集合包括：
+
+- `userContent.dataId`
+- `responseChatItemId`
+
+先过滤空值，再检查集合内是否重复。重复时直接抛错，不进入数据库查询和工作流执行。
+
+### 3. 校验库内重复
+
+对有效 dataId 查询 `MongoChatItem`：
+
+- `appId`
+- `chatId`
+- `dataId: { $in: validDataIds }`
+
+只要命中已有记录，就抛业务错误。
+
+### 4. 三个入口在工作流前调用
+
+接入点：
+
+- `/api/v1/chat/completions`
+- `/api/v2/chat/completions`
+- `/api/core/chat/chatTest`
+
+校验发生在 `saveChatId`、`responseChatItemId` 已确定之后，且早于 workflow dispatch。
+
+## 涉及文件
+
+- `packages/service/core/chat/dataIdValidation.ts`
+  - 新增 dataId 校验工具。
+- `projects/app/src/pages/api/v1/chat/completions.ts`
+  - 在 v1 对话入口工作流执行前校验当前轮 dataId。
+- `projects/app/src/pages/api/v2/chat/completions.ts`
+  - 在 v2 对话入口工作流执行前校验当前轮 dataId。
+- `projects/app/src/pages/api/core/chat/chatTest.ts`
+  - 在 chatTest 入口工作流执行前校验当前轮 dataId。
+- `packages/service/test/core/chat/dataIdValidation.test.ts`
+  - 覆盖请求内重复、库内重复和非重复场景。
+
+## 验证点
+
+1. 请求内 `userContent.dataId === responseChatItemId` 时抛业务错误。
+2. 请求 dataId 已存在于 `MongoChatItem` 时抛业务错误。
+3. 空 dataId 不参与重复校验。
+4. 非重复 dataId 可以继续进入后续流程。
+5. v1、v2、chatTest 三个入口都在工作流执行前完成校验。
+
+## 后续迁移
+
+本 PR 只阻止新重复数据继续产生，不处理既有历史重复。
+
+既有数据需要通过独立迁移 PR 处理：
+
+- dry-run 扫描重复 `chat_items.dataId`
+- apply 改写重复 dataId
+- 同步修复 `chat_item_response.chatItemDataId`
+- 重复数归零后再考虑唯一索引
+
+## TODO
+
+- [x] 新增 chat dataId 校验模块
+- [x] 校验请求内 human/AI dataId 重复
+- [x] 校验当前会话库内已有 dataId
+- [x] v1 入口接入前置校验
+- [x] v2 入口接入前置校验
+- [x] chatTest 入口接入前置校验
+- [x] 增加 dataId 校验单元测试

--- a/packages/service/core/chat/dataIdValidation.ts
+++ b/packages/service/core/chat/dataIdValidation.ts
@@ -1,0 +1,80 @@
+import type { ChatItemMiniType, UserChatItemType } from '@fastgpt/global/core/chat/type';
+import { UserError } from '@fastgpt/global/common/error/utils';
+import { MongoChatItem } from './chatItemSchema';
+
+export const CHAT_DATA_ID_DUPLICATE_ERROR_MESSAGE = 'Chat dataId already exists';
+
+type ValidateChatRoundDataIdsParams = {
+  appId: string;
+  chatId: string;
+  userContent: UserChatItemType & { dataId?: string };
+  responseChatItemId: string;
+};
+
+const getValidDataIds = (dataIds: Array<string | undefined>) =>
+  dataIds.filter((dataId): dataId is string => typeof dataId === 'string' && dataId.length > 0);
+
+const findDuplicateDataId = (dataIds: string[]) => {
+  const seen = new Set<string>();
+
+  for (const dataId of dataIds) {
+    if (seen.has(dataId)) return dataId;
+    seen.add(dataId);
+  }
+};
+
+export const getChatMessagesDataIds = (chatMessages: ChatItemMiniType[]) =>
+  getValidDataIds(chatMessages.map((item) => item.dataId));
+
+export const assertNoDuplicateChatDataIdsInRequest = (dataIds: Array<string | undefined>) => {
+  const duplicateDataId = findDuplicateDataId(getValidDataIds(dataIds));
+
+  if (duplicateDataId) {
+    throw new UserError(`${CHAT_DATA_ID_DUPLICATE_ERROR_MESSAGE}: ${duplicateDataId}`);
+  }
+};
+
+export const assertNoExistingChatDataIds = async ({
+  appId,
+  chatId,
+  dataIds
+}: {
+  appId: string;
+  chatId: string;
+  dataIds: Array<string | undefined>;
+}) => {
+  const validDataIds = getValidDataIds(dataIds);
+  if (validDataIds.length === 0) return;
+
+  const existingChatItem = await MongoChatItem.findOne(
+    {
+      appId,
+      chatId,
+      dataId: { $in: validDataIds }
+    },
+    'dataId'
+  )
+    .lean()
+    .exec();
+
+  if (existingChatItem?.dataId) {
+    throw new UserError(`${CHAT_DATA_ID_DUPLICATE_ERROR_MESSAGE}: ${existingChatItem.dataId}`);
+  }
+};
+
+export const validateChatRoundDataIds = async ({
+  appId,
+  chatId,
+  userContent,
+  responseChatItemId
+}: ValidateChatRoundDataIdsParams) => {
+  const currentRoundDataIds = [userContent.dataId, responseChatItemId];
+
+  assertNoDuplicateChatDataIdsInRequest(currentRoundDataIds);
+
+  await assertNoExistingChatDataIds({
+    appId,
+    chatId,
+    dataIds: currentRoundDataIds
+  });
+};

--- a/packages/service/test/core/chat/dataIdValidation.test.ts
+++ b/packages/service/test/core/chat/dataIdValidation.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getNanoid } from '@fastgpt/global/common/string/tools';
+import { ChatRoleEnum } from '@fastgpt/global/core/chat/constants';
+import { MongoChatItem } from '@fastgpt/service/core/chat/chatItemSchema';
+import {
+  CHAT_DATA_ID_DUPLICATE_ERROR_MESSAGE,
+  assertNoDuplicateChatDataIdsInRequest,
+  getChatMessagesDataIds,
+  validateChatRoundDataIds
+} from '@fastgpt/service/core/chat/dataIdValidation';
+import { MongoApp } from '@fastgpt/service/core/app/schema';
+import { AppTypeEnum } from '@fastgpt/global/core/app/constants';
+import { getUser } from '@test/datas/users';
+
+describe('chat dataId validation', () => {
+  let testUser: Awaited<ReturnType<typeof getUser>>;
+  let appId: string;
+  let chatId: string;
+
+  beforeEach(async () => {
+    testUser = await getUser('test-user');
+    chatId = getNanoid(24);
+
+    const app = await MongoApp.create({
+      name: 'Test App',
+      type: AppTypeEnum.simple,
+      teamId: testUser.teamId,
+      tmbId: testUser.tmbId,
+      modules: []
+    });
+    appId = String(app._id);
+  });
+
+  it('should collect only valid dataIds from chat messages', () => {
+    expect(
+      getChatMessagesDataIds([
+        {
+          obj: ChatRoleEnum.Human,
+          dataId: 'human-1',
+          value: [{ text: { content: 'hello' } }]
+        },
+        {
+          obj: ChatRoleEnum.AI,
+          value: [{ text: { content: 'hi' } }]
+        },
+        {
+          obj: ChatRoleEnum.Human,
+          dataId: '',
+          value: [{ text: { content: 'next' } }]
+        }
+      ])
+    ).toEqual(['human-1']);
+  });
+
+  it('should reject duplicate dataIds in the current request', () => {
+    expect(() =>
+      assertNoDuplicateChatDataIdsInRequest(['history-1', undefined, 'history-1'])
+    ).toThrow(`${CHAT_DATA_ID_DUPLICATE_ERROR_MESSAGE}: history-1`);
+  });
+
+  it('should reject human and ai sharing one dataId', async () => {
+    await expect(
+      validateChatRoundDataIds({
+        appId,
+        chatId,
+        userContent: {
+          obj: ChatRoleEnum.Human,
+          dataId: 'same-data-id',
+          value: [{ text: { content: 'hello' } }]
+        },
+        responseChatItemId: 'same-data-id'
+      })
+    ).rejects.toThrow(`${CHAT_DATA_ID_DUPLICATE_ERROR_MESSAGE}: same-data-id`);
+  });
+
+  it('should reject dataIds that already exist in chat items', async () => {
+    await MongoChatItem.create({
+      teamId: testUser.teamId,
+      tmbId: testUser.tmbId,
+      appId,
+      chatId,
+      dataId: 'existing-ai',
+      obj: ChatRoleEnum.AI,
+      value: [{ text: { content: 'old answer' } }]
+    });
+
+    await expect(
+      validateChatRoundDataIds({
+        appId,
+        chatId,
+        userContent: {
+          obj: ChatRoleEnum.Human,
+          dataId: 'new-human',
+          value: [{ text: { content: 'hello' } }]
+        },
+        responseChatItemId: 'existing-ai'
+      })
+    ).rejects.toThrow(`${CHAT_DATA_ID_DUPLICATE_ERROR_MESSAGE}: existing-ai`);
+  });
+
+  it('should allow unique current round dataIds', async () => {
+    await expect(
+      validateChatRoundDataIds({
+        appId,
+        chatId,
+        userContent: {
+          obj: ChatRoleEnum.Human,
+          dataId: 'new-human',
+          value: [{ text: { content: 'hello' } }]
+        },
+        responseChatItemId: 'new-ai'
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/projects/app/src/pages/api/core/chat/chatTest.ts
+++ b/projects/app/src/pages/api/core/chat/chatTest.ts
@@ -62,22 +62,24 @@ import {
   STREAM_RESUME_REQUEST_HEADER
 } from '@fastgpt/global/core/chat/constants';
 import { getStreamResumeMirror } from '@fastgpt/service/core/chat/resume';
+import { validateChatRoundDataIds } from '@fastgpt/service/core/chat/dataIdValidation';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   let streamResumeMirror: Awaited<ReturnType<typeof getStreamResumeMirror>>;
   let workflowResponseWrite: ReturnType<typeof getWorkflowResponseWrite> | undefined;
   let usePreparedRound = false;
-  let {
+  const chatTestProps = ChatTestPropsSchema.parse(req.body);
+  const {
     nodes = [],
     edges = [],
     messages = [],
     responseChatItemId: responseChatItemIdFromBody,
-    variables = {},
     appName,
     appId,
     chatConfig,
     chatId
-  } = ChatTestPropsSchema.parse(req.body);
+  } = chatTestProps;
+  let { variables = {} } = chatTestProps;
   const responseChatItemId = responseChatItemIdFromBody ?? getNanoid(24);
   const source = ChatSourceEnum.test;
   try {
@@ -158,6 +160,14 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     const newHistories = concatHistories(histories, chatMessages);
     const interactive = getLastInteractiveValue(newHistories);
     usePreparedRound = !interactive;
+
+    await validateChatRoundDataIds({
+      appId: String(app._id),
+      chatId,
+      userContent: userQuestion,
+      responseChatItemId
+    });
+
     // Get runtimeNodes
     let runtimeNodes = storeNodes2RuntimeNodes(nodes, getWorkflowEntryNodeIds(nodes, interactive));
     if (isPlugin) {

--- a/projects/app/src/pages/api/v1/chat/completions.ts
+++ b/projects/app/src/pages/api/v1/chat/completions.ts
@@ -64,6 +64,7 @@ import { formatTime2YMDHM } from '@fastgpt/global/common/string/time';
 import { LimitTypeEnum, teamFrequencyLimit } from '@fastgpt/service/common/api/frequencyLimit';
 import { getIpFromRequest } from '@fastgpt/service/common/geo';
 import { pushTrack } from '@fastgpt/service/common/middle/tracks/utils';
+import { validateChatRoundDataIds } from '@fastgpt/service/core/chat/dataIdValidation';
 
 const logger = getLogger(LogCategories.MODULE.CHAT.ITEM);
 
@@ -241,6 +242,13 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     runtimeNodes = rewriteNodeOutputByHistories(runtimeNodes, interactive);
 
     const saveChatId = chatId || getNanoid(24);
+    await validateChatRoundDataIds({
+      appId: String(app._id),
+      chatId: saveChatId,
+      userContent: userQuestion,
+      responseChatItemId
+    });
+
     const source = (() => {
       if (shareId) {
         return ChatSourceEnum.share;

--- a/projects/app/src/pages/api/v2/chat/completions.ts
+++ b/projects/app/src/pages/api/v2/chat/completions.ts
@@ -74,10 +74,12 @@ import {
   ChatGenerateStatusEnum,
   STREAM_RESUME_REQUEST_HEADER
 } from '@fastgpt/global/core/chat/constants';
+import { validateChatRoundDataIds } from '@fastgpt/service/core/chat/dataIdValidation';
 const logger = getLogger(LogCategories.MODULE.CHAT.ITEM);
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
-  let {
+  const completionProps = CompletionsPropsSchema.parse(req.body);
+  const {
     chatId,
     appId,
     customUid,
@@ -89,14 +91,12 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     teamToken,
 
     stream,
-    detail,
-    retainDatasetCite,
     showSkillReferences,
     messages,
-    variables,
     responseChatItemId,
     metadata
-  } = CompletionsPropsSchema.parse(req.body);
+  } = completionProps;
+  let { detail, retainDatasetCite, variables } = completionProps;
 
   const originIp = getIpFromRequest(req);
 
@@ -258,6 +258,13 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     runtimeNodes = rewriteNodeOutputByHistories(runtimeNodes, interactive);
 
     const saveChatId = chatId || getNanoid(24);
+    await validateChatRoundDataIds({
+      appId: String(app._id),
+      chatId: saveChatId,
+      userContent: userQuestion,
+      responseChatItemId: finalResponseChatItemId
+    });
+
     const source = (() => {
       if (shareId) {
         return ChatSourceEnum.share;


### PR DESCRIPTION
## Summary
- add a shared chat dataId validation helper for the current human/AI round
- reject human and assistant using the same dataId before workflow execution
- reject current-round dataIds that already exist in chat_items before workflow execution
- wire the check into v1 chat completions, v2 chat completions, and chatTest
- keep the final unique-index/data migration work for the follow-up PR

## Tests
- pnpm --filter @fastgpt/service test test/core/chat/dataIdValidation.test.ts
- pnpm --filter @fastgpt/app typecheck
- pnpm exec eslint --fix "projects/app/src/pages/api/core/chat/chatTest.ts" "projects/app/src/pages/api/v1/chat/completions.ts" "projects/app/src/pages/api/v2/chat/completions.ts" "packages/service/core/chat/dataIdValidation.ts" "packages/service/test/core/chat/dataIdValidation.test.ts"