### PR TITLE
fix: align dataset index modal layout

### DIFF
--- a/projects/app/src/pageComponents/dataset/detail/components/InputDataModal/index.tsx
+++ b/projects/app/src/pageComponents/dataset/detail/components/InputDataModal/index.tsx
@@ -66,15 +66,6 @@ const InputDataModal = ({
       borderRadius={'10px'}
       bg={'white'}
       boxShadow={'3.5'}
-      headerStyles={{
-        px: [5, '32px']
-      }}
-      bodyStyles={{
-        h: 'auto',
-        flex: '1 1 0',
-        minH: 0,
-        px: [5, '32px']
-      }}
       title={
         <Box
           className={'textEllipsis'}

--- a/projects/app/src/pageComponents/dataset/detail/components/InputDataModal/index.tsx
+++ b/projects/app/src/pageComponents/dataset/detail/components/InputDataModal/index.tsx
@@ -66,9 +66,15 @@ const InputDataModal = ({
       borderRadius={'10px'}
       bg={'white'}
       boxShadow={'3.5'}
-      px={[5, '32px']}
-      py={[5, '32px']}
-      headerStyles={{ px: 0 }}
+      headerStyles={{
+        px: [5, '32px']
+      }}
+      bodyStyles={{
+        h: 'auto',
+        flex: '1 1 0',
+        minH: 0,
+        px: [5, '32px']
+      }}
       title={
         <Box
           className={'textEllipsis'}


### PR DESCRIPTION
## What
- Align the dataset index modal title and content with the Figma layout by moving padding to the modal header/body slots.
- Preserve the existing update-index button and restore its visible bottom placement by fixing the modal body flex height.

## Why
The modal was applying padding on `ModalContent` while `MyModal` also applies separate header/body spacing. That double layout layer shifted the filename away from the body content and squeezed the left column so the update-index button could fall out of view.

## Validation
- `git diff --check`
- `pnpm exec prettier --check projects/app/src/pageComponents/dataset/detail/components/InputDataModal/index.tsx`
- `pnpm --filter @fastgpt/app typecheck`