### PR TITLE
fix: bind S3 object keys to authorized resources

### DIFF
--- a/.agents/design/api/s3-object-key-authorization.md
+++ b/.agents/design/api/s3-object-key-authorization.md
@@ -1,0 +1,78 @@
+# S3 Object Key 授权绑定设计
+
+## 背景
+
+FastGPT 的私有对象存储 key 是 bucket 内的全局路径字符串，例如：
+
+- `chat/<appId>/<uid>/<chatId>/<filename>`
+- `dataset/<datasetId>/<filename>`
+- `temp/<teamId>/<filename>`
+- `helperBot/<type>/<userId>/<chatId>/<filename>`
+
+这些路径段携带资源归属信息，但 S3 和下载代理本身只验证签名，不理解业务权限。因此任何来自请求体、query、工具参数或外部输入的 object key，在签发 URL、读取、预览、解析前，都必须先绑定到当前已鉴权的业务资源。
+
+## 漏洞模式
+
+危险模式是“校验 A 资源，使用 B key”：
+
+1. API 先校验调用者可访问某个 app、dataset 或 team。
+2. API 直接把请求里的 `key`、`fileId`、`sourceId` 传给 S3 签名或读取函数。
+3. 如果 key 实际属于其他团队或资源，S3 签名仍然会成功，造成跨团队文件读取。
+
+不能把以下条件当作权限：
+
+- S3 对象存在。
+- key 形如某个合法 source 前缀。
+- 下载 JWT 签名有效。
+- 请求里同时带了一个调用者有权限的 appId/datasetId。
+
+## 统一授权 helper
+
+新增入口必须优先复用 `packages/service/common/s3/utils.ts` 中的 helper：
+
+- `parseChatFileS3Key` / `isAuthorizedChatFileS3Key`
+- `parseDatasetFileS3Key` / `isAuthorizedDatasetFileS3Key`
+- `parseHelperBotFileS3Key` / `isAuthorizedHelperBotFileS3Key`
+- `isAuthorizedTempFileS3Key`
+
+这些 helper 只负责 key 结构解析和 key 与已鉴权上下文的绑定判断。业务权限仍由对应 auth 函数负责：
+
+- chat 文件：先 `authChatCrud`，再校验 `chat` key 的 `appId + uid`。
+- dataset 文件：用 `authDatasetFileKey` 从 `dataset/<datasetId>/...` 解析 datasetId，并复用 dataset 权限体系。
+- temp 文件：先得到当前 `teamId`，再校验 `temp/<teamId>/...`。
+- helperBot 文件：先 `authCert` 得到 `userId`，再校验 `helperBot` key 的 `userId`。
+
+## 新增入口规范
+
+当 API 或工具入口接收外部传入的 S3 key 时，必须满足以下规则：
+
+1. 使用 `parseApiInput` 校验请求入参。
+2. 先完成业务资源鉴权，拿到可信的 `teamId`、`appId`、`datasetId`、`uid` 或 `userId`。
+3. 使用对应 `isAuthorized*FileS3Key` helper 绑定 key 与可信上下文。
+4. 绑定失败时返回通用未授权错误，不暴露 key 是否存在。
+5. 只有通过绑定后，才允许调用 `createExternalUrl`、`createGet*URL`、`jwtSignS3DownloadToken`、`downloadObject`、`getDatasetFileRawText`、`isObjectExists` 等存储层能力。
+
+## 底层防线
+
+`S3BaseBucket.createExternalUrl` 是裸存储签名方法，只保证 token 有效，不做业务权限判断。调用方不能把它当成鉴权接口。
+
+`readDatasetSourceRawText` 在 `fileLocal` 分支额外校验 `sourceId` 必须属于传入的 `datasetId`，用于防止未来新增入口绕过 API 层鉴权。
+
+`authDatasetFileKey` 会先按 key 内的 datasetId 复用 dataset 权限体系，再检查对象是否存在。对象存在性不能出现在权限校验之前。
+
+## 排查结论
+
+已排查当前主要 S3 签名/读取点：
+
+- 请求体直接传 key 的聊天文件下载、helperBot 文件预览、数据集预览、搜索测试临时图片已接入统一授权 helper。
+- 其他 dataset data、training detail、collection read 等签名点使用的是数据库记录中的 key，并且前置查询已经绑定 `teamId/datasetId/collectionId` 权限边界。
+- 通用 `/api/system/file/*` 代理只校验 token，它不是业务鉴权入口；安全性依赖 token 签发前的业务授权绑定。
+
+## 测试要求
+
+新增类似入口时至少补充以下测试：
+
+- 合法 key 可以签名或读取。
+- 同 source 但不同 app/dataset/user/team 的 key 被拒绝。
+- 错误 source 或畸形 key 被拒绝。
+- 被拒绝场景不得调用底层 S3 签名或读取 mock。

--- a/packages/service/common/s3/buckets/base.ts
+++ b/packages/service/common/s3/buckets/base.ts
@@ -233,6 +233,13 @@ export class S3BaseBucket {
     }
   }
 
+  /**
+   * 为对象 key 生成外部可访问 URL。
+   *
+   * 该方法只负责存储层签名，不做 team/app/dataset/user 的业务归属校验。任何 API 边界或
+   * 用户可控 key 调用到这里前，必须先使用 common/s3/utils 中的授权绑定 helper 校验 key
+   * 属于当前已鉴权资源。
+   */
   async createExternalUrl(params: createPreviewUrlParams) {
     const parsed = CreateGetPresignedUrlParamsSchema.parse(params);
 

--- a/packages/service/common/s3/sources/dataset/index.ts
+++ b/packages/service/common/s3/sources/dataset/index.ts
@@ -18,10 +18,10 @@ import { addHours } from 'date-fns';
 import { getLogger, LogCategories } from '../../../logger';
 import { detectFileEncoding } from '@fastgpt/global/common/file/tools';
 import { readFileContentByBuffer } from '../../../file/read/utils';
-import path from 'node:path';
 import { ensureTextContentTypeCharset, isTextLikeFile, resolveMimeType } from '../../utils/mime';
 import { datasetAllowedExtensions } from '../../utils/uploadConstraints';
 import { getFileS3Key, truncateFilename } from '../../utils';
+import { isAuthorizedDatasetFileS3Key } from '../../utils';
 import type { S3RawTextSource } from '../rawText';
 import { getS3RawTextSource } from '../rawText';
 
@@ -102,8 +102,12 @@ export class S3DatasetSource extends S3PrivateBucket {
   }
 
   async getDatasetFileRawText(params: GetDatasetFileContentParams) {
-    const { fileId, teamId, tmbId, customPdfParse, getFormatText, usageId } =
+    const { fileId, teamId, tmbId, customPdfParse, getFormatText, usageId, datasetId } =
       GetDatasetFileContentParamsSchema.parse(params);
+
+    if (!isAuthorizedDatasetFileS3Key({ key: fileId, datasetId })) {
+      return Promise.reject('Invalid dataset file key');
+    }
 
     const rawTextBuffer = await this.rawTextSource.getRawTextBuffer({
       customPdfParse,

--- a/packages/service/common/s3/sources/helperbot/index.ts
+++ b/packages/service/common/s3/sources/helperbot/index.ts
@@ -10,7 +10,7 @@ import {
 import { differenceInHours } from 'date-fns';
 import { S3Buckets } from '../../config/constants';
 import path from 'path';
-import { getFileS3Key } from '../../utils';
+import { getFileS3Key, parseHelperBotFileS3Key } from '../../utils';
 
 export class S3HelperBotSource extends S3PrivateBucket {
   private static instance: S3HelperBotSource;
@@ -54,8 +54,7 @@ export class S3HelperBotSource extends S3PrivateBucket {
   }
 
   parseKey(key: string) {
-    const [type, chatId, userId, filename] = key.split('/');
-    return { type, chatId, userId, filename };
+    return parseHelperBotFileS3Key(key);
   }
 
   async createGetFileURL(params: {

--- a/packages/service/common/s3/utils.ts
+++ b/packages/service/common/s3/utils.ts
@@ -9,6 +9,7 @@ import { getNanoid } from '@fastgpt/global/common/string/tools';
 import path from 'node:path';
 import type { ParsedFileContentS3KeyParams } from './sources/dataset/type';
 import type { HelperBotTypeEnumType } from '@fastgpt/global/core/chat/helperBot/type';
+import { HelperBotTypeEnumSchema } from '@fastgpt/global/core/chat/helperBot/type';
 
 export { jwtSignS3ObjectKey, jwtVerifyS3ObjectKey, jwtSignS3DownloadToken } from './security/token';
 
@@ -263,6 +264,135 @@ export function isS3ObjectKey<T extends keyof typeof S3Sources>(
   source: T
 ): key is `${T}/${string}` {
   return typeof key === 'string' && key.startsWith(`${S3Sources[source]}/`);
+}
+
+/**
+ * 解析聊天文件的 S3 key。
+ *
+ * 聊天文件 key 的授权边界由 appId、uid、chatId 共同决定。任何签名或读取前都应先解析
+ * 这些路径段并与已鉴权上下文绑定，避免只校验一个无关 app 后签发任意 object key。
+ */
+export function parseChatFileS3Key(key: string): {
+  appId: string;
+  uid: string;
+  chatId: string;
+  filename: string;
+} | null {
+  if (!isS3ObjectKey(key, 'chat')) return null;
+
+  const [, appId, uid, chatId, ...filenameParts] = key.split('/');
+  const filename = filenameParts.join('/');
+
+  if (!appId || !uid || !chatId || !filename) return null;
+
+  return {
+    appId,
+    uid,
+    chatId,
+    filename
+  };
+}
+
+/**
+ * 判断聊天文件 key 是否属于已鉴权的 app 与聊天用户。
+ */
+export function isAuthorizedChatFileS3Key({
+  key,
+  appId,
+  uid
+}: {
+  key: string;
+  appId: string;
+  uid: string;
+}) {
+  const parsedKey = parseChatFileS3Key(key);
+
+  return (
+    !!parsedKey &&
+    String(parsedKey.appId) === String(appId) &&
+    String(parsedKey.uid) === String(uid)
+  );
+}
+
+/**
+ * 解析数据集文件的 S3 key。
+ *
+ * 数据集文件的第二段是 datasetId。调用方应基于解析出的 datasetId 做权限校验，而不是把
+ * S3 对象存在性当作访问权限。
+ */
+export function parseDatasetFileS3Key(key: string): {
+  datasetId: string;
+  filename: string;
+} | null {
+  if (!isS3ObjectKey(key, 'dataset')) return null;
+
+  const [, datasetId, ...filenameParts] = key.split('/');
+  const filename = filenameParts.join('/');
+
+  if (!datasetId || !filename) return null;
+
+  return {
+    datasetId,
+    filename
+  };
+}
+
+/**
+ * 判断数据集文件 key 是否属于指定 dataset。
+ */
+export function isAuthorizedDatasetFileS3Key({
+  key,
+  datasetId
+}: {
+  key: string;
+  datasetId: string;
+}) {
+  const parsedKey = parseDatasetFileS3Key(key);
+
+  return !!parsedKey && String(parsedKey.datasetId) === String(datasetId);
+}
+
+/**
+ * 解析 HelperBot 文件 key。
+ *
+ * HelperBot 文件 key 的第一段是固定 source，后续才是 type/user/chat 维度。
+ */
+export function parseHelperBotFileS3Key(key: string): {
+  type: HelperBotTypeEnumType;
+  userId: string;
+  chatId: string;
+  filename: string;
+} | null {
+  if (!isS3ObjectKey(key, 'helperBot')) return null;
+
+  const [, type, userId, chatId, ...filenameParts] = key.split('/');
+  const filename = filenameParts.join('/');
+  const parsedType = HelperBotTypeEnumSchema.safeParse(type);
+
+  if (!parsedType.success || !userId || !chatId || !filename) return null;
+
+  return {
+    type: parsedType.data,
+    userId,
+    chatId,
+    filename
+  };
+}
+
+/**
+ * 判断 HelperBot 文件 key 是否属于当前用户。
+ */
+export function isAuthorizedHelperBotFileS3Key({ key, userId }: { key: string; userId: string }) {
+  const parsedKey = parseHelperBotFileS3Key(key);
+
+  return !!parsedKey && String(parsedKey.userId) === String(userId);
+}
+
+/**
+ * 判断临时文件 key 是否属于指定团队。
+ */
+export function isAuthorizedTempFileS3Key({ key, teamId }: { key: string; teamId: string }) {
+  return isS3ObjectKey(key, 'temp') && key.startsWith(`temp/${teamId}/`);
 }
 
 export function sanitizeS3ObjectKey(key: string) {

--- a/packages/service/core/dataset/read.ts
+++ b/packages/service/core/dataset/read.ts
@@ -16,8 +16,9 @@ import { getFileMaxSize } from '../../common/file/utils';
 import { UserError } from '@fastgpt/global/common/error/utils';
 import { getAxiosHeaderValue } from '@fastgpt/global/common/axios/utils';
 import { getS3DatasetSource } from '../../common/s3/sources/dataset';
-import { getFileS3Key, isS3ObjectKey } from '../../common/s3/utils';
+import { getFileS3Key, isS3ObjectKey, isAuthorizedDatasetFileS3Key } from '../../common/s3/utils';
 import { getLogger, LogCategories } from '../../common/logger';
+import { DatasetErrEnum } from '@fastgpt/global/common/error/code/dataset';
 
 const logger = getLogger(LogCategories.MODULE.DATASET.FILE);
 
@@ -191,6 +192,10 @@ export const readDatasetSourceRawText = async ({
   if (type === DatasetSourceReadTypeEnum.fileLocal) {
     if (!datasetId || !isS3ObjectKey(sourceId, 'dataset')) {
       return Promise.reject('datasetId is required for S3 files');
+    }
+
+    if (!isAuthorizedDatasetFileS3Key({ key: sourceId, datasetId })) {
+      return Promise.reject(DatasetErrEnum.unAuthDatasetFile);
     }
 
     const { filename, rawText } = await getS3DatasetSource().getDatasetFileRawText({

--- a/packages/service/support/permission/auth/file.ts
+++ b/packages/service/support/permission/auth/file.ts
@@ -1,43 +1,55 @@
 import { type AuthModeType, type AuthResponseType } from '../type';
 import { CommonErrEnum } from '@fastgpt/global/common/error/code/common';
-import { OwnerPermissionVal, ReadRoleVal } from '@fastgpt/global/support/permission/constant';
-import { Permission } from '@fastgpt/global/support/permission/controller';
+import { OwnerPermissionVal } from '@fastgpt/global/support/permission/constant';
 import type { FileTokenQuery } from '@fastgpt/global/common/file/type';
-import { addMinutes } from 'date-fns';
-import { parseHeaderCert } from './common';
 import jwt from 'jsonwebtoken';
 import { ERROR_ENUM } from '@fastgpt/global/common/error/errorCode';
 import { getS3DatasetSource } from '../../../common/s3/sources/dataset';
-import { isS3ObjectKey } from '../../../common/s3/utils';
+import { parseDatasetFileS3Key } from '../../../common/s3/utils';
 import { serviceEnv } from '../../../env';
+import { authDataset } from '../dataset/auth';
 
-export const authCollectionFile = async ({
+/**
+ * 校验来自请求的 dataset S3 object key 是否属于调用者有权限访问的数据集。
+ *
+ * 该函数会从 `dataset/<datasetId>/...` 中解析 datasetId，并复用数据集权限体系完成
+ * team/成员/协作者校验。S3 对象存在性只能作为最后的文件存在检查，不能作为权限依据。
+ */
+export const authDatasetFileKey = async ({
   fileId,
   per = OwnerPermissionVal,
   ...props
 }: AuthModeType & {
   fileId: string;
 }): Promise<AuthResponseType> => {
-  const authRes = await parseHeaderCert(props);
-
-  if (isS3ObjectKey(fileId, 'dataset')) {
-    const exists = await getS3DatasetSource().isObjectExists(fileId);
-    if (!exists) return Promise.reject(CommonErrEnum.fileNotFound);
-  } else {
+  const parsedKey = parseDatasetFileS3Key(fileId);
+  if (!parsedKey) {
     return Promise.reject('Invalid dataset file key');
   }
 
-  const permission = new Permission({ role: ReadRoleVal, isOwner: true });
+  // 先按 key 内的 datasetId 做权限校验，再检查对象是否存在，避免用存在性绕过团队边界。
+  const authRes = await authDataset({
+    ...props,
+    datasetId: parsedKey.datasetId,
+    per
+  });
 
-  if (!permission.checkPer(per)) {
+  const exists = await getS3DatasetSource().isObjectExists(fileId);
+  if (!exists) {
+    return Promise.reject(CommonErrEnum.fileNotFound);
+  }
+
+  if (!authRes.permission.checkPer(per)) {
     return Promise.reject(CommonErrEnum.unAuthFile);
   }
 
   return {
     ...authRes,
-    permission
+    permission: authRes.permission
   };
 };
+
+export const authCollectionFile = authDatasetFileKey;
 
 export const authFileToken = (token?: string) =>
   new Promise<FileTokenQuery>((resolve, reject) => {

--- a/packages/service/test/common/s3/utils.test.ts
+++ b/packages/service/test/common/s3/utils.test.ts
@@ -5,7 +5,14 @@ import {
   truncateFilename,
   S3_FILENAME_MAX_LENGTH,
   isS3ObjectKey,
-  getFileS3Key
+  getFileS3Key,
+  isAuthorizedChatFileS3Key,
+  isAuthorizedDatasetFileS3Key,
+  isAuthorizedHelperBotFileS3Key,
+  isAuthorizedTempFileS3Key,
+  parseChatFileS3Key,
+  parseDatasetFileS3Key,
+  parseHelperBotFileS3Key
 } from '@fastgpt/service/common/s3/utils';
 import * as stringTools from '@fastgpt/global/common/string/tools';
 
@@ -502,6 +509,59 @@ describe('isS3ObjectKey', () => {
       expect(isS3ObjectKey(key, 'chat')).toBe(false);
       expect(isS3ObjectKey(key, 'dataset')).toBe(false);
     });
+  });
+});
+
+describe('authorized S3 object key helpers', () => {
+  it('parses and authorizes chat file keys by appId and uid', () => {
+    const key = 'chat/app-1/user-1/chat-1/folder/demo.pdf';
+
+    expect(parseChatFileS3Key(key)).toEqual({
+      appId: 'app-1',
+      uid: 'user-1',
+      chatId: 'chat-1',
+      filename: 'folder/demo.pdf'
+    });
+    expect(isAuthorizedChatFileS3Key({ key, appId: 'app-1', uid: 'user-1' })).toBe(true);
+    expect(isAuthorizedChatFileS3Key({ key, appId: 'app-2', uid: 'user-1' })).toBe(false);
+    expect(isAuthorizedChatFileS3Key({ key, appId: 'app-1', uid: 'user-2' })).toBe(false);
+    expect(parseChatFileS3Key('temp/app-1/user-1/chat-1/demo.pdf')).toBeNull();
+  });
+
+  it('parses and authorizes dataset file keys by datasetId', () => {
+    const key = 'dataset/dataset-1/folder/demo.pdf';
+
+    expect(parseDatasetFileS3Key(key)).toEqual({
+      datasetId: 'dataset-1',
+      filename: 'folder/demo.pdf'
+    });
+    expect(isAuthorizedDatasetFileS3Key({ key, datasetId: 'dataset-1' })).toBe(true);
+    expect(isAuthorizedDatasetFileS3Key({ key, datasetId: 'dataset-2' })).toBe(false);
+    expect(parseDatasetFileS3Key('dataset/dataset-1')).toBeNull();
+  });
+
+  it('parses and authorizes helper bot file keys by userId', () => {
+    const key = 'helperBot/topAgent/user-1/chat-1/demo.pdf';
+
+    expect(parseHelperBotFileS3Key(key)).toEqual({
+      type: 'topAgent',
+      userId: 'user-1',
+      chatId: 'chat-1',
+      filename: 'demo.pdf'
+    });
+    expect(isAuthorizedHelperBotFileS3Key({ key, userId: 'user-1' })).toBe(true);
+    expect(isAuthorizedHelperBotFileS3Key({ key, userId: 'user-2' })).toBe(false);
+    expect(parseHelperBotFileS3Key('helperBot/unknown/user-1/chat-1/demo.pdf')).toBeNull();
+  });
+
+  it('authorizes temp file keys by exact team path segment', () => {
+    expect(isAuthorizedTempFileS3Key({ key: 'temp/team-1/demo.pdf', teamId: 'team-1' })).toBe(true);
+    expect(isAuthorizedTempFileS3Key({ key: 'temp/team-11/demo.pdf', teamId: 'team-1' })).toBe(
+      false
+    );
+    expect(isAuthorizedTempFileS3Key({ key: 'dataset/team-1/demo.pdf', teamId: 'team-1' })).toBe(
+      false
+    );
   });
 });
 

--- a/packages/service/test/core/dataset/read.test.ts
+++ b/packages/service/test/core/dataset/read.test.ts
@@ -1,0 +1,61 @@
+import { DatasetErrEnum } from '@fastgpt/global/common/error/code/dataset';
+import { DatasetSourceReadTypeEnum } from '@fastgpt/global/core/dataset/constants';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getDatasetFileRawText: vi.fn()
+}));
+
+vi.mock('@fastgpt/service/common/s3/sources/dataset', () => ({
+  getS3DatasetSource: () => ({
+    getDatasetFileRawText: mocks.getDatasetFileRawText
+  })
+}));
+
+import { readDatasetSourceRawText } from '@fastgpt/service/core/dataset/read';
+
+describe('readDatasetSourceRawText', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getDatasetFileRawText.mockResolvedValue({
+      filename: 'demo.pdf',
+      rawText: 'demo content'
+    });
+  });
+
+  it('rejects a local dataset file key that is not under the authorized dataset id', async () => {
+    await expect(
+      readDatasetSourceRawText({
+        teamId: 'team-a',
+        tmbId: 'tmb-a',
+        type: DatasetSourceReadTypeEnum.fileLocal,
+        sourceId: 'dataset/victim-dataset/secret.pdf',
+        datasetId: 'attacker-dataset'
+      })
+    ).rejects.toBe(DatasetErrEnum.unAuthDatasetFile);
+
+    expect(mocks.getDatasetFileRawText).not.toHaveBeenCalled();
+  });
+
+  it('reads a local dataset file key under the authorized dataset id', async () => {
+    await expect(
+      readDatasetSourceRawText({
+        teamId: 'team-a',
+        tmbId: 'tmb-a',
+        type: DatasetSourceReadTypeEnum.fileLocal,
+        sourceId: 'dataset/dataset-a/demo.pdf',
+        datasetId: 'dataset-a'
+      })
+    ).resolves.toEqual({
+      title: 'demo.pdf',
+      rawText: 'demo content'
+    });
+
+    expect(mocks.getDatasetFileRawText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileId: 'dataset/dataset-a/demo.pdf',
+        datasetId: 'dataset-a'
+      })
+    );
+  });
+});

--- a/packages/service/test/support/permission/dataset/auth.test.ts
+++ b/packages/service/test/support/permission/dataset/auth.test.ts
@@ -1,19 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DatasetErrEnum } from '@fastgpt/global/common/error/code/dataset';
-import { ReadPermissionVal } from '@fastgpt/global/support/permission/constant';
+import { OwnerPermissionVal, ReadPermissionVal } from '@fastgpt/global/support/permission/constant';
 
 const {
   mockParseHeaderCert,
   mockGetCollectionWithDataset,
   mockFindDataset,
   mockGetTmbInfoByTmbId,
-  mockGetTmbPermission
+  mockGetTmbPermission,
+  mockIsObjectExists
 } = vi.hoisted(() => ({
   mockParseHeaderCert: vi.fn(),
   mockGetCollectionWithDataset: vi.fn(),
   mockFindDataset: vi.fn(),
   mockGetTmbInfoByTmbId: vi.fn(),
-  mockGetTmbPermission: vi.fn()
+  mockGetTmbPermission: vi.fn(),
+  mockIsObjectExists: vi.fn()
 }));
 
 vi.mock('@fastgpt/service/support/permission/auth/common', () => ({
@@ -44,7 +46,14 @@ vi.mock('@fastgpt/service/core/dataset/data/schema', () => ({
   }
 }));
 
+vi.mock('@fastgpt/service/common/s3/sources/dataset', () => ({
+  getS3DatasetSource: () => ({
+    isObjectExists: mockIsObjectExists
+  })
+}));
+
 import { authDatasetCollection } from '@fastgpt/service/support/permission/dataset/auth';
+import { authCollectionFile } from '@fastgpt/service/support/permission/auth/file';
 
 const datasetId = '507f1f77bcf86cd799439011';
 const collectionId = '507f1f77bcf86cd799439012';
@@ -69,6 +78,7 @@ describe('authDatasetCollection', () => {
       permission: { isOwner: true }
     });
     mockGetTmbPermission.mockResolvedValue(0);
+    mockIsObjectExists.mockResolvedValue(true);
     mockDatasetQuery({
       _id: datasetId,
       teamId: 'team-a',
@@ -109,5 +119,62 @@ describe('authDatasetCollection', () => {
     });
 
     expect(result.collection._id).toBe(collectionId);
+  });
+});
+
+describe('authCollectionFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockParseHeaderCert.mockResolvedValue({
+      teamId: 'team-a',
+      tmbId: 'tmb-a',
+      userId: 'user-a',
+      isRoot: false
+    });
+    mockGetTmbInfoByTmbId.mockResolvedValue({
+      teamId: 'team-a',
+      permission: { isOwner: true }
+    });
+    mockGetTmbPermission.mockResolvedValue(0);
+    mockIsObjectExists.mockResolvedValue(true);
+  });
+
+  it('authorizes a dataset file through the dataset id embedded in the key', async () => {
+    mockDatasetQuery({
+      _id: datasetId,
+      teamId: 'team-a',
+      tmbId: 'tmb-a',
+      inheritPermission: false
+    });
+
+    const result = await authCollectionFile({
+      req: {} as any,
+      authToken: true,
+      fileId: `dataset/${datasetId}/demo.pdf`,
+      per: OwnerPermissionVal
+    });
+
+    expect(result.teamId).toBe('team-a');
+    expect(mockIsObjectExists).toHaveBeenCalledWith(`dataset/${datasetId}/demo.pdf`);
+  });
+
+  it('rejects a dataset file key that belongs to another team', async () => {
+    mockDatasetQuery({
+      _id: datasetId,
+      teamId: 'team-b',
+      tmbId: 'tmb-b',
+      inheritPermission: false
+    });
+
+    await expect(
+      authCollectionFile({
+        req: {} as any,
+        authToken: true,
+        fileId: `dataset/${datasetId}/secret.pdf`,
+        per: OwnerPermissionVal
+      })
+    ).rejects.toBe(DatasetErrEnum.unAuthDataset);
+
+    expect(mockIsObjectExists).not.toHaveBeenCalled();
   });
 });

--- a/projects/app/src/pages/api/core/chat/file/presignChatFileGetUrl.ts
+++ b/projects/app/src/pages/api/core/chat/file/presignChatFileGetUrl.ts
@@ -4,6 +4,8 @@ import { getS3ChatSource } from '@fastgpt/service/common/s3/sources/chat';
 import { authChatCrud } from '@/service/support/permission/auth/chat';
 import { PresignChatFileGetUrlSchema } from '@fastgpt/global/openapi/core/chat/file/api';
 import { parseApiInput } from '@fastgpt/service/common/zod/requestParseError';
+import { isAuthorizedChatFileS3Key } from '@fastgpt/service/common/s3/utils';
+import { ChatErrEnum } from '@fastgpt/global/common/error/code/chat';
 
 async function handler(req: ApiRequestProps): Promise<string> {
   const { key, appId, mode, outLinkAuthData } = parseApiInput({
@@ -11,13 +13,17 @@ async function handler(req: ApiRequestProps): Promise<string> {
     bodySchema: PresignChatFileGetUrlSchema
   }).body;
 
-  await authChatCrud({
+  const authRes = await authChatCrud({
     req,
     authToken: true,
     authApiKey: true,
     appId,
     ...outLinkAuthData
   });
+
+  if (!isAuthorizedChatFileS3Key({ key, appId, uid: authRes.uid })) {
+    return Promise.reject(ChatErrEnum.unAuthChat);
+  }
 
   const { url } = await getS3ChatSource().createGetChatFileURL({ key, external: true, mode });
 

--- a/projects/app/src/pages/api/core/chat/helperBot/getFilePreviewUrl.ts
+++ b/projects/app/src/pages/api/core/chat/helperBot/getFilePreviewUrl.ts
@@ -4,6 +4,7 @@ import type { GetHelperBotFilePreviewParamsType } from '@fastgpt/global/openapi/
 import { authCert } from '@fastgpt/service/support/permission/auth/common';
 import { getS3HelperBotSource } from '@fastgpt/service/common/s3/sources/helperbot';
 import { ChatErrEnum } from '@fastgpt/global/common/error/code/chat';
+import { isAuthorizedHelperBotFileS3Key } from '@fastgpt/service/common/s3/utils';
 
 async function handler(req: ApiRequestProps<GetHelperBotFilePreviewParamsType>): Promise<string> {
   const { key, mode } = req.body;
@@ -12,9 +13,7 @@ async function handler(req: ApiRequestProps<GetHelperBotFilePreviewParamsType>):
     authToken: true
   });
 
-  const { type, chatId, userId: uid, filename } = getS3HelperBotSource().parseKey(key);
-
-  if (userId !== uid) {
+  if (!isAuthorizedHelperBotFileS3Key({ key, userId })) {
     return Promise.reject(ChatErrEnum.unAuthChat);
   }
 

--- a/projects/app/src/pages/api/core/dataset/file/getPreviewChunks.ts
+++ b/projects/app/src/pages/api/core/dataset/file/getPreviewChunks.ts
@@ -2,12 +2,10 @@ import { DatasetSourceReadTypeEnum } from '@fastgpt/global/core/dataset/constant
 import { rawText2Chunks, readDatasetSourceRawText } from '@fastgpt/service/core/dataset/read';
 import { NextAPI } from '@/service/middleware/entry';
 import type { ApiRequestProps } from '@fastgpt/service/type/next';
-import {
-  OwnerPermissionVal,
-  WritePermissionVal
-} from '@fastgpt/global/support/permission/constant';
-import { authCollectionFile } from '@fastgpt/service/support/permission/auth/file';
+import { WritePermissionVal } from '@fastgpt/global/support/permission/constant';
+import { authDatasetFileKey } from '@fastgpt/service/support/permission/auth/file';
 import { authDataset } from '@fastgpt/service/support/permission/dataset/auth';
+import { isAuthorizedDatasetFileS3Key } from '@fastgpt/service/common/s3/utils';
 import {
   computedCollectionChunkSettings,
   getLLMMaxChunkSize
@@ -42,14 +40,21 @@ async function handler(
     throw new Error('sourceId is empty');
   }
 
+  if (
+    type === DatasetSourceReadTypeEnum.fileLocal &&
+    !isAuthorizedDatasetFileS3Key({ key: sourceId, datasetId })
+  ) {
+    return Promise.reject(CommonErrEnum.unAuthFile);
+  }
+
   const fileAuthRes =
     type === DatasetSourceReadTypeEnum.fileLocal
-      ? await authCollectionFile({
+      ? await authDatasetFileKey({
           req,
           authToken: true,
           authApiKey: true,
           fileId: sourceId,
-          per: OwnerPermissionVal
+          per: WritePermissionVal
         })
       : undefined;
 

--- a/projects/app/src/pages/api/core/dataset/file/getSearchTestImagePreviewUrls.ts
+++ b/projects/app/src/pages/api/core/dataset/file/getSearchTestImagePreviewUrls.ts
@@ -4,7 +4,10 @@ import { authDataset } from '@fastgpt/service/support/permission/dataset/auth';
 import { ReadPermissionVal } from '@fastgpt/global/support/permission/constant';
 import { addHours } from 'date-fns';
 import { S3Buckets } from '@fastgpt/service/common/s3/config/constants';
-import { isS3ObjectKey, jwtSignS3DownloadToken } from '@fastgpt/service/common/s3/utils';
+import {
+  isAuthorizedTempFileS3Key,
+  jwtSignS3DownloadToken
+} from '@fastgpt/service/common/s3/utils';
 import { parseApiInput } from '@fastgpt/service/common/zod/requestParseError';
 import {
   GetSearchTestImagePreviewUrlsBodySchema,
@@ -29,7 +32,7 @@ async function handler(
   });
 
   const result = keys
-    .filter((key) => isS3ObjectKey(key, 'temp') && key.startsWith(`temp/${teamId}/`))
+    .filter((key) => isAuthorizedTempFileS3Key({ key, teamId }))
     .map((key) => ({
       key,
       previewUrl: jwtSignS3DownloadToken({

--- a/projects/app/src/pages/api/core/dataset/searchTest.ts
+++ b/projects/app/src/pages/api/core/dataset/searchTest.ts
@@ -12,7 +12,7 @@ import { getRerankModel } from '@fastgpt/service/core/ai/model';
 import { addAuditLog } from '@fastgpt/service/support/user/audit/util';
 import { AuditEventEnum } from '@fastgpt/global/support/user/audit/constants';
 import { getI18nDatasetType } from '@fastgpt/service/support/user/audit/util';
-import { isS3ObjectKey } from '@fastgpt/service/common/s3/utils';
+import { isAuthorizedTempFileS3Key } from '@fastgpt/service/common/s3/utils';
 import { getS3DatasetSource } from '@fastgpt/service/common/s3/sources/dataset';
 import {
   SearchDatasetTestBodySchema,
@@ -63,8 +63,8 @@ export async function handler(
 
   // Search-test images must be temp objects created by this team. Client-supplied keys are not
   // proof of ownership, so reject dataset/chat/foreign-team keys before any S3 read happens.
-  const validQueryImageKeys = queryImageUrls.filter(
-    (key) => isS3ObjectKey(key, 'temp') && key.startsWith(`temp/${teamId}/`)
+  const validQueryImageKeys = queryImageUrls.filter((key) =>
+    isAuthorizedTempFileS3Key({ key, teamId })
   );
 
   if (validQueryImageKeys.length !== queryImageUrls.length) {

--- a/projects/app/test/pages/api/core/chat/file/presignChatFileGetUrl.test.ts
+++ b/projects/app/test/pages/api/core/chat/file/presignChatFileGetUrl.test.ts
@@ -1,0 +1,85 @@
+import { ChatErrEnum } from '@fastgpt/global/common/error/code/chat';
+import type { ApiRequestProps } from '@fastgpt/service/type/next';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  authChatCrud: vi.fn(),
+  createGetChatFileURL: vi.fn()
+}));
+
+vi.mock('@/service/middleware/entry', () => ({
+  NextAPI: (handler: unknown) => handler
+}));
+
+vi.mock('@/service/support/permission/auth/chat', () => ({
+  authChatCrud: mocks.authChatCrud
+}));
+
+vi.mock('@fastgpt/service/common/s3/sources/chat', () => ({
+  getS3ChatSource: () => ({
+    createGetChatFileURL: mocks.createGetChatFileURL
+  })
+}));
+
+import handler from '@/pages/api/core/chat/file/presignChatFileGetUrl';
+
+const appId = '507f1f77bcf86cd799439011';
+const uid = 'user-id';
+const chatId = 'chat-id';
+const presignHandler = handler as unknown as (req: ApiRequestProps) => Promise<string>;
+
+const callHandler = (body: Record<string, unknown>) =>
+  presignHandler({
+    body
+  } as ApiRequestProps);
+
+describe('presignChatFileGetUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.authChatCrud.mockResolvedValue({
+      teamId: 'team-id',
+      uid
+    });
+    mocks.createGetChatFileURL.mockResolvedValue({
+      url: 'https://example.com/download-token'
+    });
+  });
+
+  it('signs a chat file only when the key belongs to the authorized app and uid', async () => {
+    await expect(
+      callHandler({
+        appId,
+        key: `chat/${appId}/${uid}/${chatId}/demo.pdf`
+      })
+    ).resolves.toBe('https://example.com/download-token');
+
+    expect(mocks.createGetChatFileURL).toHaveBeenCalledWith({
+      key: `chat/${appId}/${uid}/${chatId}/demo.pdf`,
+      external: true,
+      mode: undefined
+    });
+  });
+
+  it('rejects a key from another app before signing', async () => {
+    await expect(
+      callHandler({
+        appId,
+        key: `chat/507f1f77bcf86cd799439099/${uid}/${chatId}/demo.pdf`
+      })
+    ).rejects.toBe(ChatErrEnum.unAuthChat);
+
+    expect(mocks.createGetChatFileURL).not.toHaveBeenCalled();
+  });
+
+  it('rejects a key from another chat uid before signing', async () => {
+    await expect(
+      callHandler({
+        appId,
+        key: `chat/${appId}/victim-uid/${chatId}/demo.pdf`
+      })
+    ).rejects.toBe(ChatErrEnum.unAuthChat);
+
+    expect(mocks.createGetChatFileURL).not.toHaveBeenCalled();
+  });
+});

--- a/projects/app/test/pages/api/core/chat/helperBot/getFilePreviewUrl.test.ts
+++ b/projects/app/test/pages/api/core/chat/helperBot/getFilePreviewUrl.test.ts
@@ -1,0 +1,78 @@
+import { ChatErrEnum } from '@fastgpt/global/common/error/code/chat';
+import type { ApiRequestProps } from '@fastgpt/service/type/next';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  authCert: vi.fn(),
+  createGetFileURL: vi.fn()
+}));
+
+vi.mock('@/service/middleware/entry', () => ({
+  NextAPI: (handler: unknown) => handler
+}));
+
+vi.mock('@fastgpt/service/support/permission/auth/common', () => ({
+  authCert: mocks.authCert
+}));
+
+vi.mock('@fastgpt/service/common/s3/sources/helperbot', () => ({
+  getS3HelperBotSource: () => ({
+    createGetFileURL: mocks.createGetFileURL
+  })
+}));
+
+import handler from '@/pages/api/core/chat/helperBot/getFilePreviewUrl';
+
+const previewHandler = handler as unknown as (req: ApiRequestProps) => Promise<string>;
+
+const callHandler = (body: Record<string, unknown>) =>
+  previewHandler({
+    body
+  } as ApiRequestProps);
+
+describe('getFilePreviewUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.authCert.mockResolvedValue({
+      userId: 'user-1'
+    });
+    mocks.createGetFileURL.mockResolvedValue({
+      url: 'https://example.com/helper-bot-file'
+    });
+  });
+
+  it('signs a helper bot file only when the key belongs to the current user', async () => {
+    await expect(
+      callHandler({
+        key: 'helperBot/topAgent/user-1/chat-1/demo.pdf'
+      })
+    ).resolves.toBe('https://example.com/helper-bot-file');
+
+    expect(mocks.createGetFileURL).toHaveBeenCalledWith({
+      key: 'helperBot/topAgent/user-1/chat-1/demo.pdf',
+      external: true,
+      mode: undefined
+    });
+  });
+
+  it('rejects a helper bot file key from another user', async () => {
+    await expect(
+      callHandler({
+        key: 'helperBot/topAgent/user-2/chat-1/demo.pdf'
+      })
+    ).rejects.toBe(ChatErrEnum.unAuthChat);
+
+    expect(mocks.createGetFileURL).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed helper bot file key before signing', async () => {
+    await expect(
+      callHandler({
+        key: 'topAgent/chat-1/user-1/demo.pdf'
+      })
+    ).rejects.toBe(ChatErrEnum.unAuthChat);
+
+    expect(mocks.createGetFileURL).not.toHaveBeenCalled();
+  });
+});

--- a/projects/app/test/pages/api/core/dataset/file/getPreviewChunks.test.ts
+++ b/projects/app/test/pages/api/core/dataset/file/getPreviewChunks.test.ts
@@ -1,0 +1,128 @@
+import { DatasetSourceReadTypeEnum } from '@fastgpt/global/core/dataset/constants';
+import { CommonErrEnum } from '@fastgpt/global/common/error/code/common';
+import type { ApiRequestProps } from '@fastgpt/service/type/next';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  authDatasetFileKey: vi.fn(),
+  authDataset: vi.fn(),
+  readDatasetSourceRawText: vi.fn(),
+  rawText2Chunks: vi.fn(),
+  replaceS3KeyToPreviewUrl: vi.fn((value: string) => value)
+}));
+
+vi.mock('@/service/middleware/entry', () => ({
+  NextAPI: (handler: unknown) => handler
+}));
+
+vi.mock('@fastgpt/service/support/permission/auth/file', () => ({
+  authDatasetFileKey: mocks.authDatasetFileKey
+}));
+
+vi.mock('@fastgpt/service/support/permission/dataset/auth', () => ({
+  authDataset: mocks.authDataset
+}));
+
+vi.mock('@fastgpt/service/core/dataset/read', () => ({
+  readDatasetSourceRawText: mocks.readDatasetSourceRawText,
+  rawText2Chunks: mocks.rawText2Chunks
+}));
+
+vi.mock('@fastgpt/service/core/ai/model', () => ({
+  getEmbeddingModel: vi.fn(() => ({})),
+  getLLMModel: vi.fn(() => ({}))
+}));
+
+vi.mock('@fastgpt/global/core/dataset/training/utils', () => ({
+  computedCollectionChunkSettings: vi.fn(() => ({
+    chunkTriggerType: 'minSize',
+    chunkTriggerMinSize: 100,
+    chunkSize: 500,
+    paragraphChunkDeep: 1,
+    paragraphChunkMinSize: 100,
+    chunkSplitter: ''
+  })),
+  getLLMMaxChunkSize: vi.fn(() => 1000)
+}));
+
+vi.mock('@fastgpt/service/core/dataset/utils', () => ({
+  replaceS3KeyToPreviewUrl: mocks.replaceS3KeyToPreviewUrl
+}));
+
+import handler from '@/pages/api/core/dataset/file/getPreviewChunks';
+
+const datasetId = '507f1f77bcf86cd799439011';
+const previewHandler = handler as unknown as (req: ApiRequestProps) => Promise<unknown>;
+
+const callHandler = (body: Record<string, unknown>) =>
+  previewHandler({
+    body
+  } as ApiRequestProps);
+
+describe('getPreviewChunks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.authDatasetFileKey.mockResolvedValue({
+      tmbId: 'tmb-a',
+      isRoot: false
+    });
+    mocks.authDataset.mockResolvedValue({
+      teamId: 'team-a',
+      tmbId: 'tmb-a',
+      dataset: {
+        agentModel: 'gpt',
+        vectorModel: 'embedding'
+      }
+    });
+    mocks.readDatasetSourceRawText.mockResolvedValue({
+      rawText: 'hello'
+    });
+    mocks.rawText2Chunks.mockResolvedValue([
+      {
+        q: 'hello',
+        a: ''
+      }
+    ]);
+  });
+
+  it('rejects a local file key that is not under the target dataset before auth or read', async () => {
+    await expect(
+      callHandler({
+        type: DatasetSourceReadTypeEnum.fileLocal,
+        datasetId,
+        overlapRatio: 0.2,
+        sourceId: 'dataset/507f1f77bcf86cd799439099/secret.pdf'
+      })
+    ).rejects.toBe(CommonErrEnum.unAuthFile);
+
+    expect(mocks.authDatasetFileKey).not.toHaveBeenCalled();
+    expect(mocks.authDataset).not.toHaveBeenCalled();
+    expect(mocks.readDatasetSourceRawText).not.toHaveBeenCalled();
+  });
+
+  it('previews a local file key under the target dataset', async () => {
+    await expect(
+      callHandler({
+        type: DatasetSourceReadTypeEnum.fileLocal,
+        datasetId,
+        overlapRatio: 0.2,
+        sourceId: `dataset/${datasetId}/demo.pdf`
+      })
+    ).resolves.toMatchObject({
+      total: 1
+    });
+
+    expect(mocks.authDatasetFileKey).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileId: `dataset/${datasetId}/demo.pdf`
+      })
+    );
+    expect(mocks.readDatasetSourceRawText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        datasetId,
+        sourceId: `dataset/${datasetId}/demo.pdf`
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add shared S3 object key parsing and authorization helpers for chat, dataset, helperBot, and temp files.
- Bind user-supplied S3 keys to the already-authorized app/dataset/user/team before signing or reading.
- Add layered dataset file safeguards in API, dataset read service, and S3 dataset source.
- Document the pattern and future entry requirements in `.agents/design/api/s3-object-key-authorization.md`.

## Tests

- `pnpm vitest run test/common/s3/utils.test.ts test/support/permission/dataset/auth.test.ts test/core/dataset/read.test.ts --coverage.enabled=false` from `packages/service`
- `pnpm vitest run test/pages/api/core/chat/file/presignChatFileGetUrl.test.ts test/pages/api/core/chat/helperBot/getFilePreviewUrl.test.ts test/pages/api/core/chat/file/presignChatFilePostUrl.test.ts test/pages/api/core/dataset/searchTest.test.ts test/pages/api/core/dataset/file/getPreviewChunks.test.ts --coverage.enabled=false` from `projects/app`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc --noEmit --pretty false` from `projects/app`