### PR TITLE
fix: preserve table arrays and agent tool schemas

### DIFF
--- a/packages/global/core/workflow/runtime/utils.ts
+++ b/packages/global/core/workflow/runtime/utils.ts
@@ -15,7 +15,7 @@ import { type WorkflowInteractiveResponseType } from '../template/system/interac
 import type { RuntimeEdgeItemType, StoreEdgeItemType } from '../type/edge';
 import type { FlowNodeOutputItemType, ReferenceValueType } from '../type/io';
 import type { StoreNodeItemType } from '../type/node';
-import { isValidReferenceValueFormat } from '../utils';
+import { checkInputIsReference, isValidReferenceValueFormat } from '../utils';
 import type { RuntimeNodeItemType } from './type';
 import { isSecretValue } from '../../../common/secret/utils';
 import { isChildInteractive } from '../template/system/interactive/constants';
@@ -287,13 +287,15 @@ export const filterWorkflowEdges = (edges: RuntimeEdgeItemType[]) => {
 export const getReferenceVariableValue = ({
   value,
   nodesMap,
-  variables
+  variables,
+  isReferenceValue = true
 }: {
   value?: ReferenceValueType;
   nodesMap: Record<string, RuntimeNodeItemType> | Map<string, RuntimeNodeItemType>;
   variables: Record<string, unknown>;
+  isReferenceValue?: boolean;
 }) => {
-  if (!value) return value;
+  if (!value || !isReferenceValue) return value;
 
   const resoleValue = (value: [string, string | undefined]) => {
     const sourceNodeId = value[0];
@@ -314,7 +316,7 @@ export const getReferenceVariableValue = ({
   };
 
   // handle single reference value
-  if (isValidReferenceValueFormat(value)) {
+  if (isValidReferenceValueFormat(value, nodesMap)) {
     return resoleValue(value as [string, string | undefined]);
   }
 
@@ -456,7 +458,8 @@ export function replaceEditorVariable({
         return getReferenceVariableValue({
           value: input.value,
           nodesMap,
-          variables
+          variables,
+          isReferenceValue: checkInputIsReference(input)
         });
       }
     })();

--- a/packages/global/core/workflow/type/node.ts
+++ b/packages/global/core/workflow/type/node.ts
@@ -9,6 +9,7 @@ import { PluginStatusSchema } from '../../plugin/type';
 import { SourceMemberSchema } from '../../../support/user/type';
 import z from 'zod';
 import { BoolSchema, NumSchema } from '../../../common/zod';
+import { JSONSchemaInputTypeSchema } from '../../app/jsonschema';
 
 export const NodeToolConfigTypeSchema = z.object({
   mcpToolSet: z
@@ -186,6 +187,7 @@ const HandleTypeSchema = z.object({
 export const FlowNodeTemplateTypeSchema = FlowNodeCommonTypeSchema.extend({
   id: z.string(),
   status: PluginStatusSchema.optional(),
+  jsonSchema: JSONSchemaInputTypeSchema.optional(),
 
   showSourceHandle: BoolSchema.optional(),
   showTargetHandle: BoolSchema.optional(),
@@ -273,6 +275,7 @@ export type FlowNodeItemType = z.infer<typeof FlowNodeItemSchema>;
 // store node type
 export const StoreNodeItemTypeSchema = FlowNodeCommonTypeSchema.extend({
   nodeId: z.string(),
+  jsonSchema: JSONSchemaInputTypeSchema.optional(),
   position: z
     .object({
       x: NumSchema,

--- a/packages/global/core/workflow/utils.ts
+++ b/packages/global/core/workflow/utils.ts
@@ -410,7 +410,9 @@ export const formatEditorVariablePickerIcon = (
 // Check the value is a valid reference value format: [variableId, outputId]
 export const isValidReferenceValueFormat = (
   value: any,
-  nodesMap?: Record<string, Pick<StoreNodeItemType, 'nodeId'>> | Map<string, Pick<StoreNodeItemType, 'nodeId'>>
+  nodesMap?:
+    | Record<string, Pick<StoreNodeItemType, 'nodeId'>>
+    | Map<string, Pick<StoreNodeItemType, 'nodeId'>>
 ): value is ReferenceItemValueType => {
   if (!(Array.isArray(value) && value.length === 2 && typeof value[0] === 'string')) {
     return false;
@@ -509,8 +511,8 @@ export const removeUnauthModels = async ({
     modules.forEach((module) => {
       module.inputs.forEach((input) => {
         if (input.key === 'model') {
-          // 如果是引用类型（selectedTypeIndex 不为 0 或 value 是数组），跳过检查
-          if (input.selectedTypeIndex !== 0 || Array.isArray(input.value)) {
+          // 引用值也是数组，不能用 value 形状猜测类型，否则会误伤手动输入的二维数组。
+          if (checkInputIsReference(input)) {
             return;
           }
           if (!allowedModels.has(input.value)) {

--- a/packages/global/test/core/workflow/runtime/utils.test.ts
+++ b/packages/global/test/core/workflow/runtime/utils.test.ts
@@ -1281,6 +1281,27 @@ describe('getReferenceVariableValue', () => {
     expect(result).toEqual(tableData);
   });
 
+  it('should skip reference resolution when input is not reference mode', () => {
+    const result = getReferenceVariableValue({
+      value: [['node1', 'out1']],
+      nodesMap: {
+        node1: {
+          nodeId: 'node1',
+          name: 'test',
+          flowNodeType: FlowNodeTypeEnum.chatNode,
+          inputs: [],
+          outputs: [
+            { id: 'out1', key: 'output1', type: FlowNodeOutputTypeEnum.static, value: 'value1' }
+          ]
+        }
+      },
+      variables: {},
+      isReferenceValue: false
+    });
+
+    expect(result).toEqual([['node1', 'out1']]);
+  });
+
   it('should handle array with single reference', () => {
     const nodesMap: Record<string, RuntimeNodeItemType> = {
       node1: {

--- a/packages/global/test/core/workflow/utils.test.ts
+++ b/packages/global/test/core/workflow/utils.test.ts
@@ -1055,6 +1055,18 @@ describe('isValidReferenceValueFormat', () => {
     expect(isValidReferenceValueFormat([123, 'outputKey'])).toBe(false);
     expect(isValidReferenceValueFormat([null, 'outputKey'])).toBe(false);
   });
+
+  it('should validate source node when nodesMap is provided', () => {
+    const nodesMap = {
+      nodeId: {
+        nodeId: 'nodeId'
+      }
+    };
+
+    expect(isValidReferenceValueFormat(['nodeId', 'outputKey'], nodesMap)).toBe(true);
+    expect(isValidReferenceValueFormat([VARIABLE_NODE_ID, 'variableKey'], nodesMap)).toBe(true);
+    expect(isValidReferenceValueFormat(['指标', '金额（元）'], nodesMap)).toBe(false);
+  });
 });
 
 describe('isValidReferenceValue', () => {
@@ -1297,7 +1309,7 @@ describe('removeUnauthModels', () => {
     expect(result?.[0].inputs[0].value).toBe('unauthorized-model');
   });
 
-  it('should skip array value inputs (reference type)', async () => {
+  it('should clear array value inputs when selected render type is not reference', async () => {
     const modules = [
       {
         nodeId: 'node1',
@@ -1318,7 +1330,31 @@ describe('removeUnauthModels', () => {
     const allowedModels = new Set(['gpt-4']);
 
     const result = await removeUnauthModels({ modules, allowedModels });
-    expect(result?.[0].inputs[0].value).toEqual(['nodeId', 'outputKey']);
+    expect(result?.[0].inputs[0].value).toBeUndefined();
+  });
+
+  it('should clear two-dimensional array value inputs when selected render type is not reference', async () => {
+    const modules = [
+      {
+        nodeId: 'node1',
+        flowNodeType: FlowNodeTypeEnum.chatNode,
+        name: 'Chat',
+        inputs: [
+          {
+            key: 'model',
+            label: 'Model',
+            value: [['gpt-4', 'gpt-4o'], ['unauthorized-model']],
+            selectedTypeIndex: 0,
+            renderTypeList: [FlowNodeInputTypeEnum.selectLLMModel, FlowNodeInputTypeEnum.reference]
+          }
+        ],
+        outputs: []
+      }
+    ];
+    const allowedModels = new Set(['gpt-4']);
+
+    const result = await removeUnauthModels({ modules, allowedModels });
+    expect(result?.[0].inputs[0].value).toBeUndefined();
   });
 
   it('should handle modules with no model inputs', async () => {

--- a/packages/service/core/app/tool/controller.ts
+++ b/packages/service/core/app/tool/controller.ts
@@ -289,6 +289,10 @@ export async function getChildAppPreviewNode({
       nodeIOConfig: appData2FlowNodeIO({ chatConfig: app.workflow.chatConfig })
     };
   })();
+  const runtimeToolNode =
+    flowNodeType === FlowNodeTypeEnum.tool && app.workflow.nodes.length === 1
+      ? app.workflow.nodes[0]
+      : undefined;
 
   return {
     id: getNanoid(),
@@ -316,6 +320,7 @@ export async function getChildAppPreviewNode({
     hasSystemSecret: app.hasSystemSecret,
     isFolder: app.isFolder,
     status: app.status,
+    jsonSchema: runtimeToolNode?.jsonSchema,
 
     ...nodeIOConfig,
     outputs: nodeIOConfig.outputs.some((item) => item.type === FlowNodeOutputTypeEnum.error)

--- a/packages/service/core/workflow/dispatch/ai/agent/sub/tool/utils.ts
+++ b/packages/service/core/workflow/dispatch/ai/agent/sub/tool/utils.ts
@@ -26,6 +26,84 @@ import { getToolConfigStatus } from '@fastgpt/global/core/app/formEdit/utils';
 import { getLogger, LogCategories } from '../../../../../../../common/logger';
 import { AppToolSourceEnum } from '@fastgpt/global/core/app/tool/constants';
 
+export const formatAgentToolSchema = ({
+  toolId,
+  inputs,
+  jsonSchema: runtimeJsonSchema,
+  flowNodeType,
+  name,
+  toolDescription,
+  intro
+}: {
+  toolId: string;
+  inputs: FlowNodeInputItemType[];
+  jsonSchema?: JSONSchemaInputType;
+  flowNodeType: FlowNodeTypeEnum;
+  name: string;
+  toolDescription?: string;
+  intro?: string;
+}): ChatCompletionTool => {
+  const toolParams: FlowNodeInputItemType[] = [];
+  let toolDataInputSchema: JSONSchemaInputType | undefined;
+
+  for (const input of inputs) {
+    if (input.toolDescription) {
+      toolParams.push(input);
+    }
+
+    if (input.key === NodeInputKeyEnum.toolData) {
+      toolDataInputSchema = (input.value as McpToolDataType)?.inputSchema;
+    }
+  }
+  const jsonSchema = runtimeJsonSchema || toolDataInputSchema;
+
+  const description = JSON.stringify({
+    type: flowNodeType,
+    name: name,
+    intro: toolDescription || intro
+  });
+  const formatToolId = `t${toolId}`;
+
+  if (jsonSchema) {
+    return {
+      type: 'function',
+      function: {
+        name: formatToolId,
+        description,
+        parameters: jsonSchema
+      }
+    };
+  }
+
+  const properties: Record<string, any> = {};
+  toolParams.forEach((param) => {
+    const jsonSchema = param.valueType
+      ? valueTypeJsonSchemaMap[param.valueType] || toolValueTypeList[0].jsonSchema
+      : toolValueTypeList[0].jsonSchema;
+
+    properties[param.key] = {
+      ...jsonSchema,
+      description: param.toolDescription || '',
+      enum: param.enum?.split('\n').filter(Boolean) || undefined
+    };
+  });
+
+  const requestSchema: ChatCompletionTool = {
+    type: 'function',
+    function: {
+      name: formatToolId,
+      description,
+      parameters: {
+        type: 'object',
+        properties,
+        required: toolParams.filter((param) => param.required).map((param) => param.key)
+      }
+    }
+  };
+
+  return requestSchema;
+};
+
 export const getAgentRuntimeTools = async ({
   tools,
   tmbId,
@@ -35,79 +113,6 @@ export const getAgentRuntimeTools = async ({
   tmbId: string;
   lang?: localeType;
 }): Promise<SubAppInitType[]> => {
-  const formatSchema = ({
-    toolId,
-    inputs,
-    flowNodeType,
-    name,
-    toolDescription,
-    intro
-  }: {
-    toolId: string;
-    inputs: FlowNodeInputItemType[];
-    flowNodeType: FlowNodeTypeEnum;
-    name: string;
-    toolDescription?: string;
-    intro?: string;
-  }): ChatCompletionTool => {
-    const toolParams: FlowNodeInputItemType[] = [];
-    let jsonSchema: JSONSchemaInputType | undefined;
-
-    for (const input of inputs) {
-      if (input.toolDescription) {
-        toolParams.push(input);
-      }
-
-      if (input.key === NodeInputKeyEnum.toolData) {
-        jsonSchema = (input.value as McpToolDataType)?.inputSchema;
-      }
-    }
-
-    const description = JSON.stringify({
-      type: flowNodeType,
-      name: name,
-      intro: toolDescription || intro
-    });
-    const formatToolId = `t${toolId}`;
-
-    if (jsonSchema) {
-      return {
-        type: 'function',
-        function: {
-          name: formatToolId,
-          description,
-          parameters: jsonSchema
-        }
-      };
-    }
-
-    const properties: Record<string, any> = {};
-    toolParams.forEach((param) => {
-      const jsonSchema = param.valueType
-        ? valueTypeJsonSchemaMap[param.valueType] || toolValueTypeList[0].jsonSchema
-        : toolValueTypeList[0].jsonSchema;
-
-      properties[param.key] = {
-        ...jsonSchema,
-        description: param.toolDescription || '',
-        enum: param.enum?.split('\n').filter(Boolean) || undefined
-      };
-    });
-
-    return {
-      type: 'function',
-      function: {
-        name: formatToolId,
-        description,
-        parameters: {
-          type: 'object',
-          properties,
-          required: toolParams.filter((param) => param.required).map((param) => param.key)
-        }
-      }
-    };
-  };
-
   return Promise.all(
     tools.map<Promise<SubAppInitType[]>>(async (tool) => {
       try {
@@ -183,9 +188,10 @@ export const getAgentRuntimeTools = async ({
               version: child.version,
               toolConfig: child.toolConfig,
               params: tool.config,
-              requestSchema: formatSchema({
+              requestSchema: formatAgentToolSchema({
                 toolId: child.nodeId,
                 inputs: child.inputs,
+                jsonSchema: child.jsonSchema,
                 flowNodeType: child.flowNodeType,
                 name: child.name,
                 toolDescription: child.toolDescription,
@@ -218,9 +224,10 @@ export const getAgentRuntimeTools = async ({
                 version: child.version,
                 toolConfig: child.toolConfig,
                 params: tool.config,
-                requestSchema: formatSchema({
+                requestSchema: formatAgentToolSchema({
                   toolId: child.nodeId,
                   inputs: child.inputs,
+                  jsonSchema: child.jsonSchema,
                   flowNodeType: child.flowNodeType,
                   name: child.name,
                   toolDescription: child.toolDescription,
@@ -249,9 +256,10 @@ export const getAgentRuntimeTools = async ({
                 version: child.version,
                 toolConfig: child.toolConfig,
                 params: tool.config,
-                requestSchema: formatSchema({
+                requestSchema: formatAgentToolSchema({
                   toolId: child.nodeId,
                   inputs: child.inputs,
+                  jsonSchema: child.jsonSchema,
                   flowNodeType: child.flowNodeType,
                   name: child.name,
                   toolDescription: child.toolDescription,
@@ -284,9 +292,10 @@ export const getAgentRuntimeTools = async ({
               version: toolNode.version,
               toolConfig: toolNode.toolConfig,
               params: tool.config,
-              requestSchema: formatSchema({
+              requestSchema: formatAgentToolSchema({
                 toolId: cleanedPluginId,
                 inputs: toolNode.inputs,
+                jsonSchema: toolNode.jsonSchema,
                 flowNodeType: toolNode.flowNodeType,
                 name: toolNode.name,
                 toolDescription: toolNode.toolDescription,

--- a/packages/service/core/workflow/dispatch/index.ts
+++ b/packages/service/core/workflow/dispatch/index.ts
@@ -46,7 +46,7 @@ import { surrenderProcess } from '../../../common/system/tools';
 import type { DispatchFlowResponse, WorkflowDebugResponse } from './type';
 import { rewriteRuntimeWorkFlow, filterOrphanEdges } from './utils';
 import { WorkflowVariableState } from './utils/variables';
-import { getHandleId } from '@fastgpt/global/core/workflow/utils';
+import { checkInputIsReference, getHandleId } from '@fastgpt/global/core/workflow/utils';
 import { callbackMap } from './constants';
 import { getUserChatInfo } from '../../../support/user/team/utils';
 import { checkTeamAIPoints } from '../../../support/permission/teamLimit';
@@ -864,7 +864,8 @@ export class WorkflowQueue {
           value = getReferenceVariableValue({
             value,
             nodesMap: this.runtimeNodesMap,
-            variables: runtimeVariables
+            variables: runtimeVariables,
+            isReferenceValue: checkInputIsReference(input)
           });
 
           // Dynamic input is stored in the dynamic key

--- a/packages/service/core/workflow/dispatch/tools/http468.ts
+++ b/packages/service/core/workflow/dispatch/tools/http468.ts
@@ -19,6 +19,7 @@ import {
   replaceEditorVariable,
   valueTypeFormat
 } from '@fastgpt/global/core/workflow/runtime/utils';
+import { checkInputIsReference } from '@fastgpt/global/core/workflow/utils';
 import json5 from 'json5';
 import { JSONPath } from 'jsonpath-plus';
 import { getSecretValue } from '../../../../common/secret/utils';
@@ -62,7 +63,7 @@ type HttpResponse = DispatchNodeResultType<
 const UNDEFINED_SIGN = 'UNDEFINED_SIGN';
 
 export const dispatchHttp468Request = async (props: HttpRequestProps): Promise<HttpResponse> => {
-  let {
+  const {
     runningAppInfo: { id: appId },
     chatId,
     responseChatItemId,
@@ -72,11 +73,11 @@ export const dispatchHttp468Request = async (props: HttpRequestProps): Promise<H
     histories,
     params: {
       system_httpMethod: httpMethod = 'POST',
-      system_httpReqUrl: httpReqUrl,
-      system_httpHeader: httpHeader = [],
+      system_httpReqUrl: rawHttpReqUrl,
+      system_httpHeader: rawHttpHeader = [],
       system_httpParams: httpParams = [],
-      system_httpJsonBody: httpJsonBody = '',
-      system_httpFormBody: httpFormBody = [],
+      system_httpJsonBody: rawHttpJsonBody = '',
+      system_httpFormBody: rawHttpFormBody = [],
       system_httpContentType: httpContentType = ContentTypes.json,
       system_httpTimeout: httpTimeout = 60,
       system_header_secret: headerSecret,
@@ -84,6 +85,11 @@ export const dispatchHttp468Request = async (props: HttpRequestProps): Promise<H
       ...body
     }
   } = props;
+
+  let httpReqUrl = rawHttpReqUrl;
+  let httpHeader = rawHttpHeader;
+  let httpJsonBody = rawHttpJsonBody;
+  let httpFormBody = rawHttpFormBody;
 
   if (!httpReqUrl) {
     return Promise.reject('Http url is empty');
@@ -417,7 +423,8 @@ export const replaceJsonBodyString = (
         return getReferenceVariableValue({
           value: input.value,
           nodesMap: runtimeNodesMap,
-          variables: allVariables
+          variables: allVariables,
+          isReferenceValue: checkInputIsReference(input)
         });
       }
     })();

--- a/packages/service/test/core/workflow/dispatch/ai/agent/sub/tool/utils.test.ts
+++ b/packages/service/test/core/workflow/dispatch/ai/agent/sub/tool/utils.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { FlowNodeTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
+import { NodeInputKeyEnum, WorkflowIOValueTypeEnum } from '@fastgpt/global/core/workflow/constants';
+import { formatAgentToolSchema } from '@fastgpt/service/core/workflow/dispatch/ai/agent/sub/tool/utils';
+import type { JSONSchemaInputType } from '@fastgpt/global/core/app/jsonschema';
+
+describe('formatAgentToolSchema', () => {
+  const matrixSchema: JSONSchemaInputType = {
+    type: 'object',
+    properties: {
+      matrix: {
+        type: 'array',
+        items: {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        },
+        description: 'Two-dimensional string array.'
+      }
+    },
+    required: ['matrix']
+  };
+
+  it('uses runtime jsonSchema before valueType fallback', () => {
+    const schema = formatAgentToolSchema({
+      toolId: 'echo_matrix',
+      flowNodeType: FlowNodeTypeEnum.tool,
+      name: 'echo_matrix',
+      intro: 'Echo matrix.',
+      jsonSchema: matrixSchema,
+      inputs: [
+        {
+          key: 'matrix',
+          valueType: WorkflowIOValueTypeEnum.arrayAny,
+          toolDescription: 'Two-dimensional string array.',
+          required: true,
+          renderTypeList: []
+        } as any
+      ]
+    });
+
+    expect(schema.function.parameters).toBe(matrixSchema);
+  });
+
+  it('uses toolData input schema before valueType fallback', () => {
+    const schema = formatAgentToolSchema({
+      toolId: 'echo_matrix',
+      flowNodeType: FlowNodeTypeEnum.tool,
+      name: 'echo_matrix',
+      intro: 'Echo matrix.',
+      inputs: [
+        {
+          key: NodeInputKeyEnum.toolData,
+          value: {
+            inputSchema: matrixSchema
+          },
+          renderTypeList: []
+        } as any,
+        {
+          key: 'matrix',
+          valueType: WorkflowIOValueTypeEnum.arrayAny,
+          toolDescription: 'Two-dimensional string array.',
+          required: true,
+          renderTypeList: []
+        } as any
+      ]
+    });
+
+    expect(schema.function.parameters).toBe(matrixSchema);
+  });
+
+  it('falls back to valueType schema when no jsonSchema exists', () => {
+    const schema = formatAgentToolSchema({
+      toolId: 'echo_matrix',
+      flowNodeType: FlowNodeTypeEnum.tool,
+      name: 'echo_matrix',
+      intro: 'Echo matrix.',
+      inputs: [
+        {
+          key: 'matrix',
+          valueType: WorkflowIOValueTypeEnum.arrayAny,
+          toolDescription: 'Two-dimensional string array.',
+          required: true,
+          renderTypeList: []
+        } as any
+      ]
+    });
+
+    expect(schema.function.parameters).toEqual({
+      type: 'object',
+      properties: {
+        matrix: {
+          type: 'string',
+          description: 'Two-dimensional string array.',
+          enum: undefined
+        }
+      },
+      required: ['matrix']
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- preserve literal two-dimensional arrays when workflow inputs are not reference values
- pass runtime JSON Schema through Agent V2 tool schema generation for MCP and HTTP tools
- add coverage for reference detection and Agent V2 tool schema priority

## Tests
- pnpm --filter @fastgpt/global test -- test/core/workflow/utils.test.ts test/core/workflow/runtime/utils.test.ts -t "checkInputIsReference|isValidReferenceValueFormat|getReferenceVariableValue|removeUnauthModels" --reporter=verbose
- pnpm --filter @fastgpt/service test -- test/core/workflow/dispatch/ai/agent/sub/tool/utils.test.ts --reporter=verbose