### PR TITLE
fix: hide skill delete reference text when unused

### DIFF
--- a/projects/app/src/pageComponents/dashboard/skill/List.tsx
+++ b/projects/app/src/pageComponents/dashboard/skill/List.tsx
@@ -366,13 +366,14 @@ const List = ({
             label: t('common:Delete'),
             onClick: () =>
               openConfirmDelete({
-                customContent: (
-                  <Trans
-                    i18nKey={i18nT('skill:confirm_delete_with_refs')}
-                    values={{ count: isFolder ? 0 : relatedAppsCount }}
-                    components={{ bold: <Box as={'span'} fontWeight={'600'} /> }}
-                  />
-                ),
+                customContent:
+                  !isFolder && relatedAppsCount > 0 ? (
+                    <Trans
+                      i18nKey={i18nT('skill:confirm_delete_with_refs')}
+                      values={{ count: relatedAppsCount }}
+                      components={{ bold: <Box as={'span'} fontWeight={'600'} /> }}
+                    />
+                  ) : null,
                 onConfirm: () => onClickDeleteSkill(skill._id),
                 confirmText: t('skill:confirm_delete_action'),
                 confirmButtonVariant: 'dangerFill',

--- a/projects/app/src/pageComponents/dashboard/skill/detail/Header.tsx
+++ b/projects/app/src/pageComponents/dashboard/skill/detail/Header.tsx
@@ -224,13 +224,14 @@ export const LeftHeader = () => {
             onClick: () => {
               if (!skillDetail) return;
               openConfirmDelete({
-                customContent: (
-                  <Trans
-                    i18nKey={i18nT('skill:confirm_delete_with_refs')}
-                    values={{ count: skillDetail?.appCount ?? 0 }}
-                    components={{ bold: <Box as={'span'} fontWeight={'600'} /> }}
-                  />
-                ),
+                customContent:
+                  (skillDetail.appCount ?? 0) > 0 ? (
+                    <Trans
+                      i18nKey={i18nT('skill:confirm_delete_with_refs')}
+                      values={{ count: skillDetail.appCount }}
+                      components={{ bold: <Box as={'span'} fontWeight={'600'} /> }}
+                    />
+                  ) : null,
                 onConfirm: () => onClickDeleteSkill(skillDetail._id),
                 confirmText: t('skill:confirm_delete_action'),
                 confirmButtonVariant: 'dangerFill',


### PR DESCRIPTION
<img width="416" height="262" alt="PixPin_2026-07-05_15-40-27" src="https://github.com/user-attachments/assets/44c534d0-cab1-42f7-b6c5-133cc1c1589d" />

no reference ui