### PR TITLE
fix: avoid standalone reasoning messages

### DIFF
--- a/packages/global/core/chat/adapt.ts
+++ b/packages/global/core/chat/adapt.ts
@@ -30,10 +30,18 @@ export const GPT2Chat = {
   [ChatCompletionRequestMessageRoleEnum.Tool]: ChatRoleEnum.AI
 };
 
+/**
+ * 将 OpenAI/GPT message role 映射为 FastGPT 内部聊天角色。
+ * function/tool message 是 assistant 工具上下文的一部分，因此统一归到 AI 角色。
+ */
 export function adaptRole_Message2Chat(role: `${ChatCompletionRequestMessageRoleEnum}`) {
   return GPT2Chat[role];
 }
 
+/**
+ * 压缩用户 content part：纯文本保持旧版 string，多模态或多段内容保留数组。
+ * 这样既兼容历史文本上下文，也不会丢失图片、文件等结构化输入。
+ */
 export const simpleUserContentPart = (content: ChatCompletionContentPart[]) => {
   if (content.length === 1 && content[0].type === 'text') {
     return content[0].text;
@@ -41,18 +49,194 @@ export const simpleUserContentPart = (content: ChatCompletionContentPart[]) => {
   return content;
 };
 
+/**
+ * 规整 assistant 拆分字段消息。
+ *
+ * FastGPT 历史可能把 reasoning、text、tools 拆成多个 value；转成 GPT message 时需要
+ * 重新合并成 provider 能接受的 assistant payload：
+ * - reasoning 不能作为孤立 assistant message 发送，必须附着到后续 text/tool/function。
+ * - 连续 reasoning 使用空行拼接，再附着到同一轮的后续载体上。
+ * - dataId/hideInUI 不同表示不同上下文边界，不能跨边界合并。
+ * - 没有可附着目标的孤立 reasoning 会被丢弃，避免生成非法上下文。
+ */
+export const mergeAssistantFieldMessages = (messages: ChatCompletionMessageParam[]) => {
+  type AssistantToolCallMessage = Extract<ChatCompletionMessageParam, { role: 'assistant' }> & {
+    tool_calls: ChatCompletionMessageToolCall[];
+  };
+
+  type ToolMessage = Extract<ChatCompletionMessageParam, { role: 'tool' }> & {
+    tool_call_id: string;
+  };
+
+  // 多段 reasoning 属于同一个待发送 payload 时，用空行拼接，便于上下文阅读。
+  const appendSeparatedText = (current: string | undefined, next: string) => {
+    if (!next) return current;
+    return current ? `${current}\n\n${next}` : next;
+  };
+
+  const hasAssistantToolCalls = (message: ChatCompletionMessageParam) =>
+    message.role === ChatCompletionRequestMessageRoleEnum.Assistant &&
+    Array.isArray(message.tool_calls) &&
+    message.tool_calls.length > 0;
+
+  const hasAssistantFunctionCall = (message: ChatCompletionMessageParam) =>
+    message.role === ChatCompletionRequestMessageRoleEnum.Assistant &&
+    Boolean(message.function_call);
+
+  const isAssistantFieldMessage = (message?: ChatCompletionMessageParam) => {
+    if (message?.role !== ChatCompletionRequestMessageRoleEnum.Assistant) return false;
+
+    return (
+      !message.tool_calls &&
+      (typeof message.content === 'string' || typeof message.reasoning_content === 'string')
+    );
+  };
+
+  const isAssistantToolCallMessage = (
+    message?: ChatCompletionMessageParam
+  ): message is AssistantToolCallMessage => {
+    if (message?.role !== ChatCompletionRequestMessageRoleEnum.Assistant) return false;
+
+    const hasNoAssistantText =
+      message.content === undefined || message.content === null || message.content === '';
+
+    return (
+      hasAssistantToolCalls(message) &&
+      hasNoAssistantText &&
+      typeof message.reasoning_content !== 'string'
+    );
+  };
+
+  const isToolResponseForToolCalls = (
+    message: ChatCompletionMessageParam | undefined,
+    toolCallIds: Set<string>
+  ): message is ToolMessage =>
+    message?.role === ChatCompletionRequestMessageRoleEnum.Tool &&
+    toolCallIds.has(message.tool_call_id || '');
+
+  const hasSameAssistantContext = (
+    message: ChatCompletionMessageParam | undefined,
+    assistantMessage: ChatCompletionMessageParam
+  ) =>
+    (message?.hideInUI ?? false) === (assistantMessage.hideInUI ?? false) &&
+    message?.dataId === assistantMessage.dataId;
+
+  const mergedMessages: ChatCompletionMessageParam[] = [];
+
+  for (let index = 0; index < messages.length; index++) {
+    const currentMessage = messages[index];
+    if (!isAssistantFieldMessage(currentMessage)) {
+      mergedMessages.push(currentMessage);
+      continue;
+    }
+
+    const assistantMessage: ChatCompletionMessageParam = { ...currentMessage };
+    let cursor = index + 1;
+
+    // 先消费同一上下文内连续的 assistant 字段消息，例如 reasoning -> reasoning -> text。
+    while (isAssistantFieldMessage(messages[cursor])) {
+      const nextMessage = messages[cursor];
+      if (!hasSameAssistantContext(nextMessage, assistantMessage)) break;
+
+      const nextReasoning =
+        typeof nextMessage.reasoning_content === 'string' ? nextMessage.reasoning_content : '';
+      const nextContent = typeof nextMessage.content === 'string' ? nextMessage.content : '';
+
+      // text 后再次出现 reasoning 通常已经是下一段思考，不能挂回前一个 answer。
+      if (nextReasoning && typeof assistantMessage.content === 'string') {
+        break;
+      }
+
+      if (nextReasoning) {
+        assistantMessage.reasoning_content = appendSeparatedText(
+          typeof assistantMessage.reasoning_content === 'string'
+            ? assistantMessage.reasoning_content
+            : undefined,
+          nextReasoning
+        );
+      }
+
+      if (typeof nextMessage.content === 'string') {
+        if (typeof assistantMessage.content === 'string') {
+          assistantMessage.content += nextContent;
+        } else {
+          assistantMessage.content = nextContent;
+        }
+      }
+
+      cursor++;
+    }
+
+    const toolCalls: ChatCompletionMessageToolCall[] = [];
+    const toolResponses: ChatCompletionMessageParam[] = [];
+
+    // 再消费紧随其后的 tool_calls 与对应 tool response，恢复为一个 assistant payload。
+    let assistantToolMessage: ChatCompletionMessageParam | undefined = messages[cursor];
+    while (isAssistantToolCallMessage(assistantToolMessage)) {
+      if (!hasSameAssistantContext(assistantToolMessage, assistantMessage)) break;
+
+      const currentToolCalls = assistantToolMessage.tool_calls;
+      const currentToolCallIds = new Set(currentToolCalls.map((toolCall) => toolCall.id));
+      const currentToolResponses: ChatCompletionMessageParam[] = [];
+      let responseCursor = cursor + 1;
+
+      // 只消费属于当前 tool_calls 的 response，防止把下一轮工具结果串进来。
+      while (isToolResponseForToolCalls(messages[responseCursor], currentToolCallIds)) {
+        currentToolResponses.push(messages[responseCursor]);
+        responseCursor++;
+      }
+
+      toolCalls.push(...currentToolCalls);
+      toolResponses.push(...currentToolResponses);
+      cursor = responseCursor;
+      assistantToolMessage = messages[cursor];
+    }
+
+    if (!toolCalls.length) {
+      // 孤立 reasoning 没有合法载体；只有 text/function_call 才能保留。
+      if (
+        typeof assistantMessage.content === 'string' ||
+        hasAssistantFunctionCall(assistantMessage)
+      ) {
+        mergedMessages.push(assistantMessage);
+      }
+      index = cursor - 1;
+      continue;
+    }
+
+    mergedMessages.push({
+      ...assistantMessage,
+      tool_calls: toolCalls
+    } as ChatCompletionMessageParam);
+    mergedMessages.push(...toolResponses);
+    index = cursor - 1;
+  }
+
+  return mergedMessages;
+};
+
+/**
+ * 将 FastGPT 内部 ChatItem 历史转换为 GPT request messages。
+ *
+ * 关键约定：
+ * - reserveTool=false 时只保留自然语言上下文，不把历史工具调用带入分类/普通对话。
+ * - reserveReason=false 时去掉 reasoning_content，适用于问题分类、内容提取等不需要思考过程的节点。
+ * - 输出前会调用 mergeAssistantFieldMessages，保证 reasoning 不以独立 assistant message 出现。
+ */
 export const chats2GPTMessages = ({
   messages,
   reserveId,
-  reserveTool = false
+  reserveTool = false,
+  reserveReason = true
 }: {
   messages: ChatItemMiniType[];
   reserveId: boolean;
   reserveTool?: boolean;
+  reserveReason?: boolean;
 }): ChatCompletionMessageParam[] => {
   let results: ChatCompletionMessageParam[] = [];
 
-  messages.forEach((item, index) => {
+  messages.forEach((item) => {
     const dataId = reserveId ? item.dataId : undefined;
     if (item.obj === ChatRoleEnum.System) {
       const content = item.value?.[0]?.text?.content;
@@ -106,7 +290,7 @@ export const chats2GPTMessages = ({
     } else {
       const aiResults: ChatCompletionMessageParam[] = [];
 
-      item.value.forEach((value, i) => {
+      item.value.forEach((value) => {
         /* Plan agent 产生的上下文都需要合并到一个 toolCall 里。
           Plan agent 产生的上下文都会携带 planId
           value.plan 代表的是 plan 的具体内容，根据这个值去转化成 toolcall
@@ -115,7 +299,7 @@ export const chats2GPTMessages = ({
 
         const hasTools = Array.isArray(value.tools) && value.tools.length > 0;
 
-        if (typeof value.reasoning?.content === 'string') {
+        if (reserveReason && typeof value.reasoning?.content === 'string') {
           aiResults.push({
             dataId,
             role: ChatCompletionRequestMessageRoleEnum.Assistant,
@@ -123,6 +307,18 @@ export const chats2GPTMessages = ({
           });
         }
 
+        // 同一个 value 同时有 text/tool 时，text 必须先入队，后续 merge 才能还原成
+        // assistant(content + tool_calls) 的合法结构。
+        if (typeof value.text?.content === 'string') {
+          if (!value.text.content && item.value.length > 1) {
+            return;
+          }
+          aiResults.push({
+            dataId,
+            role: ChatCompletionRequestMessageRoleEnum.Assistant,
+            content: value.text.content
+          });
+        }
         if (reserveTool && (hasTools || value.tool)) {
           const tools = hasTools ? value.tools! : [value.tool!];
           const tool_calls: ChatCompletionMessageToolCall[] = [];
@@ -143,43 +339,13 @@ export const chats2GPTMessages = ({
             });
           });
 
-          const lastResult = aiResults[aiResults.length - 1];
-          if (
-            lastResult &&
-            lastResult.role === ChatCompletionRequestMessageRoleEnum.Assistant &&
-            lastResult.reasoning_content
-          ) {
-            lastResult.tool_calls = tool_calls;
-          } else {
-            aiResults.push({
-              dataId,
-              role: ChatCompletionRequestMessageRoleEnum.Assistant,
-              tool_calls
-            });
-          }
+          aiResults.push({
+            dataId,
+            role: ChatCompletionRequestMessageRoleEnum.Assistant,
+            tool_calls
+          });
 
           aiResults.push(...toolResponse);
-        }
-        if (typeof value.text?.content === 'string') {
-          if (!value.text.content && item.value.length > 1) {
-            return;
-          }
-          // Concat text
-          const lastResult = aiResults[aiResults.length - 1];
-          if (
-            lastResult?.role === ChatCompletionRequestMessageRoleEnum.Assistant &&
-            typeof lastResult?.content === 'string'
-          ) {
-            lastResult.content += value.text.content;
-          } else if (lastResult?.reasoning_content) {
-            lastResult.content = value.text.content;
-          } else {
-            aiResults.push({
-              dataId,
-              role: ChatCompletionRequestMessageRoleEnum.Assistant,
-              content: value.text.content
-            });
-          }
         }
         if (value.plan) {
           // 查找该 Plan 产生的上下文，组成一个 toolcall
@@ -224,14 +390,20 @@ export const chats2GPTMessages = ({
         }
       });
 
-      // Auto add empty assistant message
-      results = results.concat(aiResults);
+      results = results.concat(mergeAssistantFieldMessages(aiResults));
     }
   });
 
   return results;
 };
 
+/**
+ * 将 GPT messages 转回 FastGPT ChatItem。
+ *
+ * GPTMessages2Chats 只恢复当前 message 已经聚合好的结构，不跨 message 追踪 reasoning。
+ * reasoning_content 必须和 content/tool_calls/function_call 在同一个 assistant message 上才会恢复；
+ * 孤立 reasoning 会被过滤，避免把下一轮或未知归属的思考误挂到后续消息。
+ */
 export const GPTMessages2Chats = ({
   messages,
   reserveTool = true,
@@ -326,28 +498,14 @@ export const GPTMessages2Chats = ({
         item.role === ChatCompletionRequestMessageRoleEnum.Assistant
       ) {
         const value: AIChatItemValueItemType[] = [];
+        const assistantValue: AIChatItemValueItemType = {};
 
-        if (typeof item.reasoning_content === 'string' && item.reasoning_content && reserveReason) {
-          value.push({
-            reasoning: {
-              content: item.reasoning_content
-            }
-          });
-        }
         if (typeof item.content === 'string' && item.content) {
-          const lastValue = value[value.length - 1];
-          if (lastValue && lastValue.text) {
-            lastValue.text.content += item.content;
-          } else {
-            value.push({
-              text: {
-                content: item.content
-              }
-            });
-          }
+          assistantValue.text = {
+            content: item.content
+          };
         }
         if (item.tool_calls && reserveTool) {
-          // save tool calls
           const toolCalls = item.tool_calls as ChatCompletionMessageToolCall[];
 
           const tools = toolCalls.flatMap<ToolModuleResponseItemType>((tool) => {
@@ -377,9 +535,7 @@ export const GPTMessages2Chats = ({
               }
             ];
           });
-          value.push({
-            tools
-          });
+          assistantValue.tools = tools;
         }
         if (item.function_call && reserveTool) {
           const functionCall = item.function_call as ChatCompletionMessageFunctionCall;
@@ -390,17 +546,28 @@ export const GPTMessages2Chats = ({
           ) as ChatCompletionFunctionMessageParam;
 
           if (functionResponse) {
-            value.push({
-              tool: {
-                id: functionCall.id || '',
-                toolName: functionCall.toolName || '',
-                toolAvatar: functionCall.toolAvatar || '',
-                functionName: functionCall.name,
-                params: functionCall.arguments,
-                response: functionResponse.content || ''
-              }
-            });
+            assistantValue.tool = {
+              id: functionCall.id || '',
+              toolName: functionCall.toolName || '',
+              toolAvatar: functionCall.toolAvatar || '',
+              functionName: functionCall.name,
+              params: functionCall.arguments,
+              response: functionResponse.content || ''
+            };
           }
+        }
+        if (
+          typeof item.reasoning_content === 'string' &&
+          item.reasoning_content &&
+          reserveReason &&
+          (assistantValue.text || assistantValue.tools || assistantValue.tool)
+        ) {
+          assistantValue.reasoning = {
+            content: item.reasoning_content
+          };
+        }
+        if (assistantValue.text || assistantValue.tools || assistantValue.tool) {
+          value.push(assistantValue);
         }
         if (item.interactive) {
           value.push({
@@ -425,7 +592,7 @@ export const GPTMessages2Chats = ({
     })
     .filter((item) => item.value.length > 0);
 
-  // Merge data with the same dataId（Sequential obj merging）
+  // 相邻同 dataId/obj 的记录归并，保持一轮 AI 多个 value 在同一个 ChatItem 中展示。
   const result = chatMessages.reduce((result: ChatItemMiniType[], currentItem) => {
     const lastItem = result[result.length - 1];
 
@@ -442,6 +609,9 @@ export const GPTMessages2Chats = ({
   return result;
 };
 
+/**
+ * 将聊天 value 提取成运行时用户输入。文件保留结构，文本按展示顺序拼接。
+ */
 export const chatValue2RuntimePrompt = (value: ChatItemValueItemType[]): RuntimeUserPromptType => {
   const prompt: RuntimeUserPromptType = {
     files: [],
@@ -457,6 +627,9 @@ export const chatValue2RuntimePrompt = (value: ChatItemValueItemType[]): Runtime
   return prompt;
 };
 
+/**
+ * 将运行时 prompt 恢复为用户聊天 value，主要用于调试/重放入口。
+ */
 export const runtimePrompt2ChatsValue = (prompt: {
   files?: UserChatItemFileItemType[];
   text?: string;
@@ -479,6 +652,9 @@ export const runtimePrompt2ChatsValue = (prompt: {
   return value;
 };
 
+/**
+ * 用一条 System ChatItem 包装系统提示词，便于统一走 ChatItem -> GPT message 转换链。
+ */
 export const getSystemPrompt_ChatItemType = (prompt?: string): ChatItemMiniType[] => {
   if (!prompt) return [];
   return [

--- a/packages/global/core/chat/type.ts
+++ b/packages/global/core/chat/type.ts
@@ -223,7 +223,8 @@ export const AIChatItemValueSchema = z.object({
   stepTitle: StepTitleItemSchema.nullish(),
 
   /** @deprecated */
-  tool: ToolModuleResponseItemSchema.nullish()
+  tool: ToolModuleResponseItemSchema.nullish(),
+  hideReason: z.boolean().optional()
 });
 
 export type AIChatItemValueItemType = z.infer<typeof AIChatItemValueSchema>;

--- a/packages/global/core/chat/utils.ts
+++ b/packages/global/core/chat/utils.ts
@@ -228,27 +228,25 @@ export const removeAIResponseCite = <T extends AIChatItemValueItemType[] | strin
     return removeDatasetCiteText(value, false) as T;
   }
 
-  return value.map<AIChatItemValueItemType>((item) => {
-    if (item.text?.content) {
-      return {
-        ...item,
-        text: {
-          ...item.text,
-          content: removeDatasetCiteText(item.text.content, false)
+  return value.map<AIChatItemValueItemType>((item) => ({
+    ...item,
+    ...(item.text?.content
+      ? {
+          text: {
+            ...item.text,
+            content: removeDatasetCiteText(item.text.content, false)
+          }
         }
-      };
-    }
-    if (item.reasoning?.content) {
-      return {
-        ...item,
-        reasoning: {
-          ...item.reasoning,
-          content: removeDatasetCiteText(item.reasoning.content, false)
+      : {}),
+    ...(item.reasoning?.content
+      ? {
+          reasoning: {
+            ...item.reasoning,
+            content: removeDatasetCiteText(item.reasoning.content, false)
+          }
         }
-      };
-    }
-    return item;
-  }) as T;
+      : {})
+  })) as T;
 };
 
 export const removeEmptyUserInput = (input?: UserChatItemValueItemType[]) => {

--- a/packages/global/test/core/chat/adapt.test.ts
+++ b/packages/global/test/core/chat/adapt.test.ts
@@ -7,7 +7,8 @@ import {
   GPTMessages2Chats,
   chatValue2RuntimePrompt,
   runtimePrompt2ChatsValue,
-  getSystemPrompt_ChatItemType
+  getSystemPrompt_ChatItemType,
+  mergeAssistantFieldMessages
 } from '@fastgpt/global/core/chat/adapt';
 import { ChatRoleEnum, ChatFileTypeEnum } from '@fastgpt/global/core/chat/constants';
 import { ChatCompletionRequestMessageRoleEnum } from '@fastgpt/global/core/ai/constants';
@@ -63,6 +64,395 @@ describe('simpleUserContentPart', () => {
       { type: 'image_url' as const, image_url: { url: 'http://example.com/img.png' } }
     ];
     expect(simpleUserContentPart(content)).toEqual(content);
+  });
+});
+
+describe('mergeAssistantFieldMessages', () => {
+  it('should merge assistant reasoning, text and following tool calls', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'Need external data.'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        content: 'I will search first.'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        tool_calls: [
+          {
+            id: 'call_search',
+            type: 'function',
+            function: {
+              name: 'search_web',
+              arguments: '{"query":"FastGPT"}'
+            }
+          }
+        ]
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Tool,
+        tool_call_id: 'call_search',
+        content: 'compressed result'
+      }
+    ];
+
+    expect(mergeAssistantFieldMessages(messages)).toEqual([
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'Need external data.',
+        content: 'I will search first.',
+        tool_calls: [
+          {
+            id: 'call_search',
+            type: 'function',
+            function: {
+              name: 'search_web',
+              arguments: '{"query":"FastGPT"}'
+            }
+          }
+        ]
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Tool,
+        tool_call_id: 'call_search',
+        content: 'compressed result'
+      }
+    ]);
+  });
+
+  it('should merge consecutive assistant text fields', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        content: 'Part 1'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        content: ' Part 2'
+      }
+    ];
+
+    expect(mergeAssistantFieldMessages(messages)).toEqual([
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        content: 'Part 1 Part 2'
+      }
+    ]);
+  });
+
+  it('should start a new assistant payload when reasoning appears after content', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        content: 'Draft answer.'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'Second step thinking.'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        content: 'Final answer.'
+      }
+    ];
+
+    expect(mergeAssistantFieldMessages(messages)).toEqual([
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        content: 'Draft answer.'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'Second step thinking.',
+        content: 'Final answer.'
+      }
+    ]);
+  });
+
+  it('should drop orphan reasoning when the next assistant message has different visibility', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'Hidden reasoning.',
+        hideInUI: true
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        content: 'Visible answer.'
+      }
+    ];
+
+    expect(mergeAssistantFieldMessages(messages)).toEqual([
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        content: 'Visible answer.'
+      }
+    ]);
+  });
+
+  it('should drop orphan reasoning when the next assistant message has different dataId', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        dataId: 'old-ai',
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'Reason from another response.'
+      },
+      {
+        dataId: 'current-ai',
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        content: 'Current answer.'
+      }
+    ];
+
+    expect(mergeAssistantFieldMessages(messages)).toEqual([
+      {
+        dataId: 'current-ai',
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        content: 'Current answer.'
+      }
+    ]);
+  });
+
+  it('should not attach orphan reasoning to tool calls with different dataId', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        dataId: 'old-ai',
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'Reason from another response.'
+      },
+      {
+        dataId: 'current-ai',
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        tool_calls: [
+          {
+            id: 'call_search',
+            type: 'function',
+            function: {
+              name: 'search_web',
+              arguments: '{}'
+            }
+          }
+        ]
+      },
+      {
+        dataId: 'current-ai',
+        role: ChatCompletionRequestMessageRoleEnum.Tool,
+        tool_call_id: 'call_search',
+        content: '{}'
+      }
+    ];
+
+    expect(mergeAssistantFieldMessages(messages)).toEqual([
+      {
+        dataId: 'current-ai',
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        tool_calls: [
+          {
+            id: 'call_search',
+            type: 'function',
+            function: {
+              name: 'search_web',
+              arguments: '{}'
+            }
+          }
+        ]
+      },
+      {
+        dataId: 'current-ai',
+        role: ChatCompletionRequestMessageRoleEnum.Tool,
+        tool_call_id: 'call_search',
+        content: '{}'
+      }
+    ]);
+  });
+
+  it('should merge consecutive assistant reasoning fields into the next assistant payload', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'reason 1'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'reason 2'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        content: 'Final answer.'
+      }
+    ];
+
+    expect(mergeAssistantFieldMessages(messages)).toEqual([
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'reason 1\n\nreason 2',
+        content: 'Final answer.'
+      }
+    ]);
+  });
+
+  it('should drop orphan assistant reasoning fields', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'reason only'
+      }
+    ];
+
+    expect(mergeAssistantFieldMessages(messages)).toEqual([]);
+  });
+
+  it('should merge consecutive tool call groups into one assistant message', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'Need weather and time.'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        content: 'Checking both tools.'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        tool_calls: [
+          {
+            id: 'call_weather',
+            type: 'function',
+            function: {
+              name: 'weather',
+              arguments: '{"city":"Beijing"}'
+            }
+          }
+        ]
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Tool,
+        tool_call_id: 'call_weather',
+        content: 'compressed weather'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        tool_calls: [
+          {
+            id: 'call_time',
+            type: 'function',
+            function: {
+              name: 'time',
+              arguments: '{}'
+            }
+          }
+        ]
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Tool,
+        tool_call_id: 'call_time',
+        content: 'compressed time'
+      }
+    ];
+
+    expect(mergeAssistantFieldMessages(messages)).toEqual([
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'Need weather and time.',
+        content: 'Checking both tools.',
+        tool_calls: [
+          {
+            id: 'call_weather',
+            type: 'function',
+            function: {
+              name: 'weather',
+              arguments: '{"city":"Beijing"}'
+            }
+          },
+          {
+            id: 'call_time',
+            type: 'function',
+            function: {
+              name: 'time',
+              arguments: '{}'
+            }
+          }
+        ]
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Tool,
+        tool_call_id: 'call_weather',
+        content: 'compressed weather'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Tool,
+        tool_call_id: 'call_time',
+        content: 'compressed time'
+      }
+    ]);
+  });
+
+  it('should keep already merged reasoning and tool calls idempotent', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'Need a tool.',
+        tool_calls: [
+          {
+            id: 'call_search',
+            type: 'function',
+            function: {
+              name: 'search_web',
+              arguments: '{}'
+            }
+          }
+        ]
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Tool,
+        tool_call_id: 'call_search',
+        content: '{}'
+      }
+    ];
+
+    expect(mergeAssistantFieldMessages(messages)).toEqual(messages);
+  });
+
+  it('should attach reasoning to provider tool call messages with empty content', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'Need a tool.'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        content: '',
+        tool_calls: [
+          {
+            id: 'tool-1',
+            type: 'function',
+            function: {
+              name: 'search_web',
+              arguments: '{}'
+            }
+          }
+        ]
+      }
+    ];
+
+    expect(mergeAssistantFieldMessages(messages)).toEqual([
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'Need a tool.',
+        tool_calls: [
+          {
+            id: 'tool-1',
+            type: 'function',
+            function: {
+              name: 'search_web',
+              arguments: '{}'
+            }
+          }
+        ]
+      }
+    ]);
   });
 });
 
@@ -445,7 +835,7 @@ describe('chats2GPTMessages', () => {
     expect(result).toHaveLength(2);
   });
 
-  it('should convert AI message with reasoning only', () => {
+  it('should drop AI message with reasoning only', () => {
     const messages: ChatItemMiniType[] = [
       {
         obj: ChatRoleEnum.AI,
@@ -455,10 +845,7 @@ describe('chats2GPTMessages', () => {
 
     const result = chats2GPTMessages({ messages, reserveId: false });
 
-    expect(result).toHaveLength(1);
-    expect(result[0].role).toBe(ChatCompletionRequestMessageRoleEnum.Assistant);
-    expect((result[0] as any).reasoning_content).toBe('Let me think...');
-    expect((result[0] as any).content).toBeUndefined();
+    expect(result).toHaveLength(0);
   });
 
   it('should merge reasoning + text into a single assistant message', () => {
@@ -511,7 +898,104 @@ describe('chats2GPTMessages', () => {
     expect(result[1].role).toBe(ChatCompletionRequestMessageRoleEnum.Tool);
   });
 
-  it('should keep tool_calls separate when no reasoning precedes them', () => {
+  it('should concatenate continuous reasoning values before attaching to text', () => {
+    const messages: ChatItemMiniType[] = [
+      {
+        obj: ChatRoleEnum.AI,
+        value: [
+          { reasoning: { content: 'reason 1' } },
+          { reasoning: { content: 'reason 2' } },
+          { text: { content: 'Final answer' } }
+        ]
+      }
+    ];
+
+    const result = chats2GPTMessages({ messages, reserveId: false });
+
+    expect(result).toEqual([
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'reason 1\n\nreason 2',
+        content: 'Final answer'
+      }
+    ]);
+  });
+
+  it('should remove reasoning when reserveReason is false', () => {
+    const messages: ChatItemMiniType[] = [
+      {
+        obj: ChatRoleEnum.AI,
+        value: [
+          { reasoning: { content: 'hidden thought' } },
+          { text: { content: 'Visible answer' } }
+        ]
+      }
+    ];
+
+    const result = chats2GPTMessages({ messages, reserveId: false, reserveReason: false });
+
+    expect(result).toEqual([
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        content: 'Visible answer'
+      }
+    ]);
+  });
+
+  it('should keep tool calls and remove reasoning when reserveReason is false', () => {
+    const messages: ChatItemMiniType[] = [
+      {
+        obj: ChatRoleEnum.AI,
+        value: [
+          {
+            reasoning: {
+              content: 'Do not send this reasoning'
+            },
+            tools: [
+              {
+                id: 'tool-1',
+                toolName: 'Search',
+                toolAvatar: '',
+                functionName: 'search_web',
+                params: '{"q":"x"}',
+                response: '{"ok":true}'
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    expect(
+      chats2GPTMessages({
+        messages,
+        reserveId: false,
+        reserveTool: true,
+        reserveReason: false
+      })
+    ).toEqual([
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        tool_calls: [
+          {
+            id: 'tool-1',
+            type: 'function',
+            function: {
+              name: 'search_web',
+              arguments: '{"q":"x"}'
+            }
+          }
+        ]
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Tool,
+        tool_call_id: 'tool-1',
+        content: '{"ok":true}'
+      }
+    ]);
+  });
+
+  it('should attach preceding text to following tool_calls', () => {
     const messages: ChatItemMiniType[] = [
       {
         obj: ChatRoleEnum.AI,
@@ -533,12 +1017,71 @@ describe('chats2GPTMessages', () => {
 
     const result = chats2GPTMessages({ messages, reserveId: false, reserveTool: true });
 
-    // text assistant + tool_calls assistant + tool response
-    expect(result).toHaveLength(3);
+    expect(result).toHaveLength(2);
     expect((result[0] as any).content).toBe('Calling tool');
-    expect((result[0] as any).tool_calls).toBeUndefined();
-    expect((result[1] as any).tool_calls).toHaveLength(1);
-    expect(result[2].role).toBe(ChatCompletionRequestMessageRoleEnum.Tool);
+    expect((result[0] as any).tool_calls).toHaveLength(1);
+    expect((result[0] as any).tool_calls[0].function.name).toBe('search_web');
+    expect(result[1].role).toBe(ChatCompletionRequestMessageRoleEnum.Tool);
+  });
+
+  it('should attach same-value text to tool_calls', () => {
+    const messages: ChatItemMiniType[] = [
+      {
+        obj: ChatRoleEnum.AI,
+        value: [
+          {
+            text: { content: 'Calling tool' },
+            tool: {
+              id: 'tool-1',
+              toolName: 'Search',
+              toolAvatar: '',
+              functionName: 'search_web',
+              params: '{}',
+              response: '{}'
+            }
+          }
+        ]
+      }
+    ];
+
+    const result = chats2GPTMessages({ messages, reserveId: false, reserveTool: true });
+
+    expect(result).toHaveLength(2);
+    expect((result[0] as any).content).toBe('Calling tool');
+    expect((result[0] as any).tool_calls).toHaveLength(1);
+    expect((result[0] as any).tool_calls[0].function.name).toBe('search_web');
+    expect(result[1].role).toBe(ChatCompletionRequestMessageRoleEnum.Tool);
+  });
+
+  it('should attach same-value reasoning and text to tool_calls', () => {
+    const messages: ChatItemMiniType[] = [
+      {
+        obj: ChatRoleEnum.AI,
+        value: [
+          {
+            reasoning: { content: 'Need a tool.' },
+            text: { content: 'Calling tool' },
+            tool: {
+              id: 'tool-1',
+              toolName: 'Search',
+              toolAvatar: '',
+              functionName: 'search_web',
+              params: '{}',
+              response: '{}'
+            }
+          }
+        ]
+      }
+    ];
+
+    const result = chats2GPTMessages({ messages, reserveId: false, reserveTool: true });
+
+    expect(result).toHaveLength(2);
+    expect((result[0] as any).reasoning_content).toBe('Need a tool.');
+    expect((result[0] as any).content).toBe('Calling tool');
+    expect((result[0] as any).tool_calls).toHaveLength(1);
+    expect((result[0] as any).tool_calls[0].function.name).toBe('search_web');
+    expect(result[1].role).toBe(ChatCompletionRequestMessageRoleEnum.Tool);
   });
 
   it('should handle multiple reasoning values producing separate assistant entries', () => {
@@ -643,9 +1186,250 @@ describe('GPTMessages2Chats', () => {
     const result = GPTMessages2Chats({ messages });
 
     expect(result).toHaveLength(1);
-    const reasoningValue = result[0].value[0] as { reasoning?: { content: string } };
-    expect(reasoningValue.reasoning?.content).toBe('Let me think about this...');
-    expect(result[0].value[1].text?.content).toBe('Final answer');
+    expect(result[0].value).toEqual([
+      {
+        reasoning: {
+          content: 'Let me think about this...'
+        },
+        text: {
+          content: 'Final answer'
+        }
+      }
+    ]);
+  });
+
+  it('should drop separated reasoning assistant messages before following content', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'reason 1'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'reason 2'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        content: 'Final answer'
+      }
+    ];
+
+    const result = GPTMessages2Chats({ messages });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toEqual([
+      {
+        text: {
+          content: 'Final answer'
+        }
+      }
+    ]);
+  });
+
+  it('should keep only reasoning that already exists on the attach target', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'pending reason'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'target reason',
+        content: 'Final answer'
+      }
+    ];
+
+    const result = GPTMessages2Chats({ messages });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toEqual([
+      {
+        reasoning: {
+          content: 'target reason'
+        },
+        text: {
+          content: 'Final answer'
+        }
+      }
+    ]);
+  });
+
+  it('should ignore separated reasoning across non-assistant message boundaries', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'Reason before user boundary'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.User,
+        content: 'New user turn'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        content: 'Answer after user turn'
+      }
+    ];
+
+    const result = GPTMessages2Chats({ messages });
+
+    expect(result).toEqual([
+      {
+        dataId: undefined,
+        obj: ChatRoleEnum.Human,
+        hideInUI: undefined,
+        value: [
+          {
+            text: {
+              content: 'New user turn'
+            }
+          }
+        ]
+      },
+      {
+        dataId: undefined,
+        obj: ChatRoleEnum.AI,
+        hideInUI: undefined,
+        value: [
+          {
+            text: {
+              content: 'Answer after user turn'
+            }
+          }
+        ]
+      }
+    ]);
+  });
+
+  it('should drop separated reasoning assistant message before following tool calls', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'Need current time.'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        tool_calls: [
+          {
+            id: 'call_time',
+            type: 'function',
+            function: {
+              name: 'get_time',
+              arguments: '{}'
+            }
+          }
+        ]
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Tool,
+        tool_call_id: 'call_time',
+        content: '{"time":"2026-05-21 17:19:15"}'
+      }
+    ];
+
+    const result = GPTMessages2Chats({ messages, reserveTool: true });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toEqual([
+      {
+        tools: [
+          {
+            id: 'call_time',
+            toolName: '',
+            toolAvatar: '',
+            functionName: 'get_time',
+            params: '{}',
+            response: '{"time":"2026-05-21 17:19:15"}'
+          }
+        ]
+      }
+    ]);
+  });
+
+  it('should keep reasoning that is already attached to tool calls', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'Need current time.',
+        tool_calls: [
+          {
+            id: 'call_time',
+            type: 'function',
+            function: {
+              name: 'get_time',
+              arguments: '{}'
+            }
+          }
+        ]
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Tool,
+        tool_call_id: 'call_time',
+        content: '{"time":"2026-05-21 17:19:15"}'
+      }
+    ];
+
+    const result = GPTMessages2Chats({ messages, reserveTool: true });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toEqual([
+      {
+        reasoning: {
+          content: 'Need current time.'
+        },
+        tools: [
+          {
+            id: 'call_time',
+            toolName: '',
+            toolAvatar: '',
+            functionName: 'get_time',
+            params: '{}',
+            response: '{"time":"2026-05-21 17:19:15"}'
+          }
+        ]
+      }
+    ]);
+  });
+
+  it('should not attach separated reasoning to a later answer after filtered tool calls', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        reasoning_content: 'Reasoning for a tool call only.'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        tool_calls: [
+          {
+            id: 'call_search',
+            type: 'function',
+            function: {
+              name: 'search_web',
+              arguments: '{}'
+            }
+          }
+        ]
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Tool,
+        tool_call_id: 'call_search',
+        content: '{}'
+      },
+      {
+        role: ChatCompletionRequestMessageRoleEnum.Assistant,
+        content: 'Final visible answer.'
+      }
+    ];
+
+    const result = GPTMessages2Chats({ messages, reserveTool: false, reserveReason: true });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toEqual([
+      {
+        text: {
+          content: 'Final visible answer.'
+        }
+      }
+    ]);
   });
 
   it('should drop reasoning when reserveReason is false', () => {
@@ -665,7 +1449,7 @@ describe('GPTMessages2Chats', () => {
     expect((result[0].value[0] as any).reasoning).toBeUndefined();
   });
 
-  it('should keep only reasoning when assistant message has no content', () => {
+  it('should drop reasoning when assistant message has no content', () => {
     const messages: ChatCompletionMessageParam[] = [
       {
         role: ChatCompletionRequestMessageRoleEnum.Assistant,
@@ -676,10 +1460,7 @@ describe('GPTMessages2Chats', () => {
 
     const result = GPTMessages2Chats({ messages });
 
-    expect(result).toHaveLength(1);
-    expect(result[0].value).toHaveLength(1);
-    const value = result[0].value[0] as { reasoning?: { content: string } };
-    expect(value.reasoning?.content).toBe('Thinking only');
+    expect(result).toHaveLength(0);
   });
 
   it('should merge messages with same dataId', () => {

--- a/packages/service/core/ai/utils.ts
+++ b/packages/service/core/ai/utils.ts
@@ -40,7 +40,13 @@ export const computedTemperature = ({
 };
 
 // LLM utils
-// Parse <think></think> tags to think and answer - unstream response
+const normalizeFirstAnswerAfterReasoning = (answer: string) => answer.trimStart();
+
+/**
+ * 从非流式模型结果中拆分 <think></think> 思考内容和最终回答。
+ * </think> 后面的前导空白只用于分隔 reasoning 与 answer，不作为正文保留，
+ * 避免 reasoning-only 输出被解析成 answerText="\n"。
+ */
 export const parseReasoningContent = (text: string): [string, string] => {
   const regex = /<think>([\s\S]*?)<\/think>/;
   const match = text.match(regex);
@@ -52,7 +58,9 @@ export const parseReasoningContent = (text: string): [string, string] => {
   const thinkContent = match[1].trim();
 
   // Add answer (remaining text after think tag)
-  const answerContent = text.slice(match.index! + match[0].length);
+  const answerContent = normalizeFirstAnswerAfterReasoning(
+    text.slice(match.index! + match[0].length)
+  );
 
   return [thinkContent, answerContent];
 };
@@ -75,6 +83,29 @@ export const parseLLMStreamResponse = () => {
   let buffer_reasoningContent = '';
   let buffer_content = '';
   let error: any = undefined;
+  let shouldNormalizeFirstAnswer = false;
+
+  const normalizeContentBoundary = ({
+    reasoningContent,
+    content
+  }: {
+    reasoningContent: string;
+    content: string;
+  }) => {
+    if (reasoningContent) {
+      shouldNormalizeFirstAnswer = true;
+    }
+
+    if (!content || !shouldNormalizeFirstAnswer) return content;
+
+    const normalizedContent = normalizeFirstAnswerAfterReasoning(content);
+
+    if (normalizedContent) {
+      shouldNormalizeFirstAnswer = false;
+    }
+
+    return normalizedContent;
+  };
 
   /* 
     parseThinkTag - 只控制是否主动解析 <think></think>，如果接口已经解析了，则不再解析。
@@ -117,7 +148,7 @@ export const parseLLMStreamResponse = () => {
       const isStreamEnd = !!buffer_finishReason;
 
       // Parse think
-      const { reasoningContent: parsedThinkReasoningContent, content: parsedThinkContent } =
+      const { reasoningContent: parsedThinkReasoningContent, content: rawParsedThinkContent } =
         (() => {
           if (reasoningContent || !parseThinkTag) {
             isInThinkTag = false;
@@ -233,6 +264,11 @@ export const parseLLMStreamResponse = () => {
             content: ''
           };
         })();
+
+      const parsedThinkContent = normalizeContentBoundary({
+        reasoningContent: parsedThinkReasoningContent,
+        content: rawParsedThinkContent
+      });
 
       // Parse datset cite
       if (retainDatasetCite) {

--- a/packages/service/core/workflow/dispatch/ai/classifyQuestion.ts
+++ b/packages/service/core/workflow/dispatch/ai/classifyQuestion.ts
@@ -147,7 +147,7 @@ const completions = async ({
     body: {
       model: cqModel.model,
       temperature: 0.01,
-      messages: chats2GPTMessages({ messages, reserveId: false }),
+      messages: chats2GPTMessages({ messages, reserveId: false, reserveReason: false }),
       stream: true
     },
     userKey: externalProvider.openaiAccount

--- a/packages/service/core/workflow/dispatch/ai/extract.ts
+++ b/packages/service/core/workflow/dispatch/ai/extract.ts
@@ -20,11 +20,7 @@ import json5 from 'json5';
 import { getLogger, LogCategories } from '../../../../common/logger';
 
 const logger = getLogger(LogCategories.MODULE.WORKFLOW.AI);
-import {
-  type ChatCompletionMessageParam,
-  type ChatCompletionTool
-} from '@fastgpt/global/core/ai/llm/type';
-import { ChatCompletionRequestMessageRoleEnum } from '@fastgpt/global/core/ai/constants';
+import { type ChatCompletionTool } from '@fastgpt/global/core/ai/llm/type';
 import { type DispatchNodeResultType } from '@fastgpt/global/core/workflow/runtime/type';
 import {
   getExtractJsonPrompt,
@@ -214,7 +210,11 @@ const toolChoice = async (props: ActionProps) => {
       ]
     }
   ];
-  const adaptMessages = chats2GPTMessages({ messages, reserveId: false });
+  const adaptMessages = chats2GPTMessages({
+    messages,
+    reserveId: false,
+    reserveReason: false
+  });
   const filterMessages = await filterGPTMessageByMaxContext({
     messages: adaptMessages,
     maxContext: extractModel.maxContext
@@ -270,13 +270,6 @@ const toolChoice = async (props: ActionProps) => {
     }
   })();
 
-  const AIMessages: ChatCompletionMessageParam[] = [
-    {
-      role: ChatCompletionRequestMessageRoleEnum.Assistant,
-      tool_calls: toolCalls
-    }
-  ];
-
   return {
     inputTokens,
     outputTokens,
@@ -328,7 +321,7 @@ const completions = async (props: ActionProps) => {
     body: {
       model: extractModel.model,
       temperature: 0.01,
-      messages: chats2GPTMessages({ messages, reserveId: false }),
+      messages: chats2GPTMessages({ messages, reserveId: false, reserveReason: false }),
       stream: true
     },
     userKey: externalProvider.openaiAccount

--- a/packages/service/core/workflow/dispatch/index.ts
+++ b/packages/service/core/workflow/dispatch/index.ts
@@ -1193,15 +1193,16 @@ export class WorkflowQueue {
       if (assistantResponses) {
         this.chatAssistantResponse = this.chatAssistantResponse.concat(assistantResponses);
       } else {
-        if (reasoningText) {
-          this.chatAssistantResponse.push({
-            reasoning: {
-              content: reasoningText
-            }
-          });
-        }
+        // reasoning 不能独立落历史；只有存在可见文本时才附着保存。
         if (answerText) {
           this.chatAssistantResponse.push({
+            ...(reasoningText
+              ? {
+                  reasoning: {
+                    content: reasoningText
+                  }
+                }
+              : {}),
             text: {
               content: answerText
             }

--- a/packages/service/test/core/ai/utils.test.ts
+++ b/packages/service/test/core/ai/utils.test.ts
@@ -85,6 +85,14 @@ describe('parseReasoningContent', () => {
     expect(parseReasoningContent('<think>reasoning</think>')).toEqual(['reasoning', '']);
   });
 
+  it('should remove separator whitespace after think tag', () => {
+    expect(parseReasoningContent('<think>reasoning</think>\n')).toEqual(['reasoning', '']);
+    expect(parseReasoningContent('<think>reasoning</think>\n\nanswer')).toEqual([
+      'reasoning',
+      'answer'
+    ]);
+  });
+
   it('should handle multiline think content', () => {
     expect(parseReasoningContent('<think>line1\nline2</think>answer')).toEqual([
       'line1\nline2',
@@ -189,6 +197,22 @@ describe('parseLLMStreamResponse', () => {
           { content: '你好3' }
         ],
         correct: { answer: '你好1你好2你好3', reasoning: '这是思考过程' }
+      },
+      {
+        data: [{ content: '<think>这是' }, { content: '思考过程</think>\n' }],
+        correct: { answer: '', reasoning: '这是思考过程' }
+      },
+      {
+        data: [{ content: '<think>这是' }, { content: '思考过程</think>\n' }, { content: '你好1' }],
+        correct: { answer: '你好1', reasoning: '这是思考过程' }
+      },
+      {
+        data: [{ content: '<think>这是' }, { content: '思考过程</think>\n\n你好1' }],
+        correct: { answer: '你好1', reasoning: '这是思考过程' }
+      },
+      {
+        data: [{ reasoning_content: '这是思考过程' }, { content: '\n' }, { content: '你好1' }],
+        correct: { answer: '你好1', reasoning: '这是思考过程' }
       },
       {
         data: [

--- a/projects/app/src/components/core/chat/components/AIResponseBox.tsx
+++ b/projects/app/src/components/core/chat/components/AIResponseBox.tsx
@@ -475,10 +475,23 @@ const AIResponseBox = ({
   const tools = value.tool ? [value.tool] : value.tools;
   const disableStreamingInteraction = isChatting && isLastChild;
   const skills = value.skills;
+  const responseNodes: React.ReactNode[] = [];
 
+  if ('reasoning' in value && value.reasoning && !value.hideReason) {
+    responseNodes.push(
+      <RenderResoningContent
+        key={'reasoning'}
+        isChatting={isChatting}
+        isLastResponseValue={isLastResponseValue}
+        content={value.reasoning.content}
+        isDisabled={disableStreamingInteraction}
+      />
+    );
+  }
   if ('text' in value && value.text) {
-    return (
+    responseNodes.push(
       <RenderText
+        key={'text'}
         chatItemDataId={chatItemDataId}
         showAnimation={isChatting && isLastResponseValue}
         text={value.text.content}
@@ -487,29 +500,33 @@ const AIResponseBox = ({
       />
     );
   }
-  if ('reasoning' in value && value.reasoning) {
-    return (
-      <RenderResoningContent
-        isChatting={isChatting}
-        isLastResponseValue={isLastResponseValue}
-        content={value.reasoning.content}
-        isDisabled={disableStreamingInteraction}
-      />
+  if (tools && showRunningStatus) {
+    responseNodes.push(
+      ...tools.map((tool) => (
+        <Box key={tool.id}>
+          <RenderTool showAnimation={isChatting} tool={tool} />
+        </Box>
+      ))
     );
   }
-  if (tools && showRunningStatus) {
-    return tools.map((tool) => (
-      <Box key={tool.id} _notLast={{ mb: 2 }}>
-        <RenderTool showAnimation={isChatting} tool={tool} />
-      </Box>
-    ));
-  }
   if (skills && showSkillReferences && showRunningStatus) {
-    return skills.map((skill) => (
-      <Box key={skill.id} _notLast={{ mb: 2 }}>
-        <RenderSkill showAnimation={isChatting} skill={skill} />
-      </Box>
-    ));
+    responseNodes.push(
+      ...skills.map((skill) => (
+        <Box key={skill.id}>
+          <RenderSkill showAnimation={isChatting} skill={skill} />
+        </Box>
+      ))
+    );
+  }
+
+  if (responseNodes.length > 0) {
+    return responseNodes.length === 1 ? (
+      responseNodes[0]
+    ) : (
+      <Flex flexDirection={'column'} gap={2}>
+        {responseNodes}
+      </Flex>
+    );
   }
   if ('interactive' in value && value.interactive) {
     const interactive = extractDeepestInteractive(value.interactive);


### PR DESCRIPTION
## What

- Add `reserveReason` support when adapting chat histories to GPT messages.
- Drop reasoning from question classification and content extraction contexts.
- Merge separated assistant reasoning into the next valid assistant content/tool-call message, and drop orphan reasoning.
- Keep reasoning attached to text/tool values instead of storing it as a standalone chat value.
- Normalize separator whitespace after reasoning output so reasoning-only responses do not become `"\n"` answers.

## Tests

- `pnpm --dir packages/global test test/core/chat/adapt.test.ts`
- `pnpm --dir packages/service test test/core/ai/utils.test.ts`
- `pnpm --dir projects/app typecheck`
