### PR TITLE
fix: preserve two-column table workflow inputs

### DIFF
--- a/packages/global/core/workflow/runtime/utils.ts
+++ b/packages/global/core/workflow/runtime/utils.ts
@@ -322,7 +322,7 @@ export const getReferenceVariableValue = ({
   if (
     Array.isArray(value) &&
     value.length > 0 &&
-    value.every((item) => isValidReferenceValueFormat(item))
+    value.every((item) => isValidReferenceValueFormat(item, nodesMap))
   ) {
     return value
       .map<any>((val) => {

--- a/packages/global/core/workflow/utils.ts
+++ b/packages/global/core/workflow/utils.ts
@@ -408,8 +408,20 @@ export const formatEditorVariablePickerIcon = (
 };
 
 // Check the value is a valid reference value format: [variableId, outputId]
-export const isValidReferenceValueFormat = (value: any): value is ReferenceItemValueType => {
-  return Array.isArray(value) && value.length === 2 && typeof value[0] === 'string';
+export const isValidReferenceValueFormat = (
+  value: any,
+  nodesMap?: Record<string, Pick<StoreNodeItemType, 'nodeId'>> | Map<string, Pick<StoreNodeItemType, 'nodeId'>>
+): value is ReferenceItemValueType => {
+  if (!(Array.isArray(value) && value.length === 2 && typeof value[0] === 'string')) {
+    return false;
+  }
+
+  if (!nodesMap) return true;
+
+  const sourceNodeId = value[0];
+  if (sourceNodeId === VARIABLE_NODE_ID) return true;
+
+  return nodesMap instanceof Map ? nodesMap.has(sourceNodeId) : !!nodesMap[sourceNodeId];
 };
 /*
   Check whether the value([variableId, outputId]) value is a valid reference value:

--- a/packages/global/test/core/workflow/runtime/utils.test.ts
+++ b/packages/global/test/core/workflow/runtime/utils.test.ts
@@ -1265,6 +1265,22 @@ describe('getReferenceVariableValue', () => {
     expect(result).toBe('plain string');
   });
 
+  it('should keep two-column table data as a two-dimensional array', () => {
+    const tableData = [
+      ['指标', '金额（元）'],
+      ['资产总额（期末余额）', '22,701,764,055.63'],
+      ['负债总额（期末余额）', '4,809,415,705.17']
+    ];
+
+    const result = getReferenceVariableValue({
+      value: tableData,
+      nodesMap: {},
+      variables: {}
+    });
+
+    expect(result).toEqual(tableData);
+  });
+
   it('should handle array with single reference', () => {
     const nodesMap: Record<string, RuntimeNodeItemType> = {
       node1: {


### PR DESCRIPTION
## What changed

- Tightened workflow reference-array detection so two-column table data is not mistaken for reference tuples.
- Kept the original lightweight reference-format behavior when no node map is provided.
- Added a regression test for two-column `string[][]` table input preservation.

## Why

Workflow runtime treated any array of two-string arrays as an array of node references, then flattened the resolved values. This broke table-like inputs such as MCP/tool parameters that expect `string[][]`.

## Validation

```bash
pnpm --filter @fastgpt/global test -- test/core/workflow/runtime/utils.test.ts -t getReferenceVariableValue --reporter=verbose
```

Result: 72 test files passed, 1621 tests passed.
