### PR TITLE
fix(dataset): enable API Key auth for dataset update endpoint (#7006)

### DIFF
--- a/projects/app/src/pages/api/core/dataset/update.ts
+++ b/projects/app/src/pages/api/core/dataset/update.ts
@@ -88,6 +88,7 @@ async function handler(req: ApiRequestProps<UpdateDatasetBody>) {
   const { dataset, permission, tmbId, teamId } = await authDataset({
     req,
     authToken: true,
+    authApiKey: true,
     datasetId: id,
     per: ReadPermissionVal
   });
@@ -108,6 +109,7 @@ async function handler(req: ApiRequestProps<UpdateDatasetBody>) {
       const { dataset: targetDataset } = await authDataset({
         req,
         authToken: true,
+        authApiKey: true,
         datasetId: parentId,
         per: ManagePermissionVal
       });
@@ -120,6 +122,7 @@ async function handler(req: ApiRequestProps<UpdateDatasetBody>) {
       await authDataset({
         req,
         authToken: true,
+        authApiKey: true,
         datasetId: dataset.parentId,
         per: ManagePermissionVal
       });

--- a/projects/app/test/api/core/dataset/update.test.ts
+++ b/projects/app/test/api/core/dataset/update.test.ts
@@ -1,0 +1,87 @@
+import updateHandler from '@/pages/api/core/dataset/update';
+import type { UpdateDatasetBody } from '@fastgpt/global/openapi/core/dataset/api';
+import { DatasetTypeEnum } from '@fastgpt/global/core/dataset/constants';
+import { TeamDatasetCreatePermissionVal } from '@fastgpt/global/support/permission/user/constant';
+import { MongoResourcePermission } from '@fastgpt/service/support/permission/schema';
+import { MongoDataset } from '@fastgpt/service/core/dataset/schema';
+import { getFakeUsers } from '@test/datas/users';
+import { Call } from '@test/utils/request';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+describe('update dataset', () => {
+  beforeEach(async () => {
+    // Clean up any datasets created during tests
+    await MongoDataset.deleteMany({});
+  });
+
+  it('should return 200 when update dataset with token auth', async () => {
+    const users = await getFakeUsers(1);
+    await MongoResourcePermission.create({
+      resourceType: 'team',
+      teamId: users.members[0].teamId,
+      resourceId: null,
+      tmbId: users.members[0].tmbId,
+      permission: TeamDatasetCreatePermissionVal
+    });
+
+    // Create a dataset first
+    const createRes = await Call<UpdateDatasetBody, {}, string>(updateHandler, {
+      // We need a create endpoint to create first, but since we're testing update
+      // let's create via raw mongo for simplicity
+      body: {}
+    });
+
+    // Create a dataset via raw Mongo for testing update
+    const { MongoTeam } = await import('@fastgpt/service/support/user/team/teamSchema');
+    const { MongoTeamMember } = await import('@fastgpt/service/support/user/team/teamMemberSchema');
+
+    const dataset = await MongoDataset.create({
+      teamId: users.members[0].teamId,
+      tmbId: users.members[0].tmbId,
+      name: 'old-name',
+      type: DatasetTypeEnum.dataset
+    });
+
+    const res = await Call<UpdateDatasetBody, {}, string>(updateHandler, {
+      auth: users.members[0],
+      body: {
+        id: String(dataset._id),
+        name: 'updated-name'
+      }
+    });
+
+    expect(res.error).toBeUndefined();
+    expect(res.code).toBe(200);
+  });
+
+  it('should return 200 when update dataset with API Key auth (#7006)', async () => {
+    const users = await getFakeUsers(1);
+
+    // Create a dataset
+    const dataset = await MongoDataset.create({
+      teamId: users.members[0].teamId,
+      tmbId: users.members[0].tmbId,
+      name: 'old-name',
+      type: DatasetTypeEnum.dataset
+    });
+
+    // Verify authType is not apikey - this test ensures authApiKey flag is respected
+    // by the parseHeaderCert mock which grants access based on the auth object
+    const apikeyAuth = {
+      ...users.members[0],
+      authType: 'apikey' as const,
+      apikey: 'test-api-key'
+    };
+
+    const res = await Call<UpdateDatasetBody, {}, string>(updateHandler, {
+      auth: apikeyAuth,
+      body: {
+        id: String(dataset._id),
+        name: 'updated-by-apikey'
+      }
+    });
+
+    expect(res.error).toBeUndefined();
+    expect(res.code).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Enable API Key authentication for the dataset update endpoint. The `api/core/dataset/update.ts` API route was missing the `authApiKey: true` flag in all three `authDataset()` calls, causing the endpoint to reject API Key authenticated requests with a 403 error.

## Motivation

Users can list, create, and delete datasets via API Key, but updating a dataset (PATCH/POST to `api/core/dataset/update`) always returned 403 `unAuthorization`. This is because `parseHeaderCert()` defaults `authApiKey` to `false`, and without the flag set, the API Key authorization branch is never reached.

Related: #7006

## Changes

- Added `authApiKey: true` to the main `authDataset()` call in `update.ts` (L88-93) -- the entry point for dataset updates
- Added `authApiKey: true` to the target folder permission check when moving a dataset (L108-113)
- Added `authApiKey: true` to the source folder permission check when moving a dataset (L120-126)
- Added regression test covering both token auth and API Key auth flows for the update endpoint

## Tests

Test file: `projects/app/test/api/core/dataset/update.test.ts`
- `should return 200 when update dataset with token auth`
- `should return 200 when update dataset with API Key auth (#7006)`

## Duplicate check

I searched open PRs/issues with keywords: `dataset update apikey auth 7006`
I did not find an existing open PR addressing this issue.
