### PR TITLE
feat: support image dataset search in agent v2

### DIFF
--- a/.codex/design/agentv2-图搜图-功能开发文档.md
+++ b/.codex/design/agentv2-图搜图-功能开发文档.md
@@ -1,0 +1,227 @@
+# agentv2-图搜图-功能开发文档
+
+关联文档：
+
+- `.codex/design/agentv2-图搜图-需求确认文档.md`
+- `.codex/design/agentv2-图搜图-测试设计文档.md`
+
+## 实现结论
+
+采用最小修复方案：让 Agent v2 内置 `dataset_search` 工具显式接收图片文件 id，并在工具执行层把 id 映射为图片 URL，随后复用普通 workflow 已有的 `defaultSearchDatasetData` 多模态检索主流程。
+
+不要把图片 URL 拼进文本 query。图片必须作为 `imageQueries` 进入底层检索，别整那种“字符串大杂烩”，后面计费、预览、融合权重全得乱套。
+
+## 开发任务
+
+### D-AGENT-IMG-001 扩展 dataset_search 工具协议
+
+测试映射：T-AGENT-IMG-001、T-AGENT-IMG-002、T-AGENT-IMG-003。
+
+文件：
+
+- `packages/service/core/workflow/dispatch/ai/agent/sub/dataset/utils.ts`
+
+改动：
+
+- `DatasetSearchToolSchema` 从 `{ query: z.string() }` 扩展为：
+  - `query: z.string().default('')` 或 `query: z.string()`
+  - `imageIds: z.array(z.string()).optional()`
+- `datasetSearchTool.function.parameters.properties` 增加 `imageIds`：
+  - 类型：`array<string>`
+  - 语义：`# Input Files` 中 `type=image` 的文件 id
+  - 描述要明确“需要按图片内容检索知识库时传入”
+- 是否允许 `query` 为空：
+  - 推荐允许空字符串，纯图片检索不能逼模型编假 query。
+  - 若使用 zod default，需要确认 `parseJsonArgs` 返回缺失 query 时的兼容行为。
+
+完成定义：
+
+- schema 能接受 `{ "query": "", "imageIds": ["current-0"] }`。
+- 旧 `{ "query": "xxx" }` 仍通过。
+
+### D-AGENT-IMG-002 将图片文件映射传入工具执行器
+
+测试映射：T-AGENT-IMG-006、T-AGENT-IMG-007、T-AGENT-IMG-008。
+
+文件：
+
+- `packages/service/core/workflow/dispatch/ai/agent/utils.ts`
+- `packages/service/core/workflow/dispatch/ai/agent/index.ts`
+- `packages/service/core/workflow/dispatch/ai/agent/piAgent/index.ts`
+- 如需类型复用：`packages/service/core/workflow/dispatch/ai/agent/adapter/userContext.ts`
+
+改动：
+
+- `ToolDispatchContext` 增加 `allFilesMap` 或更窄的 `imageFilesMap`。
+- `dispatchRunAgent` 创建 runtime 时，把 `buildAgentUserContextInput` 返回的 `allFilesMap` 传入 context。
+- `dispatchPiAgent` 创建 `toolCtx` 时同样传入 `allFilesMap`，避免 `AGENT_ENGINE=pi` 分支漏掉。
+- `getExecuteTool` 在 `SubAppIds.datasetSearch` 分支中解析 `DatasetSearchToolSchema` 结果对应的图片 id：
+  - 只接受 `allFilesMap[id]?.type === ChatFileTypeEnum.image`
+  - 去重后得到 `imageUrls`
+  - 不存在或非图片 id 默认忽略，并可记录 debug/warn
+
+完成定义：
+
+- `read_files` 仍使用 `filesMap`，只读 document。
+- `dataset_search` 能拿到 image id 对应 URL。
+- sandbox 现有 `allFilesMap` 用法不受影响。
+
+### D-AGENT-IMG-003 改造 Agent dataset search 执行参数
+
+测试映射：T-AGENT-IMG-001、T-AGENT-IMG-002、T-AGENT-IMG-003、T-AGENT-IMG-009。
+
+文件：
+
+- `packages/service/core/workflow/dispatch/ai/agent/sub/dataset/index.ts`
+- 可复用：`packages/service/core/workflow/dispatch/dataset/utils.ts`
+
+改动：
+
+- `DatasetSearchParams` 增加图片 URL 入参，例如 `imageUrls?: string[]`。
+- tool args 中的 `query` 和执行器映射出的 `imageUrls` 组合后生成：
+  - `textQueries`: 非空 query 进入文本查询。
+  - `imageQueries`: 图片 URL 进入图片查询。
+- 不建议直接调用 `normalizeDatasetSearchInput([...query, ...imageUrls])` 处理全部输入，原因：
+  - Agent 文件 URL 可能是相对路径，`normalizeDatasetSearchInput` 当前只把 http(s) 当文件候选。
+  - 执行器已经通过 `allFilesMap` 证明这些 id 是 image，没必要再靠 URL 后缀猜。
+- 可以抽一个小 helper，例如 `buildAgentDatasetSearchQueries({ query, imageUrls })`，只放在 Agent dataset 子目录，别上升成公共模块。
+- 空查询处理：
+  - `textQueries.length === 0 && imageQueries.length === 0` 时返回空结果。
+  - `query === '' && imageQueries.length > 0` 时允许继续搜索。
+
+完成定义：
+
+- `defaultSearchDatasetData` 收到 `textQueries` / `imageQueries`。
+- 纯文本行为不变。
+- 纯图片和图文混合触发底层多模态召回。
+
+### D-AGENT-IMG-004 读取 `vlmModel` 并传到底层搜索
+
+测试映射：T-AGENT-IMG-002、T-AGENT-IMG-004。
+
+文件：
+
+- `packages/service/core/workflow/dispatch/ai/agent/sub/dataset/index.ts`
+
+改动：
+
+- `MongoDataset.findById(datasetIds[0], 'vectorModel').lean()` 改为读取 `'vectorModel vlmModel'`。
+- `searchData` 增加 `vlmModel: dataset?.vlmModel`。
+- 保持 `getEmbeddingModel(dataset?.vectorModel)` 逻辑。
+
+完成定义：
+
+- 有 VLM 时，底层 `getImageCaptionQueries` 能生成 caption query。
+- 无 VLM 时，底层自动降级，仅尝试图片向量召回，不抛错。
+
+### D-AGENT-IMG-005 补齐图片 caption usage 和 nodeResponse
+
+测试映射：T-AGENT-IMG-004、T-AGENT-IMG-005。
+
+文件：
+
+- `packages/service/core/workflow/dispatch/ai/agent/sub/dataset/index.ts`
+- 复用：`packages/service/core/workflow/dispatch/dataset/nodeResponse.ts`
+
+改动：
+
+- import `createImageCaptionChildNodeResponse`。
+- 从 `defaultSearchDatasetData` 解构 `imageCaptionResult`。
+- 参考 `packages/service/core/workflow/dispatch/dataset/search.ts` 的图片解析 usage 逻辑：
+  - `moduleName: i18nT('account_usage:image_parse')`
+  - `usedUserOpenAIKey ? 0 : totalPoints`
+  - push 到 `usages`
+  - push `createImageCaptionChildNodeResponse(...)` 到 `childrenResponses`
+- 计算 `childTotalPoints`，nodeResponse 中保留。
+- nodeResponse 建议从 `query` 扩展为：
+  - `query`: 文本 query，保留旧字段
+  - `datasetQueries`: `[...textQueries, ...imageQueries]`
+  - `quoteList`: 最终 `searchResults`
+
+完成定义：
+
+- 图片 caption 计费能在运行详情展示。
+- 外部 OpenAI key 时图片 caption 点数为 0。
+- 前端 WholeResponse/运行详情沿用已有 dataset node response 字段，不要求新增 UI。
+
+### D-AGENT-IMG-006 调整 chunk selection 的 query 文本
+
+测试映射：T-AGENT-IMG-002、T-AGENT-IMG-003。
+
+文件：
+
+- `packages/service/core/workflow/dispatch/ai/agent/sub/dataset/index.ts`
+
+改动：
+
+- 当前 `selectRelevantChunksByLLM({ query })` 只适合文本 query。
+- 对纯图片检索，构造一个可读 query，例如：
+  - 有文本：使用文本 query。
+  - 无文本有图片：使用 `用户上传的图片`
+  - 图文混合：使用文本 query，不把图片 URL 放进 prompt。
+- 不要把图片 URL 或 base64 放入 chunk selection prompt，避免泄露长 URL/临时签名。
+
+完成定义：
+
+- 纯图片检索结果过长时，chunk selection 仍可运行，不因为 query 为空生成奇怪 prompt。
+
+### D-AGENT-IMG-007 日志与错误策略
+
+测试映射：T-AGENT-IMG-006、T-AGENT-IMG-007、M-AGENT-IMG-001。
+
+文件：
+
+- `packages/service/core/workflow/dispatch/ai/agent/utils.ts`
+- `packages/service/core/workflow/dispatch/ai/agent/sub/dataset/index.ts`
+
+改动：
+
+- 复用 `getLogger(LogCategories.MODULE.AI.AGENT)`。
+- 非法 image id 建议 `debug` 或 `warn`，字段包含：
+  - `imageId`
+  - `toolId`
+  - `teamId`
+  - 不记录完整用户问题、不记录 token/key。
+- `dispatchAgentDatasetSearch` catch 保留现有错误日志。
+
+完成定义：
+
+- 日志结构化，不输出密钥、完整对话、大段 URL/base64。
+
+## 实施顺序
+
+1. D-AGENT-IMG-001：先改工具 schema，让测试能表达新协议。
+2. D-AGENT-IMG-002：打通 `allFilesMap` 到工具执行器。
+3. D-AGENT-IMG-003：让 Agent dataset search 产生 `textQueries/imageQueries`。
+4. D-AGENT-IMG-004：读取并传递 `vlmModel`。
+5. D-AGENT-IMG-005：补 usage/nodeResponse。
+6. D-AGENT-IMG-006：处理纯图片检索下的 chunk selection query。
+7. D-AGENT-IMG-007：补日志与错误策略。
+8. 按测试设计文档执行单测，再做 Agent v2 手工验证。
+
+## 关键兼容策略
+
+- 旧工具调用 `{ "query": "xxx" }` 必须继续可用。
+- `imageIds` 是可选字段，不影响不上传图片的 Agent。
+- `filesMap` 的 document-only 语义不变；图片走新增的 map 或 `allFilesMap`。
+- 不改普通 workflow 的 `normalizeDatasetSearchInput`，避免为了 Agent 相对路径把已有工作流行为搅浑。
+- 不改底层 `defaultSearchDatasetData` 的召回权重和融合逻辑，本需求只负责把 Agent 输入接入。
+
+## MECE 核查
+
+`发现问题 -> 影响范围 -> 修订动作 -> 修订后结果`
+
+- Agent v2 和普通 workflow 检索入口职责重叠 -> 可能重复实现图搜图逻辑 -> 开发方案规定只在 Agent 层做输入适配，底层召回复用 `defaultSearchDatasetData` -> 检索核心唯一。
+- 图片 id、图片 URL、文本 query 语义容易混淆 -> 可能把图片 URL 拼进文本导致召回/计费错乱 -> 开发方案固定 `imageIds -> imageUrls -> imageQueries`，文本只进 `textQueries` -> 字段语义独立。
+- Pi Agent 分支可能漏改 -> `AGENT_ENGINE=pi` 下功能不可用 -> 开发任务 D-AGENT-IMG-002 明确同时修改 `dispatchRunAgent` 和 `dispatchPiAgent` -> 两条 Agent runtime 覆盖。
+- Usage 容易只补功能不补计费 -> 账单/运行详情缺失 -> D-AGENT-IMG-005 映射 T-AGENT-IMG-004/T-AGENT-IMG-005 -> 验收覆盖。
+
+## 自检清单
+
+- 不新增 UI/API/DB。
+- 不引入新依赖。
+- 不使用 `any` 扩散新类型；若测试中沿用既有 `as any`，只限 mock 数据。
+- 不把图片 URL/base64 写入日志。
+- 不修改普通 workflow 图搜图主流程。
+- 所有新增逻辑有测试 ID 映射。
+

--- a/.codex/design/agentv2-图搜图-测试设计文档.md
+++ b/.codex/design/agentv2-图搜图-测试设计文档.md
@@ -1,0 +1,66 @@
+# agentv2-图搜图-测试设计文档
+
+## 测试目标
+
+证明 Agent v2 内置知识库检索在补齐图搜图能力后：
+
+- 文本检索不回归。
+- 图片 id 能被解析成图片 URL 并传入 `imageQueries`。
+- 底层图片 caption、图片向量召回、usage、nodeResponse 与普通 workflow 口径对齐。
+- 非法图片输入不会打断 Agent 主流程。
+
+## 测试范围
+
+命中 Core、Logger、Package、BugFix。UI/API/DB 不命中，不设计 UI/API/DB 专项测试。
+
+## 测试用例
+
+| ID | 类型 | 目标文件 | 场景 | 输入 | 预期 |
+|---|---|---|---|---|---|
+| T-AGENT-IMG-001 | 单元 | `packages/service/test/core/workflow/dispatch/ai/agent/sub/dataset.test.ts` | 纯文本检索保持现状 | `args: {"query":"FastGPT"}` | `defaultSearchDatasetData` 收到 `textQueries:["FastGPT"]`，无 `imageQueries` 或为空；query extension/chunk selection 断言保持通过 |
+| T-AGENT-IMG-002 | 单元 | `packages/service/test/core/workflow/dispatch/ai/agent/sub/dataset.test.ts` | 纯图片检索 | `args: {"query":"","imageUrls":["https://host/a.png"]}` 或实现选择后的等价内部入参 | `defaultSearchDatasetData` 收到 `textQueries:[]`、`imageQueries:["https://host/a.png"]`、`vlmModel` |
+| T-AGENT-IMG-003 | 单元 | `packages/service/test/core/workflow/dispatch/ai/agent/sub/dataset.test.ts` | 图文混合检索 | `query:"找类似这张图的资料"` + 图片 URL | `textQueries` 和 `imageQueries` 分开传递，不把图片 URL 拼进文本 |
+| T-AGENT-IMG-004 | 单元 | `packages/service/test/core/workflow/dispatch/ai/agent/sub/dataset.test.ts` | 图片 caption 计费 | mock `defaultSearchDatasetData` 返回 `imageCaptionResult` | `usages` 包含 `account_usage:image_parse`，`childrenResponses` 包含图片解析子节点，`childTotalPoints` 或等价汇总正确 |
+| T-AGENT-IMG-005 | 单元 | `packages/service/test/core/workflow/dispatch/ai/agent/sub/dataset.test.ts` | 外部 OpenAI key 计费 | `imageCaptionResult.usedUserOpenAIKey=true` | 图片解析 usage `totalPoints=0` |
+| T-AGENT-IMG-006 | 单元 | `packages/service/test/core/workflow/dispatch/ai/agent/utils.test.ts` | dataset tool 获取图片映射 | `allFilesMap` 含 image，工具 args 含 image id | `dispatchAgentDatasetSearch` 收到解析后的图片 URL 或 image file map |
+| T-AGENT-IMG-007 | 单元 | `packages/service/test/core/workflow/dispatch/ai/agent/utils.test.ts` | 非图片 id 不进入图搜图 | `allFilesMap` 中 id 为 document | dataset search 不把 document URL 传为 image query |
+| T-AGENT-IMG-008 | 单元 | `packages/service/test/core/workflow/dispatch/ai/agent/adapter/userContext.test.ts` | Agent 文件上下文保留 image | 当前轮上传 image | `allFilesMap` 包含 image，`filesMap` 不包含 image，`# Input Files` 展示 type=image |
+| T-AGENT-IMG-009 | 回归 | `packages/service/test/core/workflow/dispatch/ai/agent/sub/dataset.test.ts` | 无知识库/空结果 | `datasetParams` 空或搜索结果空 | 保持 `No dataset selected` / `未找到相关信息。` 现有行为 |
+
+## 手工验证
+
+| ID | 路径 | 步骤 | 通过标准 |
+|---|---|---|---|
+| M-AGENT-IMG-001 | Agent v2 对话 | 创建/使用已选图片索引知识库的 Chat Agent v2，上传一张图片，询问“检索相似图片内容” | Agent 调用 `dataset_search`，运行详情出现知识库检索结果，能返回相关引用 |
+| M-AGENT-IMG-002 | Agent v2 图文混合 | 上传图片并输入文本限定条件 | 结果受文本和图片共同影响，不只按文本检索 |
+| M-AGENT-IMG-003 | 普通 workflow/简易应用回归 | 使用已有简易应用知识库图搜图入口上传图片检索 | 行为不变，`queryImages`/图片预览/计费不回归 |
+
+## 建议执行命令
+
+```bash
+pnpm test packages/service/test/core/workflow/dispatch/ai/agent/sub/dataset.test.ts
+pnpm test packages/service/test/core/workflow/dispatch/ai/agent/utils.test.ts
+pnpm test packages/service/test/core/workflow/dispatch/ai/agent/adapter/userContext.test.ts
+pnpm test packages/service/test/core/workflow/dispatch/dataset/search.test.ts
+```
+
+若仓库测试匹配不支持直接指定文件，则使用对应 workspace 命令：
+
+```bash
+pnpm --filter @fastgpt/service test -- core/workflow/dispatch/ai/agent/sub/dataset.test.ts
+```
+
+## Mock 约束
+
+- `defaultSearchDatasetData` 可以 mock，用于验证 Agent 传参和 usage 汇总，不在该测试里重测底层召回。
+- `MongoDataset.findById` 可以 mock，用于验证 `vectorModel vlmModel` 查询和传递。
+- `createLLMResponse` 继续按现有测试 mock，用于 chunk selection。
+- 不 mock `DatasetSearchToolSchema`，因为本需求核心就是工具参数协议。
+
+## 回归重点
+
+- Agent 文本检索仍能通过 `queryExtensionResult` 和 chunk selection。
+- `read_files` 仍只能读取 document，不因为新增图片映射误把图片传给文件解析。
+- `allFilesMap` 给 sandbox 的能力不变。
+- 图片 caption 失败时不抛出中断，底层已有 `logger.warn('Image caption generation failed during dataset search')` 降级逻辑。
+

--- a/.codex/design/agentv2-图搜图-需求确认文档.md
+++ b/.codex/design/agentv2-图搜图-需求确认文档.md
@@ -1,0 +1,115 @@
+# agentv2-图搜图-需求确认文档
+
+## 目标
+
+在 Agent v2 内置知识库检索工具中补齐图搜图能力，使其复用当前工作流/简易应用已经稳定的多模态知识库检索链路：
+
+- 用户在 Agent v2 对话中上传图片并选择知识库后，Agent 可以调用 `dataset_search` 按图片内容检索知识库。
+- 文本检索、图文混合检索、纯图片检索共用 `defaultSearchDatasetData` 的召回、融合、计费和运行详情能力。
+- 不新增 UI，不新增 API，不新增 DB 字段，不改变训练/索引生成语义。
+
+## 现状事实表
+
+| 能力项 | 现有位置 | 复用/修改/新增建议 |
+|---|---|---|
+| Agent v2 内置知识库工具定义 | `packages/service/core/workflow/dispatch/ai/agent/sub/dataset/utils.ts` 的 `DatasetSearchToolSchema` / `datasetSearchTool` | 修改：增加图片文件 id 参数，让模型能把 `# Input Files` 中的 image 传给工具 |
+| Agent v2 知识库工具执行 | `packages/service/core/workflow/dispatch/ai/agent/sub/dataset/index.ts` 的 `dispatchAgentDatasetSearch` | 修改：从纯 `textQueries: [query]` 扩展为文本 + 图片 query；读取 `vectorModel vlmModel`；补齐图片解析计费 |
+| Agent v2 工具调度 | `packages/service/core/workflow/dispatch/ai/agent/utils.ts` 的 `ToolDispatchContext` / `getExecuteTool` | 修改：把图片文件映射传给 dataset tool，而不是只给 `read_files` 传 document map |
+| Agent 文件上下文 | `packages/service/core/workflow/dispatch/ai/agent/adapter/userContext.ts` 的 `filesMap` / `allFilesMap` | 复用：`allFilesMap` 已包含 image/document；`filesMap` 仅 document，不能直接用于图搜图 |
+| 普通工作流知识库图搜图入口 | `packages/service/core/workflow/dispatch/dataset/search.ts` 的 `normalizeDatasetSearchInput`、`imageQueries`、`imageCaptionResult` | 复用：Agent v2 应对齐这里的输入拆分、`vlmModel`、usage、nodeResponse 口径 |
+| 默认多模态召回 | `packages/service/core/dataset/search/defaultRecall/index.ts` | 复用：这里已经完成图片 caption、图片向量召回、图文融合、阈值过滤、token 裁剪 |
+| 图片向量召回 | `packages/service/core/dataset/search/defaultRecall/embeddingRecall.ts` | 复用：支持图片 embedding 模型时走 `getVectors({ type: 'image' })` |
+| 图片 caption | `packages/service/core/dataset/search/defaultRecall/imageCaption.ts` | 复用：通过 `vlmModel` 生成图片描述，并输出 `imageCaptionResult` 供计费和运行详情使用 |
+| 简易应用知识库图搜图 | `projects/app/src/pageComponents/app/detail/Edit/SimpleApp/utils.ts` | 事实：简易应用把 `userChatInput` 和 `userFiles` 一起作为 `datasetSearchInput` 传给知识库节点 |
+| Chat Agent v2 配置入口 | `projects/app/src/pageComponents/app/detail/Edit/ChatAgent/utils.ts` / `packages/global/core/workflow/template/system/agent/index.ts` | 事实：Agent 节点已有 `fileUrlList`、`datasetParams`、`aiChatVision` 等配置，本需求不需要新增 UI |
+
+## 问题定位
+
+| 现象 | 代码证据 | 结论 |
+|---|---|---|
+| Agent v2 `dataset_search` 只能接文本 | `packages/service/core/workflow/dispatch/ai/agent/sub/dataset/utils.ts` 中 `DatasetSearchToolSchema` 只有 `query: z.string()` | 模型没有协议把图片 id 传给知识库工具 |
+| Agent v2 dataset tool 执行时拿不到图片 URL | `packages/service/core/workflow/dispatch/ai/agent/utils.ts` 的 `ToolDispatchContext` 只有 `filesMap`，而 `userContext.ts` 注释说明 `filesMap` 只保留 document | 即使用户上传图片，dataset tool 也没有图片 URL 映射 |
+| Agent v2 检索只走文本 query | `dispatchAgentDatasetSearch` 构造 `textQueries: [query]`，没有 `imageQueries` | 底层图搜图链路根本没被触发 |
+| Agent v2 没有读取 `vlmModel` | `MongoDataset.findById(datasetIds[0], 'vectorModel')` | 图片 caption 召回缺少模型来源 |
+| Agent v2 没有图片解析计费和运行详情 | Agent dataset tool 只处理 `queryExtensionResult`、embedding、rerank、chunk selection | 即使后续加了图片检索，不补 usage 会账单/运行详情缺口 |
+
+## 根因分析
+
+| 层级 | 根因 |
+|---|---|
+| 直接原因 | Agent v2 内置 `dataset_search` 工具协议和执行入参只按文本查询设计，没有图片 id / 图片 URL 传递通道。 |
+| 深层原因 | 工作流知识库节点已经升级为 `datasetSearchInput -> textQueries/imageQueries -> defaultSearchDatasetData` 的多模态链路，但 Agent v2 内置工具是另一条调度路径，未同步这次图搜图能力。 |
+
+## 需求范围
+
+必须做：
+
+- 为 Agent v2 `dataset_search` 增加可选图片输入参数，建议命名为 `imageIds?: string[]`，语义为 `# Input Files` 中 type=image 的文件 id。
+- `getExecuteTool` 把 Agent 当前轮与历史可访问图片映射传给 `dispatchAgentDatasetSearch`。
+- `dispatchAgentDatasetSearch` 将 `query` 和图片 URL 组合为 `textQueries` / `imageQueries`，并传入 `defaultSearchDatasetData`。
+- 读取知识库 `vectorModel vlmModel`，对齐普通工作流图片 caption 召回。
+- 对齐普通 workflow 的 `imageCaptionResult` usage、childrenResponses、`childTotalPoints` 与 `datasetQueries` 展示口径。
+- 保留 Agent v2 现有文本检索、query extension、rerank、chunk selection、外部 OpenAI key 计费口径。
+- 补充单测覆盖图搜图、图文混合、非法图片 id、空 query + 图片、外部 OpenAI key 场景。
+
+明确不做：
+
+- 不新增或修改前端 UI；当前文件上传、知识库选择、模型配置入口继续复用。
+- 不新增 API 路由或 OpenAPI 合约。
+- 不新增 DB 字段、索引或迁移。
+- 不修改知识库训练、图片索引构建、图片 embedding 模型配置流程。
+- 不把图片 URL 直接混入普通 query 字符串；图片必须作为结构化 `imageQueries` 进入检索。
+- 不修改 `read_files` 只读 document 的语义。
+
+## UI 判定
+
+UI: No。
+
+理由：Chat Agent v2 已有文件输入和知识库参数配置入口，代码锚点为 `projects/app/src/pageComponents/app/detail/Edit/ChatAgent/utils.ts` 中 `Input_Template_File_Link`、`NodeInputKeyEnum.datasetParams`，以及 `packages/global/core/workflow/template/system/agent/index.ts` 的知识库参数输入。本需求只补 Agent v2 后端工具协议和检索调度，不引入新页面、弹窗、表单状态或 Figma 设计。
+
+## 影响域判定矩阵
+
+| 维度 | 是否命中 | 证据 | 需要核对的规范 |
+|---|---|---|---|
+| API | No | 不新增 NextJS API 路由；只改 Agent 内部工具 schema | `references/style/api.md` |
+| DB | No | 不新增字段，仅读取 `MongoDataset` 已有 `vlmModel` | `references/style/db.md` |
+| Front | No | 不改页面/组件，复用现有 Agent 文件和知识库配置 | `references/style/front.md` |
+| UI | No | UI: No，理由见上 | `references/ui-design-development-standards.md` |
+| Figma | No | 未提供 Figma，且无新 UI | Figma MCP |
+| Logger | Yes | Agent dataset search 和底层图片解析已有 logger；新增非法图片 id/图片解析失败需保持结构化日志 | `references/style/logger.md` |
+| Package | Yes | 改动在 `packages/service`，需遵守 `service -> global` 依赖方向 | `references/style/package.md` |
+| BugFix | Yes | 现有 Agent v2 图搜图链路缺失，属于能力漏接/行为缺陷 | `references/bug-fix-workflow.md` |
+| DocUpdate | No | 本次先做内部设计，不要求同步产品文档 | `references/doc-update-reminder.md` |
+| DocI18n | No | 不改 `document/content/docs` | `references/doc-i18n-standards.md` |
+
+## 验收标准
+
+- Agent v2 `dataset_search` schema 含文本 query 和可选图片 id 参数，模型能按 `# Input Files` 中的 image id 调用。
+- 纯文本检索行为与当前一致，仍支持 query extension、rerank、chunk selection。
+- 纯图片检索时，即使 `query` 为空，也能通过图片 URL 进入 `imageQueries`，触发图片向量召回；若配置了可用 `vlmModel`，同时触发图片 caption 召回。
+- 图文混合检索时，文本 query 和图片 query 分别进入底层召回，不拼接成单一字符串。
+- `nodeResponse` 展示 `datasetQueries` 或等价字段，包含文本 query 与图片 URL；`quoteList` 为最终结果。
+- 图片 caption usage 进入 `usages`，并在 `childrenResponses` 中展示图片解析子调用；使用外部 OpenAI key 时图片解析点数为 0。
+- 非法/不存在/非图片 `imageIds` 不应导致整个 Agent 崩溃；应忽略无效 id 或返回可理解的工具错误，具体策略在开发文档固定。
+- 所有新增/更新测试通过。
+
+## 修复方案对比
+
+| 方案 | 做法 | 优点 | 风险 | 结论 |
+|---|---|---|---|---|
+| A 最小修复 | 在 Agent 内置 dataset tool 增加 `imageIds`，用 `allFilesMap` 映射图片 URL，在 `dispatchAgentDatasetSearch` 对齐普通 workflow 搜索参数和 usage | 改动最小，复用成熟检索链路，不动 UI/DB/API | 依赖模型按 schema 传 image id；需要 prompt/schema 描述清楚 | 推荐 |
+| B 结构修复 | 把普通 workflow `dispatchDatasetSearch` 抽成更通用 service，Agent 和 workflow 共用同一 dispatch 封装 | 长期重复更少 | 改动面大，容易影响普通 workflow，和本次问题不成比例 | 暂不采用 |
+
+## 回滚触发条件
+
+- 纯文本 Agent v2 知识库检索回归，出现 query extension、rerank、chunk selection 结果或计费异常。
+- 普通 workflow/简易应用知识库检索测试失败。
+- Agent 工具调用 schema 导致主模型频繁无法生成合法 tool args。
+- 图片检索触发异常导致 Agent 主流程中断，而不是降级为空结果。
+
+## 待确认项
+
+1. `imageIds` 无效时，期望“忽略无效图片继续按文本搜”，还是“返回工具错误提示模型重试”？建议默认忽略无效 id 并记录 debug/warn，避免用户体验炸锅。
+2. 纯图片检索时 `query` 是否允许空字符串？建议允许，否则模型为凑 required query 会编一个废话 query，挺添乱。
+3. Agent v2 nodeResponse 是否要新增 `datasetQueries` 字段并兼容旧 `query` 字段？建议保留 `query` 文本字段，同时新增 `datasetQueries`，避免前端展示老逻辑突然没饭吃。
+

--- a/packages/service/core/workflow/dispatch/ai/agent/index.ts
+++ b/packages/service/core/workflow/dispatch/ai/agent/index.ts
@@ -262,6 +262,7 @@ export const dispatchRunAgent = async (props: DispatchAgentModuleProps): Promise
         getSubApp,
         completionTools: agentCompletionTools,
         filesMap,
+        allFilesMap,
         capabilityToolCallHandler,
         streamResponseFn: workflowStreamResponse
       },

--- a/packages/service/core/workflow/dispatch/ai/agent/piAgent/index.ts
+++ b/packages/service/core/workflow/dispatch/ai/agent/piAgent/index.ts
@@ -214,6 +214,7 @@ export const dispatchPiAgent = async (props: DispatchAgentModuleProps): Promise<
       getSubApp,
       completionTools: agentCompletionTools,
       filesMap,
+      allFilesMap,
       capabilityToolCallHandler
     };
 

--- a/packages/service/core/workflow/dispatch/ai/agent/sub/dataset/index.ts
+++ b/packages/service/core/workflow/dispatch/ai/agent/sub/dataset/index.ts
@@ -23,6 +23,7 @@ import type { OpenaiAccountType } from '@fastgpt/global/support/user/team/type';
 import type { ChatHistoryItemResType } from '@fastgpt/global/core/chat/type';
 import {
   createChunkSelectionChildNodeResponse,
+  createImageCaptionChildNodeResponse,
   createQueryExtensionChildNodeResponse
 } from '../../../../dataset/nodeResponse';
 const logger = getLogger(LogCategories.MODULE.AI.AGENT);
@@ -31,6 +32,7 @@ type DatasetSearchParams = {
   teamId: string;
   tmbId: string;
   args: string;
+  imageUrls?: string[];
   llmModel: string;
   userKey?: OpenaiAccountType;
   datasetParams?: AppFormEditFormType['dataset'];
@@ -161,6 +163,7 @@ ${chunkSummaries}
 
 export const dispatchAgentDatasetSearch = async ({
   args,
+  imageUrls,
   datasetParams,
   teamId,
   llmModel,
@@ -179,28 +182,55 @@ export const dispatchAgentDatasetSearch = async ({
     };
   }
 
-  const query = toolParams.data.query;
+  const query = toolParams.data.query.trim();
+  // Agent v2 工具允许纯图检索，此时 query 为空，只把图片 URL 传给底层检索。
+  const textQueries = query ? [query] : [];
+  const seenImageUrls = new Set<string>();
+  // 同一张图片可能被模型重复传入 imageIds；这里按 URL 去重，避免重复 embedding/VLM 消耗。
+  const imageQueries = (imageUrls || [])
+    .map((url) => url.trim())
+    .filter((url) => {
+      if (!url || seenImageUrls.has(url)) return false;
+      seenImageUrls.add(url);
+      return true;
+    });
+
+  if (textQueries.length === 0 && imageQueries.length === 0) {
+    return {
+      response: formatDatasetSearchResponse([]),
+      usages: [],
+      nodeResponse: {
+        moduleType: FlowNodeTypeEnum.datasetSearchNode,
+        moduleName: i18nT('chat:dataset_search'),
+        query,
+        datasetQueries: [],
+        quoteList: []
+      }
+    };
+  }
 
   logger.debug('[Agent Dataset Search] Starting', {
     query,
+    imageCount: imageQueries.length,
     datasetParams
   });
 
   try {
     const datasetIds = await Promise.resolve(datasetParams.datasets.map((item) => item.datasetId));
 
-    // Get vector model
-    const vectorModel = getEmbeddingModel(
-      (await MongoDataset.findById(datasetIds[0], 'vectorModel').lean())?.vectorModel
-    );
+    // Get vector model and VLM model
+    const dataset = await MongoDataset.findById(datasetIds[0], 'vectorModel vlmModel').lean();
+    const vectorModel = getEmbeddingModel(dataset?.vectorModel);
     // Get Rerank Model
     const rerankModelData = getRerankModel(datasetParams.rerankModel);
 
     const searchData: DefaultSearchDatasetDataProps = {
       histories: [],
       teamId,
-      textQueries: [query],
+      textQueries,
+      imageQueries,
       model: vectorModel.model,
+      vlmModel: dataset?.vlmModel,
       similarity: datasetParams.similarity ?? 0.4,
       limit: datasetParams.limit || 5000,
       datasetIds,
@@ -209,6 +239,7 @@ export const dispatchAgentDatasetSearch = async ({
       usingReRank: datasetParams.usingReRank,
       rerankModel: rerankModelData,
       rerankWeight: datasetParams.rerankWeight ?? 0.5,
+      collectionFilterMatch: datasetParams.collectionFilterMatch,
       datasetSearchUsingExtensionQuery: datasetParams.datasetSearchUsingExtensionQuery ?? false,
       datasetSearchExtensionModel: datasetParams.datasetSearchExtensionModel,
       datasetSearchExtensionBg: datasetParams.datasetSearchExtensionBg,
@@ -220,7 +251,8 @@ export const dispatchAgentDatasetSearch = async ({
       reRankInputTokens,
       usingSimilarityFilter,
       usingReRank: searchUsingReRank,
-      queryExtensionResult
+      queryExtensionResult,
+      imageCaptionResult
     } = await defaultSearchDatasetData(searchData);
 
     // count bill results
@@ -296,11 +328,37 @@ export const dispatchAgentDatasetSearch = async ({
           inputTokens: reRankInputTokens
         });
       }
+      // 4. Image caption
+      if (imageCaptionResult) {
+        // 底层图搜图会先用数据集 VLM 把图片转成文本描述，这部分要作为图片解析子调用计费和展示。
+        const { totalPoints, modelName } = formatModelChars2Points({
+          model: imageCaptionResult.model,
+          inputTokens: imageCaptionResult.inputTokens,
+          outputTokens: imageCaptionResult.outputTokens
+        });
+        const imageCaptionUsage: ChatNodeUsageType = {
+          totalPoints: imageCaptionResult.usedUserOpenAIKey ? 0 : totalPoints,
+          moduleName: i18nT('account_usage:image_parse'),
+          model: modelName,
+          inputTokens: imageCaptionResult.inputTokens,
+          outputTokens: imageCaptionResult.outputTokens
+        };
+        usages.push(imageCaptionUsage);
+        childrenResponses.push(
+          createImageCaptionChildNodeResponse({
+            requestIds: imageCaptionResult.requestIds,
+            usage: imageCaptionUsage,
+            seconds: imageCaptionResult.seconds,
+            queries: imageCaptionResult.queries
+          })
+        );
+      }
     }
 
     // LLM Pick Chunks (compress search results if too long)
     const pickResults = await selectRelevantChunksByLLM({
-      query,
+      // 纯图检索没有用户文本，用稳定占位问题触发分块压缩，避免空 query 影响 chunk selection。
+      query: query || (imageQueries.length > 0 ? '用户上传的图片' : ''),
       chunks: searchRes,
       model: llmModel,
       userKey
@@ -323,11 +381,16 @@ export const dispatchAgentDatasetSearch = async ({
       }
     }
     const formattedResponse = formatDatasetSearchResponse(searchResults);
+    const childTotalPoints = childrenResponses.reduce(
+      (sum, item) => sum + (item.totalPoints || 0),
+      0
+    );
 
     const nodeResponse: DispatchSubAppResponse['nodeResponse'] = {
       moduleType: FlowNodeTypeEnum.datasetSearchNode,
       moduleName: i18nT('chat:dataset_search'),
       query,
+      datasetQueries: [...textQueries, ...imageQueries],
       embeddingModel: vectorModel.name,
       embeddingTokens,
       similarity: usingSimilarityFilter ? searchData.similarity : undefined,
@@ -345,6 +408,7 @@ export const dispatchAgentDatasetSearch = async ({
       }),
       searchUsingReRank,
       ...(childrenResponses.length > 0 ? { childrenResponses } : {}),
+      ...(childTotalPoints > 0 ? { childTotalPoints } : {}),
       // Results
       quoteList: searchResults
     };

--- a/packages/service/core/workflow/dispatch/ai/agent/sub/dataset/utils.ts
+++ b/packages/service/core/workflow/dispatch/ai/agent/sub/dataset/utils.ts
@@ -6,7 +6,8 @@ import type { DatasetSearchModeEnum } from '@fastgpt/global/core/dataset/constan
 
 // 工具参数 Schema (Agent 调用时传递的参数)
 export const DatasetSearchToolSchema = z.object({
-  query: z.string()
+  query: z.string().default(''),
+  imageIds: z.array(z.string()).optional()
 });
 
 // 工具配置类型（从 Agent 节点配置传入的预设参数）
@@ -32,13 +33,20 @@ export const datasetSearchTool: ChatCompletionTool = {
   function: {
     name: SubAppIds.datasetSearch,
     description:
-      '搜索知识库获取相关信息。当需要查询知识库中的专业知识、文档内容或历史记录时使用此工具。',
+      '搜索知识库获取相关信息。当需要查询知识库中的专业知识、文档内容、历史记录，或需要根据输入图片检索知识库图片时使用此工具。',
     parameters: {
       type: 'object',
       properties: {
         query: {
           type: 'string',
-          description: '要搜索的查询文本，描述需要查找的信息'
+          description: '要搜索的查询文本，描述需要查找的信息；如果只按图片检索，可以传空字符串'
+        },
+        imageIds: {
+          type: 'array',
+          items: {
+            type: 'string'
+          },
+          description: '# Input Files 中 type 为 image 的文件 ID；需要按图片内容检索知识库时传入'
         }
       },
       required: ['query']

--- a/packages/service/core/workflow/dispatch/ai/agent/utils.ts
+++ b/packages/service/core/workflow/dispatch/ai/agent/utils.ts
@@ -4,10 +4,11 @@ import type { DispatchSubAppResponse, GetSubAppInfoFnType, SubAppRuntimeType } f
 import { getAgentRuntimeTools } from './sub/tool/utils';
 import type { ChatCompletionTool } from '@fastgpt/global/core/ai/llm/type';
 import { readFileTool, ReadFileToolSchema } from './sub/file/utils';
-import { datasetSearchTool } from './sub/dataset/utils';
+import { DatasetSearchToolSchema, datasetSearchTool } from './sub/dataset/utils';
 import { SANDBOX_TOOLS, sandboxToolMap } from '@fastgpt/global/core/ai/sandbox/constants';
 import type { ChatNodeUsageType } from '@fastgpt/global/support/wallet/bill/type';
 import { SubAppIds } from '@fastgpt/global/core/workflow/node/agent/constants';
+import { ChatFileTypeEnum } from '@fastgpt/global/core/chat/constants';
 import { dispatchFileRead } from './sub/file';
 import type { DispatchAgentModuleProps } from '.';
 import { dispatchAgentDatasetSearch } from './sub/dataset';
@@ -121,6 +122,7 @@ export type ToolDispatchContext = Pick<
   getSubApp: (id: string) => SubAppRuntimeType | undefined;
   completionTools: ChatCompletionTool[];
   filesMap: Record<string, string>;
+  allFilesMap?: Record<string, { url: string; name: string; type: string }>;
   capabilityToolCallHandler?: CapabilityToolCallHandlerType;
   streamResponseFn?: (args: WorkflowResponseItemType) => void | undefined;
 };
@@ -133,6 +135,7 @@ export const getExecuteTool = ({
   getSubAppInfo,
   getSubApp,
   filesMap,
+  allFilesMap = {},
   capabilityToolCallHandler,
   checkIsStopping,
   chatConfig,
@@ -221,8 +224,24 @@ export const getExecuteTool = ({
           };
         }
         if (toolId === SubAppIds.datasetSearch) {
+          const toolParams = DatasetSearchToolSchema.safeParse(parseJsonArgs(args));
+          const seenImageUrls = new Set<string>();
+          // dataset_search 只信任 # Input Files 中已登记的图片文件，避免模型伪造 URL 或把文档当图片检索。
+          const imageUrls = toolParams.success
+            ? (toolParams.data.imageIds || [])
+                .map((id) => allFilesMap[id])
+                .filter((file) => file?.type === ChatFileTypeEnum.image)
+                .map((file) => file.url)
+                .filter((url) => {
+                  if (!url || seenImageUrls.has(url)) return false;
+                  seenImageUrls.add(url);
+                  return true;
+                })
+            : [];
+
           const result = await dispatchAgentDatasetSearch({
             args: args,
+            imageUrls,
             datasetParams,
             teamId: runningUserInfo.teamId,
             tmbId: runningUserInfo.tmbId,

--- a/packages/service/test/core/workflow/dispatch/ai/agent/sub/dataset.test.ts
+++ b/packages/service/test/core/workflow/dispatch/ai/agent/sub/dataset.test.ts
@@ -64,7 +64,8 @@ describe('dispatchAgentDatasetSearch', () => {
     vi.clearAllMocks();
     findDatasetByIdMock.mockReturnValue({
       lean: vi.fn().mockResolvedValue({
-        vectorModel: 'embedding-model'
+        vectorModel: 'embedding-model',
+        vlmModel: 'vlm-model'
       })
     });
     countPromptTokensMock.mockResolvedValue(100);
@@ -190,6 +191,213 @@ describe('dispatchAgentDatasetSearch', () => {
     );
     expect(result.nodeResponse?.quoteList?.map((item: { id: string }) => item.id)).toEqual([
       'chunk_2'
+    ]);
+  });
+
+  it('passes image queries and vlm model to dataset search for image-only search', async () => {
+    countPromptTokensMock.mockResolvedValueOnce(0);
+    defaultSearchDatasetDataMock.mockResolvedValue({
+      searchRes: [],
+      embeddingTokens: 0,
+      reRankInputTokens: 0,
+      usingSimilarityFilter: false,
+      usingReRank: false
+    });
+
+    const result = await dispatchAgentDatasetSearch({
+      args: JSON.stringify({ query: '', imageIds: ['current-0'] }),
+      imageUrls: ['https://file.example.com/cat.png'],
+      teamId: 'team_1',
+      tmbId: 'tmb_1',
+      llmModel: 'gpt-main',
+      datasetParams: {
+        datasets: [{ datasetId: 'dataset_1' }],
+        similarity: 0.4,
+        limit: 5000,
+        searchMode: DatasetSearchModeEnum.embedding,
+        embeddingWeight: 0.5,
+        usingReRank: false,
+        rerankWeight: 0.5,
+        datasetSearchUsingExtensionQuery: true
+      } as any
+    });
+
+    expect(defaultSearchDatasetDataMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        textQueries: [],
+        imageQueries: ['https://file.example.com/cat.png'],
+        vlmModel: 'vlm-model'
+      })
+    );
+    expect(result.response).toBe('未找到相关信息。');
+    expect(result.nodeResponse).toEqual(
+      expect.objectContaining({
+        query: '',
+        datasetQueries: ['https://file.example.com/cat.png'],
+        quoteList: []
+      })
+    );
+  });
+
+  it('keeps text and image queries separated for mixed search', async () => {
+    countPromptTokensMock.mockResolvedValueOnce(0);
+    defaultSearchDatasetDataMock.mockResolvedValue({
+      searchRes: [
+        {
+          id: 'chunk_1',
+          q: 'image question',
+          a: 'image answer',
+          sourceName: 'image.png',
+          score: [{ type: SearchScoreTypeEnum.embedding, value: 0.9, index: 0 }]
+        }
+      ],
+      embeddingTokens: 3,
+      reRankInputTokens: 0,
+      usingSimilarityFilter: false,
+      usingReRank: false
+    });
+
+    await dispatchAgentDatasetSearch({
+      args: JSON.stringify({ query: '找类似图片', imageIds: ['current-0'] }),
+      imageUrls: ['https://file.example.com/cat.png'],
+      teamId: 'team_1',
+      tmbId: 'tmb_1',
+      llmModel: 'gpt-main',
+      datasetParams: {
+        datasets: [{ datasetId: 'dataset_1' }],
+        similarity: 0.4,
+        limit: 5000,
+        searchMode: DatasetSearchModeEnum.embedding,
+        embeddingWeight: 0.5,
+        usingReRank: false,
+        rerankWeight: 0.5
+      } as any
+    });
+
+    expect(defaultSearchDatasetDataMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        textQueries: ['找类似图片'],
+        imageQueries: ['https://file.example.com/cat.png']
+      })
+    );
+  });
+
+  it('adds image caption as dataset search child node response', async () => {
+    countPromptTokensMock.mockResolvedValueOnce(0);
+    defaultSearchDatasetDataMock.mockResolvedValue({
+      searchRes: [
+        {
+          id: 'chunk_1',
+          q: 'question 1',
+          a: 'answer 1',
+          sourceName: 'doc.md',
+          score: [{ type: SearchScoreTypeEnum.embedding, value: 0.9, index: 0 }]
+        }
+      ],
+      embeddingTokens: 20,
+      reRankInputTokens: 0,
+      usingSimilarityFilter: true,
+      usingReRank: false,
+      imageCaptionResult: {
+        model: 'vlm-model',
+        inputTokens: 11,
+        outputTokens: 4,
+        requestIds: ['req_image_caption'],
+        seconds: 1.5,
+        usedUserOpenAIKey: false,
+        queries: ['一只橘猫坐在窗边']
+      }
+    });
+
+    const result = await dispatchAgentDatasetSearch({
+      args: JSON.stringify({ query: '', imageIds: ['current-0'] }),
+      imageUrls: ['https://file.example.com/cat.png'],
+      teamId: 'team_1',
+      tmbId: 'tmb_1',
+      llmModel: 'gpt-main',
+      datasetParams: {
+        datasets: [{ datasetId: 'dataset_1' }],
+        similarity: 0.4,
+        limit: 5000,
+        searchMode: DatasetSearchModeEnum.embedding,
+        embeddingWeight: 0.5,
+        usingReRank: false,
+        rerankWeight: 0.5
+      } as any
+    });
+
+    expect(result.nodeResponse?.childrenResponses).toEqual([
+      expect.objectContaining({
+        id: 'req_image_caption',
+        nodeId: 'req_image_caption',
+        moduleType: FlowNodeTypeEnum.datasetSearchNode,
+        moduleName: 'account_usage:image_parse',
+        moduleLogo: 'core/workflow/template/datasetSearch',
+        model: 'vlm-model name',
+        llmRequestIds: ['req_image_caption'],
+        inputTokens: 11,
+        outputTokens: 4,
+        totalPoints: 0.15,
+        textOutput: '一只橘猫坐在窗边'
+      })
+    ]);
+    expect(result.nodeResponse).toEqual(
+      expect.objectContaining({
+        childTotalPoints: 0.15
+      })
+    );
+    expect(result.usages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          moduleName: 'account_usage:image_parse',
+          totalPoints: 0.15
+        })
+      ])
+    );
+  });
+
+  it('sets image caption LLM points to zero when user OpenAI key is valid', async () => {
+    countPromptTokensMock.mockResolvedValueOnce(0);
+    defaultSearchDatasetDataMock.mockResolvedValue({
+      searchRes: [],
+      embeddingTokens: 0,
+      reRankInputTokens: 0,
+      usingSimilarityFilter: false,
+      usingReRank: false,
+      imageCaptionResult: {
+        model: 'vlm-model',
+        inputTokens: 11,
+        outputTokens: 4,
+        requestIds: ['req_image_caption'],
+        seconds: 1.5,
+        usedUserOpenAIKey: true,
+        queries: ['一只橘猫坐在窗边']
+      }
+    });
+
+    const result = await dispatchAgentDatasetSearch({
+      args: JSON.stringify({ query: '', imageIds: ['current-0'] }),
+      imageUrls: ['https://file.example.com/cat.png'],
+      teamId: 'team_1',
+      tmbId: 'tmb_1',
+      llmModel: 'gpt-main',
+      userKey: { key: 'user-key' } as any,
+      datasetParams: {
+        datasets: [{ datasetId: 'dataset_1' }],
+        similarity: 0.4,
+        limit: 5000,
+        searchMode: DatasetSearchModeEnum.embedding,
+        embeddingWeight: 0.5,
+        usingReRank: false,
+        rerankWeight: 0.5
+      } as any
+    });
+
+    expect(result.nodeResponse?.childrenResponses).toEqual([
+      expect.objectContaining({
+        moduleName: 'account_usage:image_parse',
+        totalPoints: 0
+      })
     ]);
   });
 

--- a/packages/service/test/core/workflow/dispatch/ai/agent/utils.test.ts
+++ b/packages/service/test/core/workflow/dispatch/ai/agent/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { SubAppIds } from '@fastgpt/global/core/workflow/node/agent/constants';
+import { ChatFileTypeEnum } from '@fastgpt/global/core/chat/constants';
 import { getSubapps, getExecuteTool } from '@fastgpt/service/core/workflow/dispatch/ai/agent/utils';
 import { readFileTool } from '@fastgpt/service/core/workflow/dispatch/ai/agent/sub/file/utils';
 
@@ -169,6 +170,80 @@ describe('Agent read_files tool protocol', () => {
     expect(dispatchAgentDatasetSearchMock).toHaveBeenCalledWith(
       expect.objectContaining({
         userKey
+      })
+    );
+  });
+
+  it('passes image urls from allFilesMap to dataset search tool', async () => {
+    dispatchAgentDatasetSearchMock.mockResolvedValue({
+      response: 'dataset content',
+      usages: [],
+      nodeResponse: {
+        moduleName: 'Dataset Search'
+      }
+    });
+
+    const executeTool = getExecuteTool({
+      checkIsStopping: vi.fn(),
+      chatConfig: {},
+      runningUserInfo: {
+        teamId: 'team_1',
+        tmbId: 'tmb_1'
+      },
+      runningAppInfo: {
+        id: 'app_1'
+      },
+      chatId: 'chat_1',
+      uid: 'user_1',
+      variableState: {} as any,
+      externalProvider: {
+        openaiAccount: undefined
+      } as any,
+      lang: 'zh-CN',
+      requestOrigin: '',
+      mode: 'chat',
+      timezone: 'Asia/Shanghai',
+      retainDatasetCite: false,
+      maxRunTimes: 10,
+      workflowDispatchDeep: 0,
+      params: {
+        model: 'gpt-4',
+        agent_datasetParams: {
+          datasets: [{ datasetId: 'dataset_1' }]
+        }
+      },
+      stream: false,
+      getSubAppInfo: () => ({
+        name: 'Dataset Search',
+        avatar: '',
+        toolDescription: ''
+      }),
+      getSubApp: () => undefined,
+      completionTools: [],
+      filesMap: {},
+      allFilesMap: {
+        'current-0': {
+          name: 'cat.png',
+          type: ChatFileTypeEnum.image,
+          url: 'https://file.example.com/cat.png'
+        },
+        'current-1': {
+          name: 'doc.pdf',
+          type: ChatFileTypeEnum.file,
+          url: 'https://file.example.com/doc.pdf'
+        }
+      }
+    } as any);
+
+    await executeTool({
+      callId: 'call_dataset_search',
+      toolId: SubAppIds.datasetSearch,
+      args: '{"query":"","imageIds":["current-0","current-1","missing","current-0"]}'
+    });
+
+    expect(dispatchAgentDatasetSearchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        imageUrls: ['https://file.example.com/cat.png']
       })
     );
   });


### PR DESCRIPTION
## 变更内容

- 扩展 Agent v2 内置 dataset_search 工具协议，支持传入图片文件 ID
- 将 Agent v2 上下文中的已上传图片映射为 imageQueries 参与知识库检索
- 复用现有多模态知识库检索流程，补齐 vlmModel 传递
- 补齐图片解析的 usage 计费和运行详情子节点展示
- 增加纯图片检索、图文混合检索、用户 OpenAI Key 计费置零等测试覆盖

## 验证

- pnpm --filter @fastgpt/service exec vitest run -c vitest.config.ts test/core/workflow/dispatch/ai/agent/sub/dataset.test.ts test/core/workflow/dispatch/ai/agent/utils.test.ts
- git diff --check