### PR TITLE
fix: filter workflow debug inputs

### DIFF
--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useDebug.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useDebug.tsx
@@ -5,7 +5,7 @@ import {
   type StoreEdgeItemType
 } from '@fastgpt/global/core/workflow/type/edge';
 import { useCallback, useState, useMemo } from 'react';
-import { checkWorkflowNodeAndConnection } from '@/web/core/workflow/utils';
+import { checkWorkflowNodeAndConnection, getNodeAllSource } from '@/web/core/workflow/utils';
 import { useToast } from '@fastgpt/web/hooks/useToast';
 import { uiWorkflow2StoreWorkflow } from '../../utils';
 import { type RuntimeNodeItemType } from '@fastgpt/global/core/workflow/runtime/type';
@@ -31,7 +31,6 @@ import {
   checkInputShouldRenderInDebug,
   getDebugInputFormProps,
   getDebugInputFormValue,
-  getDebugInputRenderTypeList,
   getDebugRuntimeInputs
 } from './useDebugInput';
 
@@ -51,6 +50,12 @@ export const useDebug = () => {
   const setNodes = useContextSelector(WorkflowBufferDataContext, (v) => v.setNodes);
   const getNodes = useContextSelector(WorkflowBufferDataContext, (v) => v.getNodes);
   const edges = useContextSelector(WorkflowBufferDataContext, (v) => v.edges);
+  const systemConfigNode = useContextSelector(WorkflowBufferDataContext, (v) => v.systemConfigNode);
+  const getNodeById = useContextSelector(WorkflowBufferDataContext, (v) => v.getNodeById);
+  const childrenNodeIdListMap = useContextSelector(
+    WorkflowBufferDataContext,
+    (v) => v.childrenNodeIdListMap
+  );
   const { onUpdateNodeError, onRemoveError } = useContextSelector(WorkflowActionsContext, (v) => v);
   const onStartNodeDebug = useContextSelector(WorkflowDebugContext, (v) => v.onStartNodeDebug);
 
@@ -151,10 +156,19 @@ export const useDebug = () => {
     const runtimeNode = runtimeNodes.find((node) => node.nodeId === runtimeNodeId);
 
     if (!runtimeNode) return <></>;
-    // BUG: 工具调用的情况下，无法填写非必填
+    const referenceSourceNodes = getNodeAllSource({
+      nodeId: runtimeNode.nodeId,
+      systemConfigNode,
+      getNodeById,
+      edges,
+      chatConfig: appDetail.chatConfig,
+      t,
+      childrenNodeIdListMap
+    });
     const renderInputs = runtimeNode.inputs.filter((input) => {
       return checkInputShouldRenderInDebug(input, {
-        showValuedInputs: runtimeNode.flowNodeType === FlowNodeTypeEnum.pluginInput
+        showAllInputs: runtimeNode.flowNodeType === FlowNodeTypeEnum.pluginInput,
+        referenceSourceNodes
       });
     });
 
@@ -249,7 +263,7 @@ export const useDebug = () => {
                   label={item.debugLabel || item.label}
                   required={item.required}
                   description={t(item.placeholder || item.description)}
-                  inputType={nodeInputTypeToInputType(getDebugInputRenderTypeList(item))}
+                  inputType={nodeInputTypeToInputType(item.renderTypeList)}
                   form={variablesForm}
                   fieldName={`nodeVariables.${item.key}`}
                   bg={'myGray.50'}
@@ -314,7 +328,12 @@ export const useDebug = () => {
     internalVar,
     filteredVar,
     runtimeNodeId,
-    onStartNodeDebug
+    onStartNodeDebug,
+    systemConfigNode,
+    getNodeById,
+    edges,
+    appDetail.chatConfig,
+    childrenNodeIdListMap
   ]);
 
   return {

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useDebug.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useDebug.tsx
@@ -14,7 +14,6 @@ import dynamic from 'next/dynamic';
 import { Box, Button, Flex } from '@chakra-ui/react';
 import { type FieldErrors, useForm } from 'react-hook-form';
 import { VariableInputEnum } from '@fastgpt/global/core/workflow/constants';
-import { nodeInputIsReference } from '@fastgpt/global/core/workflow/utils';
 import { useContextSelector } from 'use-context-selector';
 import { FlowNodeTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
 import { AppContext } from '../../../context';
@@ -29,8 +28,10 @@ import { useSafeTranslation } from '@fastgpt/web/hooks/useSafeTranslation';
 import { WorkflowActionsContext } from '../../context/workflowActionsContext';
 import { WorkflowDebugContext } from '../../context/workflowDebugContext';
 import {
+  checkInputShouldRenderInDebug,
   getDebugInputFormProps,
   getDebugInputFormValue,
+  getDebugInputRenderTypeList,
   getDebugRuntimeInputs
 } from './useDebugInput';
 
@@ -152,9 +153,9 @@ export const useDebug = () => {
     if (!runtimeNode) return <></>;
     // BUG: 工具调用的情况下，无法填写非必填
     const renderInputs = runtimeNode.inputs.filter((input) => {
-      if (runtimeNode.flowNodeType === FlowNodeTypeEnum.pluginInput) return true;
-      if (nodeInputIsReference(input)) return true;
-      if (!input.value) return true;
+      return checkInputShouldRenderInDebug(input, {
+        showValuedInputs: runtimeNode.flowNodeType === FlowNodeTypeEnum.pluginInput
+      });
     });
 
     const variablesForm = useForm<Record<string, any>>({
@@ -245,10 +246,10 @@ export const useDebug = () => {
                 <LabelAndFormRender
                   {...inputProps}
                   key={item.key}
-                  label={item.label}
+                  label={item.debugLabel || item.label}
                   required={item.required}
                   description={t(item.placeholder || item.description)}
-                  inputType={nodeInputTypeToInputType(item.renderTypeList)}
+                  inputType={nodeInputTypeToInputType(getDebugInputRenderTypeList(item))}
                   form={variablesForm}
                   fieldName={`nodeVariables.${item.key}`}
                   bg={'myGray.50'}

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useDebugInput.ts
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useDebugInput.ts
@@ -1,12 +1,60 @@
 import { WorkflowIOValueTypeEnum } from '@fastgpt/global/core/workflow/constants';
 import { nodeInputIsReference } from '@fastgpt/global/core/workflow/utils';
 import type { FlowNodeInputItemType } from '@fastgpt/global/core/workflow/type/io';
+import { FlowNodeInputTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
 
 const primitiveValueTypes = new Set<WorkflowIOValueTypeEnum>([
   WorkflowIOValueTypeEnum.string,
   WorkflowIOValueTypeEnum.number,
   WorkflowIOValueTypeEnum.boolean
 ]);
+
+const debugFormInputTypes = new Set<FlowNodeInputTypeEnum>([
+  FlowNodeInputTypeEnum.input,
+  FlowNodeInputTypeEnum.textarea,
+  FlowNodeInputTypeEnum.numberInput,
+  FlowNodeInputTypeEnum.switch,
+  FlowNodeInputTypeEnum.select,
+  FlowNodeInputTypeEnum.multipleSelect,
+  FlowNodeInputTypeEnum.JSONEditor,
+  FlowNodeInputTypeEnum.selectLLMModel,
+  FlowNodeInputTypeEnum.fileSelect,
+  FlowNodeInputTypeEnum.timePointSelect,
+  FlowNodeInputTypeEnum.timeRangeSelect,
+  FlowNodeInputTypeEnum.password
+]);
+
+const hasInputValue = (value: unknown) => {
+  if (value === undefined || value === null || value === '') return false;
+  if (Array.isArray(value)) return value.length > 0;
+
+  return true;
+};
+
+/**
+ * 返回节点调试表单可使用的普通输入类型。
+ *
+ * 节点编辑器里有 `reference`、隐藏项和配置弹窗等特殊渲染类型；调试表单只需要让用户补运行值，
+ * 因此必须降级到普通表单控件，避免把配置型输入兜底渲染成空白 textarea。
+ */
+export const getDebugInputRenderTypeList = (input: FlowNodeInputItemType) =>
+  input.renderTypeList.filter((type) => debugFormInputTypes.has(type));
+
+export const checkInputShouldRenderInDebug = (
+  input: FlowNodeInputItemType,
+  options?: {
+    showValuedInputs?: boolean;
+  }
+) => {
+  if (getDebugInputRenderTypeList(input).length === 0) return false;
+  if (!input.label && !input.debugLabel) return false;
+
+  if (options?.showValuedInputs) return true;
+  if (nodeInputIsReference(input)) return true;
+  if (!hasInputValue(input.value)) return true;
+
+  return false;
+};
 
 export const getDebugInputFormValue = (input: FlowNodeInputItemType) => {
   if (nodeInputIsReference(input)) return undefined;

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useDebugInput.ts
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useDebugInput.ts
@@ -1,7 +1,10 @@
 import { WorkflowIOValueTypeEnum } from '@fastgpt/global/core/workflow/constants';
 import { nodeInputIsReference } from '@fastgpt/global/core/workflow/utils';
 import type { FlowNodeInputItemType } from '@fastgpt/global/core/workflow/type/io';
-import { FlowNodeInputTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
+import {
+  workflowReferenceValueIsSelectable,
+  type WorkflowReferenceSourceNode
+} from '@/web/core/workflow/utils';
 
 const primitiveValueTypes = new Set<WorkflowIOValueTypeEnum>([
   WorkflowIOValueTypeEnum.string,
@@ -9,49 +12,41 @@ const primitiveValueTypes = new Set<WorkflowIOValueTypeEnum>([
   WorkflowIOValueTypeEnum.boolean
 ]);
 
-const debugFormInputTypes = new Set<FlowNodeInputTypeEnum>([
-  FlowNodeInputTypeEnum.input,
-  FlowNodeInputTypeEnum.textarea,
-  FlowNodeInputTypeEnum.numberInput,
-  FlowNodeInputTypeEnum.switch,
-  FlowNodeInputTypeEnum.select,
-  FlowNodeInputTypeEnum.multipleSelect,
-  FlowNodeInputTypeEnum.JSONEditor,
-  FlowNodeInputTypeEnum.selectLLMModel,
-  FlowNodeInputTypeEnum.fileSelect,
-  FlowNodeInputTypeEnum.timePointSelect,
-  FlowNodeInputTypeEnum.timeRangeSelect,
-  FlowNodeInputTypeEnum.password
-]);
-
-const hasInputValue = (value: unknown) => {
-  if (value === undefined || value === null || value === '') return false;
-  if (Array.isArray(value)) return value.length > 0;
-
-  return true;
+const inputReferenceValueIsValid = ({
+  input,
+  referenceSourceNodes = []
+}: {
+  input: FlowNodeInputItemType;
+  referenceSourceNodes?: WorkflowReferenceSourceNode[];
+}) => {
+  return workflowReferenceValueIsSelectable({
+    value: input.value,
+    sourceNodes: referenceSourceNodes,
+    valueType: input.valueType
+  });
 };
 
 /**
- * 返回节点调试表单可使用的普通输入类型。
- *
- * 节点编辑器里有 `reference`、隐藏项和配置弹窗等特殊渲染类型；调试表单只需要让用户补运行值，
- * 因此必须降级到普通表单控件，避免把配置型输入兜底渲染成空白 textarea。
+ * 节点调试只补两类输入：插件入口的全部参数，以及普通节点里引用上游输出的参数。
+ * 其他已配置好的节点参数保持原值，不因空值或默认值额外展示调试输入框。
  */
-export const getDebugInputRenderTypeList = (input: FlowNodeInputItemType) =>
-  input.renderTypeList.filter((type) => debugFormInputTypes.has(type));
-
 export const checkInputShouldRenderInDebug = (
   input: FlowNodeInputItemType,
   options?: {
-    showValuedInputs?: boolean;
+    showAllInputs?: boolean;
+    referenceSourceNodes?: WorkflowReferenceSourceNode[];
   }
 ) => {
-  if (getDebugInputRenderTypeList(input).length === 0) return false;
-  if (!input.label && !input.debugLabel) return false;
-
-  if (options?.showValuedInputs) return true;
-  if (nodeInputIsReference(input)) return true;
-  if (!hasInputValue(input.value)) return true;
+  if (options?.showAllInputs) return true;
+  if (
+    nodeInputIsReference(input) &&
+    inputReferenceValueIsValid({
+      input,
+      referenceSourceNodes: options?.referenceSourceNodes
+    })
+  ) {
+    return true;
+  }
 
   return false;
 };
@@ -59,7 +54,7 @@ export const checkInputShouldRenderInDebug = (
 export const getDebugInputFormValue = (input: FlowNodeInputItemType) => {
   if (nodeInputIsReference(input)) return undefined;
 
-  const value = input.value ?? input.defaultValue;
+  const value = input.value;
   if (typeof value === 'object' && value !== null) {
     return JSON.stringify(value, null, 2);
   }

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/render/RenderInput/templates/Reference.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/render/RenderInput/templates/Reference.tsx
@@ -2,12 +2,9 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 import type { RenderInputProps } from '../type';
 import { Flex, Box, type ButtonProps, Grid } from '@chakra-ui/react';
 import MyIcon from '@fastgpt/web/components/common/Icon';
-import { getNodeAllSource, filterWorkflowNodeOutputsByType } from '@/web/core/workflow/utils';
+import { getNodeAllSource, filterSelectableWorkflowNodeOutputs } from '@/web/core/workflow/utils';
 import { useTranslation } from 'next-i18next';
-import {
-  NodeOutputKeyEnum,
-  WorkflowIOValueTypeEnum
-} from '@fastgpt/global/core/workflow/constants';
+import { WorkflowIOValueTypeEnum } from '@fastgpt/global/core/workflow/constants';
 import type {
   ReferenceArrayValueType,
   ReferenceItemValueType,
@@ -15,10 +12,7 @@ import type {
 } from '@fastgpt/global/core/workflow/type/io';
 import dynamic from 'next/dynamic';
 import { useContextSelector } from 'use-context-selector';
-import {
-  FlowNodeOutputTypeEnum,
-  isNestedParentNodeType
-} from '@fastgpt/global/core/workflow/node/constant';
+import { isNestedParentNodeType } from '@fastgpt/global/core/workflow/node/constant';
 import { AppContext } from '@/pageComponents/app/detail/context';
 import {
   WorkflowBufferDataContext,
@@ -103,20 +97,17 @@ export const useReference = ({
             </Flex>
           ),
           value: node.nodeId,
-          children: filterWorkflowNodeOutputsByType(node.outputs, valueType)
-            .filter((output) => {
-              if (output.type === FlowNodeOutputTypeEnum.error) {
-                return node.catchError === true;
-              }
-              return output.id !== NodeOutputKeyEnum.addOutputParam && output.invalid !== true;
-            })
-            .map((output) => {
-              return {
-                label: t(output.label as any),
-                value: output.id,
-                valueType: output.valueType
-              };
-            })
+          children: filterSelectableWorkflowNodeOutputs({
+            outputs: node.outputs,
+            valueType,
+            catchError: node.catchError
+          }).map((output) => {
+            return {
+              label: t(output.label as any),
+              value: output.id,
+              valueType: output.valueType
+            };
+          })
         };
       })
       .filter((item) => item.children.length > 0);

--- a/projects/app/src/web/core/workflow/utils.ts
+++ b/projects/app/src/web/core/workflow/utils.ts
@@ -27,7 +27,8 @@ import { type TFunction } from 'next-i18next';
 import {
   type FlowNodeInputItemType,
   type FlowNodeOutputItemType,
-  type ReferenceItemValueType
+  type ReferenceItemValueType,
+  type ReferenceValueType
 } from '@fastgpt/global/core/workflow/type/io';
 import { type IfElseListItemType } from '@fastgpt/global/core/workflow/template/system/ifElse/type';
 import { LoopRunModeEnum } from '@fastgpt/global/core/workflow/template/system/loopRun/loopRun';
@@ -384,6 +385,93 @@ export const filterWorkflowNodeOutputsByType = (
       output.valueType === WorkflowIOValueTypeEnum.any ||
       validTypeMap[valueType]?.includes(output.valueType)
   );
+};
+
+export type WorkflowReferenceSourceNode = {
+  nodeId: string;
+  outputs: FlowNodeOutputItemType[];
+  catchError?: boolean;
+};
+
+/**
+ * 过滤引用选择器中真正可选的输出。
+ * ReferenceSelector 和节点 debug 的引用有效性判断必须共用这套规则，避免已删除、类型不匹配、
+ * addOutputParam、invalid output 或未开启 catchError 的错误输出在不同入口表现不一致。
+ */
+export const filterSelectableWorkflowNodeOutputs = ({
+  outputs,
+  valueType,
+  catchError
+}: {
+  outputs: FlowNodeOutputItemType[];
+  valueType?: WorkflowIOValueTypeEnum;
+  catchError?: boolean;
+}) => {
+  return filterWorkflowNodeOutputsByType(outputs, valueType ?? WorkflowIOValueTypeEnum.any).filter(
+    (output) => {
+      if (output.type === FlowNodeOutputTypeEnum.error) {
+        return catchError === true;
+      }
+
+      return output.id !== NodeOutputKeyEnum.addOutputParam && output.invalid !== true;
+    }
+  );
+};
+
+const referenceItemIsSelectable = ({
+  value,
+  sourceNodes,
+  valueType
+}: {
+  value: ReferenceItemValueType;
+  sourceNodes: WorkflowReferenceSourceNode[];
+  valueType?: WorkflowIOValueTypeEnum;
+}) => {
+  const [sourceNodeId, outputId] = value;
+  if (!sourceNodeId || !outputId) return false;
+
+  const sourceNode = sourceNodes.find((node) => node.nodeId === sourceNodeId);
+  if (!sourceNode) return false;
+
+  return filterSelectableWorkflowNodeOutputs({
+    outputs: sourceNode.outputs,
+    valueType,
+    catchError: sourceNode.catchError
+  }).some((output) => output.id === outputId);
+};
+
+/**
+ * 判断引用值是否仍能被 ReferenceSelector 选中。
+ * 单选引用要求当前二元组命中；多选引用只要存在一个仍可选的引用项，选择器就会展示有效值。
+ */
+export const workflowReferenceValueIsSelectable = ({
+  value,
+  sourceNodes,
+  valueType
+}: {
+  value?: ReferenceValueType;
+  sourceNodes: WorkflowReferenceSourceNode[];
+  valueType?: WorkflowIOValueTypeEnum;
+}) => {
+  if (!Array.isArray(value)) return false;
+
+  if (typeof value[0] === 'string') {
+    return referenceItemIsSelectable({
+      value: value as ReferenceItemValueType,
+      sourceNodes,
+      valueType
+    });
+  }
+
+  return value.some((item) => {
+    if (!Array.isArray(item)) return false;
+
+    return referenceItemIsSelectable({
+      value: item as ReferenceItemValueType,
+      sourceNodes,
+      valueType
+    });
+  });
 };
 
 export const getNodeAllSource = ({

--- a/projects/app/test/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useDebugInput.test.ts
+++ b/projects/app/test/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useDebugInput.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import { WorkflowIOValueTypeEnum } from '@fastgpt/global/core/workflow/constants';
-import { FlowNodeInputTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
+import {
+  FlowNodeInputTypeEnum,
+  FlowNodeOutputTypeEnum
+} from '@fastgpt/global/core/workflow/node/constant';
 import type { FlowNodeInputItemType } from '@fastgpt/global/core/workflow/type/io';
+import type { WorkflowReferenceSourceNode } from '@/web/core/workflow/utils';
 import {
   checkInputShouldRenderInDebug,
   getDebugInputFormProps,
   getDebugInputFormValue,
-  getDebugInputRenderTypeList,
   getDebugRuntimeInputs
 } from '@/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useDebugInput';
 
@@ -18,20 +21,36 @@ const makeInput = (input: Partial<FlowNodeInputItemType>): FlowNodeInputItemType
   ...input
 });
 
+const validReferenceContext = {
+  referenceSourceNodes: [
+    {
+      nodeId: 'source',
+      outputs: [
+        {
+          id: 'text',
+          key: 'text',
+          label: 'Text',
+          type: FlowNodeOutputTypeEnum.static,
+          valueType: WorkflowIOValueTypeEnum.string
+        }
+      ]
+    }
+  ] satisfies WorkflowReferenceSourceNode[]
+};
+
 describe('useDebugInput', () => {
-  it('should render reference inputs that have a normal debug form type', () => {
+  it('should render reference inputs in node debug form', () => {
     const input = makeInput({
       key: 'userChatInput',
       renderTypeList: [FlowNodeInputTypeEnum.reference, FlowNodeInputTypeEnum.textarea],
       selectedTypeIndex: 0,
-      value: [['workflowStart', 'userChatInput']]
+      value: [['source', 'text']]
     });
 
-    expect(checkInputShouldRenderInDebug(input)).toBe(true);
-    expect(getDebugInputRenderTypeList(input)).toEqual([FlowNodeInputTypeEnum.textarea]);
+    expect(checkInputShouldRenderInDebug(input, validReferenceContext)).toBe(true);
   });
 
-  it('should not render reference-only config inputs in node debug form', () => {
+  it('should render reference config inputs in node debug form', () => {
     const input = makeInput({
       key: 'datasetSelectList',
       renderTypeList: [
@@ -39,52 +58,110 @@ describe('useDebugInput', () => {
         FlowNodeInputTypeEnum.selectDatasetParamsModal
       ],
       selectedTypeIndex: 0,
-      value: [['workflowStart', 'datasetSelectList']]
+      value: [['source', 'text']]
     });
 
-    expect(checkInputShouldRenderInDebug(input)).toBe(false);
-    expect(getDebugInputRenderTypeList(input)).toEqual([]);
+    expect(checkInputShouldRenderInDebug(input, validReferenceContext)).toBe(true);
   });
 
-  it('should not render hidden dataset search config inputs in node debug form', () => {
+  it('should not render reference inputs without selected reference value', () => {
+    const input = makeInput({
+      key: 'userChatInput',
+      renderTypeList: [FlowNodeInputTypeEnum.reference, FlowNodeInputTypeEnum.textarea],
+      selectedTypeIndex: 0,
+      value: []
+    });
+
+    expect(checkInputShouldRenderInDebug(input, validReferenceContext)).toBe(false);
+  });
+
+  it('should not render reference inputs with incomplete reference value', () => {
+    const input = makeInput({
+      key: 'userChatInput',
+      renderTypeList: [FlowNodeInputTypeEnum.reference, FlowNodeInputTypeEnum.textarea],
+      selectedTypeIndex: 0,
+      value: [['workflowStart', '']]
+    });
+
+    expect(checkInputShouldRenderInDebug(input, validReferenceContext)).toBe(false);
+  });
+
+  it('should not render reference inputs when source node is missing', () => {
+    const input = makeInput({
+      key: 'userChatInput',
+      renderTypeList: [FlowNodeInputTypeEnum.reference, FlowNodeInputTypeEnum.textarea],
+      selectedTypeIndex: 0,
+      value: [['deletedNode', 'text']]
+    });
+
+    expect(checkInputShouldRenderInDebug(input, validReferenceContext)).toBe(false);
+  });
+
+  it('should not render reference inputs when source output is missing', () => {
+    const input = makeInput({
+      key: 'userChatInput',
+      renderTypeList: [FlowNodeInputTypeEnum.reference, FlowNodeInputTypeEnum.textarea],
+      selectedTypeIndex: 0,
+      value: [['source', 'deletedOutput']]
+    });
+
+    expect(checkInputShouldRenderInDebug(input, validReferenceContext)).toBe(false);
+  });
+
+  it('should not render reference inputs when source output type cannot be selected', () => {
+    const input = makeInput({
+      key: 'userChatInput',
+      renderTypeList: [FlowNodeInputTypeEnum.reference, FlowNodeInputTypeEnum.textarea],
+      selectedTypeIndex: 0,
+      valueType: WorkflowIOValueTypeEnum.number,
+      value: [['source', 'text']]
+    });
+
+    expect(checkInputShouldRenderInDebug(input, validReferenceContext)).toBe(false);
+  });
+
+  it('should not render non-reference inputs in node debug form', () => {
     const input = makeInput({
       key: 'datasetSearchUsingExtensionQuery',
-      label: '',
-      renderTypeList: [FlowNodeInputTypeEnum.hidden],
+      renderTypeList: [FlowNodeInputTypeEnum.textarea],
       valueType: WorkflowIOValueTypeEnum.boolean,
-      value: true
+      value: undefined
     });
 
-    expect(checkInputShouldRenderInDebug(input)).toBe(false);
+    expect(checkInputShouldRenderInDebug(input, validReferenceContext)).toBe(false);
   });
 
-  it('should keep false and zero values from being treated as missing debug inputs', () => {
-    const booleanInput = makeInput({
-      key: 'enable',
-      renderTypeList: [FlowNodeInputTypeEnum.switch],
-      valueType: WorkflowIOValueTypeEnum.boolean,
-      value: false
-    });
-    const numberInput = makeInput({
-      key: 'count',
-      renderTypeList: [FlowNodeInputTypeEnum.numberInput],
-      valueType: WorkflowIOValueTypeEnum.number,
-      value: 0
+  it('should render all plugin input fields', () => {
+    const input = makeInput({
+      key: 'query',
+      renderTypeList: [FlowNodeInputTypeEnum.textarea],
+      valueType: WorkflowIOValueTypeEnum.string,
+      value: 'fixed value'
     });
 
-    expect(checkInputShouldRenderInDebug(booleanInput)).toBe(false);
-    expect(checkInputShouldRenderInDebug(numberInput)).toBe(false);
+    expect(checkInputShouldRenderInDebug(input, { showAllInputs: true })).toBe(true);
   });
 
-  it('should render empty array values as missing debug inputs', () => {
+  it('should render plugin input reference fields even without selected reference value', () => {
+    const input = makeInput({
+      key: 'query',
+      renderTypeList: [FlowNodeInputTypeEnum.reference],
+      selectedTypeIndex: 0,
+      value: []
+    });
+
+    expect(checkInputShouldRenderInDebug(input, { showAllInputs: true })).toBe(true);
+  });
+
+  it('should not render default values as missing debug inputs', () => {
     const input = makeInput({
       key: 'query',
       renderTypeList: [FlowNodeInputTypeEnum.textarea],
       valueType: WorkflowIOValueTypeEnum.arrayString,
-      value: []
+      defaultValue: ['default query']
     });
 
-    expect(checkInputShouldRenderInDebug(input)).toBe(true);
+    expect(checkInputShouldRenderInDebug(input, validReferenceContext)).toBe(false);
   });
 
   it('should not use reference value as node debug form default value', () => {
@@ -108,6 +185,16 @@ describe('useDebugInput', () => {
 
     expect(props).not.toHaveProperty('value');
     expect(props).not.toHaveProperty('defaultValue');
+  });
+
+  it('should not use default value as node debug form default value', () => {
+    const input = makeInput({
+      key: 'query',
+      renderTypeList: [FlowNodeInputTypeEnum.input],
+      defaultValue: 'default'
+    });
+
+    expect(getDebugInputFormValue(input)).toBeUndefined();
   });
 
   it('should clear old reference value when a rendered debug field is submitted empty', () => {

--- a/projects/app/test/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useDebugInput.test.ts
+++ b/projects/app/test/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useDebugInput.test.ts
@@ -3,8 +3,10 @@ import { WorkflowIOValueTypeEnum } from '@fastgpt/global/core/workflow/constants
 import { FlowNodeInputTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
 import type { FlowNodeInputItemType } from '@fastgpt/global/core/workflow/type/io';
 import {
+  checkInputShouldRenderInDebug,
   getDebugInputFormProps,
   getDebugInputFormValue,
+  getDebugInputRenderTypeList,
   getDebugRuntimeInputs
 } from '@/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useDebugInput';
 
@@ -17,6 +19,74 @@ const makeInput = (input: Partial<FlowNodeInputItemType>): FlowNodeInputItemType
 });
 
 describe('useDebugInput', () => {
+  it('should render reference inputs that have a normal debug form type', () => {
+    const input = makeInput({
+      key: 'userChatInput',
+      renderTypeList: [FlowNodeInputTypeEnum.reference, FlowNodeInputTypeEnum.textarea],
+      selectedTypeIndex: 0,
+      value: [['workflowStart', 'userChatInput']]
+    });
+
+    expect(checkInputShouldRenderInDebug(input)).toBe(true);
+    expect(getDebugInputRenderTypeList(input)).toEqual([FlowNodeInputTypeEnum.textarea]);
+  });
+
+  it('should not render reference-only config inputs in node debug form', () => {
+    const input = makeInput({
+      key: 'datasetSelectList',
+      renderTypeList: [
+        FlowNodeInputTypeEnum.reference,
+        FlowNodeInputTypeEnum.selectDatasetParamsModal
+      ],
+      selectedTypeIndex: 0,
+      value: [['workflowStart', 'datasetSelectList']]
+    });
+
+    expect(checkInputShouldRenderInDebug(input)).toBe(false);
+    expect(getDebugInputRenderTypeList(input)).toEqual([]);
+  });
+
+  it('should not render hidden dataset search config inputs in node debug form', () => {
+    const input = makeInput({
+      key: 'datasetSearchUsingExtensionQuery',
+      label: '',
+      renderTypeList: [FlowNodeInputTypeEnum.hidden],
+      valueType: WorkflowIOValueTypeEnum.boolean,
+      value: true
+    });
+
+    expect(checkInputShouldRenderInDebug(input)).toBe(false);
+  });
+
+  it('should keep false and zero values from being treated as missing debug inputs', () => {
+    const booleanInput = makeInput({
+      key: 'enable',
+      renderTypeList: [FlowNodeInputTypeEnum.switch],
+      valueType: WorkflowIOValueTypeEnum.boolean,
+      value: false
+    });
+    const numberInput = makeInput({
+      key: 'count',
+      renderTypeList: [FlowNodeInputTypeEnum.numberInput],
+      valueType: WorkflowIOValueTypeEnum.number,
+      value: 0
+    });
+
+    expect(checkInputShouldRenderInDebug(booleanInput)).toBe(false);
+    expect(checkInputShouldRenderInDebug(numberInput)).toBe(false);
+  });
+
+  it('should render empty array values as missing debug inputs', () => {
+    const input = makeInput({
+      key: 'query',
+      renderTypeList: [FlowNodeInputTypeEnum.textarea],
+      valueType: WorkflowIOValueTypeEnum.arrayString,
+      value: []
+    });
+
+    expect(checkInputShouldRenderInDebug(input)).toBe(true);
+  });
+
   it('should not use reference value as node debug form default value', () => {
     const input = makeInput({
       key: 'userChatInput',

--- a/projects/app/test/web/core/app/workflow/utils.test.ts
+++ b/projects/app/test/web/core/app/workflow/utils.test.ts
@@ -18,10 +18,12 @@ import {
   nodeTemplate2FlowNode,
   storeNode2FlowNode,
   filterWorkflowNodeOutputsByType,
+  filterSelectableWorkflowNodeOutputs,
+  workflowReferenceValueIsSelectable,
   checkWorkflowNodeAndConnection
 } from '@/web/core/workflow/utils';
 import type { FlowNodeOutputItemType } from '@fastgpt/global/core/workflow/type/io';
-import { VARIABLE_NODE_ID } from '@fastgpt/global/core/workflow/constants';
+import { NodeOutputKeyEnum, VARIABLE_NODE_ID } from '@fastgpt/global/core/workflow/constants';
 
 describe('nodeTemplate2FlowNode', () => {
   it('should convert template to flow node', () => {
@@ -195,6 +197,154 @@ describe('filterWorkflowNodeOutputsByType', () => {
 
     const result = filterWorkflowNodeOutputsByType(outputs, WorkflowIOValueTypeEnum.arrayString);
     expect(result).toHaveLength(2);
+  });
+});
+
+describe('filterSelectableWorkflowNodeOutputs', () => {
+  const makeOutput = (
+    id: string,
+    valueType: WorkflowIOValueTypeEnum,
+    extra?: Partial<FlowNodeOutputItemType>
+  ): FlowNodeOutputItemType => ({
+    id,
+    key: id,
+    label: id,
+    type: FlowNodeOutputTypeEnum.static,
+    valueType,
+    ...extra
+  });
+
+  it('filters outputs that cannot be selected by reference selector', () => {
+    const outputs: FlowNodeOutputItemType[] = [
+      makeOutput('text', WorkflowIOValueTypeEnum.string),
+      makeOutput('count', WorkflowIOValueTypeEnum.number),
+      makeOutput(NodeOutputKeyEnum.addOutputParam, WorkflowIOValueTypeEnum.string),
+      makeOutput('invalid', WorkflowIOValueTypeEnum.string, { invalid: true }),
+      makeOutput('error', WorkflowIOValueTypeEnum.string, { type: FlowNodeOutputTypeEnum.error })
+    ];
+
+    const result = filterSelectableWorkflowNodeOutputs({
+      outputs,
+      valueType: WorkflowIOValueTypeEnum.string,
+      catchError: false
+    });
+
+    expect(result.map((output) => output.id)).toEqual(['text']);
+  });
+
+  it('keeps error output only when source node can catch error', () => {
+    const outputs: FlowNodeOutputItemType[] = [
+      makeOutput('text', WorkflowIOValueTypeEnum.string),
+      makeOutput('error', WorkflowIOValueTypeEnum.string, { type: FlowNodeOutputTypeEnum.error })
+    ];
+
+    const result = filterSelectableWorkflowNodeOutputs({
+      outputs,
+      valueType: WorkflowIOValueTypeEnum.string,
+      catchError: true
+    });
+
+    expect(result.map((output) => output.id)).toEqual(['text', 'error']);
+  });
+});
+
+describe('workflowReferenceValueIsSelectable', () => {
+  const sourceNodes = [
+    {
+      nodeId: 'source',
+      outputs: [
+        {
+          id: 'text',
+          key: 'text',
+          label: 'text',
+          type: FlowNodeOutputTypeEnum.static,
+          valueType: WorkflowIOValueTypeEnum.string
+        },
+        {
+          id: 'count',
+          key: 'count',
+          label: 'count',
+          type: FlowNodeOutputTypeEnum.static,
+          valueType: WorkflowIOValueTypeEnum.number
+        }
+      ]
+    }
+  ];
+
+  it('returns true when single reference points to an existing selectable output', () => {
+    expect(
+      workflowReferenceValueIsSelectable({
+        value: ['source', 'text'],
+        sourceNodes,
+        valueType: WorkflowIOValueTypeEnum.string
+      })
+    ).toBe(true);
+  });
+
+  it('returns false when referenced source node has been deleted', () => {
+    expect(
+      workflowReferenceValueIsSelectable({
+        value: ['deleted', 'text'],
+        sourceNodes,
+        valueType: WorkflowIOValueTypeEnum.string
+      })
+    ).toBe(false);
+  });
+
+  it('returns false when referenced output no longer exists', () => {
+    expect(
+      workflowReferenceValueIsSelectable({
+        value: ['source', 'deleted'],
+        sourceNodes,
+        valueType: WorkflowIOValueTypeEnum.string
+      })
+    ).toBe(false);
+  });
+
+  it('returns false when referenced output type is not selectable for current value type', () => {
+    expect(
+      workflowReferenceValueIsSelectable({
+        value: ['source', 'count'],
+        sourceNodes,
+        valueType: WorkflowIOValueTypeEnum.string
+      })
+    ).toBe(false);
+  });
+
+  it('returns false for incomplete reference value', () => {
+    expect(
+      workflowReferenceValueIsSelectable({
+        value: ['source', ''],
+        sourceNodes,
+        valueType: WorkflowIOValueTypeEnum.string
+      })
+    ).toBe(false);
+  });
+
+  it('returns true for multiple references when at least one item is selectable', () => {
+    expect(
+      workflowReferenceValueIsSelectable({
+        value: [
+          ['deleted', 'text'],
+          ['source', 'text']
+        ],
+        sourceNodes,
+        valueType: WorkflowIOValueTypeEnum.string
+      })
+    ).toBe(true);
+  });
+
+  it('returns false for multiple references when none of the items are selectable', () => {
+    expect(
+      workflowReferenceValueIsSelectable({
+        value: [
+          ['deleted', 'text'],
+          ['source', 'deleted']
+        ],
+        sourceNodes,
+        valueType: WorkflowIOValueTypeEnum.string
+      })
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Filter workflow node debug inputs to only render normal form controls.
- Preserve reference-value clearing while avoiding config-only inputs falling back to blank textarea fields.
- Add focused tests for reference inputs, config-only inputs, hidden inputs, and false/zero value handling.

## Root Cause
After reference default values were cleared for node debug, config-only render types such as `selectDatasetParamsModal` could still pass the debug input filter. `nodeInputTypeToInputType` then fell back to textarea for unsupported render types, producing large blank fields in the debug drawer.

## Validation
- `git diff --check`
- `pnpm --filter @fastgpt/app test -- test/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useDebugInput.test.ts`
  - Result: 107 test files passed, 799 tests passed.
