### PR TITLE
fix(workflow): filter runtime tool params

### DIFF
--- a/packages/service/core/workflow/dispatch/ai/agent/sub/app/index.ts
+++ b/packages/service/core/workflow/dispatch/ai/agent/sub/app/index.ts
@@ -22,6 +22,7 @@ import { anyValueDecrypt } from '../../../../../../../common/secret/utils';
 import { WorkflowVariableState } from '../../../../utils/variables';
 import { getRuntimeNodeResponseSummary } from '../../../../utils';
 import { ChatSourceTypeEnum } from '@fastgpt/global/core/chat/constants';
+import { getToolRuntimeInputParams } from '../../../../child/runTool';
 
 type Props = Pick<
   RunWorkflowProps,
@@ -64,6 +65,7 @@ export const dispatchApp = async (props: Props): Promise<DispatchSubAppResponse>
     userChatInput,
     ...data
   } = props;
+  const runtimeCustomAppVariables = getToolRuntimeInputParams(customAppVariables);
 
   // Auth the app by tmbId(Not the user, but the workflow user)
   const { app: appData } = await authAppByTmbId({
@@ -94,7 +96,7 @@ export const dispatchApp = async (props: Props): Promise<DispatchSubAppResponse>
     histories: [],
     uid: data.uid,
     variablesConfig: chatConfig.variables,
-    inputVariables: customAppVariables,
+    inputVariables: runtimeCustomAppVariables,
     externalVariables: externalProvider?.externalWorkflowVariables,
     sourceVariableState: variableState
   });
@@ -145,7 +147,7 @@ export const dispatchApp = async (props: Props): Promise<DispatchSubAppResponse>
       moduleLogo: app.avatar,
       toolInput: {
         userChatInput,
-        ...customAppVariables
+        ...runtimeCustomAppVariables
       },
       toolRes: text,
       childResponseCount: runtimeSummary.childResponseCount
@@ -163,6 +165,7 @@ export const dispatchPlugin = async (props: Props): Promise<DispatchSubAppRespon
     userChatInput,
     ...data
   } = props;
+  const runtimeCustomAppVariables = getToolRuntimeInputParams(customAppVariables);
   // plugin 子应用不接收普通 userChatInput；这里解构只为了避免透传给 runWorkflow。
   void userChatInput;
 
@@ -207,15 +210,15 @@ export const dispatchPlugin = async (props: Props): Promise<DispatchSubAppRespon
           ...node,
           showStatus: false,
           inputs: node.inputs.map((input) => {
-            let val = customAppVariables[input.key] ?? input.value;
+            let val = runtimeCustomAppVariables[input.key] ?? input.value;
             if (input.renderTypeList.includes(FlowNodeInputTypeEnum.password)) {
               val = anyValueDecrypt(val);
             } else if (
               input.renderTypeList.includes(FlowNodeInputTypeEnum.fileSelect) &&
               Array.isArray(val) &&
-              customAppVariables[input.key]
+              runtimeCustomAppVariables[input.key]
             ) {
-              customAppVariables[input.key] = val.map((item) =>
+              runtimeCustomAppVariables[input.key] = val.map((item) =>
                 typeof item === 'string' ? item : item.url
               );
             }
@@ -262,7 +265,7 @@ export const dispatchPlugin = async (props: Props): Promise<DispatchSubAppRespon
     variableState: childrenVariableState,
     query: serverGetWorkflowToolRunUserQuery({
       pluginInputs: getWorkflowToolInputsFromStoreNodes(nodes),
-      variables: customAppVariables
+      variables: runtimeCustomAppVariables
     }).value,
     stream: false,
     workflowStreamResponse: undefined
@@ -290,7 +293,7 @@ export const dispatchPlugin = async (props: Props): Promise<DispatchSubAppRespon
       moduleType: FlowNodeTypeEnum.pluginModule,
       moduleName: app.name,
       moduleLogo: app.avatar,
-      toolInput: customAppVariables,
+      toolInput: runtimeCustomAppVariables,
       toolRes: pluginOutput || {},
       childResponseCount: runtimeSummary.childResponseCount
     }

--- a/packages/service/core/workflow/dispatch/ai/agent/sub/tool/index.ts
+++ b/packages/service/core/workflow/dispatch/ai/agent/sub/tool/index.ts
@@ -20,7 +20,7 @@ import { getErrText } from '@fastgpt/global/common/error/utils';
 import { getAppVersionById } from '../../../../../../app/version/controller';
 import { assertMCPUrlNotInternal, MCPClient } from '../../../../../../app/mcp';
 import { runHTTPTool } from '../../../../../../app/http';
-import { parseToolId } from '../../../../child/runTool';
+import { getToolRuntimeInputParams, parseToolId } from '../../../../child/runTool';
 import { FlowNodeTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
 import type { RequireOnlyOne } from '@fastgpt/global/common/type/utils';
 import { pluginClient } from '../../../../../../../thirdProvider/fastgptPlugin';
@@ -64,6 +64,8 @@ export const dispatchTool = async ({
   variableState,
   workflowStreamResponse
 }: Props): Promise<DispatchSubAppResponse> => {
+  const runtimeInputParams = getToolRuntimeInputParams(params);
+
   const getNodeResponse = ({
     result,
     response
@@ -75,7 +77,7 @@ export const dispatchTool = async ({
       moduleType: FlowNodeTypeEnum.tool,
       moduleName: name,
       moduleLogo: avatar,
-      toolInput: params,
+      toolInput: runtimeInputParams,
       toolRes: result || response
     };
   };
@@ -155,7 +157,7 @@ export const dispatchTool = async ({
         ...(childId ? { childId } : {}),
         version: tool.version ?? version ?? '',
         source: toolSource,
-        input: Object.fromEntries(Object.entries(params)),
+        input: runtimeInputParams,
         secrets: inputConfigParams,
         systemVar: {
           app: {
@@ -246,7 +248,7 @@ export const dispatchTool = async ({
 
       const result = await mcpClient.toolCall({
         toolName,
-        params
+        params: runtimeInputParams
       });
       return {
         response: JSON.stringify(result),
@@ -283,7 +285,7 @@ export const dispatchTool = async ({
         baseUrl: baseUrl || '',
         toolPath: httpTool.path,
         method: httpTool.method,
-        params,
+        params: runtimeInputParams,
         headerSecret: httpTool.headerSecret || headerSecret,
         customHeaders: customHeaders
           ? typeof customHeaders === 'string'

--- a/packages/service/core/workflow/dispatch/child/runTool.ts
+++ b/packages/service/core/workflow/dispatch/child/runTool.ts
@@ -51,6 +51,25 @@ type RunToolResponse = DispatchNodeResultType<
   Record<string, any>
 >;
 
+const toolRuntimeSystemInputKeys = new Set<string>([
+  NodeInputKeyEnum.systemInputConfig,
+  NodeInputKeyEnum.forbidStream,
+  NodeInputKeyEnum.toolData,
+  NodeInputKeyEnum.toolSetData,
+  'toolData'
+]);
+
+/**
+ * 过滤工具执行时只供 FastGPT runtime 使用的系统输入。
+ *
+ * 这些字段用于密钥、流式控制或旧版 MCP 工具配置，不能作为业务参数传给真实工具；
+ * 否则外部 HTTP/MCP/SystemTool 会收到诸如 system_forbid_stream 的内部控制字段。
+ */
+export const getToolRuntimeInputParams = (params: Record<string, any>) =>
+  Object.fromEntries(
+    Object.entries(params).filter(([key]) => !toolRuntimeSystemInputKeys.has(key))
+  );
+
 export const dispatchRunTool = async (props: RunToolProps): Promise<RunToolResponse> => {
   const {
     params,
@@ -68,6 +87,7 @@ export const dispatchRunTool = async (props: RunToolProps): Promise<RunToolRespo
 
   const systemToolId = toolConfig?.systemTool?.toolId;
   let toolInput: Record<string, any> = {};
+  const runtimeInputParams = getToolRuntimeInputParams(params);
 
   const getSystemToolSource = () => {
     const toolConfigSource = toolConfig?.systemTool?.source;
@@ -114,9 +134,7 @@ export const dispatchRunTool = async (props: RunToolProps): Promise<RunToolRespo
             return tool.secretsVal ?? {};
         }
       })();
-      toolInput = Object.fromEntries(
-        Object.entries(params).filter(([key]) => key !== NodeInputKeyEnum.systemInputConfig)
-      );
+      toolInput = runtimeInputParams;
 
       const invokeToken = appId
         ? new InvokeProcessor({
@@ -265,8 +283,12 @@ export const dispatchRunTool = async (props: RunToolProps): Promise<RunToolRespo
         });
       context.mcpClientMemory[url] = mcpClient;
 
-      toolInput = params;
-      const result = await mcpClient.toolCall({ toolName, params, closeConnection: false });
+      toolInput = runtimeInputParams;
+      const result = await mcpClient.toolCall({
+        toolName,
+        params: runtimeInputParams,
+        closeConnection: false
+      });
       return {
         data: { [NodeOutputKeyEnum.rawResponse]: result },
         [DispatchNodeResponseKeyEnum.nodeResponse]: {
@@ -301,12 +323,12 @@ export const dispatchRunTool = async (props: RunToolProps): Promise<RunToolRespo
         throw new Error(`HTTP tool ${toolName} not found`);
       }
 
-      toolInput = params;
+      toolInput = runtimeInputParams;
       const { data, errorMsg } = await runHTTPTool({
         baseUrl: baseUrl || '',
         toolPath: httpTool.path,
         method: httpTool.method,
-        params,
+        params: runtimeInputParams,
         headerSecret: httpTool.headerSecret || headerSecret,
         customHeaders: customHeaders
           ? typeof customHeaders === 'string'
@@ -340,7 +362,7 @@ export const dispatchRunTool = async (props: RunToolProps): Promise<RunToolRespo
       };
     } else {
       // mcp tool (old version compatible)
-      const { toolData, system_toolData, ...restParams } = params;
+      const { toolData, system_toolData } = params;
       const { name: toolName, url, headerSecret } = toolData || system_toolData;
 
       await assertMCPUrlNotInternal(url);
@@ -351,8 +373,8 @@ export const dispatchRunTool = async (props: RunToolProps): Promise<RunToolRespo
           storeSecret: headerSecret
         })
       });
-      toolInput = restParams;
-      const result = await mcpClient.toolCall({ toolName, params: restParams });
+      toolInput = runtimeInputParams;
+      const result = await mcpClient.toolCall({ toolName, params: runtimeInputParams });
 
       return {
         data: {

--- a/packages/service/test/core/workflow/dispatch/ai/agent/sub/tool/index.test.ts
+++ b/packages/service/test/core/workflow/dispatch/ai/agent/sub/tool/index.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { dispatchTool } from '@fastgpt/service/core/workflow/dispatch/ai/agent/sub/tool';
 import { ReadPermissionVal } from '@fastgpt/global/support/permission/constant';
+import { NodeInputKeyEnum } from '@fastgpt/global/core/workflow/constants';
 
 const { authAppByTmbIdMock, getAppVersionByIdMock, runHTTPToolMock, mcpToolCallMock } = vi.hoisted(
   () => ({
@@ -66,16 +67,19 @@ vi.mock('@fastgpt/service/core/app/tool/systemTool/systemTool.repo', () => ({
   }
 }));
 
-const createDispatchToolProps = (toolConfig: Record<string, any>) =>
+const createDispatchToolProps = (
+  toolConfig: Record<string, any>,
+  params: Record<string, any> = {
+    keyword: 'fastgpt'
+  }
+) =>
   ({
     tool: {
       name: 'Agent tool',
       avatar: '',
       toolConfig
     },
-    params: {
-      keyword: 'fastgpt'
-    },
+    params,
     runningAppInfo: {
       id: 'attacker-app',
       teamId: 'attacker-team',
@@ -178,6 +182,61 @@ describe('dispatchTool runtime toolset auth', () => {
       })
     );
     expect(result.response).toBe(JSON.stringify({ ok: true }));
+  });
+
+  it('should not pass FastGPT runtime system params to HTTP agent tool', async () => {
+    getAppVersionByIdMock.mockResolvedValueOnce({
+      nodes: [
+        {
+          toolConfig: {
+            httpToolSet: {
+              baseUrl: 'https://example.com',
+              toolList: [
+                {
+                  name: 'sandbox_echo',
+                  path: '/echo',
+                  method: 'post'
+                }
+              ]
+            }
+          }
+        }
+      ]
+    });
+    runHTTPToolMock.mockResolvedValueOnce({
+      data: {
+        ok: true
+      }
+    });
+
+    const result = await dispatchTool(
+      createDispatchToolProps(
+        {
+          httpTool: {
+            toolId: 'http-victim-toolset/sandbox_echo'
+          }
+        },
+        {
+          keyword: 'fastgpt',
+          [NodeInputKeyEnum.forbidStream]: false,
+          [NodeInputKeyEnum.systemInputConfig]: {
+            type: 'system',
+            value: {}
+          }
+        }
+      )
+    );
+
+    expect(runHTTPToolMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: {
+          keyword: 'fastgpt'
+        }
+      })
+    );
+    expect(result.nodeResponse?.toolInput).toEqual({
+      keyword: 'fastgpt'
+    });
   });
 
   it('should reject MCP agent tool execution when running app tmb has no parent toolset permission', async () => {


### PR DESCRIPTION
## Summary
- filter FastGPT runtime-only tool params before calling HTTP/MCP/System tools
- reuse the same runtime input sanitizer for workflow tools and Agent v2 tools
- add Agent v2 regression coverage for system_forbid_stream leakage

## Test
- pnpm --filter @fastgpt/service test test/core/workflow/dispatch/tools/runTool.test.ts test/core/workflow/dispatch/ai/agent/sub/tool/index.test.ts