### PR TITLE
Fix login language synchronization

### DIFF
--- a/packages/global/openapi/support/user/account/login/api.ts
+++ b/packages/global/openapi/support/user/account/login/api.ts
@@ -109,7 +109,8 @@ export type OauthLoginBodyType = z.infer<typeof OauthLoginBodySchema>;
 // ===== Fast Login =====
 export const FastLoginBodySchema = z.object({
   token: z.string().meta({ description: 'Token' }),
-  code: z.string().meta({ description: 'Code' })
+  code: z.string().meta({ description: 'Code' }),
+  language: LanguageSchema.optional().meta({ description: '语言' })
 });
 export type FastLoginBodyType = z.infer<typeof FastLoginBodySchema>;
 
@@ -120,7 +121,8 @@ export const WxLoginBodySchema = z.object({
   bd_vid: z.string().optional(),
   msclkid: z.string().optional(),
   fastgpt_sem: z.string().optional(),
-  sourceDomain: z.string().optional()
+  sourceDomain: z.string().optional(),
+  language: LanguageSchema.optional().meta({ description: '语言' })
 });
 export type WxLoginBodyType = z.infer<typeof WxLoginBodySchema>;
 export const GetWXLoginQRResponseSchema = z.object({

--- a/packages/global/openapi/support/user/account/password/api.ts
+++ b/packages/global/openapi/support/user/account/password/api.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { LanguageSchema } from '../../../../../common/i18n/type';
 
 // ===== Update password by old password =====
 export const UpdatePasswordByOldBodySchema = z
@@ -56,7 +57,8 @@ export const UpdatePasswordByCodeBodySchema = z.object({
   username: z.string().trim().min(1).meta({ description: '用户名' }),
   code: z.string().meta({ description: '验证码' }),
   password: z.string().trim().min(1).meta({ description: '新密码' }),
-  tmbId: z.string().optional().meta({ description: '团队成员 ID（可选）' })
+  tmbId: z.string().optional().meta({ description: '团队成员 ID（可选）' }),
+  language: LanguageSchema.optional().meta({ description: '语言' })
 });
 
 export type UpdatePasswordByCodeBodyType = z.infer<typeof UpdatePasswordByCodeBodySchema>;

--- a/projects/app/src/components/Select/I18nLngSelector.tsx
+++ b/projects/app/src/components/Select/I18nLngSelector.tsx
@@ -21,7 +21,7 @@ const I18nLngSelector = () => {
           language: lng
         });
       }
-      await onChangeLngI18n(lng, { reloadOnChange: true });
+      await onChangeLngI18n(lng);
     },
     [userInfo?.username, onChangeLngI18n, updateUserInfo]
   );

--- a/projects/app/src/pageComponents/account/AccountContainer.tsx
+++ b/projects/app/src/pageComponents/account/AccountContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Box, Flex, useTheme } from '@chakra-ui/react';
 import { useSystemStore } from '@/web/common/system/useSystemStore';
 import { useRouter } from 'next/router';
@@ -44,7 +44,7 @@ const AccountContainer = ({
     return router.pathname.split('/').pop() as TabEnum;
   }, [router.pathname]);
 
-  const tabList = useRef([
+  const tabList = [
     {
       icon: 'support/user/userLight',
       label: t('account:personal_information'),
@@ -130,7 +130,7 @@ const AccountContainer = ({
       label: t('account:logout'),
       value: TabEnum.loginout
     }
-  ]);
+  ];
 
   const { openConfirm, ConfirmModal } = useConfirm({
     content: t('account:confirm_logout')
@@ -168,7 +168,7 @@ const AccountContainer = ({
               mx={'auto'}
               mt={2}
               w={'100%'}
-              list={tabList.current}
+              list={tabList}
               value={currentTab}
               onChange={setCurrentTab}
             />
@@ -185,7 +185,7 @@ const AccountContainer = ({
               m={'auto'}
               w={'100%'}
               size={isPc ? 'md' : 'sm'}
-              list={tabList.current.map((item) => ({
+              list={tabList.map((item) => ({
                 value: item.value,
                 label: item.label
               }))}

--- a/projects/app/src/pageComponents/login/ForgetPasswordForm.tsx
+++ b/projects/app/src/pageComponents/login/ForgetPasswordForm.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'next-i18next';
 import { useRequest } from '@fastgpt/web/hooks/useRequest';
 import { checkPasswordRule } from '@fastgpt/global/common/string/password';
 import type { LoginSuccessResponseType } from '@fastgpt/global/openapi/support/user/account/login/api';
+import type { LangEnum } from '@fastgpt/global/common/i18n/type';
 
 type LoginSuccessHandler = (res: LoginSuccessResponseType) => void | Promise<void>;
 
@@ -27,7 +28,7 @@ interface RegisterType {
 
 const RegisterForm = ({ setPageType, loginSuccess }: Props) => {
   const { toast } = useToast();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { feConfigs } = useSystemStore();
   const {
     register,
@@ -60,7 +61,8 @@ const RegisterForm = ({ setPageType, loginSuccess }: Props) => {
       const loginResponse = await postFindPassword({
         username,
         code,
-        password
+        password,
+        language: i18n.language as LangEnum
       });
       await loginSuccess(loginResponse);
       toast({
@@ -69,7 +71,7 @@ const RegisterForm = ({ setPageType, loginSuccess }: Props) => {
       });
     },
     {
-      refreshDeps: [loginSuccess, t, toast]
+      refreshDeps: [i18n.language, loginSuccess, t, toast]
     }
   );
   const onSubmitErr = (err: Record<string, any>) => {

--- a/projects/app/src/pageComponents/login/LoginForm/WechatForm.tsx
+++ b/projects/app/src/pageComponents/login/LoginForm/WechatForm.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/web/support/marketing/utils';
 import PolicyTip from './PolicyTip';
 import type { LoginSuccessResponseType } from '@fastgpt/global/openapi/support/user/account/login/api';
+import type { LangEnum } from '@fastgpt/global/common/i18n/type';
 
 type LoginSuccessHandler = (res: LoginSuccessResponseType) => void | Promise<void>;
 
@@ -28,7 +29,7 @@ interface Props {
 }
 
 const WechatForm = ({ setPageType, loginSuccess }: Props) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { toast } = useToast();
 
   const { data: wechatInfo } = useQuery(['getWXLoginQR'], getWXLoginQR, {
@@ -41,7 +42,7 @@ const WechatForm = ({ setPageType, loginSuccess }: Props) => {
   });
 
   useQuery(
-    ['getWXLoginResult', wechatInfo?.code],
+    ['getWXLoginResult', wechatInfo?.code, i18n.language],
     () =>
       getWXLoginResult({
         inviterId: getInviterId(),
@@ -49,7 +50,8 @@ const WechatForm = ({ setPageType, loginSuccess }: Props) => {
         bd_vid: getBdVId(),
         msclkid: getMsclkid(),
         fastgpt_sem: getFastGPTSem(),
-        sourceDomain: getSourceDomain()
+        sourceDomain: getSourceDomain(),
+        language: i18n.language as LangEnum
       }),
     {
       refetchInterval: 3 * 1000,

--- a/projects/app/src/pageComponents/login/RegisterForm.tsx
+++ b/projects/app/src/pageComponents/login/RegisterForm.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/web/support/marketing/utils';
 import { checkPasswordRule } from '@fastgpt/global/common/string/password';
 import type { LoginSuccessResponseType } from '@fastgpt/global/openapi/support/user/account/login/api';
+import type { LangEnum } from '@fastgpt/global/common/i18n/type';
 
 type LoginSuccessHandler = (res: LoginSuccessResponseType) => void | Promise<void>;
 
@@ -35,7 +36,7 @@ interface RegisterType {
 
 const RegisterForm = ({ setPageType, loginSuccess }: Props) => {
   const { toast } = useToast();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const { feConfigs } = useSystemStore();
   const {
@@ -61,7 +62,8 @@ const RegisterForm = ({ setPageType, loginSuccess }: Props) => {
         bd_vid: getBdVId(),
         msclkid: getMsclkid(),
         fastgpt_sem: getFastGPTSem(),
-        sourceDomain: getSourceDomain()
+        sourceDomain: getSourceDomain(),
+        language: i18n.language as LangEnum
       });
       await loginSuccess(loginResponse);
       removeFastGPTSem();
@@ -72,7 +74,7 @@ const RegisterForm = ({ setPageType, loginSuccess }: Props) => {
       });
     },
     {
-      refreshDeps: [loginSuccess, t, toast]
+      refreshDeps: [i18n.language, loginSuccess, t, toast]
     }
   );
   const onSubmitErr = (err: Record<string, any>) => {

--- a/projects/app/src/pages/api/support/user/account/loginByPassword.ts
+++ b/projects/app/src/pages/api/support/user/account/loginByPassword.ts
@@ -20,12 +20,16 @@ import {
 } from '@fastgpt/global/openapi/support/user/account/login/api';
 import type { ApiRequestProps, ApiResponseType } from '@fastgpt/service/type/next';
 import { getClientIpFromRequest } from '@fastgpt/service/common/security/clientIp';
+import { parseApiInput } from '@fastgpt/service/common/zod/requestParseError';
 
 async function handler(
   req: ApiRequestProps<LoginByPasswordBodyType>,
   res: ApiResponseType
 ): Promise<LoginSuccessResponseType> {
-  const { username, password, code, language } = LoginByPasswordBodySchema.parse(req.body);
+  const { username, password, code, language } = parseApiInput({
+    req,
+    bodySchema: LoginByPasswordBodySchema
+  }).body;
 
   // Auth prelogin code
   await authCode({

--- a/projects/app/src/pages/login/fastlogin.tsx
+++ b/projects/app/src/pages/login/fastlogin.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'next-i18next';
 import { validateRedirectUrl } from '@/web/common/utils/uri';
 import type { LoginSuccessResponseType } from '@fastgpt/global/openapi/support/user/account/login/api';
 import { useLoginRedirectAfterLogin } from '@/web/support/user/loginRedirect';
+import type { LangEnum } from '@fastgpt/global/common/i18n/type';
 
 const FastLogin = ({
   code,
@@ -26,7 +27,7 @@ const FastLogin = ({
   const { setUserInfo } = useUserStore();
   const router = useRouter();
   const { toast } = useToast();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const resolveLoginRedirect = useLoginRedirectAfterLogin();
   const loginSuccess = useCallback(
     async (res: LoginSuccessResponseType) => {
@@ -53,7 +54,8 @@ const FastLogin = ({
       try {
         const res = await postFastLogin({
           code,
-          token
+          token,
+          language: i18n.language as LangEnum
         });
         if (!res) {
           toast({
@@ -75,7 +77,7 @@ const FastLogin = ({
         }, 1000);
       }
     },
-    [loginSuccess, router, t, toast]
+    [i18n.language, loginSuccess, router, t, toast]
   );
 
   useEffect(() => {

--- a/projects/app/src/pages/login/provider.tsx
+++ b/projects/app/src/pages/login/provider.tsx
@@ -20,10 +20,10 @@ import {
 } from '@/web/support/marketing/utils';
 import { postAcceptInvitationLink } from '@/web/support/user/team/api';
 import { retryFn } from '@fastgpt/global/common/system/utils';
-import type { LangEnum } from '@fastgpt/global/common/i18n/type';
 import { validateRedirectUrl } from '@/web/common/utils/uri';
 import type { LoginSuccessResponseType } from '@fastgpt/global/openapi/support/user/account/login/api';
 import { useLoginRedirectAfterLogin } from '@/web/support/user/loginRedirect';
+import type { LangEnum } from '@fastgpt/global/common/i18n/type';
 
 let isOauthLogging = false;
 

--- a/projects/app/src/web/support/user/api.ts
+++ b/projects/app/src/web/support/user/api.ts
@@ -12,7 +12,10 @@ import type {
   WxLoginBodyType,
   GetWXLoginQRResponseType
 } from '@fastgpt/global/openapi/support/user/account/login/api';
-import type { UpdatePasswordByOldBodyType } from '@fastgpt/global/openapi/support/user/account/password/api';
+import type {
+  UpdatePasswordByCodeBodyType,
+  UpdatePasswordByOldBodyType
+} from '@fastgpt/global/openapi/support/user/account/password/api';
 import type { AccountRegisterBodyType } from '@fastgpt/global/openapi/support/user/account/register/api';
 import type { LangEnum } from '@fastgpt/global/common/i18n/type';
 import type { LoginSuccessResponseType } from '@fastgpt/global/openapi/support/user/account/login/api';
@@ -63,7 +66,9 @@ export const postRegister = ({
   inviterId,
   bd_vid,
   msclkid,
-  fastgpt_sem
+  fastgpt_sem,
+  sourceDomain,
+  language
 }: AccountRegisterBodyType) =>
   POST<LoginSuccessResponseType>(`/proApi/support/user/account/register/emailAndPhone`, {
     username,
@@ -72,6 +77,8 @@ export const postRegister = ({
     bd_vid,
     msclkid,
     fastgpt_sem,
+    sourceDomain,
+    language,
     password: hashStr(password)
   });
 
@@ -79,15 +86,13 @@ export const postRegister = ({
 export const postFindPassword = ({
   username,
   code,
-  password
-}: {
-  username: string;
-  code: string;
-  password: string;
-}) =>
+  password,
+  ...props
+}: UpdatePasswordByCodeBodyType) =>
   POST<LoginSuccessResponseType>(`/proApi/support/user/account/password/updateByCode`, {
     username,
     code,
+    ...props,
     password: hashStr(password)
   });
 export const updatePasswordByOld = ({ oldPsw, newPsw }: UpdatePasswordByOldBodyType) =>

--- a/projects/app/src/web/support/user/useUserStore.ts
+++ b/projects/app/src/web/support/user/useUserStore.ts
@@ -6,7 +6,6 @@ import type { OrgType } from '@fastgpt/global/support/user/team/org/type';
 import type { UserType } from '@fastgpt/global/support/user/type';
 import type { ClientTeamPlanStatusType } from '@fastgpt/global/support/wallet/sub/type';
 import { getTeamPlanStatus } from './team/api';
-import { setLangToStorage, getLangMapping } from '@fastgpt/web/i18n/utils';
 import { setCurrentAuthTmbId } from './currentAuthTmbId';
 
 type State = {
@@ -71,11 +70,6 @@ export const useUserStore = create<State>()(
           set((state) => {
             state.userInfo = user ? user : null;
             state.isTeamAdmin = !!user?.team?.permission?.hasManagePer;
-            const lang = user?.language;
-            if (lang) {
-              const mappedLang = getLangMapping(lang);
-              setLangToStorage(mappedLang);
-            }
           });
         },
         async updateUserInfo(user: UserUpdateParams) {

--- a/projects/app/test/web/support/user/useUserStore.test.ts
+++ b/projects/app/test/web/support/user/useUserStore.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { useUserStore as useUserStoreType } from '@/web/support/user/useUserStore';
+import type { UserType } from '@fastgpt/global/support/user/type';
+import { TeamPermission } from '@fastgpt/global/support/permission/user/controller';
+
+const i18nMocks = vi.hoisted(() => ({
+  setLangToStorage: vi.fn(),
+  getLangMapping: vi.fn((lang: string) => lang)
+}));
+
+const localStorageMock = vi.hoisted(() => {
+  let store: Record<string, string> = {};
+
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+    get length() {
+      return Object.keys(store).length;
+    }
+  };
+});
+
+vi.mock('@fastgpt/web/i18n/utils', () => ({
+  setLangToStorage: i18nMocks.setLangToStorage,
+  getLangMapping: i18nMocks.getLangMapping
+}));
+
+let useUserStore: typeof useUserStoreType;
+
+const buildUser = (language: UserType['language']): UserType =>
+  ({
+    _id: 'user-id',
+    username: 'user@example.com',
+    avatar: '',
+    timezone: 'Asia/Shanghai',
+    language,
+    promotionRate: 0,
+    team: {
+      userId: 'user-id',
+      tmbId: 'tmb-id',
+      teamId: 'team-id',
+      teamName: 'Team',
+      memberName: 'Member',
+      avatar: '',
+      teamDomain: '',
+      role: 'owner',
+      status: 'active',
+      permission: new TeamPermission({ isOwner: true })
+    },
+    permission: new TeamPermission({ isOwner: true }),
+    tags: []
+  }) as UserType;
+
+describe('useUserStore', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    localStorageMock.clear();
+    vi.stubGlobal('localStorage', localStorageMock);
+    useUserStore = (await import('@/web/support/user/useUserStore')).useUserStore;
+
+    useUserStore.setState({
+      userInfo: null,
+      isTeamAdmin: false
+    });
+  });
+
+  it('does not persist backend language when setting user info', () => {
+    useUserStore.getState().setUserInfo(buildUser('en'));
+
+    expect(useUserStore.getState().userInfo?.language).toBe('en');
+    expect(i18nMocks.getLangMapping).not.toHaveBeenCalled();
+    expect(i18nMocks.setLangToStorage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 更新内容

- 各登录入口在发起登录/注册/找回密码请求时显式携带当前页面语言 `language`。
- 覆盖账号密码登录、OAuth/SSO 回调登录、fast login、微信扫码登录、注册后自动登录、找回密码后自动登录。
- 密码登录 API 使用 `parseApiInput` 解析入参，并保存请求中的语言偏好。
- 账号设置页切换语言不再强制刷新页面，并修复账号侧栏菜单文案被 `useRef` 缓存导致无刷新切换后不更新的问题。
- 更新 pro submodule 指针，配套 pro PR: https://github.com/labring/fastgpt-pro/pull/985

## 问题原因

不同登录方式原先对语言偏好的处理不一致。跨浏览器登录时，登录页可能已经按浏览器语言显示，但进入系统后账号语言仍是旧值，导致首屏出现部分文案语言不一致。

## 影响范围

- 登录接口仍负责认证和返回登录结果，但请求体会携带当前登录页语言。
- pro 侧负责在对应登录入口保存语言偏好，本 PR 通过 submodule 指针关联配套修复。
- 保留原有 `bd_vid`、`msclkid`、`fastgpt_sem`、`sourceDomain`、`inviterId` 等埋点和来源参数。
- 账号设置页切换语言可以即时更新当前页面内容，不依赖刷新。

## 验证

- `pnpm --filter @fastgpt/app typecheck`
- app 相关文件 `eslint`，0 errors，2 个既有 `react-hook-form watch()` warning
- `pnpm --filter @fastgpt/admin typecheck`
- pro 相关文件 `eslint`
- `git diff --check`
- `git -C pro diff --check`
- commit hook: `lint-staged` eslint/prettier
