### PR TITLE
Fix/bug1

### DIFF
--- a/projects/app/src/pageComponents/dataset/ApiDatasetForm.tsx
+++ b/projects/app/src/pageComponents/dataset/ApiDatasetForm.tsx
@@ -191,7 +191,7 @@ const ApiDatasetForm = ({
             />
           </Flex>
           <Flex mt={rowTopMargin} alignItems={'center'} {...rowLayoutProps}>
-            <FormLabel required flex={['', '0 0 110px']} fontSize={'sm'}>
+            <FormLabel flex={['', '0 0 110px']} fontSize={'sm'}>
               Authorization
             </FormLabel>
             <Input


### PR DESCRIPTION
修以下bug:知识库创建第三方知识库->api文件库时，未填必填项Authorization也能够正常创建api文件库

就改了一行代码，把Authorization改成选填