### PR TITLE
debug: workflow create knowledge base error

### DIFF
--- a/packages/global/openapi/core/dataset/api.ts
+++ b/packages/global/openapi/core/dataset/api.ts
@@ -3,7 +3,6 @@ import { DatasetSearchModeEnum, DatasetTypeEnum } from '../../../core/dataset/co
 import { ApiDatasetServerSchema } from '../../../core/dataset/apiDataset/type';
 import { ObjectIdSchema } from '../../../common/type/mongo';
 import { ParentIdSchema } from '../../../common/parentFolder/type';
-import { EmbeddingModelItemSchema } from '../../../core/ai/model.schema';
 import {
   ChunkSettingsSchema,
   DatasetItemSchema,
@@ -132,9 +131,16 @@ export const CreateDatasetWithFilesResponseSchema = z.object({
     example: '/imgs/dataset/avatar.png',
     description: '知识库头像'
   }),
-  vectorModel: EmbeddingModelItemSchema.meta({
-    description: '向量模型信息'
-  })
+  vectorModel: z
+    .object({
+      model: z.string().meta({
+        example: 'text-embedding-3-small',
+        description: '向量模型名称'
+      })
+    })
+    .meta({
+      description: '向量模型选择信息'
+    })
 });
 
 export type CreateDatasetWithFilesResponse = z.infer<typeof CreateDatasetWithFilesResponseSchema>;

--- a/projects/app/src/pages/api/core/dataset/createWithFiles.ts
+++ b/projects/app/src/pages/api/core/dataset/createWithFiles.ts
@@ -154,7 +154,9 @@ async function handler(req: ApiRequestProps): Promise<CreateDatasetWithFilesResp
         datasetId: dataset._id,
         name: dataset.name,
         avatar: dataset.avatar,
-        vectorModel: getEmbeddingModel(dataset.vectorModel)
+        vectorModel: {
+          model: getEmbeddingModel(dataset.vectorModel)?.model || dataset.vectorModel
+        }
       };
     });
 


### PR DESCRIPTION
把 createWithFiles 的响应从“完整 embedding 模型对象”收窄成前端实际需要的选择信息，避免 weight/priceTiers 这类模型配置字段导致创建成功但响应校验失败