### PR TITLE
fix: avoid disallowed browser sandbox workflow action

### DIFF
--- a/.github/workflows/build-browser-sandbox.yml
+++ b/.github/workflows/build-browser-sandbox.yml
@@ -132,6 +132,19 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Ali Hub
+        uses: docker/login-action@v3
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
+          password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_NAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
       - name: Build for ${{ matrix.arch }}
         id: build
         uses: docker/build-push-action@v6
@@ -144,7 +157,10 @@ jobs:
             org.opencontainers.image.description=fastgpt-browser-sandbox image
           sbom: true
           provenance: mode=max
-          outputs: type=image,"name=ghcr.io/${{ github.repository_owner }}/fastgpt-browser-sandbox",push-by-digest=true,push=true
+          outputs: |
+            type=image,"name=ghcr.io/${{ github.repository_owner }}/fastgpt-browser-sandbox",push-by-digest=true,push=true
+            type=image,"name=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-browser-sandbox",push-by-digest=true,push=true
+            type=image,"name=${{ secrets.DOCKER_IMAGE_NAME }}/fastgpt-browser-sandbox",push-by-digest=true,push=true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -224,31 +240,33 @@ jobs:
           VERSION="${{ needs.validate-version.outputs.version }}"
           echo "Git_Tag=ghcr.io/${{ github.repository_owner }}/fastgpt-browser-sandbox:${VERSION}" >> $GITHUB_ENV
           echo "Git_Latest=ghcr.io/${{ github.repository_owner }}/fastgpt-browser-sandbox:latest" >> $GITHUB_ENV
+          echo "Git_Base=ghcr.io/${{ github.repository_owner }}/fastgpt-browser-sandbox" >> $GITHUB_ENV
           echo "Ali_Tag=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-browser-sandbox:${VERSION}" >> $GITHUB_ENV
           echo "Ali_Latest=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-browser-sandbox:latest" >> $GITHUB_ENV
+          echo "Ali_Base=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-browser-sandbox" >> $GITHUB_ENV
           echo "Docker_Hub_Tag=${{ secrets.DOCKER_IMAGE_NAME }}/fastgpt-browser-sandbox:${VERSION}" >> $GITHUB_ENV
           echo "Docker_Hub_Latest=${{ secrets.DOCKER_IMAGE_NAME }}/fastgpt-browser-sandbox:latest" >> $GITHUB_ENV
+          echo "Docker_Hub_Base=${{ secrets.DOCKER_IMAGE_NAME }}/fastgpt-browser-sandbox" >> $GITHUB_ENV
 
-      - name: Create GHCR manifest list
+      - name: Create version manifest lists
         working-directory: ${{ runner.temp }}/digests
         run: |
-          docker buildx imagetools create -t "${Git_Tag}" \
-            $(printf 'ghcr.io/${{ github.repository_owner }}/fastgpt-browser-sandbox@sha256:%s ' *)
+          git_refs=()
+          ali_refs=()
+          docker_hub_refs=()
+          for digest in *; do
+            git_refs+=("${Git_Base}@sha256:${digest}")
+            ali_refs+=("${Ali_Base}@sha256:${digest}")
+            docker_hub_refs+=("${Docker_Hub_Base}@sha256:${digest}")
+          done
 
-      - name: Tag GHCR latest
-        if: needs.validate-version.outputs.stable == 'true'
-        run: docker buildx imagetools create -t "${Git_Latest}" "${Git_Tag}"
+          docker buildx imagetools create -t "${Git_Tag}" "${git_refs[@]}"
+          docker buildx imagetools create -t "${Ali_Tag}" "${ali_refs[@]}"
+          docker buildx imagetools create -t "${Docker_Hub_Tag}" "${docker_hub_refs[@]}"
 
-      - name: Set up crane
-        uses: imjasonh/setup-crane@v0.4
-
-      - name: Copy version tags to downstream registries
-        run: |
-          crane copy "${Git_Tag}" "${Ali_Tag}"
-          crane copy "${Git_Tag}" "${Docker_Hub_Tag}"
-
-      - name: Copy latest tags to downstream registries
+      - name: Create latest manifest lists
         if: needs.validate-version.outputs.stable == 'true'
         run: |
-          crane copy "${Git_Tag}" "${Ali_Latest}"
-          crane copy "${Git_Tag}" "${Docker_Hub_Latest}"
+          docker buildx imagetools create -t "${Git_Latest}" "${Git_Tag}"
+          docker buildx imagetools create -t "${Ali_Latest}" "${Ali_Tag}"
+          docker buildx imagetools create -t "${Docker_Hub_Latest}" "${Docker_Hub_Tag}"


### PR DESCRIPTION
## 变更
- 移除不在仓库 allowlist 内的 `imjasonh/setup-crane@v0.4`。
- 改为在构建阶段同时推送 GHCR、阿里云和 Docker Hub 的按 digest 镜像。
- 发布阶段使用已允许的 Docker Buildx `imagetools create` 生成多架构版本 tag 和 latest tag。
- 更新 `pro` 子模块指针到 fastgpt-pro 已合入后的 browser sandbox commit。

## 验证
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/build-browser-sandbox.yml'); puts 'yaml ok'"`
- `git diff --check`
- 确认 workflow 中无 `setup-crane`/`imjasonh`/`crane` 引用。
