### PR TITLE
chore(deploy): configure plugin service base url

### DIFF
--- a/deploy/dev/docker-compose.cn.yml
+++ b/deploy/dev/docker-compose.cn.yml
@@ -1,13 +1,13 @@
 # 用于开发的 docker-compose 文件:
 # - 只包含 FastGPT 的最小化运行条件
 # - 没有 FastGPT 本体
-# - 所有端口都映射到外层
+# - 依赖服务端口映射到外层，fastgpt-plugin 使用 host network
 #   - fastgpt-pg: 5432
 #   - fastgpt-mongo: 27017
 #   - fastgpt-redis: 6379
 #   - fastgpt-code-sandbox: 3002
 #   - fastgpt-mcp-server: 3003
-#   - fastgpt-plugin: 3004
+#   - fastgpt-plugin: 3004（host network，由 PORT 指定）
 #   - fastgpt-volume-manager: 3005
 #   - opensandbox-server: 8090
 #   - fastgpt-aiproxy: 3010
@@ -248,13 +248,15 @@ services:
     image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.0.0
     container_name: fastgpt-plugin
     restart: always
-    ports:
-      - 3004:3000
-    networks:
-      - fastgpt
+    network_mode: host
     environment:
       <<: [*x-share-db-config, *x-log-config, *x-no-proxy-config]
       AUTH_TOKEN: *x-plugin-auth-token
+      PORT: 3004
+      FASTGPT_BASE_URL: http://127.0.0.1:3000
+      MONGODB_URI: mongodb://myusername:mypassword@127.0.0.1:27017/fastgpt?authSource=admin
+      REDIS_URL: redis://default:mypassword@127.0.0.1:6379
+      STORAGE_S3_ENDPOINT: http://127.0.0.1:9000
       # 工具网络请求，最大请求和响应体
       SERVICE_REQUEST_MAX_CONTENT_LENGTH: 10
       # 最大 API 请求体大小
@@ -265,7 +267,7 @@ services:
       fastgpt-minio:
         condition: service_healthy
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:3000/health']
+      test: ['CMD', 'curl', '-f', 'http://localhost:3004/health']
       interval: 30s
       timeout: 20s
       retries: 3

--- a/deploy/dev/docker-compose.yml
+++ b/deploy/dev/docker-compose.yml
@@ -1,13 +1,13 @@
 # 用于开发的 docker-compose 文件:
 # - 只包含 FastGPT 的最小化运行条件
 # - 没有 FastGPT 本体
-# - 所有端口都映射到外层
+# - 依赖服务端口映射到外层，fastgpt-plugin 使用 host network
 #   - fastgpt-pg: 5432
 #   - fastgpt-mongo: 27017
 #   - fastgpt-redis: 6379
 #   - fastgpt-code-sandbox: 3002
 #   - fastgpt-mcp-server: 3003
-#   - fastgpt-plugin: 3004
+#   - fastgpt-plugin: 3004（host network，由 PORT 指定）
 #   - fastgpt-volume-manager: 3005
 #   - opensandbox-server: 8090
 #   - fastgpt-aiproxy: 3010
@@ -248,13 +248,15 @@ services:
     image: ghcr.io/labring/fastgpt-plugin:v1.0.0
     container_name: fastgpt-plugin
     restart: always
-    ports:
-      - 3004:3000
-    networks:
-      - fastgpt
+    network_mode: host
     environment:
       <<: [*x-share-db-config, *x-log-config, *x-no-proxy-config]
       AUTH_TOKEN: *x-plugin-auth-token
+      PORT: 3004
+      FASTGPT_BASE_URL: http://127.0.0.1:3000
+      MONGODB_URI: mongodb://myusername:mypassword@127.0.0.1:27017/fastgpt?authSource=admin
+      REDIS_URL: redis://default:mypassword@127.0.0.1:6379
+      STORAGE_S3_ENDPOINT: http://127.0.0.1:9000
       # 工具网络请求，最大请求和响应体
       SERVICE_REQUEST_MAX_CONTENT_LENGTH: 10
       # 最大 API 请求体大小
@@ -265,7 +267,7 @@ services:
       fastgpt-minio:
         condition: service_healthy
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:3000/health']
+      test: ['CMD', 'curl', '-f', 'http://localhost:3004/health']
       interval: 30s
       timeout: 20s
       retries: 3

--- a/deploy/templates/docker-compose.dev.yml
+++ b/deploy/templates/docker-compose.dev.yml
@@ -1,13 +1,13 @@
 # 用于开发的 docker-compose 文件:
 # - 只包含 FastGPT 的最小化运行条件
 # - 没有 FastGPT 本体
-# - 所有端口都映射到外层
+# - 依赖服务端口映射到外层，fastgpt-plugin 使用 host network
 #   - fastgpt-pg: 5432
 #   - fastgpt-mongo: 27017
 #   - fastgpt-redis: 6379
 #   - fastgpt-code-sandbox: 3002
 #   - fastgpt-mcp-server: 3003
-#   - fastgpt-plugin: 3004
+#   - fastgpt-plugin: 3004（host network，由 PORT 指定）
 #   - fastgpt-volume-manager: 3005
 #   - opensandbox-server: 8090
 #   - fastgpt-aiproxy: 3010
@@ -248,13 +248,15 @@ services:
     image: ${{fastgpt-plugin.image}}:${{fastgpt-plugin.tag}}
     container_name: fastgpt-plugin
     restart: always
-    ports:
-      - 3004:3000
-    networks:
-      - fastgpt
+    network_mode: host
     environment:
       <<: [*x-share-db-config, *x-log-config, *x-no-proxy-config]
       AUTH_TOKEN: *x-plugin-auth-token
+      PORT: 3004
+      FASTGPT_BASE_URL: http://127.0.0.1:3000
+      MONGODB_URI: mongodb://myusername:mypassword@127.0.0.1:27017/fastgpt?authSource=admin
+      REDIS_URL: redis://default:mypassword@127.0.0.1:6379
+      STORAGE_S3_ENDPOINT: http://127.0.0.1:9000
       # 工具网络请求，最大请求和响应体
       SERVICE_REQUEST_MAX_CONTENT_LENGTH: 10
       # 最大 API 请求体大小
@@ -265,7 +267,7 @@ services:
       fastgpt-minio:
         condition: service_healthy
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:3000/health']
+      test: ['CMD', 'curl', '-f', 'http://localhost:3004/health']
       interval: 30s
       timeout: 20s
       retries: 3

--- a/deploy/version/v4.15/docker-compose.template.yml
+++ b/deploy/version/v4.15/docker-compose.template.yml
@@ -395,6 +395,7 @@ services:
       MONGODB_URI: mongodb://myusername:mypassword@fastgpt-mongo:27017/fastgpt-plugin?authSource=admin
       DB_MAX_LINK: 100
       AUTH_TOKEN: *x-plugin-auth-token
+      FASTGPT_BASE_URL: http://fastgpt-app:3000
       # 工具网络请求，最大请求和响应体
       SERVICE_REQUEST_MAX_CONTENT_LENGTH: 10
       # 最大 API 请求体大小

--- a/document/public/deploy/docker/v4.15/cn/docker-compose.milvus.yml
+++ b/document/public/deploy/docker/v4.15/cn/docker-compose.milvus.yml
@@ -451,6 +451,7 @@ services:
       MONGODB_URI: mongodb://myusername:mypassword@fastgpt-mongo:27017/fastgpt-plugin?authSource=admin
       DB_MAX_LINK: 100
       AUTH_TOKEN: *x-plugin-auth-token
+      FASTGPT_BASE_URL: http://fastgpt-app:3000
       # 工具网络请求，最大请求和响应体
       SERVICE_REQUEST_MAX_CONTENT_LENGTH: 10
       # 最大 API 请求体大小

--- a/document/public/deploy/docker/v4.15/cn/docker-compose.oceanbase.yml
+++ b/document/public/deploy/docker/v4.15/cn/docker-compose.oceanbase.yml
@@ -429,6 +429,7 @@ services:
       MONGODB_URI: mongodb://myusername:mypassword@fastgpt-mongo:27017/fastgpt-plugin?authSource=admin
       DB_MAX_LINK: 100
       AUTH_TOKEN: *x-plugin-auth-token
+      FASTGPT_BASE_URL: http://fastgpt-app:3000
       # 工具网络请求，最大请求和响应体
       SERVICE_REQUEST_MAX_CONTENT_LENGTH: 10
       # 最大 API 请求体大小

--- a/document/public/deploy/docker/v4.15/cn/docker-compose.opengauss.yml
+++ b/document/public/deploy/docker/v4.15/cn/docker-compose.opengauss.yml
@@ -413,6 +413,7 @@ services:
       MONGODB_URI: mongodb://myusername:mypassword@fastgpt-mongo:27017/fastgpt-plugin?authSource=admin
       DB_MAX_LINK: 100
       AUTH_TOKEN: *x-plugin-auth-token
+      FASTGPT_BASE_URL: http://fastgpt-app:3000
       # 工具网络请求，最大请求和响应体
       SERVICE_REQUEST_MAX_CONTENT_LENGTH: 10
       # 最大 API 请求体大小

--- a/document/public/deploy/docker/v4.15/cn/docker-compose.pg.yml
+++ b/document/public/deploy/docker/v4.15/cn/docker-compose.pg.yml
@@ -411,6 +411,7 @@ services:
       MONGODB_URI: mongodb://myusername:mypassword@fastgpt-mongo:27017/fastgpt-plugin?authSource=admin
       DB_MAX_LINK: 100
       AUTH_TOKEN: *x-plugin-auth-token
+      FASTGPT_BASE_URL: http://fastgpt-app:3000
       # 工具网络请求，最大请求和响应体
       SERVICE_REQUEST_MAX_CONTENT_LENGTH: 10
       # 最大 API 请求体大小

--- a/document/public/deploy/docker/v4.15/cn/docker-compose.seekdb.yml
+++ b/document/public/deploy/docker/v4.15/cn/docker-compose.seekdb.yml
@@ -416,6 +416,7 @@ services:
       MONGODB_URI: mongodb://myusername:mypassword@fastgpt-mongo:27017/fastgpt-plugin?authSource=admin
       DB_MAX_LINK: 100
       AUTH_TOKEN: *x-plugin-auth-token
+      FASTGPT_BASE_URL: http://fastgpt-app:3000
       # 工具网络请求，最大请求和响应体
       SERVICE_REQUEST_MAX_CONTENT_LENGTH: 10
       # 最大 API 请求体大小

--- a/document/public/deploy/docker/v4.15/cn/docker-compose.zilliz.yml
+++ b/document/public/deploy/docker/v4.15/cn/docker-compose.zilliz.yml
@@ -394,6 +394,7 @@ services:
       MONGODB_URI: mongodb://myusername:mypassword@fastgpt-mongo:27017/fastgpt-plugin?authSource=admin
       DB_MAX_LINK: 100
       AUTH_TOKEN: *x-plugin-auth-token
+      FASTGPT_BASE_URL: http://fastgpt-app:3000
       # 工具网络请求，最大请求和响应体
       SERVICE_REQUEST_MAX_CONTENT_LENGTH: 10
       # 最大 API 请求体大小

--- a/document/public/deploy/docker/v4.15/global/docker-compose.milvus.yml
+++ b/document/public/deploy/docker/v4.15/global/docker-compose.milvus.yml
@@ -451,6 +451,7 @@ services:
       MONGODB_URI: mongodb://myusername:mypassword@fastgpt-mongo:27017/fastgpt-plugin?authSource=admin
       DB_MAX_LINK: 100
       AUTH_TOKEN: *x-plugin-auth-token
+      FASTGPT_BASE_URL: http://fastgpt-app:3000
       # 工具网络请求，最大请求和响应体
       SERVICE_REQUEST_MAX_CONTENT_LENGTH: 10
       # 最大 API 请求体大小

--- a/document/public/deploy/docker/v4.15/global/docker-compose.oceanbase.yml
+++ b/document/public/deploy/docker/v4.15/global/docker-compose.oceanbase.yml
@@ -429,6 +429,7 @@ services:
       MONGODB_URI: mongodb://myusername:mypassword@fastgpt-mongo:27017/fastgpt-plugin?authSource=admin
       DB_MAX_LINK: 100
       AUTH_TOKEN: *x-plugin-auth-token
+      FASTGPT_BASE_URL: http://fastgpt-app:3000
       # 工具网络请求，最大请求和响应体
       SERVICE_REQUEST_MAX_CONTENT_LENGTH: 10
       # 最大 API 请求体大小

--- a/document/public/deploy/docker/v4.15/global/docker-compose.opengauss.yml
+++ b/document/public/deploy/docker/v4.15/global/docker-compose.opengauss.yml
@@ -413,6 +413,7 @@ services:
       MONGODB_URI: mongodb://myusername:mypassword@fastgpt-mongo:27017/fastgpt-plugin?authSource=admin
       DB_MAX_LINK: 100
       AUTH_TOKEN: *x-plugin-auth-token
+      FASTGPT_BASE_URL: http://fastgpt-app:3000
       # 工具网络请求，最大请求和响应体
       SERVICE_REQUEST_MAX_CONTENT_LENGTH: 10
       # 最大 API 请求体大小

--- a/document/public/deploy/docker/v4.15/global/docker-compose.pg.yml
+++ b/document/public/deploy/docker/v4.15/global/docker-compose.pg.yml
@@ -411,6 +411,7 @@ services:
       MONGODB_URI: mongodb://myusername:mypassword@fastgpt-mongo:27017/fastgpt-plugin?authSource=admin
       DB_MAX_LINK: 100
       AUTH_TOKEN: *x-plugin-auth-token
+      FASTGPT_BASE_URL: http://fastgpt-app:3000
       # 工具网络请求，最大请求和响应体
       SERVICE_REQUEST_MAX_CONTENT_LENGTH: 10
       # 最大 API 请求体大小

--- a/document/public/deploy/docker/v4.15/global/docker-compose.seekdb.yml
+++ b/document/public/deploy/docker/v4.15/global/docker-compose.seekdb.yml
@@ -416,6 +416,7 @@ services:
       MONGODB_URI: mongodb://myusername:mypassword@fastgpt-mongo:27017/fastgpt-plugin?authSource=admin
       DB_MAX_LINK: 100
       AUTH_TOKEN: *x-plugin-auth-token
+      FASTGPT_BASE_URL: http://fastgpt-app:3000
       # 工具网络请求，最大请求和响应体
       SERVICE_REQUEST_MAX_CONTENT_LENGTH: 10
       # 最大 API 请求体大小

--- a/document/public/deploy/docker/v4.15/global/docker-compose.zilliz.yml
+++ b/document/public/deploy/docker/v4.15/global/docker-compose.zilliz.yml
@@ -394,6 +394,7 @@ services:
       MONGODB_URI: mongodb://myusername:mypassword@fastgpt-mongo:27017/fastgpt-plugin?authSource=admin
       DB_MAX_LINK: 100
       AUTH_TOKEN: *x-plugin-auth-token
+      FASTGPT_BASE_URL: http://fastgpt-app:3000
       # 工具网络请求，最大请求和响应体
       SERVICE_REQUEST_MAX_CONTENT_LENGTH: 10
       # 最大 API 请求体大小


### PR DESCRIPTION
Summary:
- add FASTGPT_BASE_URL for fastgpt-plugin in the v4.15 production template
- switch the dev fastgpt-plugin service to host networking and configure PORT plus host-local dependency URLs
- regenerate dev compose files and all v4.15 public docker compose variants

Validation:
- node deploy/init.mjs
- git diff --check upstream/main...HEAD
- Ruby YAML parse for 16 compose files
- rg check for FASTGPT_BASE_URL / network_mode / PORT and no v4.14 diff