### PR TITLE
fix: update private list permission count

### DIFF
--- a/projects/app/src/pages/api/core/app/list.ts
+++ b/projects/app/src/pages/api/core/app/list.ts
@@ -184,21 +184,23 @@ async function handler(req: ApiRequestProps<ListAppBodyType>): Promise<ListAppRe
           });
         };
 
-        const getClbCount = (appId: string) => {
-          return roleList.filter((item) => String(item.resourceId) === String(appId)).length;
-        };
-
         // Inherit app, check parent folder clb and it's own clb
         if (!AppFolderTypeList.includes(app.type) && app.parentId && app.inheritPermission) {
           return {
             Per: getPer(String(app.parentId)).addRole(getPer(String(app._id)).role),
-            privateApp: getClbCount(String(app.parentId)) <= 1
+            privateApp:
+              roleList.filter(
+                (item) =>
+                  String(item.resourceId) === String(app._id) ||
+                  String(item.resourceId) === String(app.parentId)
+              ).length <= 1
           };
         }
 
         return {
           Per: getPer(String(app._id)),
-          privateApp: getClbCount(String(app._id)) <= 1
+          privateApp:
+            roleList.filter((item) => String(item.resourceId) === String(app._id)).length <= 1
         };
       })();
 

--- a/projects/app/src/pages/api/core/dataset/list.ts
+++ b/projects/app/src/pages/api/core/dataset/list.ts
@@ -147,10 +147,6 @@ async function handler(req: ApiRequestProps): Promise<GetDatasetListResponse> {
             isOwner: String(dataset.tmbId) === String(tmbId) || teamPer.isOwner
           });
         };
-        const getClbCount = (datasetId: string) => {
-          return roleList.filter((item) => String(item.resourceId) === String(datasetId)).length;
-        };
-
         // inherit
         if (
           dataset.inheritPermission &&
@@ -159,12 +155,18 @@ async function handler(req: ApiRequestProps): Promise<GetDatasetListResponse> {
         ) {
           return {
             Per: getPer(String(dataset.parentId)).addRole(getPer(String(dataset._id)).role),
-            privateDataset: getClbCount(String(dataset.parentId)) <= 1
+            privateDataset:
+              roleList.filter(
+                (item) =>
+                  String(item.resourceId) === String(dataset._id) ||
+                  String(item.resourceId) === String(dataset.parentId)
+              ).length <= 1
           };
         }
         return {
           Per: getPer(String(dataset._id)),
-          privateDataset: getClbCount(String(dataset._id)) <= 1
+          privateDataset:
+            roleList.filter((item) => String(item.resourceId) === String(dataset._id)).length <= 1
         };
       })();
 


### PR DESCRIPTION
## Summary
- update app list private flag calculation for inherited apps to count both app and parent folder permission records
- update dataset list private flag calculation for inherited datasets to count both dataset and parent folder permission records

Extracted from #6949.

## Tests
- git diff --check
- pnpm exec eslint src/pages/api/core/app/list.ts src/pages/api/core/dataset/list.ts (blocked: eslint not found because node_modules is missing)
- pnpm --filter @fastgpt/app typecheck (blocked: node_modules is missing, dependencies such as zod/axios/@types/node cannot be resolved)