### PR TITLE
fix: make file_url name optional

### DIFF
--- a/packages/global/core/ai/llm/type.ts
+++ b/packages/global/core/ai/llm/type.ts
@@ -76,7 +76,7 @@ export const ChatCompletionContentPartFileSchema = z.object({
 // FastGPT 自定义扩展：外链文件
 export const ChatCompletionContentPartFileTypeSchema = z.object({
   type: z.literal('file_url'),
-  name: z.string(),
+  name: z.string().optional(),
   url: z.string(),
   key: z.string().optional()
 });

--- a/packages/global/core/chat/adapt.ts
+++ b/packages/global/core/chat/adapt.ts
@@ -587,7 +587,7 @@ export const GPTMessages2Chats = ({
               value.push({
                 file: {
                   type: ChatFileTypeEnum.file,
-                  name: item.name,
+                  name: item.name || '',
                   url: item.url,
                   key: item.key
                 }

--- a/packages/global/test/core/chat/adapt.test.ts
+++ b/packages/global/test/core/chat/adapt.test.ts
@@ -1581,6 +1581,22 @@ describe('GPTMessages2Chats', () => {
     expect(fileValue.file?.name).toBe('document.pdf');
   });
 
+  it('should convert user message with file_url content without name', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: ChatCompletionRequestMessageRoleEnum.User,
+        content: [{ type: 'file_url', url: 'http://example.com/doc.pdf', key: 'key1' }]
+      }
+    ];
+
+    const result = GPTMessages2Chats({ messages });
+
+    expect(result).toHaveLength(1);
+    const fileValue = result[0].value[0] as { file?: { type: string; name: string } };
+    expect(fileValue.file?.type).toBe(ChatFileTypeEnum.file);
+    expect(fileValue.file?.name).toBe('');
+  });
+
   it('should convert system message with array content', () => {
     const messages: ChatCompletionMessageParam[] = [
       {


### PR DESCRIPTION
## What\n- Make chat completion file_url content part name optional.\n- Keep chat value conversion stable by defaulting a missing file name to an empty string.\n- Add a regression test for file_url content without name.\n\n## Test\n- pnpm --dir packages/global exec vitest run -c vitest.config.ts test/core/chat/adapt.test.ts\n\nNote: root pnpm test packages/global/test/core/chat/adapt.test.ts is currently blocked locally because the workspace filter references @fastgpt/admin, which is not present in this checkout.