### PR TITLE
Fix/dataset-collection-list-state-restore

### DIFF
--- a/packages/web/hooks/usePagination.tsx
+++ b/packages/web/hooks/usePagination.tsx
@@ -30,7 +30,7 @@ import { useRouter } from 'next/router';
 
 const thresholdVal = 200;
 
-export function usePagination<DataT, ResT = {}>(
+export function usePagination<DataT, ResT = any>(
   api: (data: PaginationProps<DataT>) => Promise<PaginationResponse<ResT>>,
   {
     defaultPageSize = 10,
@@ -38,6 +38,7 @@ export function usePagination<DataT, ResT = {}>(
     params,
     type = 'button',
     onChange,
+    defaultPageNum,
     refreshDeps,
     scrollLoadType = 'bottom',
     EmptyTip,
@@ -46,10 +47,11 @@ export function usePagination<DataT, ResT = {}>(
     storeToQuery = false
   }: {
     defaultPageSize?: number;
+    defaultPageNum?: number;
     pageSizeOptions?: number[];
     params?: DataT;
     type?: 'button' | 'scroll';
-    onChange?: (pageNum: number) => void;
+    onChange?: (pageNum: number, pageSize?: number) => void;
     refreshDeps?: any[];
     throttleWait?: number;
     scrollLoadType?: 'top' | 'bottom';
@@ -60,8 +62,11 @@ export function usePagination<DataT, ResT = {}>(
   }
 ) {
   const router = useRouter();
-  let { page = '1' } = router.query as { page: string };
-  const numPage = Number(page);
+  const queryPage = router.query.page;
+  const initialPageNum =
+    queryPage !== undefined && String(queryPage).length > 0
+      ? Number(queryPage)
+      : (defaultPageNum ?? 1);
 
   const { toast } = useToast();
   const { isPc } = useSystem();
@@ -70,7 +75,7 @@ export function usePagination<DataT, ResT = {}>(
   const [isLoading, { setTrue, setFalse }] = useBoolean(false);
   const [error, setError] = useState<Error | null>(null);
 
-  const [pageNum, setPageNum] = useState(numPage);
+  const [pageNum, setPageNum] = useState(initialPageNum);
   const [pageSize, setPageSize] = useState(defaultPageSize);
   const pageSizeOptions = useCreation(
     () => defaultPageSizeOptions || [10, 20, 50, 100],
@@ -109,7 +114,9 @@ export function usePagination<DataT, ResT = {}>(
           });
         }
 
-        res.total !== undefined && setTotal(res.total);
+        if (res.total !== undefined) {
+          setTotal(res.total);
+        }
 
         if (type === 'scroll') {
           if (scrollLoadType === 'top') {
@@ -139,7 +146,7 @@ export function usePagination<DataT, ResT = {}>(
           setData(res.list);
         }
 
-        onChange?.(num);
+        onChange?.(num, pageSize);
       } catch (error: any) {
         setError(error);
         if (error.code !== 'ERR_CANCELED') {
@@ -337,7 +344,7 @@ export function usePagination<DataT, ResT = {}>(
     async () => {
       if (isFirstLoad.current) {
         isFirstLoad.current = false;
-        fetchData(numPage);
+        fetchData(initialPageNum);
         return;
       }
 
@@ -351,8 +358,10 @@ export function usePagination<DataT, ResT = {}>(
   );
   // Page size refresh
   useEffect(() => {
-    data.length > 0 && fetchData();
-  }, [pageSize]);
+    if (data.length > 0) {
+      fetchData();
+    }
+  }, [pageSize, data.length, fetchData]);
 
   useRequest(
     async () => {

--- a/projects/app/src/pageComponents/dataset/detail/CollectionCard/Context.tsx
+++ b/projects/app/src/pageComponents/dataset/detail/CollectionCard/Context.tsx
@@ -5,7 +5,9 @@ import {
   type SetStateAction,
   useState,
   useMemo,
-  useCallback
+  useCallback,
+  useEffect,
+  useRef
 } from 'react';
 import { useTranslation } from 'next-i18next';
 import { createContext, useContextSelector } from 'use-context-selector';
@@ -24,6 +26,39 @@ import { type WebsiteConfigFormType } from './WebsiteConfig';
 
 const WebSiteConfigModal = dynamic(() => import('./WebsiteConfig'));
 
+type CollectionListState = {
+  pageNum: number;
+  pageSize: number;
+  parentId: string;
+  searchText: string;
+  filterTags: string[];
+};
+
+const getCollectionListStorageKey = (datasetId: string) =>
+  `fastgpt_dataset_collection_list_${datasetId}`;
+
+/** 从 sessionStorage 读取知识库 collection 列表状态，SSR 安全 */
+const readCollectionListState = (datasetId: string): CollectionListState | null => {
+  if (typeof window === 'undefined' || !datasetId) return null;
+  try {
+    const raw = sessionStorage.getItem(getCollectionListStorageKey(datasetId));
+    if (!raw) return null;
+    return JSON.parse(raw) as CollectionListState;
+  } catch {
+    return null;
+  }
+};
+
+/** 将知识库 collection 列表状态写入 sessionStorage */
+const writeCollectionListState = (datasetId: string, state: CollectionListState) => {
+  if (typeof window === 'undefined' || !datasetId) return;
+  try {
+    sessionStorage.setItem(getCollectionListStorageKey(datasetId), JSON.stringify(state));
+  } catch {
+    // sessionStorage 写入失败时静默忽略
+  }
+};
+
 type CollectionPageContextType = {
   openDatasetSyncConfirm: () => void;
   onOpenWebsiteModal: () => void;
@@ -34,6 +69,7 @@ type CollectionPageContextType = {
   isGetting: boolean;
   pageNum: number;
   pageSize: number;
+  parentId: string;
   searchText: string;
   setSearchText: Dispatch<SetStateAction<string>>;
   filterTags: string[];
@@ -52,18 +88,19 @@ export const CollectionPageContext = createContext<CollectionPageContextType>({
     throw new Error('Function not implemented.');
   },
   total: 0,
-  getData: function (e: number): void {
+  getData: function (_pageNum: number): void {
     throw new Error('Function not implemented.');
   },
   isGetting: false,
   pageNum: 0,
   pageSize: 0,
+  parentId: '',
   searchText: '',
-  setSearchText: function (value: SetStateAction<string>): void {
+  setSearchText: function (_value: SetStateAction<string>): void {
     throw new Error('Function not implemented.');
   },
   filterTags: [],
-  setFilterTags: function (value: SetStateAction<string[]>): void {
+  setFilterTags: function (_value: SetStateAction<string[]>): void {
     throw new Error('Function not implemented.');
   }
 });
@@ -71,16 +108,44 @@ export const CollectionPageContext = createContext<CollectionPageContextType>({
 const CollectionPageContextProvider = ({ children }: { children: ReactNode }) => {
   const { t } = useTranslation();
   const router = useRouter();
-  const { parentId = '' } = router.query as { parentId: string };
+  const { parentId: queryParentId = '' } = router.query as { parentId: string };
 
   const { datasetDetail, datasetId, updateDataset, loadDatasetDetail } = useContextSelector(
     DatasetPageContext,
     (v) => v
   );
 
+  const savedState = useMemo(() => readCollectionListState(datasetId), [datasetId]);
+  // parentId 以 URL 为准；目录恢复由下方 router.replace 写入 query，避免回根目录时被 sessionStorage 覆盖
+  const parentId = queryParentId;
+
+  const hasRestoredQueryRef = useRef(false);
+  useEffect(() => {
+    if (!router.isReady || !datasetId || hasRestoredQueryRef.current) return;
+    hasRestoredQueryRef.current = true;
+
+    const saved = readCollectionListState(datasetId);
+    if (!saved) return;
+
+    const queryUpdates: Record<string, string | number> = {};
+    if (!queryParentId && saved.parentId) {
+      queryUpdates.parentId = saved.parentId;
+    }
+    const queryPage = router.query.page;
+    if ((queryPage === undefined || queryPage === '') && saved.pageNum > 1) {
+      queryUpdates.page = saved.pageNum;
+    }
+    if (Object.keys(queryUpdates).length === 0) return;
+
+    router.replace({
+      pathname: router.pathname,
+      query: { ...router.query, ...queryUpdates }
+    });
+  }, [router.isReady, datasetId, queryParentId, router]);
+
   // collection list
-  const [searchText, setSearchText] = useState('');
-  const [filterTags, setFilterTags] = useState<string[]>([]);
+  const [searchText, setSearchText] = useState(savedState?.searchText ?? '');
+  const [filterTags, setFilterTags] = useState<string[]>(savedState?.filterTags ?? []);
   const {
     data: collections,
     Pagination,
@@ -90,7 +155,8 @@ const CollectionPageContextProvider = ({ children }: { children: ReactNode }) =>
     pageNum,
     pageSize
   } = usePagination(getDatasetCollections, {
-    defaultPageSize: 20,
+    defaultPageSize: savedState?.pageSize ?? 20,
+    defaultPageNum: savedState?.pageNum,
     storeToQuery: true,
     params: {
       datasetId,
@@ -100,6 +166,17 @@ const CollectionPageContextProvider = ({ children }: { children: ReactNode }) =>
     },
     refreshDeps: [parentId, searchText, filterTags]
   });
+
+  useEffect(() => {
+    if (!datasetId) return;
+    writeCollectionListState(datasetId, {
+      pageNum,
+      pageSize,
+      parentId,
+      searchText,
+      filterTags
+    });
+  }, [datasetId, pageNum, pageSize, parentId, searchText, filterTags]);
 
   const syncDataset = useCallback(async () => {
     if (datasetDetail.type === DatasetTypeEnum.websiteDataset) {
@@ -156,7 +233,8 @@ const CollectionPageContextProvider = ({ children }: { children: ReactNode }) =>
       getData,
       isGetting,
       pageNum,
-      pageSize
+      pageSize,
+      parentId
     }),
     [
       Pagination,
@@ -169,6 +247,7 @@ const CollectionPageContextProvider = ({ children }: { children: ReactNode }) =>
       openDatasetSyncConfirm,
       pageNum,
       pageSize,
+      parentId,
       searchText,
       total
     ]

--- a/projects/app/src/pageComponents/dataset/detail/CollectionCard/Header.tsx
+++ b/projects/app/src/pageComponents/dataset/detail/CollectionCard/Header.tsx
@@ -56,7 +56,6 @@ const Header = ({
   const datasetDetail = useContextSelector(DatasetPageContext, (v) => v.datasetDetail);
 
   const router = useRouter();
-  const { parentId = '' } = router.query as { parentId: string };
 
   const {
     searchText,
@@ -64,6 +63,7 @@ const Header = ({
     total,
     getData,
     pageNum,
+    parentId,
     onOpenWebsiteModal,
     openDatasetSyncConfirm
   } = useContextSelector(CollectionPageContext, (v) => v);

--- a/projects/app/src/pageComponents/dataset/detail/CollectionCard/index.tsx
+++ b/projects/app/src/pageComponents/dataset/detail/CollectionCard/index.tsx
@@ -267,6 +267,7 @@ const CollectionCard = () => {
                     if (collection.type === DatasetCollectionTypeEnum.folder) {
                       router.push({
                         query: {
+                          ...router.query,
                           datasetId: datasetDetail._id,
                           parentId: collection._id
                         }
@@ -274,6 +275,7 @@ const CollectionCard = () => {
                     } else {
                       router.push({
                         query: {
+                          ...router.query,
                           datasetId: datasetDetail._id,
                           collectionId: collection._id,
                           currentTab: TabEnum.dataCard
@@ -319,9 +321,9 @@ const CollectionCard = () => {
                   <Td py={2}>
                     {collection.trainingType
                       ? t(
-                        (DatasetCollectionDataProcessModeMap[collection.trainingType]?.label ||
-                          '-') as any
-                      )
+                          (DatasetCollectionDataProcessModeMap[collection.trainingType]?.label ||
+                            '-') as any
+                        )
                       : '-'}
                   </Td>
                   <Td py={2}>{collection.dataAmount || '-'}</Td>
@@ -398,25 +400,25 @@ const CollectionCard = () => {
                             children: [
                               ...(collectionCanSync(collection.type)
                                 ? [
-                                  {
-                                    label: (
-                                      <Flex alignItems={'center'}>
-                                        <MyIcon
-                                          name={'common/refreshLight'}
-                                          w={'0.9rem'}
-                                          mr={2}
-                                        />
-                                        {t('dataset:collection_sync')}
-                                      </Flex>
-                                    ),
-                                    onClick: () =>
-                                      openSyncConfirm({
-                                        onConfirm: () => {
-                                          onclickStartSync(collection._id);
-                                        }
-                                      })()
-                                  }
-                                ]
+                                    {
+                                      label: (
+                                        <Flex alignItems={'center'}>
+                                          <MyIcon
+                                            name={'common/refreshLight'}
+                                            w={'0.9rem'}
+                                            mr={2}
+                                          />
+                                          {t('dataset:collection_sync')}
+                                        </Flex>
+                                      ),
+                                      onClick: () =>
+                                        openSyncConfirm({
+                                          onConfirm: () => {
+                                            onclickStartSync(collection._id);
+                                          }
+                                        })()
+                                    }
+                                  ]
                                 : []),
                               {
                                 label: (
@@ -468,8 +470,8 @@ const CollectionCard = () => {
                                     customContent:
                                       collection.type === DatasetCollectionTypeEnum.folder
                                         ? t(
-                                          'common:dataset.collections.Confirm to delete the folder'
-                                        )
+                                            'common:dataset.collections.Confirm to delete the folder'
+                                          )
                                         : t('common:dataset.Confirm to delete the file')
                                   })()
                               }


### PR DESCRIPTION
问题：
知识库 collection 列表在切页、进子目录、搜关键词、筛标签后，离开再回来状态会丢。

咋修改的：
记住状态 — 在 Context.tsx 用 sessionStorage 按 datasetId 存 pageNum / pageSize / parentId / searchText / filterTags，列表变化时写入，再次进入时读出来。

恢复状态 — 首次进入且 URL 里没有对应参数时，用 router.replace 把 session 里的 parentId、page 写回 query；分页交给 usePagination 的 defaultPageNum、defaultPageSize 和 storeToQuery: true。

修回根目录 bug — parentId 只认 URL（queryParentId），不再 || savedState?.parentId。否则回根目录时 URL 已是空，session 里旧目录还会生效。目录恢复只走上面的 router.replace。