### PR TITLE
fix: build browser sandbox SDK dependency in image workflow

### DIFF
--- a/.github/workflows/build-browser-sandbox.yml
+++ b/.github/workflows/build-browser-sandbox.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Install browser-sandbox dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts --filter @fastgpt/browser-sandbox...
 
+      - name: Build browser-sandbox SDK dependencies
+        run: pnpm --filter @fastgpt-sdk/otel build
+
       - name: Typecheck browser-sandbox
         run: pnpm --filter @fastgpt/browser-sandbox typecheck
 


### PR DESCRIPTION
## 变更
- 在 `Build fastgpt-browser-sandbox images` workflow 的 validate 阶段，typecheck 前先执行 `pnpm --filter @fastgpt-sdk/otel build`。
- 解决 browser-sandbox 引入 `@fastgpt-sdk/otel/logger` 后，CI 新环境中 workspace 依赖尚未构建导致 TypeScript 找不到 `@fastgpt-sdk/otel/logger` 类型声明的问题。

## 失败原因
- 失败 run: https://github.com/labring/FastGPT/actions/runs/26626765496/job/78465324629
- 失败点：`validate-browser-sandbox / Typecheck browser-sandbox`
- 错误：`TS2307: Cannot find module '@fastgpt-sdk/otel/logger' or its corresponding type declarations.`

## 验证
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/build-browser-sandbox.yml'); puts 'yaml ok'"`
- `pnpm --filter @fastgpt-sdk/otel build`
- `pnpm --filter @fastgpt/browser-sandbox typecheck`
- `git diff --check -- .github/workflows/build-browser-sandbox.yml`
