### PR TITLE
feat(chat): improve chat feedback interactions

### DIFF
--- a/packages/web/i18n/en/chat.json
+++ b/packages/web/i18n/en/chat.json
@@ -273,6 +273,9 @@
   "tool_response_compress": "Tool response compression",
   "unsupported_file_type": "Unsupported file types",
   "variable_invisable_in_share": "External variables are not visible in login-free links",
+  "interactive.user_select.collapse_options": "Collapse options",
+  "interactive.user_select.expand_options": "Expand options",
+  "interactive.user_select.selected": "Selected: {{answer}}",
   "view_all_citations": "View all",
   "view_citations": "View References"
 }

--- a/packages/web/i18n/zh-CN/chat.json
+++ b/packages/web/i18n/zh-CN/chat.json
@@ -273,7 +273,7 @@
   "tool_response_compress": "工具响应压缩",
   "unsupported_file_type": "不支持的文件类型",
   "variable_invisable_in_share": "外部变量在免登录链接中不可见",
-  "interactive.user_select.collapse_options": "折叠选项",
+  "interactive.user_select.collapse_options": "收起选项",
   "interactive.user_select.expand_options": "展开选项",
   "interactive.user_select.selected": "已选择：{{answer}}",
   "view_all_citations": "查看全部",

--- a/packages/web/i18n/zh-CN/chat.json
+++ b/packages/web/i18n/zh-CN/chat.json
@@ -273,6 +273,9 @@
   "tool_response_compress": "工具响应压缩",
   "unsupported_file_type": "不支持的文件类型",
   "variable_invisable_in_share": "外部变量在免登录链接中不可见",
+  "interactive.user_select.collapse_options": "折叠选项",
+  "interactive.user_select.expand_options": "展开选项",
+  "interactive.user_select.selected": "已选择：{{answer}}",
   "view_all_citations": "查看全部",
   "view_citations": "查看引用"
 }

--- a/packages/web/i18n/zh-Hant/chat.json
+++ b/packages/web/i18n/zh-Hant/chat.json
@@ -269,7 +269,7 @@
   "tool_response_compress": "工具回應壓縮",
   "unsupported_file_type": "不支援的檔案類型",
   "variable_invisable_in_share": "外部變量在免登錄鏈接中不可見",
-  "interactive.user_select.collapse_options": "折疊選項",
+  "interactive.user_select.collapse_options": "收起選項",
   "interactive.user_select.expand_options": "展開選項",
   "interactive.user_select.selected": "已選擇：{{answer}}",
   "view_all_citations": "查看全部",

--- a/packages/web/i18n/zh-Hant/chat.json
+++ b/packages/web/i18n/zh-Hant/chat.json
@@ -269,6 +269,9 @@
   "tool_response_compress": "工具回應壓縮",
   "unsupported_file_type": "不支援的檔案類型",
   "variable_invisable_in_share": "外部變量在免登錄鏈接中不可見",
+  "interactive.user_select.collapse_options": "折疊選項",
+  "interactive.user_select.expand_options": "展開選項",
+  "interactive.user_select.selected": "已選擇：{{answer}}",
   "view_all_citations": "查看全部",
   "view_citations": "檢視引用"
 }

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/ChatController.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/ChatController.tsx
@@ -90,6 +90,10 @@ const ChatController = ({
     <MyTooltip label={label}>{children}</MyTooltip>
   );
   const iconStyle = isFooter ? footerIconStyle : controlIconStyle;
+  const getIconHoverStyle = (color: string) => ({
+    color,
+    ...(isFooter ? { transform: 'translateY(-1px)' } : {})
+  });
   const activeFeedbackStyle = isFooter
     ? {
         color: 'primary.600'
@@ -142,7 +146,7 @@ const ChatController = ({
               {...iconStyle}
               name={'copy'}
               borderLeftRadius={isFooter ? undefined : 'sm'}
-              _hover={{ color: 'primary.600' }}
+              _hover={getIconHoverStyle('primary.600')}
               onClick={() => copyData(chatText)}
             />
           )}
@@ -154,7 +158,7 @@ const ChatController = ({
                   <MyIcon
                     {...iconStyle}
                     name={'common/retryLight'}
-                    _hover={{ color: isFooter ? 'primary.600' : 'green.500' }}
+                    _hover={getIconHoverStyle(isFooter ? 'primary.600' : 'green.500')}
                     onClick={onRetry}
                   />
                 )}
@@ -163,7 +167,7 @@ const ChatController = ({
                 <MyIcon
                   {...iconStyle}
                   name={'delete'}
-                  _hover={{ color: isFooter ? 'primary.600' : 'red.600' }}
+                  _hover={getIconHoverStyle(isFooter ? 'primary.600' : 'red.600')}
                   onClick={onDelete}
                 />
               )}
@@ -209,7 +213,7 @@ const ChatController = ({
                       fill: 'currentColor'
                     }
                   }}
-                  _hover={{ color: isFooter ? 'primary.600' : '#E74694' }}
+                  _hover={getIconHoverStyle(isFooter ? 'primary.600' : '#E74694')}
                   onClick={async () => {
                     setAudioPlayingChatId(chat.dataId);
                     const response = await playAudioByText({
@@ -238,7 +242,7 @@ const ChatController = ({
               <MyIcon
                 {...iconStyle}
                 name={'core/app/markLight'}
-                _hover={{ color: isFooter ? 'primary.600' : '#67c13b' }}
+                _hover={getIconHoverStyle(isFooter ? 'primary.600' : '#67c13b')}
                 onClick={onMark}
               />
             )}
@@ -314,7 +318,7 @@ const ChatController = ({
                           {...(!!chat.userGoodFeedback
                             ? activeFeedbackStyle
                             : {
-                                _hover: { color: 'primary.600' }
+                                _hover: getIconHoverStyle('primary.600')
                               })}
                           borderRight={!onAddUserDislike ? 'none' : 'base'}
                           borderRightRadius={!onAddUserDislike ? 'sm' : 'none'}
@@ -331,7 +335,7 @@ const ChatController = ({
                         {...(!!chat.userBadFeedback
                           ? activeBadFeedbackStyle
                           : {
-                              _hover: { color: 'primary.600' }
+                              _hover: getIconHoverStyle('primary.600')
                             })}
                         borderRight={isFooter ? undefined : 'none'}
                         borderRightRadius={isFooter ? undefined : 'sm'}

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/ChatController.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/ChatController.tsx
@@ -13,6 +13,7 @@ import MyImage from '@fastgpt/web/components/common/Image/MyImage';
 import { ChatRecordContext } from '@/web/core/chat/context/chatRecordContext';
 import { useRequest } from '@fastgpt/web/hooks/useRequest';
 import { eventBus, EventNameEnum } from '@/web/common/utils/eventbus';
+import LikeFeedbackButton from './LikeFeedbackButton';
 
 export type ChatControllerProps = {
   isLastChild: boolean;
@@ -23,6 +24,7 @@ export type ChatControllerProps = {
   onMark?: () => void;
   onAddUserLike?: () => void;
   onAddUserDislike?: () => void;
+  likeFeedbackEffectTrigger?: number;
   onToggleFeedbackReadStatus?: () => void;
   showFeedbackContent?: boolean;
   onToggleFeedbackContent?: () => void;
@@ -47,7 +49,8 @@ const footerIconStyle = {
   cursor: 'pointer',
   p: '4px',
   color: 'myGray.400',
-  _hover: { color: 'primary.600' }
+  transition: 'color 180ms ease, transform 180ms ease, filter 180ms ease',
+  _hover: { color: 'primary.600', transform: 'translateY(-1px)' }
 };
 
 const ChatController = ({
@@ -58,6 +61,7 @@ const ChatController = ({
   onDelete,
   onAddUserDislike,
   onAddUserLike,
+  likeFeedbackEffectTrigger,
   onToggleFeedbackReadStatus,
   showFeedbackContent,
   onToggleFeedbackContent,
@@ -297,20 +301,27 @@ const ChatController = ({
                 <>
                   {!!onAddUserLike && (
                     <MyTooltip label={t('chat:feedback_helpful')}>
-                      <MyIcon
-                        {...iconStyle}
-                        {...(!!chat.userGoodFeedback
-                          ? activeFeedbackStyle
-                          : {
-                              _hover: { color: 'primary.600' }
-                            })}
-                        borderRight={isFooter ? undefined : !onAddUserDislike ? 'none' : 'base'}
-                        borderRightRadius={
-                          isFooter ? undefined : !onAddUserDislike ? 'sm' : 'none'
-                        }
-                        name={'core/chat/feedback/goodLight'}
-                        onClick={onAddUserLike}
-                      />
+                      {isFooter ? (
+                        <LikeFeedbackButton
+                          {...iconStyle}
+                          isActive={!!chat.userGoodFeedback}
+                          effectTrigger={likeFeedbackEffectTrigger}
+                          onClick={onAddUserLike}
+                        />
+                      ) : (
+                        <MyIcon
+                          {...iconStyle}
+                          {...(!!chat.userGoodFeedback
+                            ? activeFeedbackStyle
+                            : {
+                                _hover: { color: 'primary.600' }
+                              })}
+                          borderRight={!onAddUserDislike ? 'none' : 'base'}
+                          borderRightRadius={!onAddUserDislike ? 'sm' : 'none'}
+                          name={'core/chat/feedback/goodLight'}
+                          onClick={onAddUserLike}
+                        />
+                      )}
                     </MyTooltip>
                   )}
                   {!!onAddUserDislike && (

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/ChatRecordsList.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/ChatRecordsList.tsx
@@ -38,6 +38,10 @@ export type ChatRecordsListProps = {
   onMark: (chat: ChatSiteItemType, q?: string) => (() => void) | undefined;
   onAddUserLike: (chat: ChatSiteItemType) => (() => void) | undefined;
   onAddUserDislike: (chat: ChatSiteItemType) => (() => void) | undefined;
+  likeFeedbackEffect?: {
+    dataId: string;
+    trigger: number;
+  };
   onCloseCustomFeedback: (
     chat: ChatSiteItemType,
     index: number
@@ -71,6 +75,7 @@ const ChatRecordsList = ({
   onMark,
   onAddUserLike,
   onAddUserDislike,
+  likeFeedbackEffect,
   onCloseCustomFeedback,
   onToggleFeedbackReadStatus
 }: ChatRecordsListProps) => {
@@ -213,6 +218,10 @@ const ChatRecordsList = ({
                         ),
                         onAddUserLike: onAddUserLike(item),
                         onAddUserDislike: onAddUserDislike(item),
+                        likeFeedbackEffectTrigger:
+                          likeFeedbackEffect?.dataId === item.dataId
+                            ? likeFeedbackEffect.trigger
+                            : undefined,
                         onToggleFeedbackReadStatus: onToggleFeedbackReadStatus(item)
                       }}
                     >

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/LikeFeedbackButton.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/LikeFeedbackButton.tsx
@@ -1,0 +1,216 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { Box, type IconProps } from '@chakra-ui/react';
+import MyIcon from '@fastgpt/web/components/common/Icon';
+import styles from '../index.module.scss';
+
+type Particle = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  gravity: number;
+  life: number;
+  size: number;
+  rotation: number;
+  vr: number;
+  color: string;
+};
+
+type LikeFeedbackButtonProps = Omit<IconProps, 'color' | 'filter' | '_hover'> & {
+  isActive: boolean;
+  effectTrigger?: number;
+};
+
+const blueColors = ['#3370ff', '#4f82ff', '#7ca3ff'];
+const accentColor = '#efdefd';
+
+const getParticles = (x: number, y: number): Particle[] =>
+  Array.from({ length: 10 }, (_, index) => {
+    const spread = -Math.PI * 0.72 + Math.PI * 0.44 * (index / 9);
+    const speed = 2 + Math.random() * 2.4;
+
+    return {
+      x,
+      y,
+      vx: Math.cos(spread) * speed,
+      vy: Math.sin(spread) * speed,
+      gravity: 0.09 + Math.random() * 0.03,
+      life: 26 + Math.random() * 8,
+      size: 3 + Math.random() * 3,
+      rotation: Math.random() * Math.PI,
+      vr: (Math.random() - 0.5) * 0.14,
+      color:
+        Math.random() < 0.28
+          ? accentColor
+          : blueColors[Math.floor(Math.random() * blueColors.length)]
+    };
+  });
+
+/**
+ * 渲染点赞按钮的局部成功反馈。
+ *
+ * hover、图标弹跳和 canvas 粒子参数都对齐 prototype，只有新的 effectTrigger 会播放撒花。
+ */
+const LikeFeedbackButton = ({
+  isActive,
+  effectTrigger,
+  cursor,
+  onClick,
+  ...iconProps
+}: LikeFeedbackButtonProps) => {
+  const buttonRef = useRef<HTMLSpanElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const particlesRef = useRef<Particle[]>([]);
+  const rafRef = useRef<number>();
+  const playedTriggerRef = useRef<number>();
+
+  const resizeCanvas = useCallback(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext('2d');
+
+    if (!canvas || !ctx) return;
+
+    const ratio = window.devicePixelRatio || 1;
+    canvas.width = window.innerWidth * ratio;
+    canvas.height = window.innerHeight * ratio;
+    canvas.style.width = `${window.innerWidth}px`;
+    canvas.style.height = `${window.innerHeight}px`;
+    ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+  }, []);
+
+  const removeCanvas = useCallback(() => {
+    canvasRef.current?.remove();
+    canvasRef.current = null;
+  }, []);
+
+  const stopAnimation = useCallback(() => {
+    if (rafRef.current) {
+      window.cancelAnimationFrame(rafRef.current);
+      rafRef.current = undefined;
+    }
+
+    particlesRef.current = [];
+
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext('2d');
+    ctx?.clearRect(0, 0, window.innerWidth, window.innerHeight);
+    removeCanvas();
+  }, [removeCanvas]);
+
+  const createCanvas = useCallback(() => {
+    if (typeof document === 'undefined') return null;
+
+    removeCanvas();
+
+    const canvas = document.createElement('canvas');
+    canvas.className = styles.likeFeedbackCanvas;
+    document.body.appendChild(canvas);
+    canvasRef.current = canvas;
+
+    return canvas;
+  }, [removeCanvas]);
+
+  useEffect(() => {
+    if (!effectTrigger) {
+      stopAnimation();
+      return;
+    }
+
+    if (playedTriggerRef.current === effectTrigger) return;
+
+    playedTriggerRef.current = effectTrigger;
+    stopAnimation();
+
+    const button = buttonRef.current;
+    if (!button) return;
+
+    const canvas = createCanvas();
+    if (!canvas) return;
+
+    resizeCanvas();
+
+    const ctx = canvas?.getContext('2d');
+
+    if (!canvas || !ctx) {
+      stopAnimation();
+      return;
+    }
+
+    const rect = button.getBoundingClientRect();
+    particlesRef.current = getParticles(rect.left + rect.width / 2, rect.top + rect.height / 2 - 2);
+
+    const animate = () => {
+      ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
+      particlesRef.current = particlesRef.current.filter((particle) => particle.life > 0);
+
+      for (const particle of particlesRef.current) {
+        particle.x += particle.vx;
+        particle.y += particle.vy;
+        particle.vy += particle.gravity;
+        particle.life -= 1;
+        particle.rotation += particle.vr;
+
+        ctx.save();
+        ctx.translate(particle.x, particle.y);
+        ctx.rotate(particle.rotation);
+        ctx.globalAlpha = Math.max(particle.life / 45, 0);
+        ctx.fillStyle = particle.color;
+        ctx.fillRect(-particle.size / 2, -particle.size / 3, particle.size, particle.size * 0.66);
+        ctx.restore();
+      }
+
+      if (particlesRef.current.length > 0) {
+        rafRef.current = window.requestAnimationFrame(animate);
+      } else {
+        rafRef.current = undefined;
+        removeCanvas();
+      }
+    };
+
+    animate();
+
+    window.addEventListener('resize', resizeCanvas);
+
+    return () => {
+      window.removeEventListener('resize', resizeCanvas);
+      stopAnimation();
+    };
+  }, [createCanvas, effectTrigger, removeCanvas, resizeCanvas, stopAnimation]);
+
+  useEffect(() => stopAnimation, [stopAnimation]);
+
+  return (
+    <Box
+      as="span"
+      ref={buttonRef}
+      display="inline-flex"
+      position="relative"
+      w="24px"
+      h="24px"
+      alignItems="center"
+      justifyContent="center"
+      overflow="visible"
+      cursor={cursor ?? 'pointer'}
+      color={isActive ? 'primary.600' : 'myGray.400'}
+      filter={isActive ? 'drop-shadow(0 6px 12px rgba(51, 112, 255, 0.18))' : undefined}
+      transition="color 180ms ease, transform 180ms ease, filter 180ms ease"
+      _hover={{
+        color: 'primary.600',
+        transform: 'translateY(-1px)'
+      }}
+      onClick={onClick}
+    >
+      <MyIcon
+        key={effectTrigger || 'idle'}
+        {...iconProps}
+        cursor={undefined}
+        color="currentColor"
+        _hover={undefined}
+        className={effectTrigger ? styles.likeFeedbackIconPop : undefined}
+        name="core/chat/feedback/goodLight"
+      />
+    </Box>
+  );
+};
+
+export default React.memo(LikeFeedbackButton);

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/LikeFeedbackButton.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/LikeFeedbackButton.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import { Box, type IconProps } from '@chakra-ui/react';
+import { Box, type BoxProps, type IconProps } from '@chakra-ui/react';
 import MyIcon from '@fastgpt/web/components/common/Icon';
 import styles from '../index.module.scss';
 
@@ -16,10 +16,11 @@ type Particle = {
   color: string;
 };
 
-type LikeFeedbackButtonProps = Omit<IconProps, 'color' | 'filter' | '_hover'> & {
-  isActive: boolean;
-  effectTrigger?: number;
-};
+type LikeFeedbackButtonProps = Omit<BoxProps, 'color' | 'filter' | '_hover'> &
+  Pick<IconProps, 'w' | 'h' | 'boxSize'> & {
+    isActive: boolean;
+    effectTrigger?: number;
+  };
 
 const blueColors = ['#3370ff', '#4f82ff', '#7ca3ff'];
 const accentColor = '#efdefd';

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/LikeFeedbackButton.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/components/LikeFeedbackButton.tsx
@@ -16,8 +16,8 @@ type Particle = {
   color: string;
 };
 
-type LikeFeedbackButtonProps = Omit<BoxProps, 'color' | 'filter' | '_hover'> &
-  Pick<IconProps, 'w' | 'h' | 'boxSize'> & {
+type LikeFeedbackButtonProps = Pick<BoxProps, 'cursor' | 'onClick'> &
+  Pick<IconProps, 'w' | 'h' | 'boxSize' | 'p'> & {
     isActive: boolean;
     effectTrigger?: number;
   };
@@ -57,7 +57,10 @@ const LikeFeedbackButton = ({
   effectTrigger,
   cursor,
   onClick,
-  ...iconProps
+  w,
+  h,
+  boxSize,
+  p
 }: LikeFeedbackButtonProps) => {
   const buttonRef = useRef<HTMLSpanElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -203,7 +206,10 @@ const LikeFeedbackButton = ({
     >
       <MyIcon
         key={effectTrigger || 'idle'}
-        {...iconProps}
+        w={w}
+        h={h}
+        boxSize={boxSize}
+        p={p}
         cursor={undefined}
         color="currentColor"
         _hover={undefined}

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/hooks/useChatFeedbackActions.ts
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/hooks/useChatFeedbackActions.ts
@@ -1,4 +1,4 @@
-import { useState, type ChangeEvent } from 'react';
+import { useEffect, useRef, useState, type ChangeEvent } from 'react';
 import { useContextSelector } from 'use-context-selector';
 import { useMemoizedFn } from 'ahooks';
 import { ChatRoleEnum } from '@fastgpt/global/core/chat/constants';
@@ -24,6 +24,10 @@ type UseChatFeedbackActionsProps = {
 };
 
 type AdminMarkState = AdminMarkType & { dataId: string };
+type LikeFeedbackEffectState = {
+  dataId: string;
+  trigger: number;
+};
 
 /**
  * 管理 ChatBox 中反馈、标注和反馈已读状态相关动作。
@@ -47,11 +51,31 @@ export const useChatFeedbackActions = ({
 }: UseChatFeedbackActionsProps) => {
   const [feedbackId, setFeedbackId] = useState<string>();
   const [adminMarkData, setAdminMarkData] = useState<AdminMarkState>();
+  const [likeFeedbackEffect, setLikeFeedbackEffect] = useState<LikeFeedbackEffectState>();
+  const likeFeedbackEffectTrigger = useRef(0);
+  const likeFeedbackEffectTimer = useRef<ReturnType<typeof setTimeout>>();
 
   const setChatRecords = useContextSelector(ChatRecordContext, (v) => v.setChatRecords);
   const appId = useContextSelector(WorkflowRuntimeContext, (v) => v.appId);
   const chatId = useContextSelector(WorkflowRuntimeContext, (v) => v.chatId);
   const outLinkAuthData = useContextSelector(WorkflowRuntimeContext, (v) => v.outLinkAuthData);
+
+  useEffect(() => {
+    return () => {
+      if (likeFeedbackEffectTimer.current) {
+        clearTimeout(likeFeedbackEffectTimer.current);
+      }
+    };
+  }, []);
+
+  // 取消赞或进入点踩流程时立即清理一次性视觉反馈，避免非点赞动作残留撒花。
+  const clearLikeFeedbackEffect = useMemoizedFn(() => {
+    if (likeFeedbackEffectTimer.current) {
+      clearTimeout(likeFeedbackEffectTimer.current);
+      likeFeedbackEffectTimer.current = undefined;
+    }
+    setLikeFeedbackEffect(undefined);
+  });
 
   /**
    * 生成 admin mark 入口回调。
@@ -109,6 +133,21 @@ export const useChatFeedbackActions = ({
             : chatItem
         )
       );
+      if (!isGoodFeedback) {
+        const trigger = ++likeFeedbackEffectTrigger.current;
+        if (likeFeedbackEffectTimer.current) {
+          clearTimeout(likeFeedbackEffectTimer.current);
+        }
+        setLikeFeedbackEffect({
+          dataId: chat.dataId,
+          trigger
+        });
+        likeFeedbackEffectTimer.current = setTimeout(() => {
+          setLikeFeedbackEffect((state) => (state?.trigger === trigger ? undefined : state));
+        }, 800);
+      } else {
+        clearLikeFeedbackEffect();
+      }
 
       try {
         updateChatUserFeedback({
@@ -134,6 +173,7 @@ export const useChatFeedbackActions = ({
 
     if (chat.userBadFeedback) {
       return () => {
+        clearLikeFeedbackEffect();
         if (!chat.dataId || !chatId || !appId) return;
         setChatRecords((state) =>
           state.map((chatItem) =>
@@ -152,7 +192,10 @@ export const useChatFeedbackActions = ({
       };
     }
 
-    return () => setFeedbackId(chat.dataId);
+    return () => {
+      clearLikeFeedbackEffect();
+      setFeedbackId(chat.dataId);
+    };
   });
 
   /**
@@ -230,6 +273,7 @@ export const useChatFeedbackActions = ({
    * 并关闭 modal，避免等待下一次 records reload 才看到反馈状态。
    */
   const onFeedbackSuccess = useMemoizedFn((content: string) => {
+    clearLikeFeedbackEffect();
     setChatRecords((state) =>
       state.map((item) =>
         item.dataId === feedbackId
@@ -273,6 +317,7 @@ export const useChatFeedbackActions = ({
     setFeedbackId,
     adminMarkData,
     setAdminMarkData,
+    likeFeedbackEffect,
     onMark,
     onAddUserLike,
     onAddUserDislike,

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/index.module.scss
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/index.module.scss
@@ -1,6 +1,18 @@
 .statusAnimation {
   animation: statusBox 0.8s linear infinite alternate;
 }
+
+.likeFeedbackIconPop {
+  animation: likeFeedbackIconPop 320ms ease;
+}
+
+.likeFeedbackCanvas {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  pointer-events: none;
+}
+
 @keyframes statusBox {
   0% {
     opacity: 1;
@@ -8,5 +20,19 @@
 
   100% {
     opacity: 0.11;
+  }
+}
+
+@keyframes likeFeedbackIconPop {
+  0% {
+    transform: scale(1);
+  }
+
+  35% {
+    transform: scale(1.18);
+  }
+
+  100% {
+    transform: scale(1);
   }
 }

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/index.tsx
@@ -333,6 +333,7 @@ const ChatBox = ({
     setFeedbackId,
     adminMarkData,
     setAdminMarkData,
+    likeFeedbackEffect,
     onMark,
     onAddUserLike,
     onAddUserDislike,
@@ -530,6 +531,7 @@ const ChatBox = ({
       onMark,
       onAddUserLike,
       onAddUserDislike,
+      likeFeedbackEffect,
       onCloseCustomFeedback,
       onToggleFeedbackReadStatus
     }),
@@ -547,6 +549,7 @@ const ChatBox = ({
       onMark,
       onAddUserLike,
       onAddUserDislike,
+      likeFeedbackEffect,
       onCloseCustomFeedback,
       onToggleFeedbackReadStatus
     ]

--- a/projects/app/src/components/core/chat/components/AIResponseBox/RenderAgentPlanAskInteractive.tsx
+++ b/projects/app/src/components/core/chat/components/AIResponseBox/RenderAgentPlanAskInteractive.tsx
@@ -91,63 +91,68 @@ const RenderAgentPlanAskInteractive = React.memo(function RenderAgentPlanAskInte
               <SelectedAnswerText answer={effectiveAnswer} />
             </Box>
           )}
-          <Collapse in={shouldShowOptions} animateOpacity>
-            <Box p={1} m={-1}>
-              <Flex flexDirection={'column'} gap={3}>
-                <LeftRadio<string>
-                  px={4}
-                  py={4}
-                  gridGap={2}
-                  align={'center'}
-                  list={radioOptions}
-                  value={radioValue}
-                  defaultBg={'white'}
-                  activeBg={'white'}
-                  onChange={(value) => {
-                    if (!value || isDisabled) return;
-                    if (value === AGENT_PLAN_ASK_OTHER_OPTION_VALUE) {
-                      setIsOtherSelected(true);
-                      return;
-                    }
-                    setIsOtherSelected(false);
-                    setSubmittedAnswer(value);
-                    scheduleCollapse();
-                    onSendPrompt(value);
-                  }}
-                  isDisabled={isDisabled}
-                />
-                {showOtherInput && (
-                  <Flex flexDirection={'column'} gap={2}>
-                    <Textarea
-                      autoFocus={!isDisabled}
-                      bg={'white'}
-                      rows={3}
-                      resize={'vertical'}
-                      value={currentOtherAnswer}
-                      placeholder={t('common:Other')}
-                      isDisabled={isDisabled}
-                      onChange={(e) => setOtherAnswer(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                          submitOtherAnswer();
-                        }
-                      }}
-                    />
-                    <Flex justifyContent={'flex-end'}>
-                      {!isDisabled && (
-                        <Button
-                          flexShrink={0}
-                          isDisabled={!otherAnswer.trim()}
-                          onClick={submitOtherAnswer}
-                        >
-                          {t('common:Submit')}
-                        </Button>
-                      )}
-                    </Flex>
+          <Collapse
+            in={shouldShowOptions}
+            animateOpacity
+            transitionEnd={{
+              enter: { overflow: 'visible' },
+              exit: { overflow: 'hidden' }
+            }}
+          >
+            <Flex flexDirection={'column'} gap={3}>
+              <LeftRadio<string>
+                px={4}
+                py={4}
+                gridGap={2}
+                align={'center'}
+                list={radioOptions}
+                value={radioValue}
+                defaultBg={'white'}
+                activeBg={'white'}
+                onChange={(value) => {
+                  if (!value || isDisabled) return;
+                  if (value === AGENT_PLAN_ASK_OTHER_OPTION_VALUE) {
+                    setIsOtherSelected(true);
+                    return;
+                  }
+                  setIsOtherSelected(false);
+                  setSubmittedAnswer(value);
+                  scheduleCollapse();
+                  onSendPrompt(value);
+                }}
+                isDisabled={isDisabled}
+              />
+              {showOtherInput && (
+                <Flex flexDirection={'column'} gap={2}>
+                  <Textarea
+                    autoFocus={!isDisabled}
+                    bg={'white'}
+                    rows={3}
+                    resize={'vertical'}
+                    value={currentOtherAnswer}
+                    placeholder={t('common:Other')}
+                    isDisabled={isDisabled}
+                    onChange={(e) => setOtherAnswer(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                        submitOtherAnswer();
+                      }
+                    }}
+                  />
+                  <Flex justifyContent={'flex-end'}>
+                    {!isDisabled && (
+                      <Button
+                        flexShrink={0}
+                        isDisabled={!otherAnswer.trim()}
+                        onClick={submitOtherAnswer}
+                      >
+                        {t('common:Submit')}
+                      </Button>
+                    )}
                   </Flex>
-                )}
-              </Flex>
-            </Box>
+                </Flex>
+              )}
+            </Flex>
           </Collapse>
           {selectedAnswerPlacement === 'below' && (
             <Box mt={3}>

--- a/projects/app/src/components/core/chat/components/AIResponseBox/RenderAgentPlanAskInteractive.tsx
+++ b/projects/app/src/components/core/chat/components/AIResponseBox/RenderAgentPlanAskInteractive.tsx
@@ -163,6 +163,7 @@ const RenderAgentPlanAskInteractive = React.memo(function RenderAgentPlanAskInte
             answer={effectiveAnswer}
             isOptionsExpanded={isOptionsExpanded}
             onToggle={toggleOptionsExpanded}
+            mt={selectedAnswerPlacement === 'above' && !shouldShowOptions ? 0 : 3}
           />
         </Box>
       )}

--- a/projects/app/src/components/core/chat/components/AIResponseBox/RenderAgentPlanAskInteractive.tsx
+++ b/projects/app/src/components/core/chat/components/AIResponseBox/RenderAgentPlanAskInteractive.tsx
@@ -90,60 +90,62 @@ const RenderAgentPlanAskInteractive = React.memo(function RenderAgentPlanAskInte
             <SelectedAnswerText answer={effectiveAnswer} />
           )}
           <Collapse in={shouldShowOptions} animateOpacity>
-            <Flex flexDirection={'column'} gap={3}>
-              <LeftRadio<string>
-                px={4}
-                py={4}
-                gridGap={2}
-                align={'center'}
-                list={radioOptions}
-                value={radioValue}
-                defaultBg={'white'}
-                activeBg={'white'}
-                onChange={(value) => {
-                  if (!value || isDisabled) return;
-                  if (value === AGENT_PLAN_ASK_OTHER_OPTION_VALUE) {
-                    setIsOtherSelected(true);
-                    return;
-                  }
-                  setIsOtherSelected(false);
-                  setSubmittedAnswer(value);
-                  scheduleCollapse();
-                  onSendPrompt(value);
-                }}
-                isDisabled={isDisabled}
-              />
-              {showOtherInput && (
-                <Flex flexDirection={'column'} gap={2}>
-                  <Textarea
-                    autoFocus={!isDisabled}
-                    bg={'white'}
-                    rows={3}
-                    resize={'vertical'}
-                    value={currentOtherAnswer}
-                    placeholder={t('common:Other')}
-                    isDisabled={isDisabled}
-                    onChange={(e) => setOtherAnswer(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                        submitOtherAnswer();
-                      }
-                    }}
-                  />
-                  <Flex justifyContent={'flex-end'}>
-                    {!isDisabled && (
-                      <Button
-                        flexShrink={0}
-                        isDisabled={!otherAnswer.trim()}
-                        onClick={submitOtherAnswer}
-                      >
-                        {t('common:Submit')}
-                      </Button>
-                    )}
+            <Box p={1} m={-1}>
+              <Flex flexDirection={'column'} gap={3}>
+                <LeftRadio<string>
+                  px={4}
+                  py={4}
+                  gridGap={2}
+                  align={'center'}
+                  list={radioOptions}
+                  value={radioValue}
+                  defaultBg={'white'}
+                  activeBg={'white'}
+                  onChange={(value) => {
+                    if (!value || isDisabled) return;
+                    if (value === AGENT_PLAN_ASK_OTHER_OPTION_VALUE) {
+                      setIsOtherSelected(true);
+                      return;
+                    }
+                    setIsOtherSelected(false);
+                    setSubmittedAnswer(value);
+                    scheduleCollapse();
+                    onSendPrompt(value);
+                  }}
+                  isDisabled={isDisabled}
+                />
+                {showOtherInput && (
+                  <Flex flexDirection={'column'} gap={2}>
+                    <Textarea
+                      autoFocus={!isDisabled}
+                      bg={'white'}
+                      rows={3}
+                      resize={'vertical'}
+                      value={currentOtherAnswer}
+                      placeholder={t('common:Other')}
+                      isDisabled={isDisabled}
+                      onChange={(e) => setOtherAnswer(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                          submitOtherAnswer();
+                        }
+                      }}
+                    />
+                    <Flex justifyContent={'flex-end'}>
+                      {!isDisabled && (
+                        <Button
+                          flexShrink={0}
+                          isDisabled={!otherAnswer.trim()}
+                          onClick={submitOtherAnswer}
+                        >
+                          {t('common:Submit')}
+                        </Button>
+                      )}
+                    </Flex>
                   </Flex>
-                </Flex>
-              )}
-            </Flex>
+                )}
+              </Flex>
+            </Box>
           </Collapse>
           {selectedAnswerPlacement === 'below' && (
             <SelectedAnswerText answer={effectiveAnswer} />

--- a/projects/app/src/components/core/chat/components/AIResponseBox/RenderAgentPlanAskInteractive.tsx
+++ b/projects/app/src/components/core/chat/components/AIResponseBox/RenderAgentPlanAskInteractive.tsx
@@ -85,9 +85,11 @@ const RenderAgentPlanAskInteractive = React.memo(function RenderAgentPlanAskInte
         </Box>
       )}
       {normalizedOptions.length > 0 && (
-        <Flex flexDirection={'column'} gap={3}>
+        <Box>
           {selectedAnswerPlacement === 'above' && (
-            <SelectedAnswerText answer={effectiveAnswer} />
+            <Box mb={3}>
+              <SelectedAnswerText answer={effectiveAnswer} />
+            </Box>
           )}
           <Collapse in={shouldShowOptions} animateOpacity>
             <Box p={1} m={-1}>
@@ -148,14 +150,16 @@ const RenderAgentPlanAskInteractive = React.memo(function RenderAgentPlanAskInte
             </Box>
           </Collapse>
           {selectedAnswerPlacement === 'below' && (
-            <SelectedAnswerText answer={effectiveAnswer} />
+            <Box mt={3}>
+              <SelectedAnswerText answer={effectiveAnswer} />
+            </Box>
           )}
           <ChoiceCollapseToggleButton
             answer={effectiveAnswer}
             isOptionsExpanded={isOptionsExpanded}
             onToggle={toggleOptionsExpanded}
           />
-        </Flex>
+        </Box>
       )}
     </Flex>
   );

--- a/projects/app/src/components/core/chat/components/AIResponseBox/RenderAgentPlanAskInteractive.tsx
+++ b/projects/app/src/components/core/chat/components/AIResponseBox/RenderAgentPlanAskInteractive.tsx
@@ -1,10 +1,14 @@
-import { Box, Button, Flex, Textarea } from '@chakra-ui/react';
+import { Box, Button, Collapse, Flex, Textarea } from '@chakra-ui/react';
 import type { AgentPlanAskQueryInteractive } from '@fastgpt/global/core/workflow/template/system/interactive/type';
 import LeftRadio from '@fastgpt/web/components/common/Radio/LeftRadio';
 import { useTranslation } from 'next-i18next';
 import React, { useCallback, useMemo } from 'react';
 import { AGENT_PLAN_ASK_OTHER_OPTION_VALUE } from './constants';
 import { onSendPrompt } from './utils';
+import {
+  SelectedAnswerCollapseControl,
+  useInteractiveChoiceCollapse
+} from '../Interactive/InteractiveChoiceCollapse';
 
 const RenderAgentPlanAskInteractive = React.memo(function RenderAgentPlanAskInteractive({
   interactive,
@@ -28,6 +32,13 @@ const RenderAgentPlanAskInteractive = React.memo(function RenderAgentPlanAskInte
     effectiveAnswer && normalizedOptions.includes(effectiveAnswer) ? effectiveAnswer : '';
   const answeredOther =
     effectiveAnswer && !normalizedOptions.includes(effectiveAnswer) ? effectiveAnswer : '';
+  const {
+    isOptionsExpanded,
+    selectedAnswerPlacement,
+    shouldShowOptions,
+    scheduleCollapse,
+    toggleOptionsExpanded
+  } = useInteractiveChoiceCollapse(effectiveAnswer);
   const showOtherInput = !!answeredOther || isOtherSelected;
   const radioValue =
     answeredOther || isOtherSelected ? AGENT_PLAN_ASK_OTHER_OPTION_VALUE : selectedOption;
@@ -37,8 +48,9 @@ const RenderAgentPlanAskInteractive = React.memo(function RenderAgentPlanAskInte
     if (!value || isDisabled) return;
 
     setSubmittedAnswer(value);
+    scheduleCollapse();
     onSendPrompt(value);
-  }, [isDisabled, otherAnswer]);
+  }, [isDisabled, otherAnswer, scheduleCollapse]);
   const radioOptions = useMemo(
     () => [
       ...normalizedOptions.map((option) => ({
@@ -73,55 +85,75 @@ const RenderAgentPlanAskInteractive = React.memo(function RenderAgentPlanAskInte
       )}
       {normalizedOptions.length > 0 && (
         <Flex flexDirection={'column'} gap={3}>
-          <LeftRadio<string>
-            py={3}
-            gridGap={2}
-            align={'center'}
-            list={radioOptions}
-            value={radioValue}
-            defaultBg={'white'}
-            activeBg={'white'}
-            onChange={(value) => {
-              if (!value || isDisabled) return;
-              if (value === AGENT_PLAN_ASK_OTHER_OPTION_VALUE) {
-                setIsOtherSelected(true);
-                return;
-              }
-              setIsOtherSelected(false);
-              setSubmittedAnswer(value);
-              onSendPrompt(value);
-            }}
-            isDisabled={isDisabled}
-          />
-          {showOtherInput && (
-            <Flex flexDirection={'column'} gap={2}>
-              <Textarea
-                autoFocus={!isDisabled}
-                bg={'white'}
-                rows={3}
-                resize={'vertical'}
-                value={currentOtherAnswer}
-                placeholder={t('common:Other')}
-                isDisabled={isDisabled}
-                onChange={(e) => setOtherAnswer(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                    submitOtherAnswer();
+          {selectedAnswerPlacement === 'above' && (
+            <SelectedAnswerCollapseControl
+              answer={effectiveAnswer}
+              isOptionsExpanded={isOptionsExpanded}
+              onToggle={toggleOptionsExpanded}
+            />
+          )}
+          <Collapse in={shouldShowOptions} animateOpacity>
+            <Flex flexDirection={'column'} gap={3}>
+              <LeftRadio<string>
+                px={4}
+                py={4}
+                gridGap={2}
+                align={'center'}
+                list={radioOptions}
+                value={radioValue}
+                defaultBg={'white'}
+                activeBg={'white'}
+                onChange={(value) => {
+                  if (!value || isDisabled) return;
+                  if (value === AGENT_PLAN_ASK_OTHER_OPTION_VALUE) {
+                    setIsOtherSelected(true);
+                    return;
                   }
+                  setIsOtherSelected(false);
+                  setSubmittedAnswer(value);
+                  scheduleCollapse();
+                  onSendPrompt(value);
                 }}
+                isDisabled={isDisabled}
               />
-              <Flex justifyContent={'flex-end'}>
-                {!isDisabled && (
-                  <Button
-                    flexShrink={0}
-                    isDisabled={!otherAnswer.trim()}
-                    onClick={submitOtherAnswer}
-                  >
-                    {t('common:Submit')}
-                  </Button>
-                )}
-              </Flex>
+              {showOtherInput && (
+                <Flex flexDirection={'column'} gap={2}>
+                  <Textarea
+                    autoFocus={!isDisabled}
+                    bg={'white'}
+                    rows={3}
+                    resize={'vertical'}
+                    value={currentOtherAnswer}
+                    placeholder={t('common:Other')}
+                    isDisabled={isDisabled}
+                    onChange={(e) => setOtherAnswer(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                        submitOtherAnswer();
+                      }
+                    }}
+                  />
+                  <Flex justifyContent={'flex-end'}>
+                    {!isDisabled && (
+                      <Button
+                        flexShrink={0}
+                        isDisabled={!otherAnswer.trim()}
+                        onClick={submitOtherAnswer}
+                      >
+                        {t('common:Submit')}
+                      </Button>
+                    )}
+                  </Flex>
+                </Flex>
+              )}
             </Flex>
+          </Collapse>
+          {selectedAnswerPlacement === 'below' && (
+            <SelectedAnswerCollapseControl
+              answer={effectiveAnswer}
+              isOptionsExpanded={isOptionsExpanded}
+              onToggle={toggleOptionsExpanded}
+            />
           )}
         </Flex>
       )}

--- a/projects/app/src/components/core/chat/components/AIResponseBox/RenderAgentPlanAskInteractive.tsx
+++ b/projects/app/src/components/core/chat/components/AIResponseBox/RenderAgentPlanAskInteractive.tsx
@@ -6,7 +6,8 @@ import React, { useCallback, useMemo } from 'react';
 import { AGENT_PLAN_ASK_OTHER_OPTION_VALUE } from './constants';
 import { onSendPrompt } from './utils';
 import {
-  SelectedAnswerCollapseControl,
+  ChoiceCollapseToggleButton,
+  SelectedAnswerText,
   useInteractiveChoiceCollapse
 } from '../Interactive/InteractiveChoiceCollapse';
 
@@ -86,11 +87,7 @@ const RenderAgentPlanAskInteractive = React.memo(function RenderAgentPlanAskInte
       {normalizedOptions.length > 0 && (
         <Flex flexDirection={'column'} gap={3}>
           {selectedAnswerPlacement === 'above' && (
-            <SelectedAnswerCollapseControl
-              answer={effectiveAnswer}
-              isOptionsExpanded={isOptionsExpanded}
-              onToggle={toggleOptionsExpanded}
-            />
+            <SelectedAnswerText answer={effectiveAnswer} />
           )}
           <Collapse in={shouldShowOptions} animateOpacity>
             <Flex flexDirection={'column'} gap={3}>
@@ -149,12 +146,13 @@ const RenderAgentPlanAskInteractive = React.memo(function RenderAgentPlanAskInte
             </Flex>
           </Collapse>
           {selectedAnswerPlacement === 'below' && (
-            <SelectedAnswerCollapseControl
-              answer={effectiveAnswer}
-              isOptionsExpanded={isOptionsExpanded}
-              onToggle={toggleOptionsExpanded}
-            />
+            <SelectedAnswerText answer={effectiveAnswer} />
           )}
+          <ChoiceCollapseToggleButton
+            answer={effectiveAnswer}
+            isOptionsExpanded={isOptionsExpanded}
+            onToggle={toggleOptionsExpanded}
+          />
         </Flex>
       )}
     </Flex>

--- a/projects/app/src/components/core/chat/components/AIResponseBox/RenderAgentPlanAskInteractive.tsx
+++ b/projects/app/src/components/core/chat/components/AIResponseBox/RenderAgentPlanAskInteractive.tsx
@@ -99,7 +99,7 @@ const RenderAgentPlanAskInteractive = React.memo(function RenderAgentPlanAskInte
               exit: { overflow: 'hidden' }
             }}
           >
-            <Flex flexDirection={'column'} gap={3}>
+            <Flex w={'360px'} maxW={'100%'} flexDirection={'column'} gap={3}>
               <LeftRadio<string>
                 px={4}
                 py={4}

--- a/projects/app/src/components/core/chat/components/Interactive/InteractiveChoiceCollapse.tsx
+++ b/projects/app/src/components/core/chat/components/Interactive/InteractiveChoiceCollapse.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Button } from '@chakra-ui/react';
+import { Box } from '@chakra-ui/react';
 import { useTranslation } from 'next-i18next';
 
 type SelectedAnswerPlacement = 'above' | 'below';
@@ -92,13 +92,19 @@ export const ChoiceCollapseToggleButton = React.memo(function ChoiceCollapseTogg
 
   return (
     <Box mt={3}>
-      <Button
+      <Box
+        as="button"
+        type="button"
+        display={'inline-flex'}
+        alignItems={'center'}
         mx={'8px'}
         px={0}
         h={'16px'}
         minW={0}
-        variant={'unstyled'}
+        border={0}
+        bg={'transparent'}
         color={'primary.600'}
+        cursor={'pointer'}
         fontSize={'11px'}
         fontWeight={500}
         lineHeight={'16px'}
@@ -107,7 +113,7 @@ export const ChoiceCollapseToggleButton = React.memo(function ChoiceCollapseTogg
         {isOptionsExpanded
           ? t('chat:interactive.user_select.collapse_options')
           : t('chat:interactive.user_select.expand_options')}
-      </Button>
+      </Box>
     </Box>
   );
 });

--- a/projects/app/src/components/core/chat/components/Interactive/InteractiveChoiceCollapse.tsx
+++ b/projects/app/src/components/core/chat/components/Interactive/InteractiveChoiceCollapse.tsx
@@ -97,6 +97,7 @@ export const ChoiceCollapseToggleButton = React.memo(function ChoiceCollapseTogg
       display={'inline-flex'}
       alignItems={'center'}
       alignSelf={'flex-start'}
+      position={'relative'}
       mx={'8px'}
       px={0}
       h={'16px'}
@@ -108,11 +109,26 @@ export const ChoiceCollapseToggleButton = React.memo(function ChoiceCollapseTogg
       fontSize={'11px'}
       fontWeight={500}
       lineHeight={'16px'}
+      _before={{
+        content: '""',
+        position: 'absolute',
+        inset: '-6px -8px',
+        borderRadius: '6px',
+        bg: 'transparent',
+        transition: 'background-color 150ms ease'
+      }}
+      _hover={{
+        _before: {
+          bg: 'myGray.100'
+        }
+      }}
       onClick={onToggle}
     >
-      {isOptionsExpanded
-        ? t('chat:interactive.user_select.collapse_options')
-        : t('chat:interactive.user_select.expand_options')}
+      <Box as="span" position={'relative'} zIndex={1}>
+        {isOptionsExpanded
+          ? t('chat:interactive.user_select.collapse_options')
+          : t('chat:interactive.user_select.expand_options')}
+      </Box>
     </Box>
   );
 });

--- a/projects/app/src/components/core/chat/components/Interactive/InteractiveChoiceCollapse.tsx
+++ b/projects/app/src/components/core/chat/components/Interactive/InteractiveChoiceCollapse.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { Box, Button } from '@chakra-ui/react';
+import { useTranslation } from 'next-i18next';
+
+type SelectedAnswerPlacement = 'above' | 'below';
+
+/**
+ * 管理交互选项在提交答案后的展示状态。
+ * 选中后先保留选项 1 秒用于反馈，再折叠为答案摘要；刷新后如果已有答案则默认折叠。
+ */
+export const useInteractiveChoiceCollapse = (selectedAnswer?: string) => {
+  const [isOptionsExpanded, setIsOptionsExpanded] = React.useState(!selectedAnswer);
+  const [selectedAnswerPlacement, setSelectedAnswerPlacement] =
+    React.useState<SelectedAnswerPlacement>(selectedAnswer ? 'above' : 'below');
+  const collapseTimerRef = React.useRef<ReturnType<typeof setTimeout>>();
+
+  const clearCollapseTimer = React.useCallback(() => {
+    if (collapseTimerRef.current) {
+      clearTimeout(collapseTimerRef.current);
+      collapseTimerRef.current = undefined;
+    }
+  }, []);
+
+  React.useEffect(() => {
+    if (!selectedAnswer) {
+      clearCollapseTimer();
+      setIsOptionsExpanded(true);
+      setSelectedAnswerPlacement('below');
+    }
+  }, [clearCollapseTimer, selectedAnswer]);
+
+  React.useEffect(() => {
+    return () => {
+      clearCollapseTimer();
+    };
+  }, [clearCollapseTimer]);
+
+  const scheduleCollapse = React.useCallback(() => {
+    clearCollapseTimer();
+    setSelectedAnswerPlacement('below');
+    setIsOptionsExpanded(true);
+    collapseTimerRef.current = setTimeout(() => {
+      setIsOptionsExpanded(false);
+      setSelectedAnswerPlacement('above');
+      collapseTimerRef.current = undefined;
+    }, 1000);
+  }, [clearCollapseTimer]);
+
+  const toggleOptionsExpanded = React.useCallback(() => {
+    clearCollapseTimer();
+    setSelectedAnswerPlacement('above');
+    setIsOptionsExpanded((state) => !state);
+  }, [clearCollapseTimer]);
+
+  return {
+    isOptionsExpanded,
+    selectedAnswerPlacement,
+    shouldShowOptions: !selectedAnswer || isOptionsExpanded,
+    scheduleCollapse,
+    toggleOptionsExpanded
+  };
+};
+
+export const SelectedAnswerCollapseControl = React.memo(function SelectedAnswerCollapseControl({
+  answer,
+  isOptionsExpanded,
+  onToggle
+}: {
+  answer?: string;
+  isOptionsExpanded: boolean;
+  onToggle: () => void;
+}) {
+  const { t } = useTranslation();
+
+  if (!answer) return null;
+
+  return (
+    <Box mt={3}>
+      <Box color={'myGray.500'} fontSize={'sm'} lineHeight={'20px'}>
+        {t('chat:interactive.user_select.selected', { answer })}
+      </Box>
+      <Button
+        mt={1}
+        mx={'8px'}
+        px={0}
+        h={'22px'}
+        minW={0}
+        variant={'unstyled'}
+        color={'primary.600'}
+        fontSize={'11px'}
+        fontWeight={500}
+        lineHeight={'20px'}
+        onClick={onToggle}
+      >
+        {isOptionsExpanded
+          ? t('chat:interactive.user_select.collapse_options')
+          : t('chat:interactive.user_select.expand_options')}
+      </Button>
+    </Box>
+  );
+});

--- a/projects/app/src/components/core/chat/components/Interactive/InteractiveChoiceCollapse.tsx
+++ b/projects/app/src/components/core/chat/components/Interactive/InteractiveChoiceCollapse.tsx
@@ -95,13 +95,13 @@ export const ChoiceCollapseToggleButton = React.memo(function ChoiceCollapseTogg
       <Button
         mx={'8px'}
         px={0}
-        h={'22px'}
+        h={'16px'}
         minW={0}
         variant={'unstyled'}
         color={'primary.600'}
         fontSize={'11px'}
         fontWeight={500}
-        lineHeight={'20px'}
+        lineHeight={'16px'}
         onClick={onToggle}
       >
         {isOptionsExpanded

--- a/projects/app/src/components/core/chat/components/Interactive/InteractiveChoiceCollapse.tsx
+++ b/projects/app/src/components/core/chat/components/Interactive/InteractiveChoiceCollapse.tsx
@@ -106,6 +106,7 @@ export const ChoiceCollapseToggleButton = React.memo(function ChoiceCollapseTogg
       alignItems={'center'}
       alignSelf={'flex-start'}
       position={'relative'}
+      mt={3}
       mx={'8px'}
       px={0}
       h={'16px'}

--- a/projects/app/src/components/core/chat/components/Interactive/InteractiveChoiceCollapse.tsx
+++ b/projects/app/src/components/core/chat/components/Interactive/InteractiveChoiceCollapse.tsx
@@ -13,44 +13,52 @@ export const useInteractiveChoiceCollapse = (selectedAnswer?: string) => {
   const [selectedAnswerPlacement, setSelectedAnswerPlacement] =
     React.useState<SelectedAnswerPlacement>(selectedAnswer ? 'above' : 'below');
   const collapseTimerRef = React.useRef<ReturnType<typeof setTimeout>>();
+  const placementTimerRef = React.useRef<ReturnType<typeof setTimeout>>();
 
-  const clearCollapseTimer = React.useCallback(() => {
+  const clearCollapseTimers = React.useCallback(() => {
     if (collapseTimerRef.current) {
       clearTimeout(collapseTimerRef.current);
       collapseTimerRef.current = undefined;
+    }
+    if (placementTimerRef.current) {
+      clearTimeout(placementTimerRef.current);
+      placementTimerRef.current = undefined;
     }
   }, []);
 
   React.useEffect(() => {
     if (!selectedAnswer) {
-      clearCollapseTimer();
+      clearCollapseTimers();
       setIsOptionsExpanded(true);
       setSelectedAnswerPlacement('below');
     }
-  }, [clearCollapseTimer, selectedAnswer]);
+  }, [clearCollapseTimers, selectedAnswer]);
 
   React.useEffect(() => {
     return () => {
-      clearCollapseTimer();
+      clearCollapseTimers();
     };
-  }, [clearCollapseTimer]);
+  }, [clearCollapseTimers]);
 
   const scheduleCollapse = React.useCallback(() => {
-    clearCollapseTimer();
+    clearCollapseTimers();
     setSelectedAnswerPlacement('below');
     setIsOptionsExpanded(true);
     collapseTimerRef.current = setTimeout(() => {
       setIsOptionsExpanded(false);
-      setSelectedAnswerPlacement('above');
       collapseTimerRef.current = undefined;
+      placementTimerRef.current = setTimeout(() => {
+        setSelectedAnswerPlacement('above');
+        placementTimerRef.current = undefined;
+      }, 240);
     }, 1000);
-  }, [clearCollapseTimer]);
+  }, [clearCollapseTimers]);
 
   const toggleOptionsExpanded = React.useCallback(() => {
-    clearCollapseTimer();
+    clearCollapseTimers();
     setSelectedAnswerPlacement('above');
     setIsOptionsExpanded((state) => !state);
-  }, [clearCollapseTimer]);
+  }, [clearCollapseTimers]);
 
   return {
     isOptionsExpanded,

--- a/projects/app/src/components/core/chat/components/Interactive/InteractiveChoiceCollapse.tsx
+++ b/projects/app/src/components/core/chat/components/Interactive/InteractiveChoiceCollapse.tsx
@@ -91,29 +91,28 @@ export const ChoiceCollapseToggleButton = React.memo(function ChoiceCollapseTogg
   if (!answer) return null;
 
   return (
-    <Box mt={3}>
-      <Box
-        as="button"
-        type="button"
-        display={'inline-flex'}
-        alignItems={'center'}
-        mx={'8px'}
-        px={0}
-        h={'16px'}
-        minW={0}
-        border={0}
-        bg={'transparent'}
-        color={'primary.600'}
-        cursor={'pointer'}
-        fontSize={'11px'}
-        fontWeight={500}
-        lineHeight={'16px'}
-        onClick={onToggle}
-      >
-        {isOptionsExpanded
-          ? t('chat:interactive.user_select.collapse_options')
-          : t('chat:interactive.user_select.expand_options')}
-      </Box>
+    <Box
+      as="button"
+      type="button"
+      display={'inline-flex'}
+      alignItems={'center'}
+      alignSelf={'flex-start'}
+      mx={'8px'}
+      px={0}
+      h={'16px'}
+      minW={0}
+      border={0}
+      bg={'transparent'}
+      color={'primary.600'}
+      cursor={'pointer'}
+      fontSize={'11px'}
+      fontWeight={500}
+      lineHeight={'16px'}
+      onClick={onToggle}
+    >
+      {isOptionsExpanded
+        ? t('chat:interactive.user_select.collapse_options')
+        : t('chat:interactive.user_select.expand_options')}
     </Box>
   );
 });

--- a/projects/app/src/components/core/chat/components/Interactive/InteractiveChoiceCollapse.tsx
+++ b/projects/app/src/components/core/chat/components/Interactive/InteractiveChoiceCollapse.tsx
@@ -61,7 +61,23 @@ export const useInteractiveChoiceCollapse = (selectedAnswer?: string) => {
   };
 };
 
-export const SelectedAnswerCollapseControl = React.memo(function SelectedAnswerCollapseControl({
+export const SelectedAnswerText = React.memo(function SelectedAnswerText({
+  answer
+}: {
+  answer?: string;
+}) {
+  const { t } = useTranslation();
+
+  if (!answer) return null;
+
+  return (
+    <Box color={'myGray.500'} fontSize={'sm'} lineHeight={'20px'}>
+      {t('chat:interactive.user_select.selected', { answer })}
+    </Box>
+  );
+});
+
+export const ChoiceCollapseToggleButton = React.memo(function ChoiceCollapseToggleButton({
   answer,
   isOptionsExpanded,
   onToggle
@@ -76,11 +92,7 @@ export const SelectedAnswerCollapseControl = React.memo(function SelectedAnswerC
 
   return (
     <Box mt={3}>
-      <Box color={'myGray.500'} fontSize={'sm'} lineHeight={'20px'}>
-        {t('chat:interactive.user_select.selected', { answer })}
-      </Box>
       <Button
-        mt={1}
         mx={'8px'}
         px={0}
         h={'22px'}

--- a/projects/app/src/components/core/chat/components/Interactive/InteractiveChoiceCollapse.tsx
+++ b/projects/app/src/components/core/chat/components/Interactive/InteractiveChoiceCollapse.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box } from '@chakra-ui/react';
+import { Box, type BoxProps } from '@chakra-ui/react';
 import { useTranslation } from 'next-i18next';
 
 type SelectedAnswerPlacement = 'above' | 'below';
@@ -88,11 +88,13 @@ export const SelectedAnswerText = React.memo(function SelectedAnswerText({
 export const ChoiceCollapseToggleButton = React.memo(function ChoiceCollapseToggleButton({
   answer,
   isOptionsExpanded,
-  onToggle
+  onToggle,
+  mt = 3
 }: {
   answer?: string;
   isOptionsExpanded: boolean;
   onToggle: () => void;
+  mt?: BoxProps['mt'];
 }) {
   const { t } = useTranslation();
 
@@ -106,7 +108,7 @@ export const ChoiceCollapseToggleButton = React.memo(function ChoiceCollapseTogg
       alignItems={'center'}
       alignSelf={'flex-start'}
       position={'relative'}
-      mt={3}
+      mt={mt}
       mx={'8px'}
       px={0}
       h={'16px'}


### PR DESCRIPTION
## What changed

- Refined the `/chat` like feedback interaction with the Figma-exported confetti-style animation.
- Updated Agent v2 choice prompts so option items use 16px padding.
- Added selected-answer feedback with automatic collapse, plus expand/collapse controls.
- Persisted render behavior relies on the existing `agentPlanAskQuery.params.answer` value when chat history reloads.

## Notes

- The Agent v2 selected answer appears below the options immediately after selection, then moves above the options after the list collapses.
- Existing unrelated local `pro` changes were not included.

## Validation

- Not run, per instruction: no lint/check/build.
