### PR TITLE
fix(mcp): only fall back to legacy SSE transport on a 4xx Streamable HTTP error

### DIFF
--- a/packages/service/core/app/mcp.ts
+++ b/packages/service/core/app/mcp.ts
@@ -1,13 +1,16 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {
+  StreamableHTTPClientTransport,
+  StreamableHTTPError
+} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { AppSchemaType } from '@fastgpt/global/core/app/type';
 import { type McpToolConfigType } from '@fastgpt/global/core/app/tool/mcpTool/type';
 import { retryFn } from '@fastgpt/global/common/system/utils';
 import { AppToolSourceEnum } from '@fastgpt/global/core/app/tool/constants';
 import { MongoApp } from './schema';
 import type { McpToolDataType } from '@fastgpt/global/core/app/tool/mcpTool/type';
-import { UserError } from '@fastgpt/global/common/error/utils';
+import { getErrText, UserError } from '@fastgpt/global/common/error/utils';
 import $RefParser from '@apidevtools/json-schema-ref-parser';
 import { getLogger, LogCategories } from '../../common/logger';
 import { isInternalAddress, PRIVATE_URL_TEXT } from '../../common/system/utils';
@@ -18,6 +21,26 @@ export const assertMCPUrlNotInternal = async (url: string) => {
   if (await isInternalAddress(url)) {
     return Promise.reject(PRIVATE_URL_TEXT);
   }
+};
+
+/**
+ * Decide whether a failed Streamable HTTP connection should fall back to the
+ * legacy HTTP+SSE transport.
+ *
+ * Following the MCP spec's backwards-compatibility flow, the legacy transport is
+ * only attempted when the server rejects the Streamable HTTP request with a 4xx
+ * status (e.g. 404/405), which signals it does not speak Streamable HTTP. Other
+ * failures (network errors, 5xx, or an error raised after a successful
+ * initialize) are not a protocol mismatch, so they must surface as-is instead of
+ * being masked by a misleading SSE error.
+ */
+const shouldFallbackToSSE = (error: unknown): boolean => {
+  return (
+    error instanceof StreamableHTTPError &&
+    typeof error.code === 'number' &&
+    error.code >= 400 &&
+    error.code < 500
+  );
 };
 
 export class MCPClient {
@@ -49,6 +72,36 @@ export class MCPClient {
     return this.connectionPromise;
   }
 
+  private createSSETransport(): SSEClientTransport {
+    return new SSEClientTransport(new URL(this.url), {
+      requestInit: {
+        headers: this.headers
+      },
+      eventSourceInit: {
+        fetch: (url, init) => {
+          const mergedHeaders: Record<string, string> = {
+            ...this.headers
+          };
+
+          if (init?.headers) {
+            if (init.headers instanceof Headers) {
+              init.headers.forEach((value, key) => {
+                mergedHeaders[key] = value;
+              });
+            } else if (typeof init.headers === 'object') {
+              Object.assign(mergedHeaders, init.headers);
+            }
+          }
+
+          return fetch(url, {
+            ...init,
+            headers: mergedHeaders
+          });
+        }
+      }
+    });
+  }
+
   private async doConnect(): Promise<Client> {
     await assertMCPUrlNotInternal(this.url);
 
@@ -63,36 +116,26 @@ export class MCPClient {
         }
       });
       await this.client.connect(transport);
-    } catch (error) {
-      await this.client.connect(
-        new SSEClientTransport(new URL(this.url), {
-          requestInit: {
-            headers: this.headers
-          },
-          eventSourceInit: {
-            fetch: (url, init) => {
-              const mergedHeaders: Record<string, string> = {
-                ...this.headers
-              };
+    } catch (streamableError) {
+      // Only fall back to the legacy SSE transport when the server signals it
+      // does not support Streamable HTTP. Otherwise surface the original error.
+      if (!shouldFallbackToSSE(streamableError)) {
+        throw streamableError;
+      }
 
-              if (init?.headers) {
-                if (init.headers instanceof Headers) {
-                  init.headers.forEach((value, key) => {
-                    mergedHeaders[key] = value;
-                  });
-                } else if (typeof init.headers === 'object') {
-                  Object.assign(mergedHeaders, init.headers);
-                }
-              }
+      logger.debug('Streamable HTTP connect failed, falling back to SSE transport', {
+        url: this.url,
+        error: streamableError
+      });
 
-              return fetch(url, {
-                ...init,
-                headers: mergedHeaders
-              });
-            }
-          }
-        })
-      );
+      try {
+        await this.client.connect(this.createSSETransport());
+      } catch (sseError) {
+        // Surface both failures so the Streamable HTTP root cause is not lost.
+        throw new Error(
+          `Failed to connect MCP server. Streamable HTTP: ${getErrText(streamableError)}; SSE: ${getErrText(sseError)}`
+        );
+      }
     }
 
     this.client.onerror = (error) => {

--- a/packages/service/core/app/mcp.ts
+++ b/packages/service/core/app/mcp.ts
@@ -1,6 +1,9 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {
+  StreamableHTTPClientTransport,
+  StreamableHTTPError
+} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { AppSchemaType } from '@fastgpt/global/core/app/type';
 import { type McpToolConfigType } from '@fastgpt/global/core/app/tool/mcpTool/type';
 import { retryFn } from '@fastgpt/global/common/system/utils';
@@ -27,6 +30,14 @@ const shouldFallbackToSSE = (error: unknown): boolean => {
     error.code >= 400 &&
     error.code < 500
   );
+};
+
+const getErrorMessage = (error: unknown) => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
 };
 
 export class MCPClient {
@@ -110,7 +121,11 @@ export class MCPClient {
         );
       } catch (sseError: any) {
         logger.info('SSE error', sseError);
-        throw sseError;
+        throw new Error(
+          `MCP connection failed. Streamable HTTP: ${getErrorMessage(
+            streamableError
+          )}; SSE: ${getErrorMessage(sseError)}`
+        );
       }
     }
 

--- a/packages/service/core/app/mcp.ts
+++ b/packages/service/core/app/mcp.ts
@@ -1,16 +1,13 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
-import {
-  StreamableHTTPClientTransport,
-  StreamableHTTPError
-} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { AppSchemaType } from '@fastgpt/global/core/app/type';
 import { type McpToolConfigType } from '@fastgpt/global/core/app/tool/mcpTool/type';
 import { retryFn } from '@fastgpt/global/common/system/utils';
 import { AppToolSourceEnum } from '@fastgpt/global/core/app/tool/constants';
 import { MongoApp } from './schema';
 import type { McpToolDataType } from '@fastgpt/global/core/app/tool/mcpTool/type';
-import { getErrText, UserError } from '@fastgpt/global/common/error/utils';
+import { UserError } from '@fastgpt/global/common/error/utils';
 import $RefParser from '@apidevtools/json-schema-ref-parser';
 import { getLogger, LogCategories } from '../../common/logger';
 import { isInternalAddress, PRIVATE_URL_TEXT } from '../../common/system/utils';
@@ -23,17 +20,6 @@ export const assertMCPUrlNotInternal = async (url: string) => {
   }
 };
 
-/**
- * Decide whether a failed Streamable HTTP connection should fall back to the
- * legacy HTTP+SSE transport.
- *
- * Following the MCP spec's backwards-compatibility flow, the legacy transport is
- * only attempted when the server rejects the Streamable HTTP request with a 4xx
- * status (e.g. 404/405), which signals it does not speak Streamable HTTP. Other
- * failures (network errors, 5xx, or an error raised after a successful
- * initialize) are not a protocol mismatch, so they must surface as-is instead of
- * being masked by a misleading SSE error.
- */
 const shouldFallbackToSSE = (error: unknown): boolean => {
   return (
     error instanceof StreamableHTTPError &&
@@ -72,36 +58,6 @@ export class MCPClient {
     return this.connectionPromise;
   }
 
-  private createSSETransport(): SSEClientTransport {
-    return new SSEClientTransport(new URL(this.url), {
-      requestInit: {
-        headers: this.headers
-      },
-      eventSourceInit: {
-        fetch: (url, init) => {
-          const mergedHeaders: Record<string, string> = {
-            ...this.headers
-          };
-
-          if (init?.headers) {
-            if (init.headers instanceof Headers) {
-              init.headers.forEach((value, key) => {
-                mergedHeaders[key] = value;
-              });
-            } else if (typeof init.headers === 'object') {
-              Object.assign(mergedHeaders, init.headers);
-            }
-          }
-
-          return fetch(url, {
-            ...init,
-            headers: mergedHeaders
-          });
-        }
-      }
-    });
-  }
-
   private async doConnect(): Promise<Client> {
     await assertMCPUrlNotInternal(this.url);
 
@@ -116,25 +72,45 @@ export class MCPClient {
         }
       });
       await this.client.connect(transport);
-    } catch (streamableError) {
-      // Only fall back to the legacy SSE transport when the server signals it
-      // does not support Streamable HTTP. Otherwise surface the original error.
+    } catch (streamableError: any) {
       if (!shouldFallbackToSSE(streamableError)) {
+        logger.info('Streamable HTTP error', streamableError);
         throw streamableError;
       }
 
-      logger.debug('Streamable HTTP connect failed, falling back to SSE transport', {
-        url: this.url,
-        error: streamableError
-      });
-
       try {
-        await this.client.connect(this.createSSETransport());
-      } catch (sseError) {
-        // Surface both failures so the Streamable HTTP root cause is not lost.
-        throw new Error(
-          `Failed to connect MCP server. Streamable HTTP: ${getErrText(streamableError)}; SSE: ${getErrText(sseError)}`
+        await this.client.connect(
+          new SSEClientTransport(new URL(this.url), {
+            requestInit: {
+              headers: this.headers
+            },
+            eventSourceInit: {
+              fetch: (url, init) => {
+                const mergedHeaders: Record<string, string> = {
+                  ...this.headers
+                };
+
+                if (init?.headers) {
+                  if (init.headers instanceof Headers) {
+                    init.headers.forEach((value, key) => {
+                      mergedHeaders[key] = value;
+                    });
+                  } else if (typeof init.headers === 'object') {
+                    Object.assign(mergedHeaders, init.headers);
+                  }
+                }
+
+                return fetch(url, {
+                  ...init,
+                  headers: mergedHeaders
+                });
+              }
+            }
+          })
         );
+      } catch (sseError: any) {
+        logger.info('SSE error', sseError);
+        throw sseError;
       }
     }
 

--- a/packages/service/test/core/app/mcp.test.ts
+++ b/packages/service/test/core/app/mcp.test.ts
@@ -18,6 +18,7 @@ vi.mock('@fastgpt/service/core/app/schema', () => ({
   }
 }));
 
+import { StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { MCPClient, assertMCPUrlNotInternal, getMCPChildren } from '@fastgpt/service/core/app/mcp';
 import type { AppSchemaType } from '@fastgpt/global/core/app/type';
 
@@ -423,13 +424,13 @@ describe('MCPClient', () => {
   });
 
   describe('getConnection', () => {
-    it('should fallback to SSE when StreamableHTTP fails', async () => {
+    it('should fallback to SSE when server rejects Streamable HTTP with a 4xx', async () => {
       const mcpClient = new MCPClient(config);
       const client = getPrivateClient(mcpClient);
-      // First connect (StreamableHTTP) fails, second (SSE) succeeds
+      // StreamableHTTP rejected with 405 (server speaks legacy SSE), SSE succeeds
       client.connect = vi
         .fn()
-        .mockRejectedValueOnce(new Error('streamable failed'))
+        .mockRejectedValueOnce(new StreamableHTTPError(405, 'Method Not Allowed'))
         .mockResolvedValueOnce(undefined);
 
       const result = await (mcpClient as any).getConnection();
@@ -437,12 +438,39 @@ describe('MCPClient', () => {
       expect(result).toBe(client);
     });
 
-    it('should reject when both transports fail', async () => {
+    it('should not fallback to SSE on a non-HTTP (e.g. network) error', async () => {
       const mcpClient = new MCPClient(config);
       const client = getPrivateClient(mcpClient);
-      client.connect = vi.fn().mockRejectedValue(new Error('all failed'));
+      client.connect = vi.fn().mockRejectedValue(new Error('network unreachable'));
 
-      await expect((mcpClient as any).getConnection()).rejects.toThrow('all failed');
+      await expect((mcpClient as any).getConnection()).rejects.toThrow('network unreachable');
+      // Original error surfaces as-is, SSE transport is not attempted
+      expect(client.connect).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not fallback to SSE when Streamable HTTP fails with a 5xx', async () => {
+      const mcpClient = new MCPClient(config);
+      const client = getPrivateClient(mcpClient);
+      client.connect = vi
+        .fn()
+        .mockRejectedValue(new StreamableHTTPError(500, 'Internal Server Error'));
+
+      await expect((mcpClient as any).getConnection()).rejects.toThrow('Internal Server Error');
+      expect(client.connect).toHaveBeenCalledTimes(1);
+    });
+
+    it('should surface both errors when the SSE fallback also fails', async () => {
+      const mcpClient = new MCPClient(config);
+      const client = getPrivateClient(mcpClient);
+      client.connect = vi
+        .fn()
+        .mockRejectedValueOnce(new StreamableHTTPError(404, 'Not Found'))
+        .mockRejectedValueOnce(new Error('SSE handshake failed'));
+
+      await expect((mcpClient as any).getConnection()).rejects.toThrow(
+        /Streamable HTTP:.*Not Found.*SSE:.*SSE handshake failed/s
+      );
+      expect(client.connect).toHaveBeenCalledTimes(2);
     });
 
     it('should return client on StreamableHTTP success', async () => {


### PR DESCRIPTION
## Problem

Closes #7047.

When connecting to an MCP server, `MCPClient.doConnect` wraps the Streamable HTTP `client.connect()` in a `try/catch` and, on **any** error, immediately retries with the legacy HTTP+SSE transport:

```ts
try {
  await this.client.connect(streamableHttpTransport);
} catch (error) {
  await this.client.connect(sseTransport); // fallback on ANY error
}
```

For a server that speaks **Streamable HTTP only** (POST JSON-RPC works, but it does not offer the optional `GET` SSE stream), this is wrong in two ways:

1. **It can mask the real failure.** A failure that is *not* a protocol mismatch — a network error, a `5xx`, or an error raised after a successful `initialize` — triggers the SSE retry, and the user ends up seeing a misleading error from the SSE attempt (e.g. `SSE error: Non-200 status code (405)`) instead of the actual Streamable HTTP root cause. This is exactly what #7047 reports: `getTools` logs `StreamableHTTP connect failed, falling back to SSE` followed by `SSE error: Non-200 status code (405)`, while the same endpoint serves `initialize` / `tools/list` / `tools/call` over POST just fine.
2. **It diverges from the MCP spec.** The spec's backwards-compatibility flow says the legacy transport should be tried **only** when the server rejects the Streamable HTTP request with a `4xx` (e.g. `404`/`405`), which is the signal that it does not support Streamable HTTP.

## Solution

Make the fallback conditional, matching the spec:

- Fall back to the legacy SSE transport **only** when the error is a `StreamableHTTPError` with a `4xx` status code.
- For any other error, re-throw the original error as-is so the real cause is preserved.
- When the SSE fallback *is* attempted and also fails, surface **both** errors instead of only the SSE one.

Legacy HTTP+SSE servers are unaffected: they reject the Streamable HTTP `POST initialize` with `405`/`404`, which still triggers the fallback. The behavior only changes for non-`4xx` failures, which previously produced a confusing second attempt and a misleading message.

The long SSE-transport construction (with its header-merging `fetch`) is extracted into a small `createSSETransport()` helper so the connect flow stays readable.

## Testing

`packages/service/test/core/app/mcp.test.ts` — updated the existing fallback test to use a `4xx` `StreamableHTTPError`, and added cases covering:

- 4xx Streamable HTTP error → falls back to SSE
- non-HTTP (e.g. network) error → no fallback, original error surfaces
- 5xx Streamable HTTP error → no fallback
- 4xx then SSE also fails → both errors reported

```
pnpm --filter @fastgpt/service test -- test/core/app/mcp.test.ts
# Test Files  1 passed (1)
#      Tests  28 passed (28)
```

ESLint and Prettier are clean on the changed files.