### PR TITLE
Codex/siigure http https

### DIFF
--- a/packages/global/common/system/types/index.ts
+++ b/packages/global/common/system/types/index.ts
@@ -166,6 +166,10 @@ export type SystemEnvType = {
   customPdfParse?: customPdfParseType;
   fileUrlWhitelist?: string[];
   customDomain?: customDomainType;
+  workflowHttpNode?: {
+    /** 是否允许工作流 HTTP 节点忽略 HTTPS 证书校验。 */
+    ignoreHttpsCertificate?: boolean;
+  };
 };
 
 export type customDomainType = {

--- a/packages/service/common/api/axios.ts
+++ b/packages/service/common/api/axios.ts
@@ -1,5 +1,5 @@
 import _, { type AxiosInstance, type AxiosRequestConfig } from 'axios';
-import { ProxyAgent } from 'proxy-agent';
+import { ProxyAgent, type ProxyAgentOptions } from 'proxy-agent';
 import { isDevEnv } from '@fastgpt/global/common/system/constants';
 import { isInternalAddress, PRIVATE_URL_TEXT } from '../system/utils';
 import { isAbsoluteUrl } from '../security/network';
@@ -26,8 +26,18 @@ const addSSRFInterceptor = (instance: AxiosInstance) => {
   return instance;
 };
 
+const createProxyAgent = (options?: ProxyAgentOptions) => new ProxyAgent(options);
+
+/**
+ * 工作流 HTTP 节点跳过 HTTPS 证书校验专用 agent。
+ * 仍复用 ProxyAgent,只调整目标站 TLS 校验策略,避免改变部署环境的代理语义。
+ */
+export const httpsCertificateIgnoreAgent = createProxyAgent({
+  rejectUnauthorized: false
+});
+
 export function createProxyAxios(config?: AxiosRequestConfig, ssrfCheck = true) {
-  const agent = new ProxyAgent();
+  const agent = createProxyAgent();
 
   const instance = isDevEnv
     ? _.create(config)

--- a/packages/service/common/system/config/controller.ts
+++ b/packages/service/common/system/config/controller.ts
@@ -20,6 +20,7 @@ export const getFastGPTConfigFromDB = async (): Promise<{
     }).sort({
       createTime: -1
     }),
+
     MongoSystemConfigs.findOne({
       type: SystemConfigsTypeEnum.license
     }).sort({

--- a/packages/service/core/workflow/dispatch/tools/http468.ts
+++ b/packages/service/core/workflow/dispatch/tools/http468.ts
@@ -19,6 +19,7 @@ import {
   replaceEditorVariable,
   valueTypeFormat
 } from '@fastgpt/global/core/workflow/runtime/utils';
+import type { AxiosRequestConfig } from 'axios';
 import json5 from 'json5';
 import { JSONPath } from 'jsonpath-plus';
 import { getSecretValue } from '../../../../common/secret/utils';
@@ -27,9 +28,36 @@ import { getLogger, LogCategories } from '../../../../common/logger';
 import { formatHttpError } from '../utils';
 import { isInternalAddress, PRIVATE_URL_TEXT } from '../../../../common/system/utils';
 import { serviceRequestMaxContentLength } from '../../../../common/system/constants';
-import { axios } from '../../../../common/api/axios';
+import { axios, httpsCertificateIgnoreAgent } from '../../../../common/api/axios';
 
 const logger = getLogger(LogCategories.MODULE.WORKFLOW.TOOLS);
+
+/**
+ * 仅工作流 HTTP 节点允许按系统配置跳过 HTTPS 证书校验。
+ * 该配置不下沉到通用 axios,避免影响模型请求、HTTP 工具集等其它出站链路。
+ */
+export const getWorkflowHttpNodeHttpsAgentConfig = (
+  url: string
+): Pick<AxiosRequestConfig, 'httpsAgent'> => {
+  const ignoreHttpsCertificate =
+    global.systemEnv?.workflowHttpNode?.ignoreHttpsCertificate === true;
+
+  if (!ignoreHttpsCertificate) {
+    return {};
+  }
+
+  try {
+    if (new URL(url).protocol !== 'https:') {
+      return {};
+    }
+  } catch {
+    return {};
+  }
+
+  return {
+    httpsAgent: httpsCertificateIgnoreAgent
+  };
+};
 
 type PropsArrType = {
   key: string;
@@ -268,7 +296,11 @@ export const dispatchHttp468Request = async (props: HttpRequestProps): Promise<H
         Object.keys(results).length > 0 ? results : rawResponse
     };
   } catch (error) {
-    logger.warn('HTTP tool request failed', { error, httpReqUrl: requestUrl });
+    logger.warn('HTTP tool request failed', {
+      error,
+      httpReqUrl: requestUrl,
+      ignoreHttpsCertificate: global.systemEnv?.workflowHttpNode?.ignoreHttpsCertificate === true
+    });
 
     // @adapt
     if (node.catchError === undefined) {
@@ -515,7 +547,8 @@ async function fetchData({
     },
     timeout: timeout * 1000,
     params: params,
-    data: ['POST', 'PUT', 'PATCH'].includes(method) ? body : undefined
+    data: ['POST', 'PUT', 'PATCH'].includes(method) ? body : undefined,
+    ...getWorkflowHttpNodeHttpsAgentConfig(url)
   });
 
   return {

--- a/packages/service/test/core/workflow/dispatch/tools/http.test.ts
+++ b/packages/service/test/core/workflow/dispatch/tools/http.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { replaceJsonBodyString } from '@fastgpt/service/core/workflow/dispatch/tools/http468';
+import { afterEach, describe, it, expect } from 'vitest';
+import {
+  getWorkflowHttpNodeHttpsAgentConfig,
+  replaceJsonBodyString
+} from '@fastgpt/service/core/workflow/dispatch/tools/http468';
+import { httpsCertificateIgnoreAgent } from '@fastgpt/service/common/api/axios';
 import type { RuntimeNodeItemType } from '@fastgpt/global/core/workflow/runtime/type';
 
 describe('replaceJsonBodyString', () => {
@@ -638,5 +642,49 @@ describe('replaceJsonBodyString', () => {
       expect(typeof parsed.templateTests.inject).toBe('string');
       expect(parsed.templateTests.inject).toBe(''); // Non-existent variables become "null"
     });
+  });
+});
+
+describe('getWorkflowHttpNodeHttpsAgentConfig', () => {
+  const originalSystemEnv = global.systemEnv;
+
+  afterEach(() => {
+    global.systemEnv = originalSystemEnv;
+  });
+
+  it('should not inject httpsAgent when ignoreHttpsCertificate is disabled', () => {
+    global.systemEnv = {
+      ...originalSystemEnv,
+      workflowHttpNode: {
+        ignoreHttpsCertificate: false
+      }
+    };
+
+    expect(getWorkflowHttpNodeHttpsAgentConfig('https://example.com')).toEqual({});
+  });
+
+  it('should inject httpsAgent only for HTTPS requests when enabled', () => {
+    global.systemEnv = {
+      ...originalSystemEnv,
+      workflowHttpNode: {
+        ignoreHttpsCertificate: true
+      }
+    };
+
+    const httpsConfig = getWorkflowHttpNodeHttpsAgentConfig('https://example.com');
+    expect(httpsConfig.httpsAgent).toBe(httpsCertificateIgnoreAgent);
+    expect(httpsConfig).not.toHaveProperty('proxy');
+    expect(getWorkflowHttpNodeHttpsAgentConfig('http://example.com')).toEqual({});
+  });
+
+  it('should ignore invalid urls and let request layer report url errors', () => {
+    global.systemEnv = {
+      ...originalSystemEnv,
+      workflowHttpNode: {
+        ignoreHttpsCertificate: true
+      }
+    };
+
+    expect(getWorkflowHttpNodeHttpsAgentConfig('invalid-url')).toEqual({});
   });
 });

--- a/projects/app/src/service/common/system/volumnMongoWatch.ts
+++ b/projects/app/src/service/common/system/volumnMongoWatch.ts
@@ -28,11 +28,9 @@ const reloadConfigWatch = () => {
       if (
         change.operationType === 'update' ||
         (change.operationType === 'insert' &&
-          [
-            SystemConfigsTypeEnum.fastgpt,
-            SystemConfigsTypeEnum.fastgptPro,
-            SystemConfigsTypeEnum.license
-          ].includes(change.fullDocument.type))
+          [SystemConfigsTypeEnum.fastgptPro, SystemConfigsTypeEnum.license].includes(
+            change.fullDocument.type
+          ))
       ) {
         await initSystemConfig();
         logger.info('System config refreshed via Mongo change stream');

--- a/projects/app/src/service/common/system/volumnMongoWatch.ts
+++ b/projects/app/src/service/common/system/volumnMongoWatch.ts
@@ -28,9 +28,11 @@ const reloadConfigWatch = () => {
       if (
         change.operationType === 'update' ||
         (change.operationType === 'insert' &&
-          [SystemConfigsTypeEnum.fastgptPro, SystemConfigsTypeEnum.license].includes(
-            change.fullDocument.type
-          ))
+          [
+            SystemConfigsTypeEnum.fastgpt,
+            SystemConfigsTypeEnum.fastgptPro,
+            SystemConfigsTypeEnum.license
+          ].includes(change.fullDocument.type))
       ) {
         await initSystemConfig();
         logger.info('System config refreshed via Mongo change stream');


### PR DESCRIPTION
方案
需求核心是：给工作流 HTTP 请求节点加一个 admin 全局开关。开关开启后，只有工作流 HTTP 节点请求 HTTPS 时会忽略证书校验；其他 HTTP 工具集、模型请求、插件请求都不受影响，SSRF 内网防护也保留。

实现思路：
1.在系统配置 systemEnv 里新增配置项：workflowHttpNode.ignoreHttpsCertificate
2.新增 admin API 读写这个配置：GET /api/admin/core/system/workflowHttpNodeConfig   
PUT /api/admin/core/system/workflowHttpNodeConfig
3.新增 /config/system 页面，root 管理员可以打开/关闭这个开关。
4.HTTP 节点运行时读取：global.systemEnv?.workflowHttpNode?.ignoreHttpsCertificate
5.如果开关开启，并且 URL 是 https:，则给这次 axios 请求追加忽略证书的 agent。

为了不破坏代理环境，没用裸 https.Agent，而是在 packages/service/common/api/axios.ts 里抽了：
createProxyAgent()
HTTP 节点用createProxyAgent({ rejectUnauthorized: false })创建，这样开启忽略证书时仍然保留原来的 ProxyAgent 行为。