### PR TITLE
fix: preserve Agent V2 MCP runtime schemas

### DIFF
--- a/packages/service/core/ai/llm/request/requestBody.ts
+++ b/packages/service/core/ai/llm/request/requestBody.ts
@@ -1,10 +1,45 @@
-import type { ChatCompletionCreateParams } from '@fastgpt/global/core/ai/llm/type';
+import type {
+  ChatCompletionCreateParams,
+  ChatCompletionTool
+} from '@fastgpt/global/core/ai/llm/type';
 import { getLLMSupportParams } from '@fastgpt/global/core/ai/llm/utils';
 import json5 from 'json5';
 import { computedMaxToken, computedTemperature } from '../../utils';
 import { getLLMModel } from '../../model';
 import type { InferCompletionsBody, LLMRequestBodyType } from './types';
 import type { LLMModelItemType } from '@fastgpt/global/core/ai/model.schema';
+
+const privateToolSchemaKeys = new Set(['toolDescription', 'x-tool-description', 'isSecret']);
+
+/**
+ * 清理 FastGPT 内部工具参数扩展字段，避免 OpenAI-compatible SDK 转成 Gemini 等原生
+ * function declaration 时，把 toolDescription 这类非供应商 schema 字段透传出去。
+ */
+const sanitizeToolParametersSchema = (schema: unknown): unknown => {
+  if (Array.isArray(schema)) {
+    return schema.map(sanitizeToolParametersSchema);
+  }
+  if (!schema || typeof schema !== 'object') {
+    return schema;
+  }
+
+  return Object.fromEntries(
+    Object.entries(schema as Record<string, unknown>)
+      .filter(([key]) => !privateToolSchemaKeys.has(key))
+      .map(([key, value]) => [key, sanitizeToolParametersSchema(value)])
+  );
+};
+
+const sanitizeCompletionTools = (tools?: ChatCompletionTool[]): ChatCompletionTool[] | undefined =>
+  tools?.map((tool) => ({
+    ...tool,
+    function: {
+      ...tool.function,
+      parameters: sanitizeToolParametersSchema(
+        tool.function.parameters
+      ) as ChatCompletionTool['function']['parameters']
+    }
+  }));
 
 /**
  * 把 FastGPT 内部 LLM body 转成 OpenAI SDK 可请求的 completions body。
@@ -22,6 +57,7 @@ export const llmCompletionsBodyFormat = async <T extends ChatCompletionCreatePar
   modelData: LLMModelItemType;
 }> => {
   const { tools, tool_choice, parallel_tool_calls, toolCallMode, ...body } = input;
+  const sanitizedTools = sanitizeCompletionTools(tools);
   // 这些字段只影响 FastGPT 自身逻辑，不能透传给模型供应商。
   delete body.retainDatasetCite;
   delete body.useVision;
@@ -82,8 +118,8 @@ export const llmCompletionsBodyFormat = async <T extends ChatCompletionCreatePar
     stop: formatStop?.length ? formatStop : undefined,
     // prompt tool 模式通过 prompt 描述工具，直接传 tools 会让部分模型同时触发两套协议。
     ...(toolCallMode === 'toolChoice' &&
-      tools?.length && {
-        tools,
+      sanitizedTools?.length && {
+        tools: sanitizedTools,
         tool_choice,
         parallel_tool_calls
       })

--- a/packages/service/core/workflow/dispatch/ai/agent/sub/tool/utils.ts
+++ b/packages/service/core/workflow/dispatch/ai/agent/sub/tool/utils.ts
@@ -246,7 +246,7 @@ export const getAgentRuntimeTools = async ({
       if (hasMcpInputSchemaProperties(tool.inputSchema)) return tool;
 
       const runtimeTool = findToolByName(runtimeToolList, tool.name);
-      if (!hasMcpInputSchemaProperties(runtimeTool?.inputSchema)) return tool;
+      if (!runtimeTool || !hasMcpInputSchemaProperties(runtimeTool.inputSchema)) return tool;
 
       return {
         ...tool,

--- a/packages/service/core/workflow/dispatch/ai/agent/sub/tool/utils.ts
+++ b/packages/service/core/workflow/dispatch/ai/agent/sub/tool/utils.ts
@@ -44,12 +44,13 @@ import {
 } from '@fastgpt/global/core/workflow/utils';
 import type { AppSchemaType } from '@fastgpt/global/core/app/type';
 import { getAppVersionById } from '../../../../../../app/version/controller';
-import { AppFolderTypeList } from '@fastgpt/global/core/app/constants';
+import { AppFolderTypeList, AppTypeEnum } from '@fastgpt/global/core/app/constants';
 import { PluginErrEnum } from '@fastgpt/global/common/error/code/plugin';
 import { parseI18nString } from '@fastgpt/global/common/i18n/utils';
 import { SystemToolRepo } from '../../../../../../app/tool/systemTool/systemTool.repo';
 import { Output_Template_Error_Message } from '@fastgpt/global/core/workflow/template/output';
 import type { NodeToolConfigType } from '@fastgpt/global/core/workflow/type/node';
+import { getMCPChildren } from '../../../../../../app/mcp';
 
 type AgentRuntimeNode = RuntimeNodeItemType & {
   currentCost?: number;
@@ -62,8 +63,8 @@ type AgentRuntimeNode = RuntimeNodeItemType & {
  * 将 Agent 选择的工具配置转换成 LLM function calling 与 runtime 执行共用的工具描述。
  *
  * 这里刻意不调用面向前端预览的 getClientToolPreviewNode：Agent runtime 只关心鉴权后的执行
- * 节点、toolConfig 和 JSON Schema。App 类工具统一读取当前发布版本；MCP/HTTP 工具集只使用
- * 当前版本节点里保存的 toolList，不额外兼容旧版 MCP 数据源。
+ * 节点、toolConfig 和 JSON Schema。App 类工具统一读取当前发布版本；MCP 工具会在运行态补齐
+ * 旧版子 App 数据或前端预览数据中被裁剪的 schema。
  */
 export const getAgentRuntimeTools = async ({
   tools,
@@ -205,6 +206,55 @@ export const getAgentRuntimeTools = async ({
     };
   };
 
+  const hasMcpInputSchemaProperties = (schema?: JSONSchemaInputType) => {
+    return !!schema?.properties && Object.keys(schema.properties).length > 0;
+  };
+
+  const findToolByName = <T extends { name: string }>(toolList: T[], toolName: string) => {
+    return getToolNameCandidates(toolName)
+      .map((name) => toolList.find((item) => item.name === name))
+      .find(Boolean);
+  };
+
+  /**
+   * Agent 工具面板保存的 MCP toolset 可能来自前端 preview，toolList 仍有工具名但
+   * inputSchema.properties 已被裁剪。运行态按名称从 MCP app 的 children 中补回完整 schema。
+   */
+  const getMcpToolListWithRuntimeSchema = async ({
+    app,
+    toolList
+  }: {
+    app?: AppSchemaType;
+    toolList?: McpToolConfigType[];
+  }): Promise<McpToolConfigType[]> => {
+    const currentToolList = toolList ?? [];
+    if (!app) return currentToolList;
+
+    if (!currentToolList.length) {
+      return getMCPChildren(app);
+    }
+
+    const hasStrippedSchema = currentToolList.some(
+      (tool) => !hasMcpInputSchemaProperties(tool.inputSchema)
+    );
+    if (!hasStrippedSchema) return currentToolList;
+
+    const runtimeToolList = await getMCPChildren(app);
+    if (!runtimeToolList.length) return currentToolList;
+
+    return currentToolList.map((tool) => {
+      if (hasMcpInputSchemaProperties(tool.inputSchema)) return tool;
+
+      const runtimeTool = findToolByName(runtimeToolList, tool.name);
+      if (!hasMcpInputSchemaProperties(runtimeTool?.inputSchema)) return tool;
+
+      return {
+        ...tool,
+        inputSchema: runtimeTool.inputSchema
+      };
+    });
+  };
+
   /**
    * 普通 App 需要根据当前版本节点形态判断运行时类型：
    * - pluginInput: 插件工作流
@@ -284,7 +334,8 @@ export const getAgentRuntimeTools = async ({
 
   /**
    * 解析单个 MCP 工具 id: mcp-${appId}/${toolName}。
-   * 只读取当前版本 toolConfig.mcpToolSet.toolList；不再通过 getMCPChildren 补旧版数据。
+   * 新版数据从当前版本 toolConfig.mcpToolSet.toolList 读取；旧版 MCP 子工具 schema
+   * 只保存在子 App 的 toolData 中，需要回退到 getMCPChildren。
    */
   const formatMcpToolNode = async ({
     app,
@@ -295,10 +346,12 @@ export const getAgentRuntimeTools = async ({
   }): Promise<AgentRuntimeNode> => {
     const { toolName } = splitToolsetToolPluginId(pluginId);
     const version = await getVersionNodes({ app });
-    const toolList = version.nodes[0]?.toolConfig?.mcpToolSet?.toolList ?? [];
-    const tool = getToolNameCandidates(toolName)
-      .map((name) => toolList.find((item) => item.name === name))
-      .find(Boolean);
+    const mcpToolSet = version.nodes[0]?.toolConfig?.mcpToolSet;
+    const toolList = await getMcpToolListWithRuntimeSchema({
+      app,
+      toolList: mcpToolSet?.toolList
+    });
+    const tool = findToolByName(toolList, toolName);
     if (!tool) return Promise.reject(PluginErrEnum.unExist);
 
     const node = getMCPToolRuntimeNode({
@@ -540,6 +593,8 @@ export const getAgentRuntimeTools = async ({
           const systemToolId = toolNode.toolConfig?.systemToolSet?.toolId;
           const mcpToolsetVal = toolNode.toolConfig?.mcpToolSet ?? toolNode.inputs[0]?.value;
           const httpToolsetVal = toolNode.toolConfig?.httpToolSet;
+          const isLegacyMcpToolSet =
+            authApp?.type === AppTypeEnum.mcpToolSet && !toolNode.toolConfig?.mcpToolSet;
 
           if (systemToolId) {
             // System toolset 的子工具由系统工具仓库展开，可能包含内置运行配置。
@@ -554,12 +609,15 @@ export const getAgentRuntimeTools = async ({
             });
 
             return children.map((child) => buildSubApp(child));
-          } else if (mcpToolsetVal) {
-            // MCP toolset 已在当前版本节点保存 toolList；展开时不再触发 DB 查询。
-            const toolList: McpToolConfigType[] = mcpToolsetVal.toolList ?? [];
+          } else if (mcpToolsetVal || isLegacyMcpToolSet) {
+            // 新版 MCP toolset 在当前版本节点保存 toolList；旧版数据只有子 App 存 toolData。
+            const finalToolList = await getMcpToolListWithRuntimeSchema({
+              app: authApp,
+              toolList: mcpToolsetVal?.toolList
+            });
 
-            const toolSetId = mcpToolsetVal.toolId || toolNode.pluginId || pluginId;
-            const children = toolList.map((tool, index) => {
+            const toolSetId = mcpToolsetVal?.toolId || toolNode.pluginId || pluginId;
+            const children = finalToolList.map((tool, index) => {
               const newToolNode = getMCPToolRuntimeNode({
                 toolSetId,
                 toolsetName: toolNode.name,

--- a/packages/service/test/core/ai/llm/request/requestBody.test.ts
+++ b/packages/service/test/core/ai/llm/request/requestBody.test.ts
@@ -151,6 +151,81 @@ describe('llmCompletionsBodyFormat', () => {
     expect(requestBody).not.toHaveProperty('tools');
   });
 
+  it('should remove FastGPT private tool schema fields before sending tools to model', async () => {
+    mockGetLLMModel.mockReturnValue(createModel());
+
+    const { requestBody } = await llmCompletionsBodyFormat({
+      model: 'gpt-4o',
+      messages,
+      stream: false,
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'search',
+            description: 'search',
+            parameters: {
+              type: 'object',
+              properties: {
+                query: {
+                  type: 'string',
+                  description: 'Search query',
+                  toolDescription: 'Query for model',
+                  'x-tool-description': 'HTTP query',
+                  isSecret: true
+                },
+                filters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      key: {
+                        type: 'string',
+                        toolDescription: 'Filter key'
+                      }
+                    },
+                    toolDescription: 'Filter object'
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      toolCallMode: 'toolChoice'
+    });
+
+    expect(requestBody.tools).toEqual([
+      {
+        type: 'function',
+        function: {
+          name: 'search',
+          description: 'search',
+          parameters: {
+            type: 'object',
+            properties: {
+              query: {
+                type: 'string',
+                description: 'Search query'
+              },
+              filters: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    key: {
+                      type: 'string'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    ]);
+  });
+
   it('should apply field map after base formatting', async () => {
     mockGetLLMModel.mockReturnValue(
       createModel({

--- a/packages/service/test/core/workflow/dispatch/ai/agent/sub/tool/utils.test.ts
+++ b/packages/service/test/core/workflow/dispatch/ai/agent/sub/tool/utils.test.ts
@@ -4,11 +4,13 @@ import { FlowNodeTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
 import { getAgentRuntimeTools } from '@fastgpt/service/core/workflow/dispatch/ai/agent/sub/tool/utils';
 import type { NodeToolConfigType } from '@fastgpt/global/core/workflow/type/node';
 
-const { authAppByTmbIdMock, getAppVersionByIdMock, getSystemToolDetailMock } = vi.hoisted(() => ({
-  authAppByTmbIdMock: vi.fn(),
-  getAppVersionByIdMock: vi.fn(),
-  getSystemToolDetailMock: vi.fn()
-}));
+const { authAppByTmbIdMock, getAppVersionByIdMock, getMCPChildrenMock, getSystemToolDetailMock } =
+  vi.hoisted(() => ({
+    authAppByTmbIdMock: vi.fn(),
+    getAppVersionByIdMock: vi.fn(),
+    getMCPChildrenMock: vi.fn(),
+    getSystemToolDetailMock: vi.fn()
+  }));
 
 vi.mock('@fastgpt/service/support/permission/app/auth', () => ({
   authAppByTmbId: authAppByTmbIdMock
@@ -16,6 +18,10 @@ vi.mock('@fastgpt/service/support/permission/app/auth', () => ({
 
 vi.mock('@fastgpt/service/core/app/version/controller', () => ({
   getAppVersionById: getAppVersionByIdMock
+}));
+
+vi.mock('@fastgpt/service/core/app/mcp', () => ({
+  getMCPChildren: getMCPChildrenMock
 }));
 
 vi.mock('@fastgpt/service/core/app/tool/systemTool/systemTool.repo', () => ({
@@ -48,6 +54,10 @@ const mcpInputSchema = {
     }
   },
   required: ['query']
+};
+
+const strippedMcpInputSchema = {
+  type: 'object'
 };
 
 const httpInputSchema = {
@@ -132,7 +142,7 @@ const createToolsetApp = ({
 }: {
   id: string;
   type: AppTypeEnum.mcpToolSet | AppTypeEnum.httpToolSet;
-  toolConfig: NodeToolConfigType;
+  toolConfig?: NodeToolConfigType;
 }) => ({
   _id: id,
   teamId: 'team_1',
@@ -151,7 +161,7 @@ const createToolsetApp = ({
       intro: `${id} intro`,
       inputs: [],
       outputs: [],
-      toolConfig
+      ...(toolConfig ? { toolConfig } : {})
     }
   ],
   edges: [],
@@ -161,6 +171,7 @@ const createToolsetApp = ({
 describe('getAgentRuntimeTools schema loading', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getMCPChildrenMock.mockResolvedValue([]);
     getSystemToolDetailMock.mockReset();
 
     authAppByTmbIdMock.mockImplementation(async ({ appId }: { appId: string }) => {
@@ -209,6 +220,26 @@ describe('getAgentRuntimeTools schema loading', () => {
           url: 'https://mcp.example.com',
           headerSecret: {},
           toolList: [mcpTool]
+        }
+      }
+    }),
+    legacy_mcp_app: createToolsetApp({
+      id: 'legacy_mcp_app',
+      type: AppTypeEnum.mcpToolSet
+    }),
+    stripped_mcp_app: createToolsetApp({
+      id: 'stripped_mcp_app',
+      type: AppTypeEnum.mcpToolSet,
+      toolConfig: {
+        mcpToolSet: {
+          url: 'https://mcp.example.com',
+          headerSecret: {},
+          toolList: [
+            {
+              ...mcpTool,
+              inputSchema: strippedMcpInputSchema
+            }
+          ]
         }
       }
     }),
@@ -290,6 +321,103 @@ describe('getAgentRuntimeTools schema loading', () => {
     expect(tools[0].id).toBe('123_appsearch');
     expect(tools[0].requestSchema.function.name).toBe('t123_appsearch');
     expect(tools[0].requestSchema.function.parameters).toEqual(mcpInputSchema);
+  });
+
+  it('fills stripped MCP toolset child schema from runtime children', async () => {
+    getMCPChildrenMock.mockResolvedValue([
+      {
+        avatar: 'mcp_app.png',
+        id: 'mcp-mcp_app/search',
+        ...mcpTool
+      }
+    ]);
+
+    const tools = await getAgentRuntimeTools({
+      tmbId: 'tmb_1',
+      tools: [
+        {
+          id: 'mcp_app',
+          config: {},
+          toolConfig: {
+            mcpToolSet: {
+              url: '',
+              toolList: [
+                {
+                  ...mcpTool,
+                  inputSchema: strippedMcpInputSchema
+                }
+              ]
+            }
+          }
+        }
+      ]
+    });
+
+    expect(getMCPChildrenMock).toHaveBeenCalledWith(appMap.mcp_app);
+    expect(tools).toHaveLength(1);
+    expect(tools[0].requestSchema.function.parameters).toEqual(mcpInputSchema);
+  });
+
+  it('fills stripped selected MCP tool schema from runtime children', async () => {
+    getMCPChildrenMock.mockResolvedValue([
+      {
+        avatar: 'stripped_mcp_app.png',
+        id: 'mcp-stripped_mcp_app/search',
+        ...mcpTool
+      }
+    ]);
+
+    const tools = await getAgentRuntimeTools({
+      tmbId: 'tmb_1',
+      tools: [{ id: 'mcp-stripped_mcp_app/search', config: {} }]
+    });
+
+    expect(getMCPChildrenMock).toHaveBeenCalledWith(appMap.stripped_mcp_app);
+    expect(tools).toHaveLength(1);
+    expect(tools[0].requestSchema.function.parameters).toEqual(mcpInputSchema);
+  });
+
+  it('loads legacy MCP toolset children from stored child tool data', async () => {
+    getMCPChildrenMock.mockResolvedValue([
+      {
+        avatar: 'legacy_mcp_app.png',
+        id: 'mcp-legacy_mcp_app/search',
+        ...mcpTool
+      }
+    ]);
+
+    const tools = await getAgentRuntimeTools({
+      tmbId: 'tmb_1',
+      tools: [{ id: 'legacy_mcp_app', config: {} }]
+    });
+
+    expect(getMCPChildrenMock).toHaveBeenCalledWith(appMap.legacy_mcp_app);
+    expect(tools).toHaveLength(1);
+    expect(tools[0].requestSchema.function.name).toBe('legacy_mcp_app0');
+    expect(tools[0].requestSchema.function.parameters).toEqual(mcpInputSchema);
+    expect(tools[0].toolConfig?.mcpTool?.toolId).toBe('mcp-legacy_mcp_app/search');
+  });
+
+  it('loads a selected legacy MCP tool with its input schema', async () => {
+    getMCPChildrenMock.mockResolvedValue([
+      {
+        avatar: 'legacy_mcp_app.png',
+        id: 'mcp-legacy_mcp_app/search',
+        ...mcpTool
+      }
+    ]);
+
+    const tools = await getAgentRuntimeTools({
+      tmbId: 'tmb_1',
+      tools: [{ id: 'mcp-legacy_mcp_app/search', config: {} }]
+    });
+
+    expect(getMCPChildrenMock).toHaveBeenCalledWith(appMap.legacy_mcp_app);
+    expect(tools).toHaveLength(1);
+    expect(tools[0].id).toBe('legacy_mcp_appsearch');
+    expect(tools[0].name).toBe('search');
+    expect(tools[0].requestSchema.function.parameters).toEqual(mcpInputSchema);
+    expect(tools[0].toolConfig?.mcpTool?.toolId).toBe('mcp-legacy_mcp_app/search');
   });
 
   it('loads HTTP toolset children with their request schema', async () => {


### PR DESCRIPTION
## Summary

**Agent V2 MCP schema handling**
- Rehydrates MCP tool input schemas at Agent V2 runtime when saved toolset data still has the tool name but its `inputSchema.properties` was stripped by preview/client data.
- Restores compatibility with legacy MCP toolsets whose child tool schema only exists in stored child app tool data.
- Keeps selected MCP child tools resolving by normalized tool names, including slash-prefixed names and legacy child ids.

**LLM request safety**
- Removes FastGPT-only tool schema metadata (`toolDescription`, `x-tool-description`, `isSecret`) before forwarding function calling schemas to OpenAI-compatible model providers.
- Applies the sanitizer recursively so nested object/array schemas do not leak private schema extensions to provider-native declarations.

## Test Coverage

```text
CODE PATHS                                                   TEST COVERAGE
[+] Agent V2 MCP runtime tools
  ├── [★★★ TESTED] Toolset child with stripped schema         packages/service/test/core/workflow/dispatch/ai/agent/sub/tool/utils.test.ts
  ├── [★★★ TESTED] Selected MCP child with stripped schema    packages/service/test/core/workflow/dispatch/ai/agent/sub/tool/utils.test.ts
  ├── [★★★ TESTED] Legacy MCP toolset child schema fallback   packages/service/test/core/workflow/dispatch/ai/agent/sub/tool/utils.test.ts
  └── [★★★ TESTED] Selected legacy MCP child schema fallback  packages/service/test/core/workflow/dispatch/ai/agent/sub/tool/utils.test.ts

[+] LLM request body tool schema formatting
  └── [★★★ TESTED] Recursive private schema field sanitizer   packages/service/test/core/ai/llm/request/requestBody.test.ts

COVERAGE: 5/5 changed runtime paths tested (100%)
QUALITY: ★★★:5 ★★:0 ★:0 | GAPS: 0
```

## Pre-Landing Review

Pre-Landing Review: No issues found.

Checked against the gstack pre-landing review checklist. No SQL/data safety, race condition, shell injection, enum completeness, or LLM output trust-boundary issues were found in the changed paths.

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN

Intent: Fix Agent V2 not receiving MCP tool schemas.

Delivered: Agent runtime now restores stripped/legacy MCP input schemas and model request formatting strips FastGPT-private schema metadata.

## Plan Completion

No plan file detected.

## Verification Results

- [x] `pnpm --dir packages/service test test/core/workflow/dispatch/ai/agent/sub/tool/utils.test.ts test/core/ai/llm/request/requestBody.test.ts` — 2 files, 21 tests passed.
- [x] `pnpm test:service` — 223 test files passed, 3025 tests passed, 35 skipped.
- [x] `git diff --check origin/main` — passed.
- [ ] `pnpm test` — blocked by repository workspace configuration: `turbo` references missing workspace package `@fastgpt/admin`.

## Test plan

- [x] MCP toolset regression tests pass
- [x] LLM request body sanitizer regression tests pass
- [x] Full `@fastgpt/service` Vitest suite passes
