### PR TITLE
fix: repair browser sandbox image workflow

### DIFF
--- a/.github/workflows/build-browser-sandbox.yml
+++ b/.github/workflows/build-browser-sandbox.yml
@@ -64,7 +64,15 @@ jobs:
           fi
 
       - name: Install pnpm
-        run: npm install -g pnpm@10.33.4
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
 
       - name: Install browser-sandbox dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts --filter @fastgpt/browser-sandbox...
@@ -86,6 +94,8 @@ jobs:
     permissions:
       packages: write
       contents: read
+      attestations: write
+      id-token: write
     strategy:
       matrix:
         include:
@@ -132,19 +142,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Ali Hub
-        uses: docker/login-action@v3
-        with:
-          registry: registry.cn-hangzhou.aliyuncs.com
-          username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
-          password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_NAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-
       - name: Build for ${{ matrix.arch }}
         id: build
         uses: docker/build-push-action@v6
@@ -157,10 +154,7 @@ jobs:
             org.opencontainers.image.description=fastgpt-browser-sandbox image
           sbom: true
           provenance: mode=max
-          outputs: |
-            type=image,"name=ghcr.io/${{ github.repository_owner }}/fastgpt-browser-sandbox",push-by-digest=true,push=true
-            type=image,"name=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-browser-sandbox",push-by-digest=true,push=true
-            type=image,"name=${{ secrets.DOCKER_IMAGE_NAME }}/fastgpt-browser-sandbox",push-by-digest=true,push=true
+          outputs: type=image,"name=ghcr.io/${{ github.repository_owner }}/fastgpt-browser-sandbox",push-by-digest=true,push=true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -202,6 +196,8 @@ jobs:
     permissions:
       packages: write
       contents: read
+      attestations: write
+      id-token: write
     needs: [validate-version, build-fastgpt-browser-sandbox-images]
     runs-on: ubuntu-24.04
     steps:
@@ -240,33 +236,34 @@ jobs:
           VERSION="${{ needs.validate-version.outputs.version }}"
           echo "Git_Tag=ghcr.io/${{ github.repository_owner }}/fastgpt-browser-sandbox:${VERSION}" >> $GITHUB_ENV
           echo "Git_Latest=ghcr.io/${{ github.repository_owner }}/fastgpt-browser-sandbox:latest" >> $GITHUB_ENV
-          echo "Git_Base=ghcr.io/${{ github.repository_owner }}/fastgpt-browser-sandbox" >> $GITHUB_ENV
           echo "Ali_Tag=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-browser-sandbox:${VERSION}" >> $GITHUB_ENV
           echo "Ali_Latest=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-browser-sandbox:latest" >> $GITHUB_ENV
-          echo "Ali_Base=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-browser-sandbox" >> $GITHUB_ENV
           echo "Docker_Hub_Tag=${{ secrets.DOCKER_IMAGE_NAME }}/fastgpt-browser-sandbox:${VERSION}" >> $GITHUB_ENV
           echo "Docker_Hub_Latest=${{ secrets.DOCKER_IMAGE_NAME }}/fastgpt-browser-sandbox:latest" >> $GITHUB_ENV
-          echo "Docker_Hub_Base=${{ secrets.DOCKER_IMAGE_NAME }}/fastgpt-browser-sandbox" >> $GITHUB_ENV
 
       - name: Create version manifest lists
         working-directory: ${{ runner.temp }}/digests
         run: |
-          git_refs=()
-          ali_refs=()
-          docker_hub_refs=()
+          refs=()
           for digest in *; do
-            git_refs+=("${Git_Base}@sha256:${digest}")
-            ali_refs+=("${Ali_Base}@sha256:${digest}")
-            docker_hub_refs+=("${Docker_Hub_Base}@sha256:${digest}")
+            refs+=("ghcr.io/${{ github.repository_owner }}/fastgpt-browser-sandbox@sha256:${digest}")
           done
 
-          docker buildx imagetools create -t "${Git_Tag}" "${git_refs[@]}"
-          docker buildx imagetools create -t "${Ali_Tag}" "${ali_refs[@]}"
-          docker buildx imagetools create -t "${Docker_Hub_Tag}" "${docker_hub_refs[@]}"
+          for tag in "${Git_Tag}" "${Ali_Tag}" "${Docker_Hub_Tag}"; do
+            docker buildx imagetools create -t "${tag}" "${refs[@]}"
+            sleep 5
+          done
 
       - name: Create latest manifest lists
         if: needs.validate-version.outputs.stable == 'true'
+        working-directory: ${{ runner.temp }}/digests
         run: |
-          docker buildx imagetools create -t "${Git_Latest}" "${Git_Tag}"
-          docker buildx imagetools create -t "${Ali_Latest}" "${Ali_Tag}"
-          docker buildx imagetools create -t "${Docker_Hub_Latest}" "${Docker_Hub_Tag}"
+          refs=()
+          for digest in *; do
+            refs+=("ghcr.io/${{ github.repository_owner }}/fastgpt-browser-sandbox@sha256:${digest}")
+          done
+
+          for tag in "${Git_Latest}" "${Ali_Latest}" "${Docker_Hub_Latest}"; do
+            docker buildx imagetools create -t "${tag}" "${refs[@]}"
+            sleep 5
+          done

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
+    "git.autofetch": false,
+    "git.detectSubmodules": true,
+    "git.autoRepositoryDetection": "subFolders",
+    "git.repositoryScanMaxDepth": 1,
     "editor.formatOnSave": true,
     "editor.mouseWheelZoom": true,
     "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1110,25 +1110,6 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.17.24)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0)(canvas@3.2.3)(utf-8-validate@5.0.10))(vite@6.2.2(@types/node@20.17.24)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.4))
 
-  pro/llm_benchmark/content_benchmark:
-    dependencies:
-      '@fastgpt/global':
-        specifier: workspace:*
-        version: link:../../../packages/global
-      '@fastgpt/service':
-        specifier: workspace:*
-        version: link:../../../packages/service
-      gpt-tokenizer:
-        specifier: 'catalog:'
-        version: 3.4.0
-      nanoid:
-        specifier: 'catalog:'
-        version: 5.1.5
-    devDependencies:
-      '@types/node':
-        specifier: 'catalog:'
-        version: 20.17.24
-
   pro/browser-sandbox:
     dependencies:
       '@modelcontextprotocol/sdk':
@@ -1156,6 +1137,34 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.21.10(typescript@6.0.3)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.20.6
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.17.24)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0)(canvas@3.2.3)(utf-8-validate@5.0.10))(vite@6.2.2(@types/node@20.17.24)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.4))
+
+  pro/llm_benchmark/content_benchmark:
+    dependencies:
+      '@fastgpt/global':
+        specifier: workspace:*
+        version: link:../../../packages/global
+      '@fastgpt/service':
+        specifier: workspace:*
+        version: link:../../../packages/service
+      gpt-tokenizer:
+        specifier: 'catalog:'
+        version: 3.4.0
+      nanoid:
+        specifier: 'catalog:'
+        version: 5.1.5
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 20.17.24
       tsx:
         specifier: 'catalog:'
         version: 4.20.6


### PR DESCRIPTION
## 变更
- 修复 `pro` 子模块更新后 root `pnpm-lock.yaml` 未同步的问题，解决 `pnpm install --frozen-lockfile --filter @fastgpt/browser-sandbox...` 失败。
- `build-browser-sandbox.yml` 的依赖安装改为仓库已有的 `pnpm/action-setup@v4` + `actions/setup-node@v4` 模式。
- 镜像构建阶段只向 GHCR 推送 digest image，发布阶段参考 `build-agent-sandbox.yml` 使用 `docker buildx imagetools create` 推送 GHCR / 阿里云 / Docker Hub manifest，避免 build job 内多 registry 输出的不确定性。
- 为启用 `sbom` / `provenance` 的 build/release job 补齐 `attestations: write` 与 `id-token: write` 权限。
- 提交 `.vscode/settings.json` 的仓库扫描配置，降低本地多仓库/子模块扫描干扰。

## 排查结论
- 失败 job 实际卡在 `Install browser-sandbox dependencies`，错误是 `ERR_PNPM_OUTDATED_LOCKFILE`。
- workflow 中已无 `setup-crane` / `imjasonh` / `crane` 引用。
- 当前使用的 action 均为 GitHub 官方 action，或仓库 allowlist 中允许的 `pnpm/action-setup@v4`、Docker actions。

## 验证
- `git -C pro fetch upstream main && git -C pro merge --ff-only upstream/main`
- `pnpm install --ignore-scripts`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm install --frozen-lockfile --ignore-scripts --filter @fastgpt/browser-sandbox...`
- `pnpm --filter @fastgpt/browser-sandbox typecheck`
- `pnpm --filter @fastgpt/browser-sandbox typecheck:test`
- `pnpm --filter @fastgpt/browser-sandbox test`
- `pnpm --filter @fastgpt/browser-sandbox build`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/build-browser-sandbox.yml'); puts 'yaml ok'"`
- `git diff --check -- .github/workflows/build-browser-sandbox.yml pnpm-lock.yaml`