### PR TITLE
chore: require OpenSandbox credentials

### DIFF
--- a/packages/service/core/ai/sandbox/provider/config.ts
+++ b/packages/service/core/ai/sandbox/provider/config.ts
@@ -66,6 +66,10 @@ export function validateSandboxConfig(config: SandboxProviderConfig): void {
     throw new Error(`Invalid runtime: ${config.runtime}`);
   }
 
+  if (config.provider === 'opensandbox' && !config.apiKey) {
+    throw new Error('Sandbox provider apiKey is required for opensandbox');
+  }
+
   if (config.provider === 'sealosdevbox' && !config.token) {
     throw new Error('Sandbox provider token is required for sealosdevbox');
   }
@@ -100,7 +104,7 @@ export function getSandboxAdapterConfig({
     case 'opensandbox': {
       const providerConfig: OpenSandboxProviderConfig = {
         provider,
-        baseUrl: serviceEnv.AGENT_SANDBOX_OPENSANDBOX_BASEURL,
+        baseUrl: serviceEnv.AGENT_SANDBOX_OPENSANDBOX_BASEURL ?? '',
         apiKey: serviceEnv.AGENT_SANDBOX_OPENSANDBOX_API_KEY ?? '',
         runtime: serviceEnv.AGENT_SANDBOX_OPENSANDBOX_RUNTIME,
         useServerProxy: serviceEnv.AGENT_SANDBOX_OPENSANDBOX_USE_SERVER_PROXY

--- a/packages/service/env.ts
+++ b/packages/service/env.ts
@@ -21,7 +21,9 @@ export const hasAgentSandboxConfig = () => {
   }
 
   if (provider === 'opensandbox') {
-    return !!process.env.AGENT_SANDBOX_OPENSANDBOX_BASEURL;
+    return !!(
+      process.env.AGENT_SANDBOX_OPENSANDBOX_BASEURL && process.env.AGENT_SANDBOX_OPENSANDBOX_API_KEY
+    );
   }
 
   return false;
@@ -81,7 +83,7 @@ export const serviceEnv = createEnv({
     AGENT_SANDBOX_SEALOS_TOKEN: z.string().optional(),
     AGENT_SANDBOX_SEALOS_WORK_DIRECTORY: z.string().default('/home/devbox/workspace'),
     // OpenSandbox配置
-    AGENT_SANDBOX_OPENSANDBOX_BASEURL: UrlSchema.default('http://127.0.0.1:8080'),
+    AGENT_SANDBOX_OPENSANDBOX_BASEURL: UrlSchema.optional(),
     AGENT_SANDBOX_OPENSANDBOX_API_KEY: z.string().optional(),
     AGENT_SANDBOX_OPENSANDBOX_RUNTIME: z.enum(['docker', 'kubernetes']).default('docker'),
     AGENT_SANDBOX_OPENSANDBOX_IMAGE_REPO: z.string().default('fastgpt-agent-sandbox'),

--- a/packages/service/test/core/ai/sandbox/provider/config.test.ts
+++ b/packages/service/test/core/ai/sandbox/provider/config.test.ts
@@ -154,6 +154,9 @@ describe('sandbox provider config', () => {
       expect(() => getSandboxAdapterConfig({ provider: 'sealosdevbox' })).toThrow(
         'Sandbox provider base URL is required'
       );
+      expect(() => getSandboxAdapterConfig({ provider: 'opensandbox' })).toThrow(
+        'Sandbox provider base URL is required'
+      );
       expect(() => getSandboxAdapterConfig({ provider: 'e2b' })).toThrow(
         'Sandbox provider apiKey is required for e2b'
       );
@@ -268,13 +271,14 @@ describe('sandbox provider config', () => {
     ).toThrow('Sandbox provider apiKey is required for e2b');
   });
 
-  it('validates base url and opensandbox runtime requirements', async () => {
+  it('validates base url, api key and opensandbox runtime requirements', async () => {
     const { validateSandboxConfig } = await loadSandboxConfigModule();
 
     expect(() =>
       validateSandboxConfig({
         provider: 'opensandbox',
         baseUrl: '',
+        apiKey: 'opensandbox-key',
         runtime: 'docker'
       })
     ).toThrow('Sandbox provider base URL is required');
@@ -283,12 +287,22 @@ describe('sandbox provider config', () => {
       validateSandboxConfig({
         provider: 'opensandbox',
         baseUrl: 'http://opensandbox.local',
+        apiKey: '',
+        runtime: 'docker'
+      })
+    ).toThrow('Sandbox provider apiKey is required for opensandbox');
+
+    expect(() =>
+      validateSandboxConfig({
+        provider: 'opensandbox',
+        baseUrl: 'http://opensandbox.local',
+        apiKey: 'opensandbox-key',
         runtime: 'invalid' as 'docker'
       })
     ).toThrow('Invalid runtime: invalid');
   });
 
-  it('does not require opensandbox api key for docker runtime', async () => {
+  it('requires opensandbox api key for docker runtime', async () => {
     const { validateSandboxConfig } = await loadSandboxConfigModule();
 
     expect(() =>
@@ -298,7 +312,7 @@ describe('sandbox provider config', () => {
         apiKey: '',
         runtime: 'docker'
       })
-    ).not.toThrow();
+    ).toThrow('Sandbox provider apiKey is required for opensandbox');
   });
 
   it('throws for unsupported provider in config switch', async () => {


### PR DESCRIPTION
## Summary
- Require OpenSandbox provider config to include both base URL and API key before creating adapters.
- Treat OpenSandbox as configured only when both base URL and API key are explicitly present, so the sandbox feature is not exposed with incomplete credentials.
- Update provider config tests to cover missing OpenSandbox base URL/API key and the new required-key behavior.

## Tests
- pnpm -C packages/service exec vitest run test/core/ai/sandbox/provider/config.test.ts --coverage=false
- pnpm exec eslint packages/service/env.ts packages/service/core/ai/sandbox/provider/config.ts packages/service/test/core/ai/sandbox/provider/config.test.ts
- git diff --check