### PR TITLE
feat(chat): show Agent v2 in team app filters

### DIFF
--- a/projects/app/src/pageComponents/chat/ChatTeamApp/TypeTag.tsx
+++ b/projects/app/src/pageComponents/chat/ChatTeamApp/TypeTag.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useMemo } from 'react';
 import { AppTypeEnum } from '@fastgpt/global/core/app/constants';
 import MyIcon from '@fastgpt/web/components/common/Icon';
 import { Box, Flex } from '@chakra-ui/react';
@@ -7,55 +7,58 @@ import { useTranslation } from 'next-i18next';
 const AppTypeTag = ({ type }: { type: AppTypeEnum }) => {
   const { t } = useTranslation();
 
-  const map = useRef({
-    [AppTypeEnum.chatAgent]: {
-      label: 'Agent',
-      icon: 'core/app/type/simple',
-      bg: '#DBF3FF',
-      color: '#0884DD'
-    },
-    [AppTypeEnum.simple]: {
-      label: t('app:type.Chat_Agent'),
-      icon: 'core/app/type/simple',
-      bg: '#DBF3FF',
-      color: '#0884DD'
-    },
-    [AppTypeEnum.workflow]: {
-      label: t('app:type.Workflow bot'),
-      icon: 'core/app/type/workflow',
-      bg: '#E4E1FC',
-      color: '#6F5DD7'
-    },
-    [AppTypeEnum.workflowTool]: {
-      label: t('app:toolType_workflow'),
-      icon: 'core/app/type/plugin',
-      bg: '#D0F5EE',
-      color: '#007E7C'
-    },
-    [AppTypeEnum.httpPlugin]: {
-      label: t('account_team:type.Http plugin'),
-      icon: 'core/app/type/httpPlugin',
-      bg: '#FFE4EE',
-      color: '#E82F72'
-    },
-    [AppTypeEnum.httpToolSet]: {
-      label: t('app:toolType_http'),
-      icon: 'core/app/type/httpPlugin',
-      bg: '#FFE4EE',
-      color: '#E82F72'
-    },
-    [AppTypeEnum.mcpToolSet]: {
-      label: t('app:toolType_mcp'),
-      icon: 'core/app/type/mcpTools',
-      bg: '',
-      color: ''
-    },
-    [AppTypeEnum.tool]: undefined,
-    [AppTypeEnum.folder]: undefined,
-    [AppTypeEnum.hidden]: undefined
-  });
+  const map = useMemo(
+    () => ({
+      [AppTypeEnum.chatAgent]: {
+        label: t('app:type.Chat_Agent_v2'),
+        icon: 'core/app/type/simple',
+        bg: '#DBF3FF',
+        color: '#0884DD'
+      },
+      [AppTypeEnum.simple]: {
+        label: t('app:type.Chat_Agent'),
+        icon: 'core/app/type/simple',
+        bg: '#DBF3FF',
+        color: '#0884DD'
+      },
+      [AppTypeEnum.workflow]: {
+        label: t('app:type.Workflow bot'),
+        icon: 'core/app/type/workflow',
+        bg: '#E4E1FC',
+        color: '#6F5DD7'
+      },
+      [AppTypeEnum.workflowTool]: {
+        label: t('app:toolType_workflow'),
+        icon: 'core/app/type/plugin',
+        bg: '#D0F5EE',
+        color: '#007E7C'
+      },
+      [AppTypeEnum.httpPlugin]: {
+        label: t('account_team:type.Http plugin'),
+        icon: 'core/app/type/httpPlugin',
+        bg: '#FFE4EE',
+        color: '#E82F72'
+      },
+      [AppTypeEnum.httpToolSet]: {
+        label: t('app:toolType_http'),
+        icon: 'core/app/type/httpPlugin',
+        bg: '#FFE4EE',
+        color: '#E82F72'
+      },
+      [AppTypeEnum.mcpToolSet]: {
+        label: t('app:toolType_mcp'),
+        icon: 'core/app/type/mcpTools',
+        bg: '',
+        color: ''
+      },
+      [AppTypeEnum.tool]: undefined,
+      [AppTypeEnum.folder]: undefined,
+      [AppTypeEnum.hidden]: undefined
+    }),
+    [t]
+  );
 
-  const data = map.current[type as keyof typeof map.current];
+  const data = map[type as keyof typeof map];
 
   return data ? (
     <Flex
@@ -69,9 +72,7 @@ const AppTypeTag = ({ type }: { type: AppTypeEnum }) => {
       whiteSpace={'nowrap'}
     >
       <MyIcon name={data.icon as any} w={'0.8rem'} color={'myGray.500'} />
-      <Box fontSize={'mini'}>
-        {data.label}
-      </Box>
+      <Box fontSize={'mini'}>{data.label}</Box>
     </Flex>
   ) : null;
 };

--- a/projects/app/src/pageComponents/chat/ChatTeamApp/index.tsx
+++ b/projects/app/src/pageComponents/chat/ChatTeamApp/index.tsx
@@ -46,7 +46,7 @@ const MyApps = ({ hideMobileHeader = false, mobileSearchKey }: MyAppsProps) => {
   const map = useMemo(
     () => ({
       all: t('common:core.module.template.all_team_app'),
-      [AppTypeEnum.chatAgent]: 'Agent',
+      [AppTypeEnum.chatAgent]: t('app:type.Chat_Agent_v2'),
       [AppTypeEnum.simple]: t('app:type.Chat_Agent'),
       [AppTypeEnum.workflow]: t('app:type.Workflow bot'),
       [AppTypeEnum.workflowTool]: t('app:toolType_workflow'),
@@ -61,7 +61,13 @@ const MyApps = ({ hideMobileHeader = false, mobileSearchKey }: MyAppsProps) => {
   );
 
   const [appType, setAppType] = useState<AppTypeEnum | 'all'>('all');
-  const tabs = ['all' as const, AppTypeEnum.simple, AppTypeEnum.workflow, AppTypeEnum.workflowTool];
+  const tabs = [
+    'all' as const,
+    AppTypeEnum.chatAgent,
+    AppTypeEnum.simple,
+    AppTypeEnum.workflow,
+    AppTypeEnum.workflowTool
+  ];
 
   return (
     <Flex flexDirection={'column'} h={'100%'}>

--- a/projects/app/src/pageComponents/dashboard/agent/utils/appListTypes.ts
+++ b/projects/app/src/pageComponents/dashboard/agent/utils/appListTypes.ts
@@ -35,6 +35,7 @@ export const resolveDashboardAppListTypes = ({
     return [
       AppTypeEnum.folder,
       AppTypeEnum.toolFolder,
+      AppTypeEnum.chatAgent,
       AppTypeEnum.simple,
       AppTypeEnum.workflow,
       AppTypeEnum.workflowTool

--- a/projects/app/test/pageComponents/dashboard/agent/utils/appListTypes.test.ts
+++ b/projects/app/test/pageComponents/dashboard/agent/utils/appListTypes.test.ts
@@ -35,4 +35,20 @@ describe('resolveDashboardAppListTypes', () => {
       })
     ).toEqual([AppTypeEnum.folder, AppTypeEnum.workflow]);
   });
+
+  it('should include chat agent v2 apps in the chat app list', () => {
+    expect(
+      resolveDashboardAppListTypes({
+        pathname: '/chat',
+        type: 'all'
+      })
+    ).toEqual([
+      AppTypeEnum.folder,
+      AppTypeEnum.toolFolder,
+      AppTypeEnum.chatAgent,
+      AppTypeEnum.simple,
+      AppTypeEnum.workflow,
+      AppTypeEnum.workflowTool
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- add Agent v2 to the chat team app filter tabs before Dialogue Agent
- include chatAgent in the chat app list type whitelist
- align the Agent v2 type tag label with existing i18n text