### PR TITLE
fix(chat): show login modal on expired auth

### DIFF
--- a/projects/app/src/pages/chat/index.tsx
+++ b/projects/app/src/pages/chat/index.tsx
@@ -26,6 +26,8 @@ import { getLogger, LogCategories } from '@fastgpt/service/common/logger';
 import { PublishChannelEnum } from '@fastgpt/global/support/outLink/constant';
 import type { LoginSuccessResponseType } from '@fastgpt/global/openapi/support/user/account/login/api';
 import type { GetPaginationRecordsBodyType } from '@fastgpt/global/openapi/core/chat/record/api';
+import { AUTH_ERROR_EVENT_NAME } from '@/web/common/api/request';
+import { clearToken } from '@/web/support/user/auth';
 
 const logger = getLogger(LogCategories.MODULE.CHAT.ITEM);
 
@@ -234,6 +236,19 @@ const Render = (props: ChatPageProps) => {
     },
     [setUserInfo]
   );
+
+  useEffect(() => {
+    const handleAuthError = () => {
+      // 全局拦截器已豁免 /chat 跳转；这里同步页面态，触发本页 LoginModal。
+      setUserInfo(null);
+      void clearToken();
+    };
+
+    window.addEventListener(AUTH_ERROR_EVENT_NAME, handleAuthError);
+    return () => {
+      window.removeEventListener(AUTH_ERROR_EVENT_NAME, handleAuthError);
+    };
+  }, [setUserInfo]);
 
   useEffect(() => {
     if (!props.shouldInitUserInfo) return;

--- a/projects/app/test/web/common/api/request.test.ts
+++ b/projects/app/test/web/common/api/request.test.ts
@@ -176,6 +176,24 @@ describe('request utils', () => {
       expect(mockLocation.replace).not.toHaveBeenCalled();
     });
 
+    it('should dispatch auth error without redirecting on chat page', async () => {
+      mockLocation.pathname = '/test-route/chat';
+      const err = {
+        response: {
+          data: {
+            code: tokenErrorCode
+          }
+        }
+      };
+
+      await expect(responseError(err)).rejects.toEqual({ message: 'common:unauth_token' });
+
+      expect(dispatchEventMock).toHaveBeenCalledWith(expect.any(CustomEvent));
+      expect(dispatchEventMock.mock.calls[0]?.[0].type).toBe(AUTH_ERROR_EVENT_NAME);
+      expect(clearToken).not.toHaveBeenCalled();
+      expect(mockLocation.replace).not.toHaveBeenCalled();
+    });
+
     it('should handle team error', async () => {
       const err = { response: { data: { statusText: TeamErrEnum.aiPointsNotEnough } } };
       await expect(responseError(err)).rejects.toEqual({


### PR DESCRIPTION
## Summary
- sync chat page user state when auth expires so the in-page LoginModal renders
- keep /chat token errors from relying on global redirect behavior
- add request interceptor coverage for /chat auth errors

## Test
- corepack pnpm --dir projects/app test test/web/common/api/request.test.ts
- corepack pnpm --dir projects/app typecheck