### PR TITLE
feat: add domestic browser sandbox search providers

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1112,6 +1112,9 @@ importers:
 
   pro/browser-sandbox:
     dependencies:
+      '@fastgpt-sdk/otel':
+        specifier: workspace:*
+        version: link:../../sdk/otel
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
         version: 1.26.0(zod@4.1.12)


### PR DESCRIPTION
## 变更
- 更新 `pro` 子模块指针，包含 browser-sandbox 的 Bocha 和 Metaso/秘塔搜索 provider。
- 新增可配置环境变量：`BROWSER_SEARCH_BOCHA_API_KEY`、`BROWSER_SEARCH_METASO_API_KEY`。
- provider 优先级：`bocha -> metaso -> brave -> serper -> tavily -> exa -> searxng`。
- 同步 browser-sandbox 请求日志能力：HTTP/MCP 请求、tool 调用、search provider 调用、agent-browser 命令均会记录关键追踪字段。
- 更新 root `pnpm-lock.yaml`，补充 `@fastgpt-sdk/otel` workspace 依赖。

## 关联
- fastgpt-pro PR: https://github.com/labring/fastgpt-pro/pull/972

## 验证
- `pnpm --filter @fastgpt/browser-sandbox typecheck`
- `pnpm --filter @fastgpt/browser-sandbox typecheck:test`
- `pnpm --filter @fastgpt/browser-sandbox test -- test/unit/search.test.ts`
- `pnpm --filter @fastgpt/browser-sandbox test`
- `pnpm --filter @fastgpt/browser-sandbox build`
- `docker build -f pro/browser-sandbox/Dockerfile --target tool-server-builder -t fastgpt-browser-sandbox-tool-server-log-test .`
