### PR TITLE
fix: preserve user language preference

### DIFF
--- a/packages/global/openapi/support/user/account/login/api.ts
+++ b/packages/global/openapi/support/user/account/login/api.ts
@@ -72,9 +72,9 @@ export const LoginByPasswordBodySchema = z
       example: '123456',
       description: '预登录验证码'
     }),
-    language: LanguageSchema.optional().default('zh-CN').meta({
+    language: LanguageSchema.optional().meta({
       example: 'zh-CN',
-      description: '用户语言偏好'
+      description: '兼容旧客户端的登录页语言字段，登录不会覆盖用户语言偏好'
     })
   })
   .meta({

--- a/packages/web/hooks/useI18n.ts
+++ b/packages/web/hooks/useI18n.ts
@@ -8,6 +8,7 @@ import {
   setLangToStorage
 } from '../i18n/utils';
 import { useTranslation } from 'next-i18next';
+import { useCallback } from 'react';
 
 type ChangeLngOptions = {
   reloadOnChange?: boolean;
@@ -24,35 +25,38 @@ export const useI18nLng = () => {
    * 切换并持久化当前语言。
    * `reloadOnChange` 只给用户主动切换入口使用，确保 SSR 数据、页面命名空间和客户端状态重新按新语言初始化。
    */
-  const onChangeLng = async (lng: string, options?: ChangeLngOptions) => {
-    const lang = getLangMapping(lng);
-    const storageKey = options?.storageKey || LANG_KEY;
-    const prevLang = getPersistedLang(storageKey);
-    const currentLang = getLangMapping(i18n?.language || prevLang || lang);
+  const onChangeLng = useCallback(
+    async (lng: string, options?: ChangeLngOptions) => {
+      const lang = getLangMapping(lng);
+      const storageKey = options?.storageKey || LANG_KEY;
+      const prevLang = getPersistedLang(storageKey);
+      const currentLang = getLangMapping(i18n?.language || prevLang || lang);
 
-    setLangToStorage(lang, storageKey);
+      setLangToStorage(lang, storageKey);
 
-    await i18n?.changeLanguage?.(lang);
+      await i18n?.changeLanguage?.(lang);
 
-    if (options?.reloadOnChange && (prevLang !== lang || currentLang !== lang)) {
-      if (typeof window !== 'undefined') {
-        window.location.reload();
+      if (options?.reloadOnChange && (prevLang !== lang || currentLang !== lang)) {
+        if (typeof window !== 'undefined') {
+          window.location.reload();
+        }
       }
-    }
-  };
+    },
+    [i18n]
+  );
 
-  const setUserDefaultLng = () => {
+  const setUserDefaultLng = useCallback(() => {
     if (typeof navigator === 'undefined' || typeof localStorage === 'undefined') return;
     // 有 Cookie 时以服务端渲染语言为准；没有 Cookie 时先迁移旧的本地偏好。
     if (getLangFromCookie(LANG_KEY)) return;
 
     return onChangeLng(getLangFromLocalStorage(LANG_KEY) || navigator.language);
-  };
+  }, [onChangeLng]);
 
   /**
    * 分享页使用独立语言 Cookie；首次没有分享页偏好时，继承 NEXT_LOCALE 作为初始值。
    */
-  const setShareDefaultLng = () => {
+  const setShareDefaultLng = useCallback(() => {
     if (typeof navigator === 'undefined' || typeof localStorage === 'undefined') return;
 
     return onChangeLng(
@@ -65,7 +69,7 @@ export const useI18nLng = () => {
         storageKey: SHARE_LANG_KEY
       }
     );
-  };
+  }, [onChangeLng]);
 
   return {
     onChangeLng,

--- a/projects/app/src/components/Layout/index.tsx
+++ b/projects/app/src/components/Layout/index.tsx
@@ -76,7 +76,7 @@ const Layout = ({ children }: { children: JSX.Element }) => {
   const { setLastRoute, loading, feConfigs, llmModelList, embeddingModelList } = useSystemStore();
   const { isPc } = useSystem();
   const { userInfo, isUpdateNotification, setIsUpdateNotification } = useUserStore();
-  const { setUserDefaultLng, setShareDefaultLng } = useI18nLng();
+  const { onChangeLng, setUserDefaultLng, setShareDefaultLng } = useI18nLng();
 
   // Auto redeem coupon
   useCheckCoupon();
@@ -104,12 +104,24 @@ const Layout = ({ children }: { children: JSX.Element }) => {
 
   useMount(() => {
     if (router.pathname === '/chat/share') {
+      // 分享页使用独立语言偏好，避免访客切换语言时污染登录用户的 NEXT_LOCALE。
       setShareDefaultLng();
       return;
     }
 
+    // 普通页面首访只初始化浏览器/本地默认语言；登录后的账号语言由下面的 effect 覆盖。
     setUserDefaultLng();
   });
+
+  useEffect(() => {
+    if (router.pathname === '/chat/share') return;
+
+    const userLang = userInfo?.language;
+    if (!userLang) return;
+
+    // 账号显式语言优先级最高，登录后必须覆盖登录页或浏览器推断出的运行时语言。
+    onChangeLng(userLang);
+  }, [onChangeLng, router.pathname, userInfo?.language]);
 
   // Check model invalid
   useDebounceEffect(

--- a/projects/app/src/pageComponents/account/AccountContainer.tsx
+++ b/projects/app/src/pageComponents/account/AccountContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Box, Flex, useTheme } from '@chakra-ui/react';
 import { useSystemStore } from '@/web/common/system/useSystemStore';
 import { useRouter } from 'next/router';
@@ -39,98 +39,117 @@ const AccountContainer = ({
   const { feConfigs, systemVersion } = useSystemStore();
   const router = useRouter();
   const { isPc } = useSystem();
+  const isPlus = feConfigs.isPlus;
+  const showPay = feConfigs.show_pay;
+  const showPromotion = feConfigs.show_promotion;
+  const customDomainEnable = feConfigs.customDomain?.enable;
+  const hasManagePer = userInfo?.team?.permission.hasManagePer;
+  const isOwner = userInfo?.team?.permission.isOwner;
+  const hasApikeyCreatePer = userInfo?.team?.permission.hasApikeyCreatePer;
 
   const currentTab = useMemo(() => {
     return router.pathname.split('/').pop() as TabEnum;
   }, [router.pathname]);
 
-  const tabList = useRef([
-    {
-      icon: 'support/user/userLight',
-      label: t('account:personal_information'),
-      value: TabEnum.info
-    },
-    ...(feConfigs?.isPlus
-      ? [
-          {
-            icon: 'support/user/usersLight',
-            label: t('account:team'),
-            value: TabEnum.team
-          },
-          {
-            icon: 'support/usage/usageRecordLight',
-            label: t('account:usage_records'),
-            value: TabEnum.usage
-          }
-        ]
-      : []),
-    ...(feConfigs?.show_pay && userInfo?.team?.permission.hasManagePer
-      ? [
-          {
-            icon: 'support/bill/payRecordLight',
-            label: t('account:bills_and_invoices'),
-            value: TabEnum.bill
-          }
-        ]
-      : []),
-    {
-      icon: 'common/thirdParty',
-      label: t('account:third_party'),
-      value: TabEnum.thirdParty
-    },
-    ...(feConfigs.isPlus && feConfigs.customDomain?.enable
-      ? [
-          {
-            icon: 'common/globalLine',
-            label: t('account:custom_domain'),
-            value: TabEnum.customDomain
-          }
-        ]
-      : []),
-    {
-      icon: 'common/model',
-      label: t('account:model_provider'),
-      value: TabEnum.model
-    },
-    ...(feConfigs?.show_promotion && userInfo?.team?.permission.isOwner
-      ? [
-          {
-            icon: 'support/account/promotionLight',
-            label: t('account:promotion_records'),
-            value: TabEnum.promotion
-          }
-        ]
-      : []),
-    ...(userInfo?.team?.permission.hasApikeyCreatePer
-      ? [
-          {
-            icon: 'key',
-            label: t('account:api_key'),
-            value: TabEnum.apikey
-          }
-        ]
-      : []),
+  const tabList = useMemo(
+    () => [
+      {
+        icon: 'support/user/userLight',
+        label: t('account:personal_information'),
+        value: TabEnum.info
+      },
+      ...(isPlus
+        ? [
+            {
+              icon: 'support/user/usersLight',
+              label: t('account:team'),
+              value: TabEnum.team
+            },
+            {
+              icon: 'support/usage/usageRecordLight',
+              label: t('account:usage_records'),
+              value: TabEnum.usage
+            }
+          ]
+        : []),
+      ...(showPay && hasManagePer
+        ? [
+            {
+              icon: 'support/bill/payRecordLight',
+              label: t('account:bills_and_invoices'),
+              value: TabEnum.bill
+            }
+          ]
+        : []),
+      {
+        icon: 'common/thirdParty',
+        label: t('account:third_party'),
+        value: TabEnum.thirdParty
+      },
+      ...(isPlus && customDomainEnable
+        ? [
+            {
+              icon: 'common/globalLine',
+              label: t('account:custom_domain'),
+              value: TabEnum.customDomain
+            }
+          ]
+        : []),
+      {
+        icon: 'common/model',
+        label: t('account:model_provider'),
+        value: TabEnum.model
+      },
+      ...(showPromotion && isOwner
+        ? [
+            {
+              icon: 'support/account/promotionLight',
+              label: t('account:promotion_records'),
+              value: TabEnum.promotion
+            }
+          ]
+        : []),
+      ...(hasApikeyCreatePer
+        ? [
+            {
+              icon: 'key',
+              label: t('account:api_key'),
+              value: TabEnum.apikey
+            }
+          ]
+        : []),
 
-    ...(feConfigs.isPlus
-      ? [
-          {
-            icon: 'support/user/informLight',
-            label: t('account:notifications'),
-            value: TabEnum.inform
-          }
-        ]
-      : []),
-    {
-      icon: 'support/usage/usageRecordLight',
-      label: t('account:language'),
-      value: TabEnum.setting
-    },
-    {
-      icon: 'support/account/loginoutLight',
-      label: t('account:logout'),
-      value: TabEnum.loginout
-    }
-  ]);
+      ...(isPlus
+        ? [
+            {
+              icon: 'support/user/informLight',
+              label: t('account:notifications'),
+              value: TabEnum.inform
+            }
+          ]
+        : []),
+      {
+        icon: 'support/usage/usageRecordLight',
+        label: t('account:language'),
+        value: TabEnum.setting
+      },
+      {
+        icon: 'support/account/loginoutLight',
+        label: t('account:logout'),
+        value: TabEnum.loginout
+      }
+    ],
+    [
+      customDomainEnable,
+      hasApikeyCreatePer,
+      hasManagePer,
+      isOwner,
+      isPlus,
+      showPay,
+      showPromotion,
+      t
+    ]
+  );
 
   const { openConfirm, ConfirmModal } = useConfirm({
     content: t('account:confirm_logout')
@@ -168,7 +187,7 @@ const AccountContainer = ({
               mx={'auto'}
               mt={2}
               w={'100%'}
-              list={tabList.current}
+              list={tabList}
               value={currentTab}
               onChange={setCurrentTab}
             />
@@ -185,7 +204,7 @@ const AccountContainer = ({
               m={'auto'}
               w={'100%'}
               size={isPc ? 'md' : 'sm'}
-              list={tabList.current.map((item) => ({
+              list={tabList.map((item) => ({
                 value: item.value,
                 label: item.label
               }))}

--- a/projects/app/src/pageComponents/login/LoginForm/LoginForm.tsx
+++ b/projects/app/src/pageComponents/login/LoginForm/LoginForm.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, type Dispatch } from 'react';
+import React, { type Dispatch } from 'react';
 import { FormControl, Flex, Input, Button, Box } from '@chakra-ui/react';
 import { useForm } from 'react-hook-form';
 import { LoginPageTypeEnum } from '@/web/support/user/login/constants';
 import { postLogin, getPreLogin } from '@/web/support/user/api';
-import { useToast } from '@fastgpt/web/hooks/useToast';
 import { useSystemStore } from '@/web/common/system/useSystemStore';
 import { useTranslation } from 'next-i18next';
 import FormLayout from './FormLayout';
@@ -13,7 +12,6 @@ import { useSearchParams } from 'next/navigation';
 import { UserErrEnum } from '@fastgpt/global/common/error/code/user';
 import { useRouter } from 'next/router';
 import { useMount } from 'ahooks';
-import type { LangEnum } from '@fastgpt/global/common/i18n/type';
 import type { LoginSuccessResponseType } from '@fastgpt/global/openapi/support/user/account/login/api';
 
 interface Props {
@@ -27,7 +25,7 @@ interface LoginFormType {
 }
 
 const LoginForm = ({ setPageType, loginSuccess }: Props) => {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const { feConfigs } = useSystemStore();
   const query = useSearchParams();
   const router = useRouter();
@@ -45,8 +43,7 @@ const LoginForm = ({ setPageType, loginSuccess }: Props) => {
         await postLogin({
           username,
           password,
-          code,
-          language: i18n.language as LangEnum
+          code
         })
       );
     },

--- a/projects/app/src/pages/api/support/user/account/loginByPassword.ts
+++ b/projects/app/src/pages/api/support/user/account/loginByPassword.ts
@@ -25,7 +25,7 @@ async function handler(
   req: ApiRequestProps<LoginByPasswordBodyType>,
   res: ApiResponseType
 ): Promise<LoginSuccessResponseType> {
-  const { username, password, code, language } = LoginByPasswordBodySchema.parse(req.body);
+  const { username, password, code } = LoginByPasswordBodySchema.parse(req.body);
 
   // Auth prelogin code
   await authCode({
@@ -57,8 +57,8 @@ async function handler(
     userId: user._id
   });
 
+  // 登录只更新本次会话使用的团队成员，不应把登录页语言写回用户偏好。
   user.lastLoginTmbId = userDetail.team.tmbId;
-  user.language = language;
   await user.save();
 
   const token = await createUserSession({

--- a/projects/app/src/pages/login/provider.tsx
+++ b/projects/app/src/pages/login/provider.tsx
@@ -20,14 +20,13 @@ import {
 } from '@/web/support/marketing/utils';
 import { postAcceptInvitationLink } from '@/web/support/user/team/api';
 import { retryFn } from '@fastgpt/global/common/system/utils';
-import type { LangEnum } from '@fastgpt/global/common/i18n/type';
 import { validateRedirectUrl } from '@/web/common/utils/uri';
 import type { LoginSuccessResponseType } from '@fastgpt/global/openapi/support/user/account/login/api';
 
 let isOauthLogging = false;
 
 const provider = () => {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const { initd, loginStore, setLoginStore } = useSystemStore();
   const { setUserInfo } = useUserStore();
   const router = useRouter();
@@ -77,8 +76,7 @@ const provider = () => {
           bd_vid: getBdVId(),
           msclkid: getMsclkid(),
           fastgpt_sem: getFastGPTSem(),
-          sourceDomain: getSourceDomain(),
-          language: i18n.language as LangEnum
+          sourceDomain: getSourceDomain()
         });
 
         if (!res) {
@@ -104,16 +102,7 @@ const provider = () => {
       }
       setLoginStore(undefined);
     },
-    [
-      errorRedirectPage,
-      i18n.language,
-      loginStore?.provider,
-      loginSuccess,
-      router,
-      setLoginStore,
-      t,
-      toast
-    ]
+    [errorRedirectPage, loginStore?.provider, loginSuccess, router, setLoginStore, t, toast]
   );
 
   useEffect(() => {

--- a/projects/app/test/api/support/user/account/loginByPassword.test.ts
+++ b/projects/app/test/api/support/user/account/loginByPassword.test.ts
@@ -49,7 +49,7 @@ describe('loginByPassword API', () => {
   });
 
   it('should login successfully with valid credentials', async () => {
-    const res = await Call<LoginByPasswordBodyType, {}, any>(loginApi.default, {
+    const res = await Call<LoginByPasswordBodyType, object, any>(loginApi.default, {
       body: {
         username: 'testuser',
         password: 'testpassword',
@@ -84,7 +84,7 @@ describe('loginByPassword API', () => {
   });
 
   it('should reject login when username is empty', async () => {
-    const res = await Call<LoginByPasswordBodyType, {}, any>(loginApi.default, {
+    const res = await Call<LoginByPasswordBodyType, object, any>(loginApi.default, {
       body: {
         username: '',
         password: 'testpassword',
@@ -97,7 +97,7 @@ describe('loginByPassword API', () => {
   });
 
   it('should reject login when password is empty', async () => {
-    const res = await Call<LoginByPasswordBodyType, {}, any>(loginApi.default, {
+    const res = await Call<LoginByPasswordBodyType, object, any>(loginApi.default, {
       body: {
         username: 'testuser',
         password: '',
@@ -114,7 +114,7 @@ describe('loginByPassword API', () => {
   it('should reject login when auth code verification fails', async () => {
     vi.mocked(authCode).mockRejectedValueOnce(new Error('Invalid code'));
 
-    const res = await Call<LoginByPasswordBodyType, {}, any>(loginApi.default, {
+    const res = await Call<LoginByPasswordBodyType, object, any>(loginApi.default, {
       body: {
         username: 'testuser',
         password: 'testpassword',
@@ -128,7 +128,7 @@ describe('loginByPassword API', () => {
   });
 
   it('should reject login when user does not exist', async () => {
-    const res = await Call<LoginByPasswordBodyType, {}, any>(loginApi.default, {
+    const res = await Call<LoginByPasswordBodyType, object, any>(loginApi.default, {
       body: {
         username: 'nonexistentuser',
         password: 'testpassword',
@@ -146,7 +146,7 @@ describe('loginByPassword API', () => {
       status: UserStatusEnum.forbidden
     });
 
-    const res = await Call<LoginByPasswordBodyType, {}, any>(loginApi.default, {
+    const res = await Call<LoginByPasswordBodyType, object, any>(loginApi.default, {
       body: {
         username: 'testuser',
         password: 'testpassword',
@@ -160,7 +160,7 @@ describe('loginByPassword API', () => {
   });
 
   it('should reject login when password is incorrect', async () => {
-    const res = await Call<LoginByPasswordBodyType, {}, any>(loginApi.default, {
+    const res = await Call<LoginByPasswordBodyType, object, any>(loginApi.default, {
       body: {
         username: 'testuser',
         password: 'wrongpassword',
@@ -173,8 +173,8 @@ describe('loginByPassword API', () => {
     expect(res.error).toBe(UserErrEnum.account_psw_error);
   });
 
-  it('should update language on successful login', async () => {
-    const res = await Call<LoginByPasswordBodyType, {}, any>(loginApi.default, {
+  it('should preserve user language on successful login', async () => {
+    const res = await Call<LoginByPasswordBodyType, object, any>(loginApi.default, {
       body: {
         username: 'testuser',
         password: 'testpassword',
@@ -186,7 +186,7 @@ describe('loginByPassword API', () => {
     expect(res.code).toBe(200);
 
     const updatedUser = await MongoUser.findById(testUser._id);
-    expect(updatedUser?.language).toBe('en');
+    expect(updatedUser?.language).toBe('zh-CN');
     expect(updatedUser?.lastLoginTmbId).toEqual(testTmb._id);
   });
 
@@ -217,7 +217,7 @@ describe('loginByPassword API', () => {
       lastLoginTmbId: rootTmb._id
     });
 
-    const res = await Call<LoginByPasswordBodyType, {}, any>(loginApi.default, {
+    const res = await Call<LoginByPasswordBodyType, object, any>(loginApi.default, {
       body: {
         username: 'root',
         password: 'rootpassword',
@@ -236,7 +236,7 @@ describe('loginByPassword API', () => {
   describe('NoSQL injection prevention', () => {
     it('should reject password as object with MongoDB operator ($ne)', async () => {
       // GHSA-jxvr-h2vx-p73r Step 2: password: {"$ne": ""} bypasses password check
-      const res = await Call<any, {}, any>(loginApi.default, {
+      const res = await Call<any, object, any>(loginApi.default, {
         body: {
           username: 'testuser',
           password: { $ne: '' },
@@ -252,7 +252,7 @@ describe('loginByPassword API', () => {
     });
 
     it('should reject password with $regex operator', async () => {
-      const res = await Call<any, {}, any>(loginApi.default, {
+      const res = await Call<any, object, any>(loginApi.default, {
         body: {
           username: 'testuser',
           password: { $regex: '.*' },
@@ -265,7 +265,7 @@ describe('loginByPassword API', () => {
     });
 
     it('should reject password with $where injection', async () => {
-      const res = await Call<any, {}, any>(loginApi.default, {
+      const res = await Call<any, object, any>(loginApi.default, {
         body: {
           username: 'testuser',
           password: { $where: 'return true' },
@@ -278,7 +278,7 @@ describe('loginByPassword API', () => {
     });
 
     it('should reject username as object with MongoDB operator', async () => {
-      const res = await Call<any, {}, any>(loginApi.default, {
+      const res = await Call<any, object, any>(loginApi.default, {
         body: {
           username: { $ne: '' },
           password: 'testpassword',
@@ -291,7 +291,7 @@ describe('loginByPassword API', () => {
     });
 
     it('should reject code as object with MongoDB operator', async () => {
-      const res = await Call<any, {}, any>(loginApi.default, {
+      const res = await Call<any, object, any>(loginApi.default, {
         body: {
           username: 'testuser',
           password: 'testpassword',
@@ -304,7 +304,7 @@ describe('loginByPassword API', () => {
     });
 
     it('should reject all fields as injection objects simultaneously', async () => {
-      const res = await Call<any, {}, any>(loginApi.default, {
+      const res = await Call<any, object, any>(loginApi.default, {
         body: {
           username: { $ne: '' },
           password: { $ne: '' },
@@ -317,7 +317,7 @@ describe('loginByPassword API', () => {
     });
 
     it('should reject password as non-string types (array, number)', async () => {
-      const arrayRes = await Call<any, {}, any>(loginApi.default, {
+      const arrayRes = await Call<any, object, any>(loginApi.default, {
         body: {
           username: 'testuser',
           password: ['testpassword'],
@@ -327,7 +327,7 @@ describe('loginByPassword API', () => {
       });
       expect(arrayRes.code).toBe(500);
 
-      const numberRes = await Call<any, {}, any>(loginApi.default, {
+      const numberRes = await Call<any, object, any>(loginApi.default, {
         body: {
           username: 'testuser',
           password: 12345,


### PR DESCRIPTION
## What

- 修复登录页当前语言会覆盖用户账号语言偏好的问题。
  - 密码登录不再把登录页 `i18n.language` 传给登录接口。
  - 登录接口不再写入 `user.language`，避免新浏览器/新窗口登录时把账号语言从中文改成英文。
- 修复账号设置页切换语言后，账号侧边栏菜单不会立即更新的问题。
  - `AccountContainer` 的菜单配置从 `useRef` 改为基于 `t`、权限和系统配置的 `useMemo`，语言切换后会重新计算菜单文案。
- 登录成功后，平台运行时语言会以账号已保存的 `userInfo.language` 为准。
  - 普通页面首访仍可按浏览器/本地语言初始化。
  - 登录态下账号语言优先级更高，避免出现页面一部分中文、一部分英文的状态。
- 保持分享页/免登录页语言隔离。
  - `/chat/share` 仍使用 `FASTGPT_SHARE_LOCALE`。
  - 新增的账号语言同步逻辑会跳过 `/chat/share`，不会污染分享页语言偏好。

## Why

用户在账号中已设置中文时，新浏览器打开登录页后可能因为登录页语言是英文，导致登录接口把账号语言写成英文。之后其他已登录窗口重新读取用户信息时，也会被同步成英文。

另外账号设置页切换语言时，左侧账号菜单之前通过 `useRef` 初始化，菜单文案只在首次渲染时计算，导致语言切换后不会立即刷新。

## Tests

- `pnpm exec prettier --check ...`
- `pnpm exec eslint ...`
- `pnpm --filter @fastgpt/app typecheck`
- `pnpm --filter @fastgpt/app test -- test/api/support/user/account/loginByPassword.test.ts`

> 注：最后一条命令在当前项目脚本下实际运行了 app 测试集，结果 `100` 个测试文件、`757` 条测试通过。