### PR TITLE
fix: preserve resumed flow node responses

### DIFF
--- a/.codex/design/bug/stream-resume-form-input-file-list.md
+++ b/.codex/design/bug/stream-resume-form-input-file-list.md
@@ -1,0 +1,375 @@
+# 流恢复表单输入值修复
+
+## 背景
+
+流恢复过程中，工作流的「表单输入」节点可以恢复出交互节点本身，但已提交的表单值没有完整恢复，其中 `fileSelect` 文件列表最容易暴露。
+
+典型表现：
+
+1. 刷新页面后，历史记录接口 `getRecords_v2` 返回的交互节点中有 `interactive.params.inputForm[].value`，已提交表单值可以从历史数据恢复。
+2. 一旦自动流恢复开始，页面上仍然能看到表单输入交互节点，但文件上传区域只剩禁用上传框，已提交字段值消失，文件字段表现为文件列表消失。
+3. 恢复流中有 `flowNodeResponse` 事件，数据里包含：
+
+```json
+{
+  "moduleType": "formInput",
+  "formInputResult": {
+    "File": [
+      "http://localhost:3000/api/system/file/download/xxx?filename=H6%E4%BA%A7%E5%93%81%E6%A6%82%E8%BF%B0V1.5_tBF8kj.docx"
+    ]
+  },
+  "nodeId": "j1Ifb41hX176ezmo"
+}
+```
+
+用户期望：表单输入节点的已提交字段值恢复到「用户交互表单节点」内部；其中 fileSelect 应恢复为文件列表，而不是展示在 AI 普通回复气泡或文本区域里。
+
+## 相关数据结构
+
+### 历史记录里的表单交互节点
+
+`getRecords_v2` 返回的交互节点中，字段值已经存在；其中文件字段是 `FileSelector` 可渲染的结构：
+
+```json
+{
+  "interactive": {
+    "type": "userInput",
+    "params": {
+      "submitted": true,
+      "inputForm": [
+        {
+          "type": "fileSelect",
+          "key": "File",
+          "value": [
+            {
+              "key": "chat/xxx.docx",
+              "name": "H6产品概述V1.5.docx",
+              "type": "file",
+              "url": "http://localhost:3000/api/system/file/download/xxx"
+            }
+          ]
+        }
+      ]
+    },
+    "entryNodeIds": ["j1Ifb41hX176ezmo"]
+  }
+}
+```
+
+### 恢复流里的节点响应
+
+`flowNodeResponse.formInputResult` 只包含字段结果，不是完整的表单渲染结构：
+
+```json
+{
+  "formInputResult": {
+    "File": ["http://localhost:3000/api/system/file/download/xxx?filename=file.docx"]
+  }
+}
+```
+
+因此前端不能直接把 `formInputResult` 当成 AI 文本渲染，也不能只展示在响应详情里；需要把它转换并回填到交互表单的 `inputForm[].value`。
+
+## 根因分析
+
+### 1. 表单控件本身不是根因
+
+以 fileSelect 为例，`FileSelector` 接收以下两类值都能渲染文件列表：
+
+```ts
+[{ name: 'file.docx', url: 'https://example.com/file.docx' }]
+```
+
+或：
+
+```ts
+[{ name: 'file.docx', key: 'chat/xxx/file.docx' }]
+```
+
+页面能看到禁用上传区域，说明：
+
+1. 交互节点已经渲染出来。
+2. `submitted=true` 已经生效。
+3. 真正缺失的是交互节点 `inputForm[].value`；fileSelect 只是表现为传给 `FileSelector` 的 value 为空。
+
+### 2. 恢复事件没有天然回填表单值
+
+恢复流的 `flowNodeResponse` 会进入 `generatingMessage`，并追加到当前 AI 记录的 `responseData`。但原始实现只保存节点响应详情，没有把 `formInputResult.File` 回填到已提交的 `interactive.params.inputForm[].value`。
+
+结果：交互节点还在，但字段值仍是空数组。
+
+### 3. completed records 会覆盖当前恢复态
+
+流恢复结束时，后端会返回 `completedChat.records`，前端用它覆盖当前 `chatRecords`。
+
+这个覆盖有两个风险：
+
+1. 恢复过程中刚回填到交互节点的字段值，被 completed records 里空的 `inputForm.value` 覆盖。
+2. 当前已回填的交互节点和 completed records 里的交互节点 `dataId` 不一定完全一致。只按 `dataId` 合并可能漏掉。
+
+因此需要在 completed 覆盖阶段保留 submitted interactive 中已经恢复出来的字段值。
+
+### 4. 仍需要渲染层兜底
+
+即使状态层做了回填和 merge，仍可能出现中间态或边界情况：
+
+1. `responseData` 已经有 `formInputResult`。
+2. `interactive.params.inputForm[].value` 被后续 records 替换成空。
+3. 渲染表单时只看 `inputForm.value`，导致已提交表单值仍然不显示。
+
+所以渲染表单时也应当能从同一条 AI 消息的 `responseData.formInputResult` 还原字段默认值。
+
+## 修复方案
+
+本次修复不是四个备选方案，而是一个组合修复。最终采用：
+
+```text
+恢复事件回填 + completed 覆盖保护 + 过期交互去重 + 渲染层兜底
+```
+
+四个修复点分别覆盖不同阶段的问题：
+
+1. 恢复流事件到达时，把节点结果写回表单交互节点。
+2. 恢复完成 records 覆盖时，保留已经写回的表单值。
+3. 恢复流重复推送交互节点时，避免过期未提交交互覆盖已提交交互。
+4. 渲染表单时，如果状态值仍为空，从同条消息的 `responseData.formInputResult` 做最后兜底。
+
+### 修复点一：恢复事件回填 submitted 表单交互节点
+
+位置：
+
+- `projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx`
+- `projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts`
+
+逻辑：
+
+1. `generatingMessage` 收到 `flowNodeResponse`。
+2. 如果 `nodeResponse.formInputResult` 存在，调用 `refreshSubmittedFormInteractiveValues`。
+3. 在当前 `chatRecords` 里寻找已提交的 `userInput` 交互节点。
+4. 匹配方式：
+   - 优先用 `interactive.entryNodeIds.includes(nodeResponse.nodeId)`。
+   - 如果只有一个 submitted 表单交互节点，并且字段 key 能匹配，也允许兜底匹配。
+5. 对 `fileSelect` 字段，把 `formInputResult.File: string[]` 转成：
+
+```ts
+[
+  {
+    name: 'file.docx',
+    url: 'http://localhost:3000/api/system/file/download/xxx?filename=file.docx'
+  }
+]
+```
+
+转换复用 `normalizeFormInputResultFile`，保证文件名从 `filename` query 或 URL path 中取。
+
+### 修复点二：completed records 覆盖时保留已回填交互值
+
+位置：
+
+- `projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts`
+
+逻辑：
+
+1. `mergeResumeCompletedChatRecords` 建立当前 AI record map。
+2. 对 completed records 的 AI 消息做合并：
+   - 保留恢复过程中 replay 出来的 `responseData`。
+   - 保留当前 submitted `userInput` 交互节点里的 `inputForm.value`。
+3. 如果 completed record 能按 `dataId` 找到当前 record，则使用对应 current values。
+4. 如果按 `dataId` 找不到，则从当前所有 AI records 中寻找 submitted interactive，并按交互身份匹配。
+
+交互身份匹配规则：
+
+```ts
+type 相同 &&
+(usageId 相同 || entryNodeIds 数组相同)
+```
+
+这个逻辑覆盖 completed records 中交互节点 `dataId` 变化的情况。
+
+### 修复点三：跳过过期的未提交恢复交互
+
+位置：
+
+- `projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts`
+
+逻辑：
+
+如果当前已经有同一个 submitted `userInput` 交互节点，恢复流里又来了同一个未提交 interactive，不再 append。
+
+作用：
+
+1. 避免恢复过程中重新插入一个空表单。
+2. 避免 submitted 表单被未提交表单视觉上覆盖。
+
+### 修复点四：渲染层从 `responseData.formInputResult` 兜底恢复表单值
+
+位置：
+
+- `projects/app/src/components/core/chat/ChatContainer/ChatBox/components/ChatItem.tsx`
+- `projects/app/src/components/core/chat/components/AIResponseBox/index.tsx`
+- `projects/app/src/components/core/chat/components/AIResponseBox/RenderUserFormInteractive.tsx`
+
+调用链：
+
+```text
+ChatItem
+  -> AIContentCard
+    -> AIResponseBox
+      -> RenderUserFormInteractive
+        -> FormInputComponent
+          -> InputRender
+            -> FileSelector
+```
+
+新增传参：
+
+1. `ChatItem` 把当前 AI 消息的 `chat.responseData` 传给 `AIContentCard`。
+2. `AIContentCard` 传给 `AIResponseBox`。
+3. `AIResponseBox` 在渲染 `userInput` 时传给 `RenderUserFormInteractive`。
+
+`RenderUserFormInteractive` 生成 `defaultValues` 时：
+
+1. 从 `responseData` 里倒序查找带 `formInputResult` 的节点响应。
+2. 优先匹配 `nodeId` 与 `interactive.entryNodeIds`。
+3. 取同名字段，例如 `File`。
+4. 如果 `formInputResult` 中存在该字段，则优先使用该字段值作为 submitted 表单的渲染默认值。
+5. 对普通输入、选择、数字等字段，直接使用 `formInputResult[key]`。
+6. 对 `fileSelect` 字段，额外把 URL 数组归一化为 `FileSelector` 可渲染的 `{ name, url }[]`。
+
+作用：
+
+即使状态层 `inputForm.value` 被 completed records 覆盖为空，只要同一条 AI 消息还带有 `responseData.formInputResult`，表单节点仍然能渲染出已提交表单值。
+
+## 非目标
+
+本 PR 不做以下事情：
+
+1. 不把 `formInputResult` 渲染到 AI 普通文字回复气泡里。
+2. 不改变 `FileSelector` 的基础交互行为。
+3. 不改变后端 `formInputResult` 的输出结构。
+4. 不迁移历史数据。
+5. 不处理非 `userInput` 类型的假想表单交互类型；当前类型定义中不存在 `agentPlanAskUserForm`。
+
+## 影响文件
+
+### 全部改动文件清单
+
+代码改动：
+
+- `projects/app/src/components/core/chat/ChatContainer/ChatBox/components/ChatItem.tsx`
+  - 把当前 AI 消息的 `chat.responseData` 传入 AI 响应渲染链路。
+- `projects/app/src/components/core/chat/components/AIResponseBox/index.tsx`
+  - 接收并继续下传 `responseData` 给表单交互组件。
+- `projects/app/src/components/core/chat/components/AIResponseBox/RenderUserFormInteractive.tsx`
+  - 表单渲染时，从 `responseData.formInputResult` 兜底恢复 submitted 表单字段值；`fileSelect` 字段额外归一化为文件列表渲染结构。
+- `projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts`
+  - 处理恢复流回填、completed records 覆盖合并、submitted interactive 保留、过期 interactive 去重。
+- `projects/app/src/components/core/chat/components/FormInputResult.tsx`
+  - 提供 `normalizeFormInputResultFile`，并支持在响应详情里展示表单输入文件结果。
+- `projects/app/src/components/core/chat/components/WholeResponseModal.tsx`
+  - 在响应详情弹窗里挂载 `FormInputResult` 展示 `formInputResult`。
+
+测试改动：
+
+- `projects/app/test/components/core/chat/ChatContainer/ChatBox/utils.test.ts`
+  - 增加恢复回填、completed 覆盖保留、`dataId` 变化保留等测试。
+- `projects/app/test/components/core/chat/components/FormInputResult.test.ts`
+  - 测试签名 URL 文件名解析和显式文件名保留。
+- `projects/app/test/components/core/app/FileSelector/utils.test.ts`
+  - 覆盖文件选择器值清洗、URL 文件保留等能力。
+
+设计文档：
+
+- `.codex/design/bug/stream-resume-form-input-file-list.md`
+  - 新增本次问题的设计说明、根因、方案、测试和 TODO。
+
+### 数据合并与恢复工具
+
+- `projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts`
+
+职责：
+
+1. `refreshSubmittedFormInteractiveValues`：把 `formInputResult` 回填到 submitted 表单节点。
+2. `mergeResumeCompletedChatRecords`：completed records 覆盖时保留已恢复的 submitted interactive values。
+3. `shouldAppendResumeInteractive`：避免追加过期未提交交互。
+
+### 聊天项渲染链路
+
+- `projects/app/src/components/core/chat/ChatContainer/ChatBox/components/ChatItem.tsx`
+- `projects/app/src/components/core/chat/components/AIResponseBox/index.tsx`
+- `projects/app/src/components/core/chat/components/AIResponseBox/RenderUserFormInteractive.tsx`
+
+职责：
+
+1. 把 `responseData` 从 chat item 下传到表单交互渲染组件。
+2. 在渲染表单默认值时，从 `responseData.formInputResult` 兜底恢复表单字段值。
+
+### 文件结果展示辅助
+
+- `projects/app/src/components/core/chat/components/FormInputResult.tsx`
+
+职责：
+
+1. 提供 `normalizeFormInputResultFile`。
+2. 详情弹窗中展示 `formInputResult` 文件。
+
+注意：详情弹窗展示不是本 bug 的核心修复，核心修复是交互节点内已提交表单值恢复，文件列表只是 fileSelect 字段的展示结果。
+
+### 测试
+
+- `projects/app/test/components/core/chat/ChatContainer/ChatBox/utils.test.ts`
+- `projects/app/test/components/core/chat/components/FormInputResult.test.ts`
+- `projects/app/test/components/core/app/FileSelector/utils.test.ts`
+
+## 测试覆盖
+
+已覆盖场景：
+
+1. `flowNodeResponse.formInputResult.File` 能回填到 submitted `userInput` 的 `inputForm[].value`。
+2. `nodeId` 不匹配但只有一个 submitted 表单交互节点时，可以按字段 key 兜底回填。
+3. completed records 覆盖时保留已恢复的 submitted interactive 字段值。
+4. completed records 中交互节点 `dataId` 变化时，仍能按交互身份保留字段值。
+5. `FormInputResult` 能从签名 URL 的 `filename` query 中解析文件名。
+6. `FileSelector` 的值清洗函数能保留可渲染 URL 字段值。
+
+局部测试命令：
+
+```bash
+source ~/.zshrc >/dev/null 2>&1; pnpm --filter @fastgpt/app test test/components/core/chat/ChatContainer/ChatBox/utils.test.ts test/components/core/chat/components/FormInputResult.test.ts test/components/core/app/FileSelector/utils.test.ts
+```
+
+当前结果：
+
+```text
+Test Files  3 passed
+Tests       32 passed
+```
+
+## 已知验证情况
+
+1. 用户本地验证：恢复流开始后，表单输入节点内文件列表已能正常展示。
+2. touched files eslint 无 error，仅剩当前文件已有 warning：
+
+```text
+projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts
+  'error' is defined but never used
+```
+
+3. `@fastgpt/app typecheck` 在当前分支仍有无关类型错误，集中在：
+   - `ChatItem.tsx` 的 `stepId/stepTitle` 类型声明缺失。
+   - `ResponseTags.tsx` / `RenderResponseDetail.tsx` 缺 `chatTime` 参数。
+   - `WholeResponseModal.tsx` 中 `queryExtensionResult` 类型名与当前 schema 不一致。
+
+这些不是本修复新增逻辑引入的问题。
+
+## TODO
+
+- [x] 确认恢复流 `flowNodeResponse` 会进入前端 `generatingMessage`。
+- [x] 回填 `formInputResult` 到 submitted 表单交互节点。
+- [x] completed records 覆盖时保留恢复出的表单字段值。
+- [x] 处理 completed 交互节点 `dataId` 变化场景。
+- [x] 渲染层从 `responseData.formInputResult` 兜底恢复表单值。
+- [x] 保证已提交表单值展示在用户交互表单节点内，而不是 AI 文本回复气泡内。
+- [x] 增加局部测试。
+- [x] 用户完成手动验证。
+- [ ] 用户确认后提交本地未提交改动并推送到 draft PR。

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/ChatItem.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/ChatItem.tsx
@@ -8,6 +8,7 @@ import Markdown from '@/components/Markdown';
 import styles from '../index.module.scss';
 import markdownStyles from '@/components/Markdown/index.module.scss';
 import { ChatRoleEnum, ChatStatusEnum } from '@fastgpt/global/core/chat/constants';
+import { FlowNodeTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
 import FilesBlock from './FilesBox';
 import { ChatBoxContext } from '../Provider';
 import { useContextSelector } from 'use-context-selector';
@@ -17,7 +18,10 @@ import { useCopyData } from '@fastgpt/web/hooks/useCopyData';
 import MyIcon from '@fastgpt/web/components/common/Icon';
 import MyTooltip from '@fastgpt/web/components/common/MyTooltip';
 import { useTranslation } from 'next-i18next';
-import type { UserChatItemValueItemType } from '@fastgpt/global/core/chat/type';
+import type {
+  ChatHistoryItemResType,
+  UserChatItemValueItemType
+} from '@fastgpt/global/core/chat/type';
 import { type AIChatItemValueItemType } from '@fastgpt/global/core/chat/type';
 import { CodeClassNameEnum } from '@/components/Markdown/utils';
 import { isEqual } from 'lodash';
@@ -33,8 +37,19 @@ import dynamic from 'next/dynamic';
 import { useMemoizedFn, useSize } from 'ahooks';
 import ChatBoxDivider from '../../../Divider';
 import { useMemoEnhance } from '@fastgpt/web/hooks/useMemoEnhance';
+import FormInputResult from '../../../components/FormInputResult';
 
 const ResponseTags = dynamic(() => import('./ResponseTags'));
+
+const getFormInputResponseDataList = (responseData?: ChatHistoryItemResType[]) =>
+  responseData
+    ?.filter(
+      (item) =>
+        item.moduleType === FlowNodeTypeEnum.formInput &&
+        item.formInputResult &&
+        typeof item.formInputResult === 'object'
+    )
+    .map((item) => item.formInputResult as Record<string, unknown>) || [];
 
 const colorMap = {
   [ChatStatusEnum.loading]: {
@@ -114,6 +129,12 @@ const AIContentCard = React.memo(function AIContentCard({
       {chatValue.map((value, i) => {
         const isLastResponse = isLastChild && i === chatValue.length - 1;
         const key = `${dataId}-ai-${i}`;
+        const folded = value.stepId
+          ? (chatValue.find((item) => item.stepTitle?.stepId === value.stepId)?.stepTitle?.folded ??
+            true)
+          : false;
+
+        if (folded) return null;
 
         return (
           <Box
@@ -198,6 +219,10 @@ const ChatItem = (props: Props) => {
     () => addStatisticalDataToHistoryItem(chat),
     [chat]
   );
+  const formInputResults = useMemoEnhance(
+    () => (chat.obj === ChatRoleEnum.AI ? getFormInputResponseDataList(chat.responseData) : []),
+    [chat]
+  );
 
   const isChatLog = chatType === 'log';
 
@@ -217,10 +242,7 @@ const ChatItem = (props: Props) => {
 
     if (chat.obj === ChatRoleEnum.AI) {
       // Remove empty text node
-      const filterList = chat.value.filter((item, i) => {
-        if (item.hideInUI) {
-          return false;
-        }
+      const filterList = chat.value.filter((item) => {
         if (item.text && !item.text.content?.trim()) {
           return false;
         }
@@ -456,9 +478,16 @@ const ChatItem = (props: Props) => {
                     questionGuides={questionGuides}
                     onOpenCiteModal={onOpenCiteModal}
                   />
+                  {isChatting &&
+                    i === splitAiResponseResults.length - 1 &&
+                    formInputResults.map((formInputResult, index) => (
+                      <Box key={index} mt={3}>
+                        <FormInputResult value={formInputResult} />
+                      </Box>
+                    ))}
                   {i === splitAiResponseResults.length - 1 && (
                     <ResponseTags
-                      showTags={!isLastChild || !isChatting}
+                      showTags={!isLastChild || !isChatting || !!chat.responseData?.length}
                       historyItem={chat}
                       onOpenCiteModal={onOpenCiteModal}
                     />

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/ChatItem.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/ChatItem.tsx
@@ -18,7 +18,10 @@ import MyIcon from '@fastgpt/web/components/common/Icon';
 import MyTooltip from '@fastgpt/web/components/common/MyTooltip';
 import { useTranslation } from 'next-i18next';
 import type { UserChatItemValueItemType } from '@fastgpt/global/core/chat/type';
-import { type AIChatItemValueItemType } from '@fastgpt/global/core/chat/type';
+import {
+  type AIChatItemValueItemType,
+  type ChatHistoryItemResType
+} from '@fastgpt/global/core/chat/type';
 import { CodeClassNameEnum } from '@/components/Markdown/utils';
 import { isEqual } from 'lodash';
 import { useSystem } from '@fastgpt/web/hooks/useSystem';
@@ -93,6 +96,7 @@ const HumanContentCard = React.memo(
 );
 const AIContentCard = React.memo(function AIContentCard({
   chatValue,
+  responseData,
   dataId,
   isLastChild,
   isChatting,
@@ -101,6 +105,7 @@ const AIContentCard = React.memo(function AIContentCard({
 }: {
   dataId: string;
   chatValue: AIChatItemValueItemType[];
+  responseData?: ChatHistoryItemResType[];
   isLastChild: boolean;
   isChatting: boolean;
   questionGuides: string[];
@@ -131,6 +136,7 @@ const AIContentCard = React.memo(function AIContentCard({
             <AIResponseBox
               chatItemDataId={dataId}
               value={value}
+              responseData={responseData}
               isLastResponseValue={isLastResponse}
               isLastChild={isLastChild}
               isChatting={isChatting}
@@ -453,6 +459,7 @@ const ChatItem = (props: Props) => {
                 <>
                   <AIContentCard
                     chatValue={value as AIChatItemValueItemType[]}
+                    responseData={chat.responseData}
                     dataId={chat.dataId}
                     isLastChild={isLastChild && i === splitAiResponseResults.length - 1}
                     isChatting={isChatting}

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/ChatItem.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/ChatItem.tsx
@@ -8,7 +8,6 @@ import Markdown from '@/components/Markdown';
 import styles from '../index.module.scss';
 import markdownStyles from '@/components/Markdown/index.module.scss';
 import { ChatRoleEnum, ChatStatusEnum } from '@fastgpt/global/core/chat/constants';
-import { FlowNodeTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
 import FilesBlock from './FilesBox';
 import { ChatBoxContext } from '../Provider';
 import { useContextSelector } from 'use-context-selector';
@@ -18,10 +17,7 @@ import { useCopyData } from '@fastgpt/web/hooks/useCopyData';
 import MyIcon from '@fastgpt/web/components/common/Icon';
 import MyTooltip from '@fastgpt/web/components/common/MyTooltip';
 import { useTranslation } from 'next-i18next';
-import type {
-  ChatHistoryItemResType,
-  UserChatItemValueItemType
-} from '@fastgpt/global/core/chat/type';
+import type { UserChatItemValueItemType } from '@fastgpt/global/core/chat/type';
 import { type AIChatItemValueItemType } from '@fastgpt/global/core/chat/type';
 import { CodeClassNameEnum } from '@/components/Markdown/utils';
 import { isEqual } from 'lodash';
@@ -37,19 +33,8 @@ import dynamic from 'next/dynamic';
 import { useMemoizedFn, useSize } from 'ahooks';
 import ChatBoxDivider from '../../../Divider';
 import { useMemoEnhance } from '@fastgpt/web/hooks/useMemoEnhance';
-import FormInputResult from '../../../components/FormInputResult';
 
 const ResponseTags = dynamic(() => import('./ResponseTags'));
-
-const getFormInputResponseDataList = (responseData?: ChatHistoryItemResType[]) =>
-  responseData
-    ?.filter(
-      (item) =>
-        item.moduleType === FlowNodeTypeEnum.formInput &&
-        item.formInputResult &&
-        typeof item.formInputResult === 'object'
-    )
-    .map((item) => item.formInputResult as Record<string, unknown>) || [];
 
 const colorMap = {
   [ChatStatusEnum.loading]: {
@@ -217,10 +202,6 @@ const ChatItem = (props: Props) => {
 
   const { totalQuoteList: quoteList = [], errorText } = useMemoEnhance(
     () => addStatisticalDataToHistoryItem(chat),
-    [chat]
-  );
-  const formInputResults = useMemoEnhance(
-    () => (chat.obj === ChatRoleEnum.AI ? getFormInputResponseDataList(chat.responseData) : []),
     [chat]
   );
 
@@ -478,13 +459,6 @@ const ChatItem = (props: Props) => {
                     questionGuides={questionGuides}
                     onOpenCiteModal={onOpenCiteModal}
                   />
-                  {isChatting &&
-                    i === splitAiResponseResults.length - 1 &&
-                    formInputResults.map((formInputResult, index) => (
-                      <Box key={index} mt={3}>
-                        <FormInputResult value={formInputResult} />
-                      </Box>
-                    ))}
                   {i === splitAiResponseResults.length - 1 && (
                     <ResponseTags
                       showTags={!isLastChild || !isChatting || !!chat.responseData?.length}

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx
@@ -43,6 +43,7 @@ import {
   formatChatValue2InputType,
   mergeResumeCompletedChatRecords,
   rewriteHistoriesByInteractiveResponse,
+  shouldAppendResumeInteractive,
   shouldReplaceResumeAiValue,
   shouldResetResumeAiPlaceholder,
   stripChatValueFileUrls
@@ -623,6 +624,15 @@ const ChatBox = ({
             resetVariables({ variables });
           }
           if (event === SseResponseEventEnum.interactive && interactive) {
+            if (
+              !shouldAppendResumeInteractive({
+                existingValues: item.value,
+                incomingInteractive: interactive
+              })
+            ) {
+              return item;
+            }
+
             const val: AIChatItemValueItemType = {
               interactive
             };

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx
@@ -43,6 +43,7 @@ import {
   formatChatValue2InputType,
   mergeResumeCompletedChatRecords,
   rewriteHistoriesByInteractiveResponse,
+  shouldReplaceResumeAiValue,
   shouldResetResumeAiPlaceholder,
   stripChatValueFileUrls
 } from './utils';
@@ -734,7 +735,13 @@ const ChatBox = ({
       setChatRecords((state) => {
         const lastItem = state[state.length - 1];
         if (lastItem?.dataId === responseChatId && lastItem.obj === ChatRoleEnum.AI) {
-          if (!text && !options?.resetExistingValue) {
+          const shouldReplaceValue = shouldReplaceResumeAiValue({
+            hasExistingAiOutput: hasMeaningfulAiOutput(lastItem),
+            text,
+            resetExistingValue: options?.resetExistingValue
+          });
+
+          if (!shouldReplaceValue && lastItem.status === status) {
             return state;
           }
 
@@ -743,14 +750,18 @@ const ChatBox = ({
               ? item
               : {
                   ...item,
-                  value: [
-                    {
-                      text: {
-                        content: text
+                  ...(shouldReplaceValue
+                    ? {
+                        value: [
+                          {
+                            text: {
+                              content: text
+                            }
+                          }
+                        ],
+                        responseData: options?.resetExistingValue ? [] : item.responseData
                       }
-                    }
-                  ],
-                  responseData: options?.resetExistingValue ? [] : item.responseData,
+                    : {}),
                   status,
                   ...(status === ChatStatusEnum.finish ? { time: new Date() } : {})
                 }

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx
@@ -42,6 +42,7 @@ import {
   getInteractiveByHistories,
   formatChatValue2InputType,
   rewriteHistoriesByInteractiveResponse,
+  shouldResetResumeAiPlaceholder,
   stripChatValueFileUrls
 } from './utils';
 import { ChatTypeEnum, textareaMinH } from './constants';
@@ -1356,6 +1357,7 @@ const ChatBox = ({
     scrollToBottom('auto', 100);
     let resumeFinalStatus = ChatGenerateStatusEnum.done;
     let hasPreparedResumeAiRecord = false;
+    let hasReceivedResumeOutput = false;
 
     (async () => {
       try {
@@ -1377,11 +1379,15 @@ const ChatBox = ({
             if (!isActiveResumeTarget({ appId: resumeForAppId, chatId: resumeForChatId })) return;
             if (shouldCreateResumeAiPlaceholder(message.event)) {
               upsertResumeAiPlaceholder(responseChatId, '', ChatStatusEnum.loading, {
-                resetExistingValue: !hasPreparedResumeAiRecord
+                resetExistingValue: shouldResetResumeAiPlaceholder({
+                  hasPreparedResumeAiRecord,
+                  hasReceivedResumeOutput
+                })
               });
               hasPreparedResumeAiRecord = true;
             }
             generatingMessage(message);
+            hasReceivedResumeOutput = true;
           }
         });
 

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx
@@ -41,6 +41,7 @@ import { ChatRoleEnum, ChatStatusEnum } from '@fastgpt/global/core/chat/constant
 import {
   getInteractiveByHistories,
   formatChatValue2InputType,
+  mergeResumeCompletedChatRecords,
   rewriteHistoriesByInteractiveResponse,
   shouldResetResumeAiPlaceholder,
   stripChatValueFileUrls
@@ -1395,11 +1396,15 @@ const ChatBox = ({
 
         if (completedChat) {
           resumeFinalStatus = completedChat.chatGenerateStatus;
-          setChatRecords(
-            completedChat.records.list.map((item) => ({
-              ...item,
-              status: ChatStatusEnum.finish
-            }))
+          setChatRecords((state) =>
+            mergeResumeCompletedChatRecords({
+              currentRecords: state,
+              completedRecords: completedChat.records.list.map((item) => ({
+                ...item,
+                status: ChatStatusEnum.finish
+              })),
+              responseChatId
+            })
           );
           scrollToBottom('auto');
           scrollToBottom('auto', 100);

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx
@@ -42,6 +42,7 @@ import {
   getInteractiveByHistories,
   formatChatValue2InputType,
   mergeResumeCompletedChatRecords,
+  refreshSubmittedFormInteractiveValues,
   rewriteHistoriesByInteractiveResponse,
   shouldAppendResumeInteractive,
   shouldReplaceResumeAiValue,
@@ -374,9 +375,16 @@ const ChatBox = ({
       durationSeconds,
       autoTTSResponse
     }: generatingMessageProps & { autoTTSResponse?: boolean }) => {
-      setChatRecords((state) =>
-        state.map((item, index) => {
-          if (index !== state.length - 1) return item;
+      setChatRecords((state) => {
+        const histories = nodeResponse?.formInputResult
+          ? refreshSubmittedFormInteractiveValues({
+              histories: state,
+              nodeResponse
+            })
+          : state;
+
+        return histories.map((item, index) => {
+          if (index !== histories.length - 1) return item;
           if (item.obj !== ChatRoleEnum.AI) return item;
 
           if (autoTTSResponse) {
@@ -653,8 +661,8 @@ const ChatBox = ({
           }
 
           return item;
-        })
-      );
+        });
+      });
 
       const forceScroll = event === SseResponseEventEnum.interactive;
       generatingScroll(forceScroll);

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts
@@ -7,7 +7,7 @@ import type {
 import type { ChatSiteItemType } from './type';
 import { type ChatBoxInputType, type UserInputFileItemType } from './type';
 import { getFileIcon } from '@fastgpt/global/common/file/icon';
-import { ChatStatusEnum } from '@fastgpt/global/core/chat/constants';
+import { ChatRoleEnum, ChatStatusEnum } from '@fastgpt/global/core/chat/constants';
 import {
   extractDeepestInteractive,
   getLastInteractiveValue
@@ -17,6 +17,8 @@ import {
   checkInteractiveResponseStatus,
   mergeChatResponseData
 } from '@fastgpt/global/core/chat/utils';
+import { FlowNodeInputTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
+import { normalizeFormInputResultFile } from '../../components/FormInputResult';
 
 export const formatChatValue2InputType = (value?: ChatItemValueItemType[]): ChatBoxInputType => {
   if (!value) {
@@ -147,16 +149,89 @@ export const shouldAppendResumeInteractive = ({
     if (
       (existingFinalInteractive.type === 'userInput' ||
         existingFinalInteractive.type === 'agentPlanAskUserForm') &&
-      existingFinalInteractive.params.submitted &&
-      (incomingFinalInteractive.type === 'userInput' ||
-        incomingFinalInteractive.type === 'agentPlanAskUserForm') &&
-      !incomingFinalInteractive.params.submitted
+      existingFinalInteractive.params.submitted
     ) {
       return true;
     }
 
     return false;
   });
+};
+
+export const refreshSubmittedFormInteractiveValues = ({
+  histories,
+  nodeResponse
+}: {
+  histories: ChatSiteItemType[];
+  nodeResponse: ChatHistoryItemResType;
+}): ChatSiteItemType[] => {
+  const formInputResult = nodeResponse.formInputResult;
+  if (!formInputResult || typeof formInputResult !== 'object' || Array.isArray(formInputResult)) {
+    return histories;
+  }
+
+  const formInputValueMap = formInputResult as Record<string, unknown>;
+  let hasUpdated = false;
+
+  const nextHistories = histories.map((history) => {
+    if (history.obj !== ChatRoleEnum.AI) return history;
+
+    const nextValues = history.value.map((value) => {
+      if (!value.interactive) return value;
+
+      const finalInteractive = extractDeepestInteractive(value.interactive);
+      if (
+        finalInteractive.type !== 'userInput' &&
+        finalInteractive.type !== 'agentPlanAskUserForm'
+      ) {
+        return value;
+      }
+      if (!finalInteractive.params.submitted) return value;
+      if (!finalInteractive.entryNodeIds?.includes(nodeResponse.nodeId)) return value;
+
+      const nextInputForm = finalInteractive.params.inputForm.map((input) => {
+        if (!(input.key in formInputValueMap)) return input;
+
+        const nextValue = (() => {
+          const responseValue = formInputValueMap[input.key];
+          if (input.type !== FlowNodeInputTypeEnum.fileSelect || !Array.isArray(responseValue)) {
+            return responseValue;
+          }
+
+          return responseValue
+            .map(normalizeFormInputResultFile)
+            .filter((file): file is NonNullable<ReturnType<typeof normalizeFormInputResultFile>> =>
+              Boolean(file)
+            );
+        })();
+
+        hasUpdated = true;
+        return {
+          ...input,
+          value: nextValue
+        };
+      });
+
+      return {
+        ...value,
+        interactive: {
+          ...finalInteractive,
+          params: {
+            ...finalInteractive.params,
+            inputForm: nextInputForm,
+            submitted: true
+          }
+        }
+      };
+    });
+
+    return {
+      ...history,
+      value: nextValues
+    };
+  });
+
+  return hasUpdated ? nextHistories : histories;
 };
 
 const isSameArray = (a?: string[], b?: string[]) => {

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts
@@ -1,4 +1,5 @@
 import type {
+  ChatHistoryItemResType,
   ChatItemValueItemType,
   UserChatItemValueItemType
 } from '@fastgpt/global/core/chat/type';
@@ -11,7 +12,10 @@ import {
   getLastInteractiveValue
 } from '@fastgpt/global/core/workflow/runtime/utils';
 import type { WorkflowInteractiveResponseType } from '@fastgpt/global/core/workflow/template/system/interactive/type';
-import { checkInteractiveResponseStatus } from '@fastgpt/global/core/chat/utils';
+import {
+  checkInteractiveResponseStatus,
+  mergeChatResponseData
+} from '@fastgpt/global/core/chat/utils';
 
 export const formatChatValue2InputType = (value?: ChatItemValueItemType[]): ChatBoxInputType => {
   if (!value) {
@@ -71,6 +75,43 @@ export const shouldResetResumeAiPlaceholder = ({
   hasPreparedResumeAiRecord: boolean;
   hasReceivedResumeOutput: boolean;
 }) => !hasPreparedResumeAiRecord && !hasReceivedResumeOutput;
+
+export const mergeResumeCompletedChatRecords = ({
+  currentRecords,
+  completedRecords,
+  responseChatId
+}: {
+  currentRecords: ChatSiteItemType[];
+  completedRecords: ChatSiteItemType[];
+  responseChatId: string;
+}) => {
+  const resumedResponseData = currentRecords.find(
+    (item) => item.dataId === responseChatId
+  )?.responseData;
+  if (!resumedResponseData?.length) return completedRecords;
+
+  return completedRecords.map((item) => {
+    if (item.dataId !== responseChatId) return item;
+
+    const mergedResponseData = mergeChatResponseData([
+      ...(item.responseData || []),
+      ...(resumedResponseData.filter(
+        (resumedItem) =>
+          !item.responseData?.some((completedItem) =>
+            areSameChatResponseDataItem(completedItem, resumedItem)
+          )
+      ) || [])
+    ]);
+
+    return {
+      ...item,
+      responseData: mergedResponseData
+    };
+  });
+};
+
+const areSameChatResponseDataItem = (a: ChatHistoryItemResType, b: ChatHistoryItemResType) =>
+  a.id === b.id && a.nodeId === b.nodeId;
 
 // 用于判断当前对话框状态。所以，如果是 child 的 interactive，需要递归去找到最后一个。
 export const getInteractiveByHistories = (

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts
@@ -119,26 +119,30 @@ export const mergeResumeCompletedChatRecords = ({
     if (item.obj !== ChatRoleEnum.AI) return item;
     const matchedCurrentAiRecord = item.dataId ? currentAiRecordMap.get(item.dataId) : undefined;
     const shouldMergeResponseData = item.dataId === responseChatId;
+    const currentValuesForInteractiveMerge = matchedCurrentAiRecord
+      ? matchedCurrentAiRecord.value
+      : Array.from(currentAiRecordMap.values()).flatMap((record) => record.value);
 
-    if (!matchedCurrentAiRecord && !shouldMergeResponseData) return item;
+    if (!currentValuesForInteractiveMerge.length && !shouldMergeResponseData) return item;
 
-    const mergedResponseData = shouldMergeResponseData && resumedResponseData?.length
-      ? mergeChatResponseData([
-          ...(item.responseData || []),
-          ...(resumedResponseData.filter(
-            (resumedItem) =>
-              !item.responseData?.some((completedItem) =>
-                areSameChatResponseDataItem(completedItem, resumedItem)
-              )
-          ) || [])
-        ])
-      : item.responseData;
+    const mergedResponseData =
+      shouldMergeResponseData && resumedResponseData?.length
+        ? mergeChatResponseData([
+            ...(item.responseData || []),
+            ...(resumedResponseData.filter(
+              (resumedItem) =>
+                !item.responseData?.some((completedItem) =>
+                  areSameChatResponseDataItem(completedItem, resumedItem)
+                )
+            ) || [])
+          ])
+        : item.responseData;
 
     return {
       ...item,
       value: mergeSubmittedInteractiveValues({
         completedValues: item.value,
-        currentValues: matchedCurrentAiRecord?.value || []
+        currentValues: currentValuesForInteractiveMerge
       }),
       responseData: mergedResponseData
     };
@@ -174,11 +178,7 @@ const mergeSubmittedInteractiveValues = ({
       if (!interactive) return false;
 
       const finalInteractive = extractDeepestInteractive(interactive);
-      return (
-        (finalInteractive.type === 'userInput' ||
-          finalInteractive.type === 'agentPlanAskUserForm') &&
-        !!finalInteractive.params.submitted
-      );
+      return finalInteractive.type === 'userInput' && !!finalInteractive.params.submitted;
     });
 
   if (!currentSubmittedInteractives.length) return completedValues;
@@ -188,7 +188,7 @@ const mergeSubmittedInteractiveValues = ({
     if (!value.interactive) return value;
 
     const finalInteractive = extractDeepestInteractive(value.interactive);
-    if (finalInteractive.type !== 'userInput' && finalInteractive.type !== 'agentPlanAskUserForm') {
+    if (finalInteractive.type !== 'userInput') {
       return value;
     }
 
@@ -228,8 +228,7 @@ export const shouldAppendResumeInteractive = ({
     if (!isSameInteractive) return false;
 
     if (
-      (existingFinalInteractive.type === 'userInput' ||
-        existingFinalInteractive.type === 'agentPlanAskUserForm') &&
+      existingFinalInteractive.type === 'userInput' &&
       existingFinalInteractive.params.submitted
     ) {
       return true;
@@ -261,11 +260,7 @@ export const refreshSubmittedFormInteractiveValues = ({
       history.value.filter((value) => {
         if (!value.interactive) return false;
         const finalInteractive = extractDeepestInteractive(value.interactive);
-        return (
-          (finalInteractive.type === 'userInput' ||
-            finalInteractive.type === 'agentPlanAskUserForm') &&
-          !!finalInteractive.params.submitted
-        );
+        return finalInteractive.type === 'userInput' && !!finalInteractive.params.submitted;
       }).length
     );
   }, 0);
@@ -278,10 +273,7 @@ export const refreshSubmittedFormInteractiveValues = ({
       if (!value.interactive) return value;
 
       const finalInteractive = extractDeepestInteractive(value.interactive);
-      if (
-        finalInteractive.type !== 'userInput' &&
-        finalInteractive.type !== 'agentPlanAskUserForm'
-      ) {
+      if (finalInteractive.type !== 'userInput') {
         return value;
       }
       if (!finalInteractive.params.submitted) return value;

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts
@@ -98,26 +98,48 @@ export const mergeResumeCompletedChatRecords = ({
   completedRecords: ChatSiteItemType[];
   responseChatId: string;
 }) => {
-  const resumedResponseData = currentRecords.find(
-    (item) => item.dataId === responseChatId
-  )?.responseData;
-  if (!resumedResponseData?.length) return completedRecords;
+  const currentAiRecordMap = new Map(
+    currentRecords
+      .filter(
+        (item): item is Extract<ChatSiteItemType, { obj: ChatRoleEnum.AI }> =>
+          item.obj === ChatRoleEnum.AI && !!item.dataId
+      )
+      .map((item) => [item.dataId as string, item])
+  );
+  const currentAiRecord = currentAiRecordMap.get(responseChatId);
+  const resumedResponseData = currentAiRecord?.responseData;
+  const hasCurrentInteractive = Array.from(currentAiRecordMap.values()).some((record) =>
+    record.value.some((value) => value.interactive)
+  );
+  if (!resumedResponseData?.length && !hasCurrentInteractive) {
+    return completedRecords;
+  }
 
   return completedRecords.map((item) => {
-    if (item.dataId !== responseChatId) return item;
+    if (item.obj !== ChatRoleEnum.AI) return item;
+    const matchedCurrentAiRecord = item.dataId ? currentAiRecordMap.get(item.dataId) : undefined;
+    const shouldMergeResponseData = item.dataId === responseChatId;
 
-    const mergedResponseData = mergeChatResponseData([
-      ...(item.responseData || []),
-      ...(resumedResponseData.filter(
-        (resumedItem) =>
-          !item.responseData?.some((completedItem) =>
-            areSameChatResponseDataItem(completedItem, resumedItem)
-          )
-      ) || [])
-    ]);
+    if (!matchedCurrentAiRecord && !shouldMergeResponseData) return item;
+
+    const mergedResponseData = shouldMergeResponseData && resumedResponseData?.length
+      ? mergeChatResponseData([
+          ...(item.responseData || []),
+          ...(resumedResponseData.filter(
+            (resumedItem) =>
+              !item.responseData?.some((completedItem) =>
+                areSameChatResponseDataItem(completedItem, resumedItem)
+              )
+          ) || [])
+        ])
+      : item.responseData;
 
     return {
       ...item,
+      value: mergeSubmittedInteractiveValues({
+        completedValues: item.value,
+        currentValues: matchedCurrentAiRecord?.value || []
+      }),
       responseData: mergedResponseData
     };
   });
@@ -125,6 +147,65 @@ export const mergeResumeCompletedChatRecords = ({
 
 const areSameChatResponseDataItem = (a: ChatHistoryItemResType, b: ChatHistoryItemResType) =>
   a.id === b.id && a.nodeId === b.nodeId;
+
+const areSameInteractive = (
+  a: WorkflowInteractiveResponseType,
+  b: WorkflowInteractiveResponseType
+) => {
+  const finalA = extractDeepestInteractive(a);
+  const finalB = extractDeepestInteractive(b);
+
+  return (
+    finalA.type === finalB.type &&
+    (finalA.usageId === finalB.usageId || isSameArray(finalA.entryNodeIds, finalB.entryNodeIds))
+  );
+};
+
+const mergeSubmittedInteractiveValues = ({
+  completedValues,
+  currentValues
+}: {
+  completedValues: AIChatItemValueItemType[];
+  currentValues: AIChatItemValueItemType[];
+}) => {
+  const currentSubmittedInteractives = currentValues
+    .map((value) => value.interactive)
+    .filter((interactive): interactive is WorkflowInteractiveResponseType => {
+      if (!interactive) return false;
+
+      const finalInteractive = extractDeepestInteractive(interactive);
+      return (
+        (finalInteractive.type === 'userInput' ||
+          finalInteractive.type === 'agentPlanAskUserForm') &&
+        !!finalInteractive.params.submitted
+      );
+    });
+
+  if (!currentSubmittedInteractives.length) return completedValues;
+
+  let hasUpdated = false;
+  const nextValues = completedValues.map((value) => {
+    if (!value.interactive) return value;
+
+    const finalInteractive = extractDeepestInteractive(value.interactive);
+    if (finalInteractive.type !== 'userInput' && finalInteractive.type !== 'agentPlanAskUserForm') {
+      return value;
+    }
+
+    const currentInteractive = currentSubmittedInteractives.find((interactive) =>
+      areSameInteractive(interactive, value.interactive!)
+    );
+    if (!currentInteractive) return value;
+
+    hasUpdated = true;
+    return {
+      ...value,
+      interactive: currentInteractive
+    };
+  });
+
+  return hasUpdated ? nextValues : completedValues;
+};
 
 export const shouldAppendResumeInteractive = ({
   existingValues,
@@ -171,6 +252,23 @@ export const refreshSubmittedFormInteractiveValues = ({
   }
 
   const formInputValueMap = formInputResult as Record<string, unknown>;
+  const formInputKeys = Object.keys(formInputValueMap);
+  const submittedFormInteractiveCount = histories.reduce((count, history) => {
+    if (history.obj !== ChatRoleEnum.AI) return count;
+
+    return (
+      count +
+      history.value.filter((value) => {
+        if (!value.interactive) return false;
+        const finalInteractive = extractDeepestInteractive(value.interactive);
+        return (
+          (finalInteractive.type === 'userInput' ||
+            finalInteractive.type === 'agentPlanAskUserForm') &&
+          !!finalInteractive.params.submitted
+        );
+      }).length
+    );
+  }, 0);
   let hasUpdated = false;
 
   const nextHistories = histories.map((history) => {
@@ -187,7 +285,12 @@ export const refreshSubmittedFormInteractiveValues = ({
         return value;
       }
       if (!finalInteractive.params.submitted) return value;
-      if (!finalInteractive.entryNodeIds?.includes(nodeResponse.nodeId)) return value;
+
+      const matchedByNodeId = finalInteractive.entryNodeIds?.includes(nodeResponse.nodeId);
+      const matchedByOnlySubmittedForm =
+        submittedFormInteractiveCount === 1 &&
+        finalInteractive.params.inputForm.some((input) => formInputKeys.includes(input.key));
+      if (!matchedByNodeId && !matchedByOnlySubmittedForm) return value;
 
       const nextInputForm = finalInteractive.params.inputForm.map((input) => {
         if (!(input.key in formInputValueMap)) return input;

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts
@@ -1,4 +1,5 @@
 import type {
+  AIChatItemValueItemType,
   ChatHistoryItemResType,
   ChatItemValueItemType,
   UserChatItemValueItemType
@@ -122,6 +123,46 @@ export const mergeResumeCompletedChatRecords = ({
 
 const areSameChatResponseDataItem = (a: ChatHistoryItemResType, b: ChatHistoryItemResType) =>
   a.id === b.id && a.nodeId === b.nodeId;
+
+export const shouldAppendResumeInteractive = ({
+  existingValues,
+  incomingInteractive
+}: {
+  existingValues: AIChatItemValueItemType[];
+  incomingInteractive: WorkflowInteractiveResponseType;
+}) => {
+  const incomingFinalInteractive = extractDeepestInteractive(incomingInteractive);
+
+  return !existingValues.some((value) => {
+    if (!value.interactive) return false;
+
+    const existingFinalInteractive = extractDeepestInteractive(value.interactive);
+    const isSameInteractive =
+      existingFinalInteractive.type === incomingFinalInteractive.type &&
+      (existingFinalInteractive.usageId === incomingFinalInteractive.usageId ||
+        isSameArray(existingFinalInteractive.entryNodeIds, incomingFinalInteractive.entryNodeIds));
+
+    if (!isSameInteractive) return false;
+
+    if (
+      (existingFinalInteractive.type === 'userInput' ||
+        existingFinalInteractive.type === 'agentPlanAskUserForm') &&
+      existingFinalInteractive.params.submitted &&
+      (incomingFinalInteractive.type === 'userInput' ||
+        incomingFinalInteractive.type === 'agentPlanAskUserForm') &&
+      !incomingFinalInteractive.params.submitted
+    ) {
+      return true;
+    }
+
+    return false;
+  });
+};
+
+const isSameArray = (a?: string[], b?: string[]) => {
+  if (!a?.length || !b?.length || a.length !== b.length) return false;
+  return a.every((item, index) => item === b[index]);
+};
 
 // 用于判断当前对话框状态。所以，如果是 child 的 interactive，需要递归去找到最后一个。
 export const getInteractiveByHistories = (

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts
@@ -76,6 +76,16 @@ export const shouldResetResumeAiPlaceholder = ({
   hasReceivedResumeOutput: boolean;
 }) => !hasPreparedResumeAiRecord && !hasReceivedResumeOutput;
 
+export const shouldReplaceResumeAiValue = ({
+  hasExistingAiOutput,
+  text,
+  resetExistingValue
+}: {
+  hasExistingAiOutput: boolean;
+  text: string;
+  resetExistingValue?: boolean;
+}) => !hasExistingAiOutput && (!!text || !!resetExistingValue);
+
 export const mergeResumeCompletedChatRecords = ({
   currentRecords,
   completedRecords,

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts
@@ -64,6 +64,14 @@ export const stripChatValueFileUrls = (value: UserChatItemValueItemType[] = []) 
     return item;
   });
 
+export const shouldResetResumeAiPlaceholder = ({
+  hasPreparedResumeAiRecord,
+  hasReceivedResumeOutput
+}: {
+  hasPreparedResumeAiRecord: boolean;
+  hasReceivedResumeOutput: boolean;
+}) => !hasPreparedResumeAiRecord && !hasReceivedResumeOutput;
+
 // 用于判断当前对话框状态。所以，如果是 child 的 interactive，需要递归去找到最后一个。
 export const getInteractiveByHistories = (
   chatHistories: ChatSiteItemType[]

--- a/projects/app/src/components/core/chat/components/AIResponseBox/RenderUserFormInteractive.tsx
+++ b/projects/app/src/components/core/chat/components/AIResponseBox/RenderUserFormInteractive.tsx
@@ -1,26 +1,89 @@
 import { Button, Flex } from '@chakra-ui/react';
+import type { ChatHistoryItemResType } from '@fastgpt/global/core/chat/type';
+import { FlowNodeInputTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
 import type { UserInputInteractive } from '@fastgpt/global/core/workflow/template/system/interactive/type';
 import { useTranslation } from 'next-i18next';
 import React, { useCallback, useMemo } from 'react';
+import { normalizeFormInputResultFile } from '../FormInputResult';
 import { FormInputComponent } from '../Interactive/InteractiveComponents';
 import { onSendPrompt } from './utils';
 
+const normalizeRecoveredFormValue = ({
+  inputType,
+  value
+}: {
+  inputType: FlowNodeInputTypeEnum;
+  value: unknown;
+}) => {
+  if (inputType !== FlowNodeInputTypeEnum.fileSelect || !Array.isArray(value)) {
+    return value;
+  }
+
+  return value
+    .map(normalizeFormInputResultFile)
+    .filter((file): file is NonNullable<ReturnType<typeof normalizeFormInputResultFile>> =>
+      Boolean(file)
+    );
+};
+
+const getInputFormValueFromResponseData = ({
+  responseData,
+  interactive,
+  inputKey
+}: {
+  responseData?: ChatHistoryItemResType[];
+  interactive: UserInputInteractive;
+  inputKey: string;
+}) => {
+  const entryNodeIds = (interactive as UserInputInteractive & { entryNodeIds?: string[] })
+    .entryNodeIds;
+  const formInputResult = responseData
+    ?.slice()
+    .reverse()
+    .find(
+      (item) =>
+        item.formInputResult &&
+        (!item.nodeId || !entryNodeIds?.length || entryNodeIds.includes(item.nodeId))
+    )?.formInputResult;
+
+  if (!formInputResult || typeof formInputResult !== 'object' || Array.isArray(formInputResult)) {
+    return;
+  }
+
+  return (formInputResult as Record<string, unknown>)[inputKey];
+};
+
 const RenderUserFormInteractive = React.memo(function RenderUserFormInteractive({
   interactive,
+  responseData,
   isLastChild
 }: {
   interactive: UserInputInteractive;
+  responseData?: ChatHistoryItemResType[];
   isLastChild: boolean;
 }) {
   const { t } = useTranslation();
 
   const defaultValues = useMemo(() => {
     return interactive.params.inputForm?.reduce((acc: Record<string, any>, item) => {
+      const responseValue = getInputFormValueFromResponseData({
+        responseData,
+        interactive,
+        inputKey: item.key
+      });
+      if (responseValue !== undefined) {
+        acc[item.key] = normalizeRecoveredFormValue({
+          inputType: item.type,
+          value: responseValue
+        });
+        return acc;
+      }
+
       // 使用 ?? 运算符，只有 undefined 或 null 时才使用 defaultValue
       acc[item.key] = item.value ?? item.defaultValue;
       return acc;
     }, {});
-  }, [interactive]);
+  }, [interactive, responseData]);
 
   const handleFormSubmit = useCallback(
     (data: Record<string, any>) => {

--- a/projects/app/src/components/core/chat/components/AIResponseBox/index.tsx
+++ b/projects/app/src/components/core/chat/components/AIResponseBox/index.tsx
@@ -1,5 +1,8 @@
 import { Box, Flex } from '@chakra-ui/react';
-import type { AIChatItemValueItemType } from '@fastgpt/global/core/chat/type';
+import type {
+  AIChatItemValueItemType,
+  ChatHistoryItemResType
+} from '@fastgpt/global/core/chat/type';
 import { extractDeepestInteractive } from '@fastgpt/global/core/workflow/runtime/utils';
 import React from 'react';
 import { useContextSelector } from 'use-context-selector';
@@ -21,6 +24,7 @@ import RenderUserSelectInteractive from './RenderUserSelectInteractive';
 const AIResponseBox = ({
   chatItemDataId,
   value,
+  responseData,
   isLastResponseValue,
   isLastChild,
   isChatting,
@@ -28,6 +32,7 @@ const AIResponseBox = ({
 }: {
   chatItemDataId: string;
   value: AIChatItemValueItemType;
+  responseData?: ChatHistoryItemResType[];
   isLastResponseValue: boolean;
   isLastChild: boolean;
   isChatting: boolean;
@@ -104,6 +109,7 @@ const AIResponseBox = ({
         <RenderUserFormInteractive
           key="interactive"
           interactive={interactive}
+          responseData={responseData}
           isLastChild={isLastChild}
         />
       );

--- a/projects/app/src/components/core/chat/components/FormInputResult.tsx
+++ b/projects/app/src/components/core/chat/components/FormInputResult.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { Box, Flex, HStack } from '@chakra-ui/react';
+import Markdown from '@/components/Markdown';
+import MyIcon from '@fastgpt/web/components/common/Icon';
+import { getFileIcon } from '@fastgpt/global/common/file/icon';
+
+export type FormInputResultFileItem = {
+  name: string;
+  url: string;
+};
+
+export const getFilenameFromFormInputFileUrl = (url: string) => {
+  try {
+    const parsedUrl = new URL(url);
+    const filename = parsedUrl.searchParams.get('filename');
+    if (filename) return filename;
+
+    const pathname = parsedUrl.pathname.split('/').pop();
+    return pathname ? decodeURIComponent(pathname) : url;
+  } catch {
+    return url;
+  }
+};
+
+export const normalizeFormInputResultFile = (
+  value: unknown
+): FormInputResultFileItem | undefined => {
+  if (typeof value === 'string') {
+    if (!value) return;
+    return {
+      name: getFilenameFromFormInputFileUrl(value),
+      url: value
+    };
+  }
+
+  if (!value || typeof value !== 'object') return;
+
+  const file = value as Record<string, unknown>;
+  const url = typeof file.url === 'string' ? file.url : undefined;
+  if (!url) return;
+
+  return {
+    name:
+      typeof file.name === 'string' && file.name ? file.name : getFilenameFromFormInputFileUrl(url),
+    url
+  };
+};
+
+const FormInputResult = React.memo(function FormInputResult({
+  value
+}: {
+  value: Record<string, unknown>;
+}) {
+  return (
+    <Flex flexDirection={'column'} gap={3}>
+      {Object.entries(value).map(([key, inputValue]) => {
+        const files = Array.isArray(inputValue)
+          ? inputValue
+              .map(normalizeFormInputResultFile)
+              .filter((file): file is FormInputResultFileItem => Boolean(file))
+          : [];
+
+        return (
+          <Box key={key}>
+            <Box fontSize={'12px'} color={'myGray.900'} fontWeight={500} mb={1}>
+              {key}
+            </Box>
+            {files.length > 0 ? (
+              <Flex flexWrap={'wrap'} gap={2}>
+                {files.map((file, index) => (
+                  <HStack
+                    key={`${file.url}-${index}`}
+                    bg={'white'}
+                    border={'1px solid'}
+                    borderColor={'myGray.200'}
+                    borderRadius={'sm'}
+                    py={1}
+                    px={2}
+                    maxW={'100%'}
+                    cursor={'pointer'}
+                    onClick={() => window.open(file.url, '_blank')}
+                  >
+                    <MyIcon name={getFileIcon(file.name) as any} w={'1rem'} flexShrink={0} />
+                    <Box className={'textEllipsis'}>{file.name}</Box>
+                  </HStack>
+                ))}
+              </Flex>
+            ) : (
+              <Markdown source={`~~~json\n${JSON.stringify(inputValue, null, 2)}`} />
+            )}
+          </Box>
+        );
+      })}
+    </Flex>
+  );
+});
+
+export default FormInputResult;

--- a/projects/app/src/components/core/chat/components/Interactive/InteractiveComponents.tsx
+++ b/projects/app/src/components/core/chat/components/Interactive/InteractiveComponents.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Button, Flex, FormControl, FormErrorMessage } from '@chakra-ui/react';
+import { Box, Flex, FormControl, FormErrorMessage } from '@chakra-ui/react';
 import { Controller, useForm, type UseFormHandleSubmit } from 'react-hook-form';
 import Markdown from '@/components/Markdown';
 import QuestionTip from '@fastgpt/web/components/common/MyTooltip/QuestionTip';
@@ -92,12 +92,16 @@ export const FormInputComponent = React.memo(function FormInputComponent({
 }) {
   const { t } = useTranslation();
 
-  const { handleSubmit, control, watch } = useForm({
+  const { handleSubmit, control, watch, reset } = useForm({
     defaultValues
   });
 
   const runtimeFileUploading = useContextSelector(WorkflowRuntimeContext, (v) => v.fileUploading);
   const formValues = watch();
+
+  React.useEffect(() => {
+    reset(defaultValues);
+  }, [defaultValues, reset]);
 
   const isFileUploading = React.useMemo(() => {
     if (runtimeFileUploading) return true;

--- a/projects/app/src/components/core/chat/components/WholeResponseModal.tsx
+++ b/projects/app/src/components/core/chat/components/WholeResponseModal.tsx
@@ -21,6 +21,7 @@ import { completionFinishReasonMap } from '@fastgpt/global/core/ai/constants';
 import { useSafeTranslation } from '@fastgpt/web/hooks/useSafeTranslation';
 import dynamic from 'next/dynamic';
 import ImagePreviewToken from '@/components/core/dataset/ImagePreviewToken';
+import FormInputResult from './FormInputResult';
 
 const RequestIdDetailModal = dynamic(() => import('@/components/core/ai/requestId'), {
   ssr: false
@@ -64,94 +65,6 @@ const QueryWithImages = React.memo(function QueryWithImages({
       )}
       <ImagePreviewToken images={queryImages} datasetId={datasetId} />
     </Box>
-  );
-});
-
-type FormInputResultFileItem = {
-  name: string;
-  url: string;
-};
-
-const getFilenameFromUrl = (url: string) => {
-  try {
-    const parsedUrl = new URL(url);
-    const filename = parsedUrl.searchParams.get('filename');
-    if (filename) return filename;
-
-    const pathname = parsedUrl.pathname.split('/').pop();
-    return pathname ? decodeURIComponent(pathname) : url;
-  } catch {
-    return url;
-  }
-};
-
-const normalizeFormInputResultFile = (value: unknown): FormInputResultFileItem | undefined => {
-  if (typeof value === 'string') {
-    if (!value) return;
-    return {
-      name: getFilenameFromUrl(value),
-      url: value
-    };
-  }
-
-  if (!value || typeof value !== 'object') return;
-
-  const file = value as Record<string, unknown>;
-  const url = typeof file.url === 'string' ? file.url : undefined;
-  if (!url) return;
-
-  return {
-    name: typeof file.name === 'string' && file.name ? file.name : getFilenameFromUrl(url),
-    url
-  };
-};
-
-const FormInputResult = React.memo(function FormInputResult({
-  value
-}: {
-  value: Record<string, unknown>;
-}) {
-  return (
-    <Flex flexDirection={'column'} gap={3}>
-      {Object.entries(value).map(([key, inputValue]) => {
-        const files = Array.isArray(inputValue)
-          ? inputValue
-              .map(normalizeFormInputResultFile)
-              .filter((file): file is FormInputResultFileItem => Boolean(file))
-          : [];
-
-        return (
-          <Box key={key}>
-            <Box fontSize={'12px'} color={'myGray.900'} fontWeight={500} mb={1}>
-              {key}
-            </Box>
-            {files.length > 0 ? (
-              <Flex flexWrap={'wrap'} gap={2}>
-                {files.map((file, index) => (
-                  <HStack
-                    key={`${file.url}-${index}`}
-                    bg={'white'}
-                    border={'1px solid'}
-                    borderColor={'myGray.200'}
-                    borderRadius={'sm'}
-                    py={1}
-                    px={2}
-                    maxW={'100%'}
-                    cursor={'pointer'}
-                    onClick={() => window.open(file.url, '_blank')}
-                  >
-                    <MyIcon name={getFileIcon(file.name) as any} w={'1rem'} flexShrink={0} />
-                    <Box className={'textEllipsis'}>{file.name}</Box>
-                  </HStack>
-                ))}
-              </Flex>
-            ) : (
-              <Markdown source={`~~~json\n${JSON.stringify(inputValue, null, 2)}`} />
-            )}
-          </Box>
-        );
-      })}
-    </Flex>
   );
 });
 

--- a/projects/app/src/components/core/chat/components/WholeResponseModal.tsx
+++ b/projects/app/src/components/core/chat/components/WholeResponseModal.tsx
@@ -1,0 +1,1206 @@
+/* eslint-disable react-hooks/static-components */
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Box, Flex, type BoxProps, useDisclosure, HStack, Grid } from '@chakra-ui/react';
+import type { ChatHistoryItemResType } from '@fastgpt/global/core/chat/type';
+import { moduleTemplatesFlat } from '@fastgpt/global/core/workflow/template/constants';
+import MyModal from '@fastgpt/web/components/v2/common/MyModal';
+import Markdown from '@/components/Markdown';
+import QuoteList from '../ChatContainer/ChatBox/components/QuoteList';
+import { DatasetSearchModeMap } from '@fastgpt/global/core/dataset/constants';
+import { formatNumber } from '@fastgpt/global/common/math/tools';
+import QuestionTip from '@fastgpt/web/components/common/MyTooltip/QuestionTip';
+import Avatar from '@fastgpt/web/components/common/Avatar';
+import { useSystem } from '@fastgpt/web/hooks/useSystem';
+import MyIcon from '@fastgpt/web/components/common/Icon';
+import { useContextSelector } from 'use-context-selector';
+import { ChatBoxContext } from '../ChatContainer/ChatBox/Provider';
+import { useRequest } from '@fastgpt/web/hooks/useRequest';
+import { getFileIcon } from '@fastgpt/global/common/file/icon';
+import EmptyTip from '@fastgpt/web/components/common/EmptyTip';
+import { completionFinishReasonMap } from '@fastgpt/global/core/ai/constants';
+import { useSafeTranslation } from '@fastgpt/web/hooks/useSafeTranslation';
+import dynamic from 'next/dynamic';
+import ImagePreviewToken from '@/components/core/dataset/ImagePreviewToken';
+
+const RequestIdDetailModal = dynamic(() => import('@/components/core/ai/requestId'), {
+  ssr: false
+});
+
+type sideTabItemType = {
+  moduleLogo?: string;
+  moduleName: string;
+  moduleNameArgs?: Record<string, any>;
+  runningTime?: number;
+  moduleType: string;
+  // nodeId:string; // abandon
+  id: string;
+  children: sideTabItemType[];
+};
+
+const QueryWithImages = React.memo(function QueryWithImages({
+  query,
+  queryImages,
+  datasetId
+}: {
+  query?: string;
+  queryImages: NonNullable<ChatHistoryItemResType['queryImages']>;
+  datasetId?: string;
+}) {
+  return (
+    <Box
+      border={'1px solid'}
+      borderColor={'myGray.200'}
+      borderRadius={'6px'}
+      bg={'myGray.50'}
+      color={'myGray.900'}
+      minH={'32px'}
+      px={3}
+      py={2}
+    >
+      {!!query && (
+        <Box whiteSpace={'pre-wrap'} mb={queryImages.length > 0 ? 2 : 0}>
+          {query}
+        </Box>
+      )}
+      <ImagePreviewToken images={queryImages} datasetId={datasetId} />
+    </Box>
+  );
+});
+
+type FormInputResultFileItem = {
+  name: string;
+  url: string;
+};
+
+const getFilenameFromUrl = (url: string) => {
+  try {
+    const parsedUrl = new URL(url);
+    const filename = parsedUrl.searchParams.get('filename');
+    if (filename) return filename;
+
+    const pathname = parsedUrl.pathname.split('/').pop();
+    return pathname ? decodeURIComponent(pathname) : url;
+  } catch {
+    return url;
+  }
+};
+
+const normalizeFormInputResultFile = (value: unknown): FormInputResultFileItem | undefined => {
+  if (typeof value === 'string') {
+    if (!value) return;
+    return {
+      name: getFilenameFromUrl(value),
+      url: value
+    };
+  }
+
+  if (!value || typeof value !== 'object') return;
+
+  const file = value as Record<string, unknown>;
+  const url = typeof file.url === 'string' ? file.url : undefined;
+  if (!url) return;
+
+  return {
+    name: typeof file.name === 'string' && file.name ? file.name : getFilenameFromUrl(url),
+    url
+  };
+};
+
+const FormInputResult = React.memo(function FormInputResult({
+  value
+}: {
+  value: Record<string, unknown>;
+}) {
+  return (
+    <Flex flexDirection={'column'} gap={3}>
+      {Object.entries(value).map(([key, inputValue]) => {
+        const files = Array.isArray(inputValue)
+          ? inputValue
+              .map(normalizeFormInputResultFile)
+              .filter((file): file is FormInputResultFileItem => Boolean(file))
+          : [];
+
+        return (
+          <Box key={key}>
+            <Box fontSize={'12px'} color={'myGray.900'} fontWeight={500} mb={1}>
+              {key}
+            </Box>
+            {files.length > 0 ? (
+              <Flex flexWrap={'wrap'} gap={2}>
+                {files.map((file, index) => (
+                  <HStack
+                    key={`${file.url}-${index}`}
+                    bg={'white'}
+                    border={'1px solid'}
+                    borderColor={'myGray.200'}
+                    borderRadius={'sm'}
+                    py={1}
+                    px={2}
+                    maxW={'100%'}
+                    cursor={'pointer'}
+                    onClick={() => window.open(file.url, '_blank')}
+                  >
+                    <MyIcon name={getFileIcon(file.name) as any} w={'1rem'} flexShrink={0} />
+                    <Box className={'textEllipsis'}>{file.name}</Box>
+                  </HStack>
+                ))}
+              </Flex>
+            ) : (
+              <Markdown source={`~~~json\n${JSON.stringify(inputValue, null, 2)}`} />
+            )}
+          </Box>
+        );
+      })}
+    </Flex>
+  );
+});
+
+/* Per response value */
+export const WholeResponseContent = ({
+  activeModule,
+  hideTabs,
+  dataId,
+  chatTime,
+  onOpenRequestIdDetail
+}: {
+  activeModule: ChatHistoryItemResType;
+  hideTabs?: boolean;
+  dataId?: string;
+  chatTime?: Date;
+  onOpenRequestIdDetail?: (requestId: string) => void;
+}) => {
+  const { t } = useSafeTranslation();
+  const queryPreviewDatasetId = activeModule?.quoteList?.[0]?.datasetId;
+
+  // Auto scroll to top
+  const ContentRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (ContentRef.current) {
+      ContentRef.current.scrollTop = 0;
+    }
+  }, [activeModule]);
+
+  const RowRender = useCallback(
+    ({ children, label, ...props }: { children: React.ReactNode; label: string } & BoxProps) => {
+      return (
+        <Box>
+          <Box
+            fontSize={'12px'}
+            lineHeight={'18px'}
+            mb={2}
+            color={'myGray.900'}
+            fontWeight={500}
+            letterSpacing={'0.5px'}
+          >
+            {label}
+          </Box>
+          <Box borderRadius={'6px'} fontSize={'12px'} bg={'myGray.50'} {...props}>
+            {children}
+          </Box>
+        </Box>
+      );
+    },
+    []
+  );
+  const Row = useCallback(
+    ({
+      label,
+      value,
+      rawDom
+    }: {
+      label: string;
+      value?: string | number | boolean | object;
+      rawDom?: React.ReactNode;
+    }) => {
+      const val = value || rawDom;
+      const isObject = typeof value === 'object';
+
+      const formatValue = useMemo(() => {
+        if (isObject) {
+          return `~~~json\n${JSON.stringify(value, null, 2)}`;
+        }
+        if (typeof value === 'string') {
+          return t(value);
+        }
+        return `${value}`;
+      }, [isObject, value]);
+
+      if (rawDom) {
+        return (
+          <RowRender label={label} bg={'transparent'}>
+            {rawDom}
+          </RowRender>
+        );
+      }
+
+      if (val === undefined || val === '' || val === 'undefined') return null;
+
+      return (
+        <RowRender
+          label={label}
+          {...(isObject
+            ? { bg: 'transparent' }
+            : {
+                minH: '32px',
+                px: 3,
+                display: 'flex',
+                alignItems: 'center',
+                border: '1px solid',
+                borderColor: 'myGray.200',
+                color: 'myGray.900',
+                bg: 'myGray.50'
+              })}
+        >
+          <Box
+            sx={{
+              '& .markdown': { fontSize: '12px !important' },
+              '& .markdown pre': { fontSize: '12px !important' }
+            }}
+          >
+            <Markdown source={formatValue} />
+          </Box>
+        </RowRender>
+      );
+    },
+    [RowRender, t]
+  );
+
+  return activeModule ? (
+    <Box
+      h={'100%'}
+      ref={ContentRef}
+      py={3}
+      px={hideTabs ? 4 : 3}
+      display={'flex'}
+      flexDirection={'column'}
+      gap={3}
+      {...(hideTabs
+        ? {}
+        : {
+            flex: '1 0 0',
+            overflow: 'auto'
+          })}
+    >
+      {/* common info */}
+      <>
+        <Row
+          label={t('chat:response.node_name')}
+          value={t(activeModule.moduleName as any, activeModule.moduleNameArgs)}
+        />
+        {activeModule?.totalPoints !== undefined && (
+          <Row
+            label={t('common:support.wallet.usage.Total points')}
+            value={formatNumber(activeModule.totalPoints)}
+          />
+        )}
+        {(activeModule?.childrenResponses ||
+          activeModule.toolDetail ||
+          activeModule.pluginDetail) && (
+          <Row
+            label={t('chat:response.child total points')}
+            value={formatNumber(
+              [
+                ...(activeModule.childrenResponses || []),
+                ...(activeModule.toolDetail || []),
+                ...(activeModule.pluginDetail || [])
+              ]?.reduce((sum, item) => sum + (item.totalPoints || 0), 0) || 0
+            )}
+          />
+        )}
+        <Row
+          label={t('workflow:response.Error')}
+          value={activeModule?.errorText ?? activeModule?.error}
+        />
+        <Row label={t('chat:response.node_inputs')} value={activeModule?.nodeInputs} />
+      </>
+      {/* ai chat */}
+      <>
+        {activeModule?.finishReason && (
+          <Row
+            label={t('chat:completion_finish_reason')}
+            value={t(completionFinishReasonMap[activeModule?.finishReason])}
+          />
+        )}
+        <Row label={t('common:core.chat.response.module model')} value={activeModule?.model} />
+        {activeModule?.tokens && (
+          <Row label={t('chat:llm_tokens')} value={`${activeModule?.tokens}`} />
+        )}
+        {(!!activeModule?.inputTokens || !!activeModule?.outputTokens) && (
+          <Row
+            label={t('chat:llm_tokens')}
+            value={`Input/Output = ${activeModule?.inputTokens || 0}/${activeModule?.outputTokens || 0}`}
+          />
+        )}
+        {activeModule.queryExtensionResult && (
+          <Row
+            label={t('chat:query_extension_IO_tokens')}
+            value={`${activeModule.queryExtensionResult.inputTokens}/${activeModule.queryExtensionResult.outputTokens}`}
+          />
+        )}
+        {(!!activeModule?.toolCallInputTokens || !!activeModule?.toolCallOutputTokens) && (
+          <Row
+            label={t('common:core.chat.response.Tool call tokens')}
+            value={`Input/Output = ${activeModule?.toolCallInputTokens || 0}/${activeModule?.toolCallOutputTokens || 0}`}
+          />
+        )}
+        {activeModule?.compressTextAgent && (
+          <>
+            <Row
+              label={t('chat:compress_llm_usage_point')}
+              value={`${activeModule.compressTextAgent.totalPoints}`}
+            />
+            <Row
+              label={t('chat:compress_llm_usage')}
+              value={`${activeModule.compressTextAgent.inputTokens}/${activeModule.compressTextAgent.outputTokens}`}
+            />
+          </>
+        )}
+        {/* LLM Request IDs */}
+        {activeModule?.llmRequestIds &&
+          activeModule.llmRequestIds.length > 0 &&
+          onOpenRequestIdDetail && (
+            <Row
+              label={t('chat:llm_request_ids')}
+              rawDom={
+                <Grid templateColumns={'repeat(2, minmax(0, 1fr))'} gap={2}>
+                  {activeModule.llmRequestIds.map((requestId, index) => (
+                    <Flex
+                      key={index}
+                      role={'group'}
+                      alignItems={'center'}
+                      gap={2}
+                      bg={'myGray.100'}
+                      borderRadius={'6px'}
+                      px={3}
+                      py={2}
+                      cursor={'pointer'}
+                      color={'myGray.900'}
+                      _hover={{ color: 'primary.600' }}
+                      onClick={() => onOpenRequestIdDetail(requestId)}
+                      title={t('common:Click_to_expand')}
+                    >
+                      <Box
+                        flex={'1 0 0'}
+                        w={0}
+                        fontSize={'12px'}
+                        lineHeight={'16px'}
+                        letterSpacing={'0.4px'}
+                        textOverflow={'ellipsis'}
+                        overflow={'hidden'}
+                        whiteSpace={'nowrap'}
+                      >
+                        {requestId}
+                      </Box>
+                      <MyIcon
+                        name={'common/upperRight'}
+                        w={'16px'}
+                        h={'16px'}
+                        color={'myGray.500'}
+                        _groupHover={{ color: 'primary.600' }}
+                      />
+                    </Flex>
+                  ))}
+                </Grid>
+              }
+            />
+          )}
+        <Row label={t('chat:step_query')} value={activeModule?.stepQuery} />
+
+        {activeModule?.queryImages && activeModule.queryImages.length > 0 ? (
+          <Row
+            label={t('common:core.chat.response.module query')}
+            rawDom={
+              <QueryWithImages
+                query={activeModule?.query}
+                queryImages={activeModule.queryImages}
+                datasetId={queryPreviewDatasetId}
+              />
+            }
+          />
+        ) : (
+          <Row label={t('common:core.chat.response.module query')} value={activeModule?.query} />
+        )}
+        <Row
+          label={t('common:core.chat.response.context total length')}
+          value={activeModule?.contextTotalLen}
+        />
+        <Row
+          label={t('common:core.chat.response.module temperature')}
+          value={activeModule?.temperature}
+        />
+        <Row
+          label={t('common:core.chat.response.module maxToken')}
+          value={activeModule?.maxToken}
+        />
+
+        <Row label={t('chat:reasoning_content')} value={activeModule?.reasoningText} />
+        <Row
+          label={t('common:core.chat.response.module historyPreview')}
+          rawDom={
+            activeModule.historyPreview ? (
+              <Box px={3} py={2} border={'base'} borderRadius={'md'}>
+                {activeModule.historyPreview?.map((item, i) => (
+                  <Box
+                    key={i}
+                    _notLast={{
+                      borderBottom: '1px solid',
+                      borderBottomColor: 'myWhite.700',
+                      mb: 2
+                    }}
+                    pb={2}
+                  >
+                    <Box fontWeight={'bold'}>{item.obj}</Box>
+                    <Box whiteSpace={'pre-wrap'}>{item.value}</Box>
+                  </Box>
+                ))}
+              </Box>
+            ) : (
+              ''
+            )
+          }
+        />
+      </>
+      {/* dataset search */}
+      <>
+        {activeModule?.searchMode && (
+          <Row
+            label={t('common:core.dataset.search.search mode')}
+            rawDom={
+              <Flex border={'base'} borderRadius={'md'} p={2}>
+                <Box>{t(DatasetSearchModeMap[activeModule.searchMode]?.title as any)}</Box>
+                {activeModule.embeddingWeight && (
+                  <>{`(${t('chat:response_hybrid_weight', {
+                    emb: activeModule.embeddingWeight,
+                    text: 1 - activeModule.embeddingWeight
+                  })})`}</>
+                )}
+              </Flex>
+            }
+          />
+        )}
+        <Row
+          label={t('common:core.chat.response.module similarity')}
+          value={activeModule?.similarity}
+        />
+        <Row label={t('common:core.chat.response.module limit')} value={activeModule?.limit} />
+        <Row label={t('chat:response_embedding_model')} value={activeModule?.embeddingModel} />
+        <Row
+          label={t('chat:response_embedding_model_tokens')}
+          value={`${activeModule?.embeddingTokens}`}
+        />
+        {activeModule?.searchUsingReRank !== undefined && (
+          <>
+            <Row
+              label={t('common:core.chat.response.search using reRank')}
+              rawDom={
+                <Box border={'base'} borderRadius={'md'} p={2}>
+                  {activeModule?.searchUsingReRank ? (
+                    activeModule?.rerankModel ? (
+                      <Box>{`${activeModule.rerankModel}: ${activeModule.rerankWeight}`}</Box>
+                    ) : (
+                      'True'
+                    )
+                  ) : (
+                    `False`
+                  )}
+                </Box>
+              }
+            />
+            <Row
+              label={t('chat:response_rerank_tokens')}
+              value={`${activeModule?.reRankInputTokens}`}
+            />
+          </>
+        )}
+        {activeModule.queryExtensionResult && (
+          <>
+            <Row
+              label={t('common:core.chat.response.Extension model')}
+              value={activeModule.queryExtensionResult.model}
+            />
+            <Row
+              label={t('chat:query_extension_IO_tokens')}
+              value={`${activeModule.queryExtensionResult.inputTokens}/${activeModule.queryExtensionResult.outputTokens}`}
+            />
+            <Row
+              label={t('chat:query_extension_result')}
+              value={activeModule.queryExtensionResult.query}
+            />
+          </>
+        )}
+        <Row
+          label={t('common:core.chat.response.Extension model')}
+          value={activeModule?.extensionModel}
+        />
+        <Row label={t('chat:query_extension_result')} value={`${activeModule?.extensionResult}`} />
+        {activeModule.quoteList && activeModule.quoteList.length > 0 && (
+          <Row
+            label={t('chat:response_search_results', { len: activeModule.quoteList.length })}
+            rawDom={<QuoteList chatItemDataId={dataId} rawSearch={activeModule.quoteList} />}
+          />
+        )}
+      </>
+      {/* dataset concat */}
+      <>
+        <Row label={t('chat:response.dataset_concat_length')} value={activeModule?.concatLength} />
+      </>
+      {/* classify question */}
+      <>
+        <Row
+          label={t('common:core.chat.response.module cq result')}
+          value={activeModule?.cqResult}
+        />
+        <Row
+          label={t('common:core.chat.response.module cq')}
+          value={(() => {
+            if (!activeModule?.cqList) return '';
+            return activeModule.cqList.map((item) => `* ${item.value}`).join('\n');
+          })()}
+        />
+      </>
+      {/* if-else */}
+      <>
+        <Row
+          label={t('common:core.chat.response.module if else Result')}
+          value={activeModule?.ifElseResult}
+        />
+      </>
+      {/* extract */}
+      <>
+        <Row
+          label={t('common:core.chat.response.module extract description')}
+          value={activeModule?.extractDescription}
+        />
+        <Row
+          label={t('common:core.chat.response.module extract result')}
+          value={activeModule?.extractResult}
+        />
+      </>
+      {/* http */}
+      <>
+        <Row label={'Headers'} value={activeModule?.headers} />
+        <Row label={'Params'} value={activeModule?.params} />
+        <Row label={'Body'} value={activeModule?.body} />
+        <Row
+          label={t('common:core.chat.response.module http result')}
+          value={activeModule?.httpResult}
+        />
+      </>
+      {/* plugin */}
+      <>
+        <Row label={t('chat:tool_input')} value={activeModule?.toolInput} />
+        <Row label={t('chat:tool_output')} value={activeModule?.pluginOutput} />
+      </>
+      {/* text output */}
+      <Row label={t('common:core.chat.response.text output')} value={activeModule?.textOutput} />
+      {/* code */}
+      <>
+        <Row label={t('workflow:response.Custom inputs')} value={activeModule?.customInputs} />
+        <Row label={t('workflow:response.Custom outputs')} value={activeModule?.customOutputs} />
+        <Row label={t('workflow:response.Code log')} value={activeModule?.codeLog} />
+      </>
+
+      {/* read files */}
+      <>
+        {activeModule?.readFiles && activeModule?.readFiles.length > 0 && (
+          <Row
+            label={t('workflow:response.read files')}
+            rawDom={
+              <Flex flexWrap={'wrap'} gap={3} px={4} py={2}>
+                {activeModule?.readFiles.map((file, i) => (
+                  <HStack
+                    key={i}
+                    bg={'white'}
+                    boxShadow={'base'}
+                    borderRadius={'sm'}
+                    py={1}
+                    px={2}
+                    {...(file.url
+                      ? {
+                          cursor: 'pointer',
+                          onClick: () => window.open(file.url)
+                        }
+                      : {})}
+                  >
+                    <MyIcon name={getFileIcon(file.name) as any} w={'1rem'} />
+                    <Box>{file.name}</Box>
+                  </HStack>
+                ))}
+              </Flex>
+            }
+          />
+        )}
+        <Row
+          label={t('workflow:response.Read file result')}
+          value={activeModule?.readFilesResult}
+        />
+      </>
+
+      {/* user select */}
+      <Row
+        label={t('common:core.chat.response.user_select_result')}
+        value={activeModule?.userSelectResult}
+      />
+
+      {/* update var */}
+      {/* `updateVarResult` is `updateList.map(...)` — outer dim = rows in the
+          variable-update config. Single-row is the common case, where the
+          outer 1-element wrapper is noise (esp. bad when inner is itself an
+          array → visual `[[...]]`). Unwrap it for all value types for
+          consistency, but keep the wrapper if inner is null/undefined:
+          Row hides rows whose `val` falsey-coerces to undefined, and `[null]`
+          preserves the "invalid reference" signal this node emits. */}
+      <Row
+        label={t('common:core.chat.response.update_var_result')}
+        value={(() => {
+          const r = activeModule?.updateVarResult;
+          if (Array.isArray(r) && r.length === 1 && r[0] !== null && r[0] !== undefined) {
+            return r[0];
+          }
+          return r;
+        })()}
+      />
+
+      {/* loop */}
+      <Row label={t('common:core.chat.response.loop_input')} value={activeModule?.loopInput} />
+      <Row label={t('common:core.chat.response.loop_output')} value={activeModule?.loopResult} />
+
+      {/* parallel */}
+      <Row
+        label={t('common:core.chat.response.parallel_input')}
+        value={activeModule?.parallelInput}
+      />
+      <Row
+        label={t('common:core.chat.response.parallel_output')}
+        value={activeModule?.parallelResult}
+      />
+      <Row
+        label={t('common:core.chat.response.parallel_run_detail')}
+        value={activeModule?.parallelRunDetail}
+      />
+
+      {/* loopRun */}
+      <Row
+        label={t('common:core.chat.response.loop_run_input')}
+        value={activeModule?.loopRunInput}
+      />
+      <Row
+        label={t('common:core.chat.response.loop_run_iterations')}
+        value={activeModule?.loopRunIterations}
+      />
+      <Row
+        label={t('common:core.chat.response.loop_run_history')}
+        value={activeModule?.loopRunHistory}
+      />
+
+      {/* loopStart */}
+      <Row
+        label={t('common:core.chat.response.loop_input_element')}
+        value={activeModule?.loopInputValue}
+      />
+
+      {/* loopEnd */}
+      <Row
+        label={t('common:core.chat.response.loop_output_element')}
+        value={activeModule?.loopOutputValue}
+      />
+
+      {/* form input */}
+      {activeModule?.formInputResult && (
+        <Row
+          label={t('workflow:form_input_result')}
+          rawDom={<FormInputResult value={activeModule.formInputResult} />}
+        />
+      )}
+
+      {/* tool params */}
+      <Row
+        label={t('workflow:tool_params.tool_params_result')}
+        value={activeModule?.toolParamsResult}
+      />
+
+      {/* tool */}
+      <Row label={t('workflow:tool.tool_result')} value={activeModule?.toolRes} />
+    </Box>
+  ) : null;
+};
+
+/* Side tab: With and without children */
+const SideTabItem = ({
+  sideBarItem,
+  onChange,
+  value,
+  index
+}: {
+  sideBarItem: sideTabItemType;
+  onChange: (id: string) => void;
+  value: string;
+  index: number;
+}) => {
+  const { t } = useSafeTranslation();
+
+  if (!sideBarItem) return null;
+
+  const AccordionSideTabItem = useCallback(
+    ({
+      sideBarItem,
+      onChange,
+      value,
+      index
+    }: {
+      sideBarItem: sideTabItemType;
+      onChange: (id: string) => void;
+      value: string;
+      index: number;
+    }) => {
+      const { isOpen: isShowAccordion, onToggle: onToggleShowAccordion } = useDisclosure({
+        defaultIsOpen: false
+      });
+      return (
+        <>
+          <Flex align={'center'} position={'relative'}>
+            <NormalSideTabItem
+              index={index}
+              value={value}
+              onChange={onChange}
+              sideBarItem={sideBarItem}
+            >
+              <MyIcon
+                h={'20px'}
+                w={'20px'}
+                name={isShowAccordion ? 'core/chat/chevronUp' : 'core/chat/chevronDown'}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleShowAccordion();
+                }}
+                _hover={{ color: 'primary.600', cursor: 'pointer' }}
+              />
+            </NormalSideTabItem>
+          </Flex>
+          {isShowAccordion && (
+            <Flex flexDirection={'column'} gap={1} position={'relative'}>
+              {sideBarItem.children.map((item) => (
+                <SideTabItem
+                  value={value}
+                  key={item.id}
+                  sideBarItem={item}
+                  onChange={onChange}
+                  index={index + 1}
+                />
+              ))}
+            </Flex>
+          )}
+        </>
+      );
+    },
+    []
+  );
+
+  const NormalSideTabItem = useCallback(
+    ({
+      sideBarItem,
+      onChange,
+      value,
+      index,
+      children
+    }: {
+      sideBarItem: sideTabItemType;
+      onChange: (id: string) => void;
+      value: string;
+      index: number;
+      children?: React.ReactNode;
+    }) => {
+      const leftIndex = index > 3 ? 3 : index;
+      const leftPad = leftIndex === 0 ? '8px' : `${8 + leftIndex * 32}px`;
+      return (
+        <Flex
+          alignItems={'center'}
+          onClick={() => {
+            onChange(sideBarItem.id);
+          }}
+          background={value === sideBarItem.id ? 'myGray.100' : ''}
+          _hover={{ background: 'myGray.100' }}
+          py={'6px'}
+          pl={leftPad}
+          pr={'4px'}
+          width={'100%'}
+          cursor={'pointer'}
+          borderRadius={'6px'}
+          position={'relative'}
+        >
+          <Avatar
+            src={
+              sideBarItem.moduleLogo ||
+              moduleTemplatesFlat.find(
+                (template) => sideBarItem.moduleType === template.flowNodeType
+              )?.avatar
+            }
+            alt={''}
+            w={'24px'}
+            h={'24px'}
+            borderRadius={'4px'}
+          />
+          <Box ml={2}>
+            <Box
+              fontSize={'12px'}
+              lineHeight={'16px'}
+              fontWeight={500}
+              color={'myGray.900'}
+              letterSpacing={'0.5px'}
+            >
+              {t(sideBarItem.moduleName as any, sideBarItem.moduleNameArgs)}
+            </Box>
+            <Box
+              fontSize={'11px'}
+              lineHeight={'16px'}
+              fontWeight={500}
+              color={'myGray.500'}
+              letterSpacing={'0.5px'}
+            >
+              {t(sideBarItem.runningTime as any) + 's'}
+            </Box>
+          </Box>
+          <Box
+            h={'24px'}
+            w={'24px'}
+            position={'absolute'}
+            right={'4px'}
+            top={'50%'}
+            transform={'translateY(-50%)'}
+          >
+            {children}
+          </Box>
+        </Flex>
+      );
+    },
+    [t]
+  );
+
+  return sideBarItem.children.length !== 0 ? (
+    <>
+      <Box>
+        <AccordionSideTabItem
+          sideBarItem={sideBarItem}
+          onChange={onChange}
+          value={value}
+          index={index}
+        />
+      </Box>
+    </>
+  ) : (
+    <NormalSideTabItem index={index} value={value} onChange={onChange} sideBarItem={sideBarItem} />
+  );
+};
+
+/* Modal main container */
+export const ResponseBox = React.memo(function ResponseBox({
+  response,
+  dataId,
+  chatTime,
+  hideTabs = false,
+  useMobile = false
+}: {
+  response: ChatHistoryItemResType[];
+  dataId?: string;
+  chatTime: Date;
+  hideTabs?: boolean;
+  useMobile?: boolean;
+}) {
+  const { t } = useSafeTranslation();
+  const { isPc } = useSystem();
+
+  // LLM Request Detail Modal state
+  const [selectedRequestId, setSelectedRequestId] = useState<string>();
+
+  const handleOpenRequestIdDetail = useCallback((requestId: string) => {
+    setSelectedRequestId(requestId);
+  }, []);
+
+  const handleCloseRequestIdModal = useCallback(() => {
+    setSelectedRequestId(undefined);
+  }, []);
+
+  const flattedResponse = useMemo(() => {
+    /* Flat response */
+    function flattenArray(arr: ChatHistoryItemResType[]) {
+      const result: ChatHistoryItemResType[] = [];
+
+      function helper(currentArray: ChatHistoryItemResType[]) {
+        currentArray.forEach((item) => {
+          if (item && typeof item === 'object') {
+            result.push(item);
+
+            if (Array.isArray(item.toolDetail)) {
+              helper(item.toolDetail);
+            }
+            if (Array.isArray(item.pluginDetail)) {
+              helper(item.pluginDetail);
+            }
+            if (Array.isArray(item.loopDetail)) {
+              helper(item.loopDetail);
+            }
+            if (Array.isArray(item.parallelDetail)) {
+              helper(item.parallelDetail);
+            }
+            if (Array.isArray(item.loopRunDetail)) {
+              helper(item.loopRunDetail);
+            }
+            if (Array.isArray(item.childrenResponses)) {
+              helper(item.childrenResponses);
+            }
+          }
+        });
+      }
+
+      helper(arr);
+      return result;
+    }
+
+    return flattenArray(response).map((item) => ({
+      ...item,
+      id: item.id ?? item.nodeId
+    }));
+  }, [response]);
+  const [currentNodeId, setCurrentNodeId] = useState(
+    flattedResponse[0]?.id ?? flattedResponse[0]?.nodeId ?? ''
+  );
+
+  const activeModule = useMemo(
+    () => flattedResponse.find((item) => item.id === currentNodeId) as ChatHistoryItemResType,
+    [currentNodeId, flattedResponse]
+  );
+
+  const sliderResponseList: sideTabItemType[] = useMemo(() => {
+    /* Format response data to slider data */
+    function pretreatmentResponse(res: ChatHistoryItemResType[]): sideTabItemType[] {
+      return res.map((item) => {
+        const children: sideTabItemType[] = [];
+
+        if (item?.toolDetail) children.push(...pretreatmentResponse(item?.toolDetail));
+        if (item?.pluginDetail) children.push(...pretreatmentResponse(item?.pluginDetail));
+        if (item?.loopDetail) children.push(...pretreatmentResponse(item?.loopDetail));
+        if (item?.parallelDetail) children.push(...pretreatmentResponse(item?.parallelDetail));
+        if (item?.loopRunDetail) children.push(...pretreatmentResponse(item?.loopRunDetail));
+        if (item?.childrenResponses)
+          children.push(...pretreatmentResponse(item?.childrenResponses));
+
+        return {
+          moduleLogo: item.moduleLogo,
+          moduleName: item.moduleName,
+          moduleNameArgs: item.moduleNameArgs,
+          runningTime: item.runningTime,
+          moduleType: item.moduleType,
+          id: item.id ?? item.nodeId,
+          children
+        };
+      });
+    }
+    return pretreatmentResponse(response);
+  }, [response]);
+
+  const {
+    isOpen: isOpenMobileModal,
+    onOpen: onOpenMobileModal,
+    onClose: onCloseMobileModal
+  } = useDisclosure();
+
+  const WholeResponseSideTab = useCallback(
+    ({
+      response,
+      value,
+      onChange,
+      isMobile = false
+    }: {
+      response: sideTabItemType[];
+      value: string;
+      onChange: (index: string) => void;
+      isMobile?: boolean;
+    }) => {
+      return (
+        <Flex flexDirection={'column'} gap={1}>
+          {response.map((item) => (
+            <Flex
+              key={item.id}
+              flexDirection={'column'}
+              gap={1}
+              bg={isMobile ? 'myGray.100' : ''}
+              m={isMobile ? 3 : 0}
+              borderRadius={'md'}
+              w={isMobile ? 'auto' : '180px'}
+            >
+              <SideTabItem value={value} onChange={onChange} sideBarItem={item} index={0} />
+            </Flex>
+          ))}
+        </Flex>
+      );
+    },
+    []
+  );
+
+  return (
+    <>
+      {isPc && !useMobile ? (
+        <Flex
+          overflow={'hidden'}
+          height={'100%'}
+          mx={'32px'}
+          bg={'myGray.25'}
+          border={'1px solid'}
+          borderColor={'myGray.200'}
+          borderRadius={'12px'}
+        >
+          <Box
+            w={'204px'}
+            flexShrink={0}
+            borderRight={'1px solid'}
+            borderColor={'myGray.200'}
+            p={3}
+            overflowY={'auto'}
+            overflowX={'hidden'}
+          >
+            <WholeResponseSideTab
+              response={sliderResponseList}
+              value={currentNodeId}
+              onChange={setCurrentNodeId}
+            />
+          </Box>
+          <Box flex={'1 0 0'} w={0} height={'100%'}>
+            <WholeResponseContent
+              dataId={dataId}
+              activeModule={activeModule}
+              hideTabs={hideTabs}
+              chatTime={chatTime}
+              onOpenRequestIdDetail={handleOpenRequestIdDetail}
+            />
+          </Box>
+        </Flex>
+      ) : (
+        <Box h={'100%'} overflow={'auto'}>
+          {!isOpenMobileModal && (
+            <WholeResponseSideTab
+              response={sliderResponseList}
+              value={currentNodeId}
+              onChange={(item: string) => {
+                setCurrentNodeId(item);
+                onOpenMobileModal();
+              }}
+              isMobile={true}
+            />
+          )}
+          {isOpenMobileModal && (
+            <Flex flexDirection={'column'} h={'100%'}>
+              <Flex
+                align={'center'}
+                justifyContent={'center'}
+                px={2}
+                py={2}
+                borderBottom={'sm'}
+                position={'relative'}
+                height={'40px'}
+              >
+                <MyIcon
+                  width={4}
+                  height={4}
+                  name="common/backLight"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onCloseMobileModal();
+                  }}
+                  position={'absolute'}
+                  left={2}
+                  top={'50%'}
+                  transform={'translateY(-50%)'}
+                  cursor={'pointer'}
+                  _hover={{ color: 'primary.500' }}
+                />
+
+                <Avatar
+                  src={
+                    activeModule.moduleLogo ||
+                    moduleTemplatesFlat.find(
+                      (template) => activeModule.moduleType === template.flowNodeType
+                    )?.avatar
+                  }
+                  w={'1.25rem'}
+                  h={'1.25rem'}
+                  borderRadius={'sm'}
+                />
+
+                <Box ml={1.5} lineHeight={'1.25rem'} alignItems={'center'}>
+                  {t(activeModule.moduleName as any, activeModule.moduleNameArgs)}
+                </Box>
+              </Flex>
+              <Box flex={'1 0 0'}>
+                <WholeResponseContent
+                  dataId={dataId}
+                  activeModule={activeModule}
+                  hideTabs={hideTabs}
+                  chatTime={chatTime}
+                  onOpenRequestIdDetail={handleOpenRequestIdDetail}
+                />
+              </Box>
+            </Flex>
+          )}
+        </Box>
+      )}
+
+      {/* LLM Request Detail Modal */}
+      {selectedRequestId && (
+        <RequestIdDetailModal onClose={handleCloseRequestIdModal} requestId={selectedRequestId} />
+      )}
+    </>
+  );
+});
+
+const WholeResponseModal = ({
+  onClose,
+  dataId,
+  chatTime
+}: {
+  onClose: () => void;
+  dataId: string;
+  chatTime: Date;
+}) => {
+  const { t } = useSafeTranslation();
+
+  const { getHistoryResponseData } = useContextSelector(ChatBoxContext, (v) => v);
+  const { loading: isLoading, data: response } = useRequest(
+    () => getHistoryResponseData({ dataId }),
+    {
+      manual: false
+    }
+  );
+
+  return (
+    <MyModal
+      isCentered
+      isOpen={true}
+      onClose={onClose}
+      isLoading={isLoading}
+      w={['90vw', '880px']}
+      maxW={['90vw', '880px']}
+      h={['90vh', '80vh']}
+      maxH={['90vh', '700px']}
+      px={0}
+      py={8}
+      headerPx={'32px'}
+      title={
+        <Flex alignItems={'center'} gap={2}>
+          <Box fontSize={'20px'} lineHeight={'26px'} letterSpacing={'0.15px'} fontWeight={500}>
+            {t('common:core.chat.response.Complete Response')}
+          </Box>
+          <QuestionTip label={t('chat:question_tip')} />
+        </Flex>
+      }
+    >
+      {!isLoading &&
+        (!!response?.length ? (
+          <ResponseBox response={response} dataId={dataId} chatTime={chatTime} />
+        ) : (
+          <EmptyTip text={t('chat:no_workflow_response')} />
+        ))}
+    </MyModal>
+  );
+};
+
+export default WholeResponseModal;

--- a/projects/app/test/components/core/chat/ChatContainer/ChatBox/utils.test.ts
+++ b/projects/app/test/components/core/chat/ChatContainer/ChatBox/utils.test.ts
@@ -286,6 +286,184 @@ describe('mergeResumeCompletedChatRecords', () => {
 
     expect(result[0].responseData).toHaveLength(1);
   });
+
+  it('preserves hydrated submitted interactive values when completed records overwrite the chat', () => {
+    const responseChatId = 'ai-data-id';
+    const hydratedInteractive = {
+      type: 'userInput',
+      entryNodeIds: ['form-node-id'],
+      memoryEdges: [],
+      nodeOutputs: [],
+      usageId: 'usage-id',
+      params: {
+        description: '',
+        submitted: true,
+        inputForm: [
+          {
+            type: 'fileSelect',
+            key: 'File',
+            label: 'File',
+            valueType: 'arrayString',
+            description: '',
+            required: false,
+            defaultValue: '',
+            canLocalUpload: true,
+            canSelectFile: true,
+            maxFiles: 5,
+            value: [
+              {
+                name: 'file.docx',
+                url: 'https://example.com/file.docx'
+              }
+            ]
+          }
+        ]
+      }
+    };
+    const currentRecords = [
+      {
+        id: responseChatId,
+        dataId: responseChatId,
+        obj: ChatRoleEnum.AI,
+        status: 'loading',
+        value: [{ interactive: hydratedInteractive }]
+      }
+    ] as ChatSiteItemType[];
+    const completedRecords = [
+      {
+        id: responseChatId,
+        dataId: responseChatId,
+        obj: ChatRoleEnum.AI,
+        status: 'finish',
+        value: [
+          {
+            interactive: {
+              ...hydratedInteractive,
+              params: {
+                ...hydratedInteractive.params,
+                inputForm: [
+                  {
+                    ...hydratedInteractive.params.inputForm[0],
+                    value: []
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ] as ChatSiteItemType[];
+
+    const result = mergeResumeCompletedChatRecords({
+      currentRecords,
+      completedRecords,
+      responseChatId
+    });
+
+    expect((result[0].value[0] as any).interactive.params.inputForm[0].value).toEqual([
+      {
+        name: 'file.docx',
+        url: 'https://example.com/file.docx'
+      }
+    ]);
+  });
+
+  it('preserves hydrated submitted interactive values outside of the streaming response record', () => {
+    const responseChatId = 'streaming-ai-data-id';
+    const interactiveChatId = 'interactive-ai-data-id';
+    const hydratedInteractive = {
+      type: 'userInput',
+      entryNodeIds: ['form-node-id'],
+      memoryEdges: [],
+      nodeOutputs: [],
+      usageId: 'usage-id',
+      params: {
+        description: '',
+        submitted: true,
+        inputForm: [
+          {
+            type: 'fileSelect',
+            key: 'File',
+            label: 'File',
+            valueType: 'arrayString',
+            description: '',
+            required: false,
+            defaultValue: '',
+            canLocalUpload: true,
+            canSelectFile: true,
+            maxFiles: 5,
+            value: [
+              {
+                name: 'file.docx',
+                url: 'https://example.com/file.docx'
+              }
+            ]
+          }
+        ]
+      }
+    };
+    const currentRecords = [
+      {
+        id: interactiveChatId,
+        dataId: interactiveChatId,
+        obj: ChatRoleEnum.AI,
+        status: 'finish',
+        value: [{ interactive: hydratedInteractive }]
+      },
+      {
+        id: responseChatId,
+        dataId: responseChatId,
+        obj: ChatRoleEnum.AI,
+        status: 'loading',
+        value: [{ text: { content: 'streaming' } }]
+      }
+    ] as ChatSiteItemType[];
+    const completedRecords = [
+      {
+        id: interactiveChatId,
+        dataId: interactiveChatId,
+        obj: ChatRoleEnum.AI,
+        status: 'finish',
+        value: [
+          {
+            interactive: {
+              ...hydratedInteractive,
+              params: {
+                ...hydratedInteractive.params,
+                inputForm: [
+                  {
+                    ...hydratedInteractive.params.inputForm[0],
+                    value: []
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      {
+        id: responseChatId,
+        dataId: responseChatId,
+        obj: ChatRoleEnum.AI,
+        status: 'finish',
+        value: [{ text: { content: 'done' } }]
+      }
+    ] as ChatSiteItemType[];
+
+    const result = mergeResumeCompletedChatRecords({
+      currentRecords,
+      completedRecords,
+      responseChatId
+    });
+
+    expect((result[0].value[0] as any).interactive.params.inputForm[0].value).toEqual([
+      {
+        name: 'file.docx',
+        url: 'https://example.com/file.docx'
+      }
+    ]);
+    expect(result[1].value).toEqual([{ text: { content: 'done' } }]);
+  });
 });
 
 describe('refreshSubmittedFormInteractiveValues', () => {
@@ -392,5 +570,67 @@ describe('refreshSubmittedFormInteractiveValues', () => {
     });
 
     expect(result).toBe(histories);
+  });
+
+  it('falls back to the only submitted form interactive when node ids do not match', () => {
+    const signedUrl =
+      'http://localhost:3000/api/system/file/download/token?filename=%E6%96%87%E4%BB%B6.docx';
+    const histories = [
+      {
+        id: 'ai-data-id',
+        dataId: 'ai-data-id',
+        obj: ChatRoleEnum.AI,
+        status: 'finish',
+        value: [
+          {
+            interactive: {
+              type: 'userInput',
+              entryNodeIds: ['different-node-id'],
+              memoryEdges: [],
+              nodeOutputs: [],
+              params: {
+                description: '',
+                submitted: true,
+                inputForm: [
+                  {
+                    type: 'fileSelect',
+                    key: 'File',
+                    label: 'File',
+                    valueType: 'arrayString',
+                    description: '',
+                    required: false,
+                    defaultValue: '',
+                    canLocalUpload: true,
+                    canSelectFile: true,
+                    maxFiles: 5,
+                    value: []
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ] as ChatSiteItemType[];
+
+    const result = refreshSubmittedFormInteractiveValues({
+      histories,
+      nodeResponse: {
+        id: 'node-response-id',
+        nodeId: 'form-node-id',
+        moduleName: '表单输入',
+        moduleType: FlowNodeTypeEnum.formInput,
+        formInputResult: {
+          File: [signedUrl]
+        }
+      }
+    });
+
+    expect((result[0].value[0] as any).interactive.params.inputForm[0].value).toEqual([
+      {
+        name: '文件.docx',
+        url: signedUrl
+      }
+    ]);
   });
 });

--- a/projects/app/test/components/core/chat/ChatContainer/ChatBox/utils.test.ts
+++ b/projects/app/test/components/core/chat/ChatContainer/ChatBox/utils.test.ts
@@ -5,6 +5,7 @@ import { FlowNodeTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
 import type { ChatSiteItemType } from '@/components/core/chat/ChatContainer/ChatBox/type';
 import {
   mergeResumeCompletedChatRecords,
+  shouldAppendResumeInteractive,
   shouldReplaceResumeAiValue,
   shouldResetResumeAiPlaceholder,
   stripChatValueFileUrls
@@ -113,6 +114,86 @@ describe('shouldReplaceResumeAiValue', () => {
         hasExistingAiOutput: false,
         text: '停止中',
         resetExistingValue: false
+      })
+    ).toBe(true);
+  });
+});
+
+describe('shouldAppendResumeInteractive', () => {
+  it('does not append an unsubmitted resume interactive over a submitted one', () => {
+    const baseInteractive = {
+      type: 'userInput',
+      entryNodeIds: ['form-node-id'],
+      memoryEdges: [],
+      nodeOutputs: [],
+      usageId: 'usage-id',
+      params: {
+        description: '',
+        inputForm: [
+          {
+            type: 'fileSelect',
+            key: 'File',
+            label: 'File',
+            valueType: 'arrayString',
+            description: '',
+            required: false,
+            defaultValue: '',
+            canLocalUpload: true,
+            canSelectFile: true,
+            maxFiles: 5,
+            value: []
+          }
+        ]
+      }
+    } as const;
+
+    expect(
+      shouldAppendResumeInteractive({
+        existingValues: [
+          {
+            interactive: {
+              ...baseInteractive,
+              params: {
+                ...baseInteractive.params,
+                submitted: true,
+                inputForm: [
+                  {
+                    ...baseInteractive.params.inputForm[0],
+                    value: [
+                      {
+                        key: 'chat/file.docx',
+                        name: 'file.docx',
+                        type: 'file',
+                        url: 'http://localhost:3000/api/system/file/download/file.docx'
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        incomingInteractive: baseInteractive
+      })
+    ).toBe(false);
+  });
+
+  it('appends a new interactive when there is no submitted matching interactive', () => {
+    expect(
+      shouldAppendResumeInteractive({
+        existingValues: [],
+        incomingInteractive: {
+          type: 'userInput',
+          entryNodeIds: ['form-node-id'],
+          memoryEdges: [],
+          nodeOutputs: [],
+          usageId: 'usage-id',
+          params: {
+            description: '',
+            inputForm: [],
+            submitted: false
+          }
+        }
       })
     ).toBe(true);
   });

--- a/projects/app/test/components/core/chat/ChatContainer/ChatBox/utils.test.ts
+++ b/projects/app/test/components/core/chat/ChatContainer/ChatBox/utils.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { ChatFileTypeEnum } from '@fastgpt/global/core/chat/constants';
+import { ChatFileTypeEnum, ChatRoleEnum } from '@fastgpt/global/core/chat/constants';
 import type { ChatItemValueItemType } from '@fastgpt/global/core/chat/type';
+import { FlowNodeTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
+import type { ChatSiteItemType } from '@/components/core/chat/ChatContainer/ChatBox/type';
 import {
+  mergeResumeCompletedChatRecords,
   shouldResetResumeAiPlaceholder,
   stripChatValueFileUrls
 } from '@/components/core/chat/ChatContainer/ChatBox/utils';
@@ -79,5 +82,93 @@ describe('shouldResetResumeAiPlaceholder', () => {
         hasReceivedResumeOutput: false
       })
     ).toBe(false);
+  });
+});
+
+describe('mergeResumeCompletedChatRecords', () => {
+  it('preserves responseData replayed during resume when completed records overwrite the chat', () => {
+    const responseChatId = 'ai-data-id';
+    const currentRecords = [
+      {
+        id: responseChatId,
+        dataId: responseChatId,
+        obj: ChatRoleEnum.AI,
+        status: 'loading',
+        value: [{ text: { content: 'streaming' } }],
+        responseData: [
+          {
+            id: 'node-response-id',
+            nodeId: 'form-node-id',
+            moduleName: '表单输入',
+            moduleType: FlowNodeTypeEnum.formInput,
+            formInputResult: {
+              File: ['http://localhost:3000/api/system/file/download/file.docx']
+            }
+          }
+        ]
+      }
+    ] as ChatSiteItemType[];
+    const completedRecords = [
+      {
+        id: responseChatId,
+        dataId: responseChatId,
+        obj: ChatRoleEnum.AI,
+        status: 'finish',
+        value: [{ text: { content: 'done' } }],
+        responseData: []
+      }
+    ] as ChatSiteItemType[];
+
+    const result = mergeResumeCompletedChatRecords({
+      currentRecords,
+      completedRecords,
+      responseChatId
+    });
+
+    expect(result[0].value).toEqual([{ text: { content: 'done' } }]);
+    expect(result[0].responseData).toEqual(currentRecords[0].responseData);
+  });
+
+  it('does not duplicate responseData already present in completed records', () => {
+    const responseChatId = 'ai-data-id';
+    const responseData = [
+      {
+        id: 'node-response-id',
+        nodeId: 'form-node-id',
+        moduleName: '表单输入',
+        moduleType: FlowNodeTypeEnum.formInput,
+        formInputResult: {
+          File: ['http://localhost:3000/api/system/file/download/file.docx']
+        }
+      }
+    ];
+    const currentRecords = [
+      {
+        id: responseChatId,
+        dataId: responseChatId,
+        obj: ChatRoleEnum.AI,
+        status: 'loading',
+        value: [{ text: { content: 'streaming' } }],
+        responseData
+      }
+    ] as ChatSiteItemType[];
+    const completedRecords = [
+      {
+        id: responseChatId,
+        dataId: responseChatId,
+        obj: ChatRoleEnum.AI,
+        status: 'finish',
+        value: [{ text: { content: 'done' } }],
+        responseData
+      }
+    ] as ChatSiteItemType[];
+
+    const result = mergeResumeCompletedChatRecords({
+      currentRecords,
+      completedRecords,
+      responseChatId
+    });
+
+    expect(result[0].responseData).toHaveLength(1);
   });
 });

--- a/projects/app/test/components/core/chat/ChatContainer/ChatBox/utils.test.ts
+++ b/projects/app/test/components/core/chat/ChatContainer/ChatBox/utils.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { ChatFileTypeEnum } from '@fastgpt/global/core/chat/constants';
 import type { ChatItemValueItemType } from '@fastgpt/global/core/chat/type';
-import { stripChatValueFileUrls } from '@/components/core/chat/ChatContainer/ChatBox/utils';
+import {
+  shouldResetResumeAiPlaceholder,
+  stripChatValueFileUrls
+} from '@/components/core/chat/ChatContainer/ChatBox/utils';
 
 describe('stripChatValueFileUrls', () => {
   it('removes signed urls from keyed files before sending messages', () => {
@@ -51,5 +54,30 @@ describe('stripChatValueFileUrls', () => {
       }
     ]);
     expect(value[0].file.url).toBe('https://preview.example.com/image.png');
+  });
+});
+
+describe('shouldResetResumeAiPlaceholder', () => {
+  it('should reset only before any resume output has been applied', () => {
+    expect(
+      shouldResetResumeAiPlaceholder({
+        hasPreparedResumeAiRecord: false,
+        hasReceivedResumeOutput: false
+      })
+    ).toBe(true);
+
+    expect(
+      shouldResetResumeAiPlaceholder({
+        hasPreparedResumeAiRecord: false,
+        hasReceivedResumeOutput: true
+      })
+    ).toBe(false);
+
+    expect(
+      shouldResetResumeAiPlaceholder({
+        hasPreparedResumeAiRecord: true,
+        hasReceivedResumeOutput: false
+      })
+    ).toBe(false);
   });
 });

--- a/projects/app/test/components/core/chat/ChatContainer/ChatBox/utils.test.ts
+++ b/projects/app/test/components/core/chat/ChatContainer/ChatBox/utils.test.ts
@@ -5,6 +5,7 @@ import { FlowNodeTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
 import type { ChatSiteItemType } from '@/components/core/chat/ChatContainer/ChatBox/type';
 import {
   mergeResumeCompletedChatRecords,
+  refreshSubmittedFormInteractiveValues,
   shouldAppendResumeInteractive,
   shouldReplaceResumeAiValue,
   shouldResetResumeAiPlaceholder,
@@ -284,5 +285,112 @@ describe('mergeResumeCompletedChatRecords', () => {
     });
 
     expect(result[0].responseData).toHaveLength(1);
+  });
+});
+
+describe('refreshSubmittedFormInteractiveValues', () => {
+  it('writes resumed form input files back into the submitted interactive node', () => {
+    const signedUrl =
+      'http://localhost:3000/api/system/file/download/token?filename=H6%E4%BA%A7%E5%93%81%E6%A6%82%E8%BF%B0V1.5_tBF8kj.docx';
+    const histories = [
+      {
+        id: 'ai-data-id',
+        dataId: 'ai-data-id',
+        obj: ChatRoleEnum.AI,
+        status: 'finish',
+        value: [
+          {
+            interactive: {
+              type: 'userInput',
+              entryNodeIds: ['form-node-id'],
+              memoryEdges: [],
+              nodeOutputs: [],
+              usageId: 'usage-id',
+              params: {
+                description: '',
+                submitted: true,
+                inputForm: [
+                  {
+                    type: 'fileSelect',
+                    key: 'File',
+                    label: 'File',
+                    valueType: 'arrayString',
+                    description: '',
+                    required: false,
+                    defaultValue: '',
+                    canLocalUpload: true,
+                    canSelectFile: true,
+                    maxFiles: 5,
+                    value: []
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ] as ChatSiteItemType[];
+
+    const result = refreshSubmittedFormInteractiveValues({
+      histories,
+      nodeResponse: {
+        id: 'node-response-id',
+        nodeId: 'form-node-id',
+        moduleName: '表单输入',
+        moduleType: FlowNodeTypeEnum.formInput,
+        formInputResult: {
+          File: [signedUrl]
+        }
+      }
+    });
+
+    expect(result).not.toBe(histories);
+    expect((result[0].value[0] as any).interactive.params.inputForm[0].value).toEqual([
+      {
+        name: 'H6产品概述V1.5_tBF8kj.docx',
+        url: signedUrl
+      }
+    ]);
+  });
+
+  it('does not update unrelated interactive nodes', () => {
+    const histories = [
+      {
+        id: 'ai-data-id',
+        dataId: 'ai-data-id',
+        obj: ChatRoleEnum.AI,
+        status: 'finish',
+        value: [
+          {
+            interactive: {
+              type: 'userInput',
+              entryNodeIds: ['other-form-node-id'],
+              memoryEdges: [],
+              nodeOutputs: [],
+              params: {
+                description: '',
+                submitted: true,
+                inputForm: []
+              }
+            }
+          }
+        ]
+      }
+    ] as ChatSiteItemType[];
+
+    const result = refreshSubmittedFormInteractiveValues({
+      histories,
+      nodeResponse: {
+        id: 'node-response-id',
+        nodeId: 'form-node-id',
+        moduleName: '表单输入',
+        moduleType: FlowNodeTypeEnum.formInput,
+        formInputResult: {
+          File: ['https://example.com/file.docx']
+        }
+      }
+    });
+
+    expect(result).toBe(histories);
   });
 });

--- a/projects/app/test/components/core/chat/ChatContainer/ChatBox/utils.test.ts
+++ b/projects/app/test/components/core/chat/ChatContainer/ChatBox/utils.test.ts
@@ -5,6 +5,7 @@ import { FlowNodeTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
 import type { ChatSiteItemType } from '@/components/core/chat/ChatContainer/ChatBox/type';
 import {
   mergeResumeCompletedChatRecords,
+  shouldReplaceResumeAiValue,
   shouldResetResumeAiPlaceholder,
   stripChatValueFileUrls
 } from '@/components/core/chat/ChatContainer/ChatBox/utils';
@@ -82,6 +83,38 @@ describe('shouldResetResumeAiPlaceholder', () => {
         hasReceivedResumeOutput: false
       })
     ).toBe(false);
+  });
+});
+
+describe('shouldReplaceResumeAiValue', () => {
+  it('does not replace loaded AI output with a resume placeholder', () => {
+    expect(
+      shouldReplaceResumeAiValue({
+        hasExistingAiOutput: true,
+        text: '',
+        resetExistingValue: true
+      })
+    ).toBe(false);
+  });
+
+  it('can initialize an empty AI record as a resume placeholder', () => {
+    expect(
+      shouldReplaceResumeAiValue({
+        hasExistingAiOutput: false,
+        text: '',
+        resetExistingValue: true
+      })
+    ).toBe(true);
+  });
+
+  it('can show resume unavailable text on an empty AI record', () => {
+    expect(
+      shouldReplaceResumeAiValue({
+        hasExistingAiOutput: false,
+        text: '停止中',
+        resetExistingValue: false
+      })
+    ).toBe(true);
   });
 });
 

--- a/projects/app/test/components/core/chat/ChatContainer/ChatBox/utils.test.ts
+++ b/projects/app/test/components/core/chat/ChatContainer/ChatBox/utils.test.ts
@@ -464,6 +464,101 @@ describe('mergeResumeCompletedChatRecords', () => {
     ]);
     expect(result[1].value).toEqual([{ text: { content: 'done' } }]);
   });
+
+  it('preserves hydrated submitted interactive values when completed interactive dataId changes', () => {
+    const responseChatId = 'streaming-ai-data-id';
+    const hydratedInteractive = {
+      type: 'userInput',
+      entryNodeIds: ['form-node-id'],
+      memoryEdges: [],
+      nodeOutputs: [],
+      usageId: 'usage-id',
+      params: {
+        description: '',
+        submitted: true,
+        inputForm: [
+          {
+            type: 'fileSelect',
+            key: 'File',
+            label: 'File',
+            valueType: 'arrayString',
+            description: '',
+            required: false,
+            defaultValue: '',
+            canLocalUpload: true,
+            canSelectFile: true,
+            maxFiles: 5,
+            value: [
+              {
+                name: 'file.docx',
+                url: 'https://example.com/file.docx'
+              }
+            ]
+          }
+        ]
+      }
+    };
+    const currentRecords = [
+      {
+        id: 'temporary-interactive-ai-data-id',
+        dataId: 'temporary-interactive-ai-data-id',
+        obj: ChatRoleEnum.AI,
+        status: 'finish',
+        value: [{ interactive: hydratedInteractive }]
+      },
+      {
+        id: responseChatId,
+        dataId: responseChatId,
+        obj: ChatRoleEnum.AI,
+        status: 'loading',
+        value: [{ text: { content: 'streaming' } }]
+      }
+    ] as ChatSiteItemType[];
+    const completedRecords = [
+      {
+        id: 'persisted-interactive-ai-data-id',
+        dataId: 'persisted-interactive-ai-data-id',
+        obj: ChatRoleEnum.AI,
+        status: 'finish',
+        value: [
+          {
+            interactive: {
+              ...hydratedInteractive,
+              params: {
+                ...hydratedInteractive.params,
+                inputForm: [
+                  {
+                    ...hydratedInteractive.params.inputForm[0],
+                    value: []
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      {
+        id: responseChatId,
+        dataId: responseChatId,
+        obj: ChatRoleEnum.AI,
+        status: 'finish',
+        value: [{ text: { content: 'done' } }]
+      }
+    ] as ChatSiteItemType[];
+
+    const result = mergeResumeCompletedChatRecords({
+      currentRecords,
+      completedRecords,
+      responseChatId
+    });
+
+    expect((result[0].value[0] as any).interactive.params.inputForm[0].value).toEqual([
+      {
+        name: 'file.docx',
+        url: 'https://example.com/file.docx'
+      }
+    ]);
+  });
 });
 
 describe('refreshSubmittedFormInteractiveValues', () => {

--- a/projects/app/test/components/core/chat/components/FormInputResult.test.ts
+++ b/projects/app/test/components/core/chat/components/FormInputResult.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getFilenameFromFormInputFileUrl,
+  normalizeFormInputResultFile
+} from '@/components/core/chat/components/FormInputResult';
+
+describe('FormInputResult', () => {
+  it('extracts the download filename from signed file urls', () => {
+    const url =
+      'http://localhost:3000/api/system/file/download/token?filename=H6%E4%BA%A7%E5%93%81%E6%A6%82%E8%BF%B0V1.5_tBF8kj.docx';
+
+    expect(getFilenameFromFormInputFileUrl(url)).toBe('H6产品概述V1.5_tBF8kj.docx');
+    expect(normalizeFormInputResultFile(url)).toEqual({
+      name: 'H6产品概述V1.5_tBF8kj.docx',
+      url
+    });
+  });
+
+  it('keeps explicit file object names', () => {
+    expect(
+      normalizeFormInputResultFile({
+        name: 'H6产品概述V1.5.docx',
+        url: 'https://example.com/download.docx'
+      })
+    ).toEqual({
+      name: 'H6产品概述V1.5.docx',
+      url: 'https://example.com/download.docx'
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- prevent resume AI placeholder reset after any replayed SSE output has already been applied
- preserve flowNodeResponse responseData such as formInput render data during stream resume
- add unit coverage for the resume placeholder reset predicate

## Tests
- pnpm --filter @fastgpt/app test test/components/core/chat/ChatContainer/ChatBox/utils.test.ts
- pnpm --filter @fastgpt/app typecheck
- pnpm exec eslint --fix "projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx" "projects/app/src/components/core/chat/ChatContainer/ChatBox/utils.ts" "projects/app/test/components/core/chat/ChatContainer/ChatBox/utils.test.ts"