### PR TITLE
Fix html preview js

### DIFF
--- a/projects/app/src/components/Markdown/codeBlock/iframe-html.tsx
+++ b/projects/app/src/components/Markdown/codeBlock/iframe-html.tsx
@@ -123,7 +123,8 @@ const StyledButton = ({
 const HtmlPreviewIframe = ({ code }: { code: string }) => (
   <iframe
     srcDoc={code}
-    sandbox="allow-popups"
+    // 预览需要执行用户生成 HTML 内的 JS，但不开放 allow-same-origin，避免脚本拿到主站上下文。
+    sandbox="allow-scripts allow-popups"
     referrerPolicy="no-referrer"
     style={{
       display: 'block',


### PR DESCRIPTION
bug：AI对话那生成代码，预览时可以显示HTML的部分，但是无法显示JavaScript的部分
原本预览那里用的是 iframe 的 sandbox，也就是写了啥，iframe 里就只能用啥。
现在的改成了JS 可以执行，但仍隔离在 sandbox 里，不能拿主站上下文。