### PR TITLE
fix: clear chat cache when switching teams

### DIFF
--- a/projects/app/src/pageComponents/account/TeamSelector.tsx
+++ b/projects/app/src/pageComponents/account/TeamSelector.tsx
@@ -8,6 +8,7 @@ import { useRequest } from '@fastgpt/web/hooks/useRequest';
 import MySelect from '@fastgpt/web/components/common/MySelect';
 import { useSystemStore } from '@/web/common/system/useSystemStore';
 import { useRouter } from 'next/router';
+import { useChatStore } from '@/web/core/chat/context/useChatStore';
 
 const TeamSelector = ({
   showManage,
@@ -23,6 +24,7 @@ const TeamSelector = ({
   const router = useRouter();
   const { userInfo } = useUserStore();
   const { setLoading } = useSystemStore();
+  const { resetChatCache } = useChatStore();
 
   const { data: myTeams = [] } = useRequest(() => getTeamList(TeamMemberStatusEnum.active), {
     manual: false,
@@ -33,6 +35,7 @@ const TeamSelector = ({
     async (teamId: string) => {
       setLoading(true);
       await putSwitchTeam(teamId);
+      resetChatCache();
     },
     {
       onFinally: () => {

--- a/projects/app/src/pageComponents/account/team/context.tsx
+++ b/projects/app/src/pageComponents/account/team/context.tsx
@@ -14,6 +14,7 @@ import type { TeamTmbItemType, TeamMemberItemType } from '@fastgpt/global/suppor
 import { useRequest } from '@fastgpt/web/hooks/useRequest';
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
+import { useChatStore } from '@/web/core/chat/context/useChatStore';
 
 const EditInfoModal = dynamic(() => import('./EditInfoModal'));
 
@@ -52,6 +53,7 @@ export const TeamModalContextProvider = ({ children }: { children: ReactNode }) 
 
   const [editTeamData, setEditTeamData] = useState<EditTeamFormDataType>();
   const { userInfo, initUserInfo } = useUserStore();
+  const { resetChatCache } = useChatStore();
 
   const {
     data: myTeams = [],
@@ -70,6 +72,7 @@ export const TeamModalContextProvider = ({ children }: { children: ReactNode }) 
   const { runAsync: onSwitchTeam, loading: isSwitchingTeam } = useRequest(
     async (teamId: string) => {
       await putSwitchTeam(teamId);
+      resetChatCache();
       return initUserInfo();
     },
     {

--- a/projects/app/src/pageComponents/login/index.tsx
+++ b/projects/app/src/pageComponents/login/index.tsx
@@ -31,18 +31,10 @@ const ipDetectURL = 'https://qifu-api.baidubce.com/ip/local/geo/v1/district';
 // Cookies Modal Component
 const CookiesModal = () => {
   const { t } = useTranslation();
-  const [isOpen, setIsOpen] = useState(false);
-
   const cookieVersion = '1';
   const [localCookieVersion, setLocalCookieVersion] =
     useLocalStorageState<string>('localCookieVersion');
-
-  useEffect(() => {
-    // Check if user has agreed to current cookie version
-    if (localCookieVersion !== cookieVersion) {
-      setIsOpen(true);
-    }
-  }, [localCookieVersion, cookieVersion]);
+  const [isOpen, setIsOpen] = useState(() => localCookieVersion !== cookieVersion);
 
   const handleAgree = () => {
     setLocalCookieVersion(cookieVersion);
@@ -102,30 +94,30 @@ const ChineseRedirectModal = () => {
   });
 
   // IP detection without cache
-  const checkIpInChina = useCallback(async () => {
-    try {
-      const res = await GET<any>(ipDetectURL);
-      const country = res?.country;
-      const isChina =
-        country === '中国' &&
-        res.prov !== '中国香港' &&
-        res.prov !== '中国澳门' &&
-        res.prov !== '中国台湾';
-
-      if (isChina) {
-        setIsOpen(true);
-      }
-    } catch (error) {
-      console.log('IP detection failed:', error);
-    }
-  }, []);
-
   useEffect(() => {
     // Only check IP if redirect URL is provided and user hasn't disabled it
-    if (chineseRedirectUrl && showRedirect) {
-      checkIpInChina();
-    }
-  }, [chineseRedirectUrl, showRedirect, checkIpInChina]);
+    if (!chineseRedirectUrl || !showRedirect) return;
+
+    const checkIpInChina = async () => {
+      try {
+        const res = await GET<any>(ipDetectURL);
+        const country = res?.country;
+        const isChina =
+          country === '中国' &&
+          res.prov !== '中国香港' &&
+          res.prov !== '中国澳门' &&
+          res.prov !== '中国台湾';
+
+        if (isChina) {
+          setIsOpen(true);
+        }
+      } catch (error) {
+        console.log('IP detection failed:', error);
+      }
+    };
+
+    checkIpInChina();
+  }, [chineseRedirectUrl, showRedirect]);
 
   const handleRedirect = () => {
     if (chineseRedirectUrl) {
@@ -188,7 +180,7 @@ export const LoginContainer = ({
 }) => {
   const { t } = useTranslation();
   const { feConfigs } = useSystemStore();
-  const { setLastChatAppId } = useChatStore();
+  const { resetChatCache } = useChatStore();
 
   const [pageType, setPageType] = useState<`${LoginPageTypeEnum}`>(LoginPageTypeEnum.passwordLogin);
   const [showCommunityModal, setShowCommunityModal] = useState(false);
@@ -204,8 +196,8 @@ export const LoginContainer = ({
   // initialization logic
   useEffect(() => {
     // reset chat state
-    setLastChatAppId('');
-  }, [feConfigs?.oauth?.wechat, setLastChatAppId]);
+    resetChatCache();
+  }, [feConfigs?.oauth?.wechat, resetChatCache]);
 
   // dynamic component based on page type
   const DynamicComponent = useMemo(() => {

--- a/projects/app/src/web/core/chat/context/useChatStore.ts
+++ b/projects/app/src/web/core/chat/context/useChatStore.ts
@@ -22,6 +22,8 @@ type State = {
 
   outLinkAuthData: OutLinkChatAuthProps;
   setOutLinkAuthData: (e: OutLinkChatAuthProps) => any;
+
+  resetChatCache: () => any;
 };
 
 const createCustomStorage = () => {
@@ -85,10 +87,6 @@ export const useChatStore = create<State>()(
               state.chatId = getNanoid(24);
             }
 
-            if (!state.appId && state.lastChatAppId) {
-              state.appId = state.lastChatAppId;
-            }
-
             state.source = e;
           });
         },
@@ -126,6 +124,17 @@ export const useChatStore = create<State>()(
         setOutLinkAuthData(e) {
           set((state) => {
             state.outLinkAuthData = e;
+          });
+        },
+        resetChatCache() {
+          set((state) => {
+            state.source = undefined;
+            state.appId = '';
+            state.lastChatAppId = '';
+            state.chatId = '';
+            state.lastChatId = '';
+            state.lastPane = ChatSidebarPaneEnum.HOME;
+            state.outLinkAuthData = {};
           });
         }
       })),

--- a/projects/app/test/web/core/chat/context/useChatStore.test.ts
+++ b/projects/app/test/web/core/chat/context/useChatStore.test.ts
@@ -155,7 +155,7 @@ describe('useChatStore', () => {
     expect(useChatStore.getState().lastChatId).toBe(`${ChatSourceEnum.api}-test-generated-id`);
   });
 
-  it('should set appId from lastChatAppId if not set', () => {
+  it('should not set appId from lastChatAppId when source changes', () => {
     useChatStore.setState({
       appId: '',
       lastChatAppId: 'last-app-id',
@@ -167,7 +167,36 @@ describe('useChatStore', () => {
     });
     const store = useChatStore.getState();
     store.setSource(ChatSourceEnum.api);
-    expect(useChatStore.getState().appId).toBe('last-app-id');
+    expect(useChatStore.getState().appId).toBe('');
+    expect(useChatStore.getState().lastChatAppId).toBe('last-app-id');
+  });
+
+  it('should reset chat cache', () => {
+    const store = useChatStore.getState();
+    useChatStore.setState({
+      source: ChatSourceEnum.share,
+      appId: 'app-id',
+      lastChatAppId: 'last-app-id',
+      chatId: 'chat-id',
+      lastChatId: `${ChatSourceEnum.share}-chat-id`,
+      lastPane: ChatSidebarPaneEnum.RECENTLY_USED_APPS,
+      outLinkAuthData: {
+        shareId: 'share-id',
+        outLinkUid: 'outlink-uid'
+      }
+    });
+
+    store.resetChatCache();
+
+    expect(useChatStore.getState()).toMatchObject({
+      source: undefined,
+      appId: '',
+      lastChatAppId: '',
+      chatId: '',
+      lastChatId: '',
+      lastPane: ChatSidebarPaneEnum.HOME,
+      outLinkAuthData: {}
+    });
   });
 
   it('should set lastPane to undefined by default', () => {


### PR DESCRIPTION
## Summary
- clear persisted chat state after switching teams
- stop restoring stale chat app ids when chat source initializes

## Test
- pnpm --dir projects/app exec tsc --noEmit
- git diff --check