### PR TITLE
fix: move index action i18n to common

### DIFF
--- a/packages/web/i18n/en/common.json
+++ b/packages/web/i18n/en/common.json
@@ -769,6 +769,7 @@
   "dataset_data_input_q": "question",
   "dataset_data_input_qa": "QA",
   "dataset_text_model_tip": "Used for text processing in the knowledge base preprocessing stage, such as automatic supplementary indexing, Q&A pair extraction.",
+  "generate_index": "Update index",
   "date_12_months": "12 Months",
   "date_1_month": "1 Month",
   "date_3_months": "3 Months",

--- a/packages/web/i18n/en/dataset.json
+++ b/packages/web/i18n/en/dataset.json
@@ -90,7 +90,6 @@
   "file_model_function_tip": "Used for QA generation, auto-indexing, and other AI-powered data processing.",
   "filename": "Filename",
   "folder_dataset": "Folder",
-  "generate_index": "Update index",
   "image_auto_parse": "Automatic image indexing",
   "image_auto_parse_tips": "Call VLM to automatically label the pictures in the document and generate additional search indexes",
   "image_auto_parse_tip_commercial": "Upgrade to the commercial edition to use this feature",

--- a/packages/web/i18n/zh-CN/common.json
+++ b/packages/web/i18n/zh-CN/common.json
@@ -769,6 +769,7 @@
   "dataset_data_input_q": "问题",
   "dataset_data_input_qa": "QA 模式",
   "dataset_text_model_tip": "用于知识库预处理阶段的文本处理，例如自动补充索引、问答对提取。",
+  "generate_index": "更新索引",
   "date_12_months": "12个月",
   "date_1_month": "1个月",
   "date_3_months": "3个月",

--- a/packages/web/i18n/zh-CN/dataset.json
+++ b/packages/web/i18n/zh-CN/dataset.json
@@ -90,7 +90,6 @@
   "file_model_function_tip": "用于增强索引和 QA 生成",
   "filename": "文件名",
   "folder_dataset": "文件夹",
-  "generate_index": "更新索引",
   "image_auto_parse": "图片自动索引",
   "image_auto_parse_tips": "调用 VLM 自动标注文档里的图片，并生成额外的检索索引",
   "image_auto_parse_tip_commercial": "请升级商业版后使用该功能",

--- a/packages/web/i18n/zh-Hant/common.json
+++ b/packages/web/i18n/zh-Hant/common.json
@@ -764,6 +764,7 @@
   "dataset_data_input_q": "問題",
   "dataset_data_input_qa": "QA 模式",
   "dataset_text_model_tip": "用於知識庫預處理階段的文字處理，例如自動補充索引、問答對提取。",
+  "generate_index": "更新索引",
   "date_12_months": "12個月",
   "date_1_month": "1個月",
   "date_6_months": "6個月",

--- a/packages/web/i18n/zh-Hant/dataset.json
+++ b/packages/web/i18n/zh-Hant/dataset.json
@@ -90,7 +90,6 @@
   "file_model_function_tip": "用於增強索引和問答生成",
   "filename": "檔案名稱",
   "folder_dataset": "資料夾",
-  "generate_index": "更新索引",
   "image_auto_parse": "圖片自動索引",
   "image_auto_parse_tips": "呼叫 VLM 自動標註文件裡的圖片，並生成額外的檢索索引",
   "image_auto_parse_tip_commercial": "請升級商業版後使用該功能",

--- a/projects/app/src/pageComponents/dataset/detail/components/InputDataModal/DataInputPanel.tsx
+++ b/projects/app/src/pageComponents/dataset/detail/components/InputDataModal/DataInputPanel.tsx
@@ -184,7 +184,7 @@ const DataInputPanel = ({
           submitData();
         }}
       >
-        {t('dataset:generate_index')}
+        {t('common:generate_index')}
       </Button>
     </Flex>
   );


### PR DESCRIPTION
## What

- Move the shared `generate_index` i18n key from the `dataset` namespace to `common`.
- Update `InputDataModal` to read the action label from `common:generate_index`.
- Remove the duplicated key from the dataset namespace across supported locales.

## Why

`InputDataModal` is reused outside dataset pages, including app annotation flows. Those pages do not necessarily load the `dataset` namespace, so `t('dataset:generate_index')` can fall back to the raw key in the UI. `common` is loaded by default and already contains the other shared labels used by this modal.

## Checks

- `node -e "for (const f of ['packages/web/i18n/zh-CN/common.json','packages/web/i18n/en/common.json','packages/web/i18n/zh-Hant/common.json','packages/web/i18n/zh-CN/dataset.json','packages/web/i18n/en/dataset.json','packages/web/i18n/zh-Hant/dataset.json']) { JSON.parse(require('fs').readFileSync(f,'utf8')); console.log('ok', f); }"`
- `rg -n "generate_index|dataset:generate_index|common:generate_index" . --glob '!projects/app/public/js/**'`
- `git diff --check`
- `pnpm --filter @fastgpt/app exec eslint src/pageComponents/dataset/detail/components/InputDataModal/DataInputPanel.tsx`
