### PR TITLE
perf(marketplace): cap tool grid columns

### DIFF
--- a/projects/app/src/pages/config/tool/marketplace.tsx
+++ b/projects/app/src/pages/config/tool/marketplace.tsx
@@ -46,6 +46,8 @@ import { useToast } from '@fastgpt/web/hooks/useToast';
 
 type QueryValue = string | string[] | undefined;
 type QueryRecord = Record<string, QueryValue>;
+const TOOL_GRID_TEMPLATE_COLUMNS =
+  'repeat(auto-fill, minmax(min(max(260px, calc((100% - 6.25rem) / 6)), 100%), 1fr))';
 
 const getComparableQueryValue = (value: QueryValue) =>
   Array.isArray(value) ? value.join('\0') : (value ?? '');
@@ -867,7 +869,7 @@ const ToolkitMarketplace = ({ marketplaceUrl }: { marketplaceUrl: string }) => {
             </Flex>
             {displayTools.length > 0 ? (
               <Grid
-                gridTemplateColumns={'repeat(auto-fill, minmax(min(260px, 100%), 1fr))'}
+                gridTemplateColumns={TOOL_GRID_TEMPLATE_COLUMNS}
                 gridGap={5}
                 alignItems={'stretch'}
               >

--- a/projects/marketplace/src/pages/index.tsx
+++ b/projects/marketplace/src/pages/index.tsx
@@ -65,6 +65,8 @@ const isSameBrowserUrl = (nextUrl: string) => {
     targetUrl.pathname === window.location.pathname && targetUrl.search === window.location.search
   );
 };
+const TOOL_GRID_TEMPLATE_COLUMNS =
+  'repeat(auto-fill, minmax(min(max(260px, calc((100% - 6.25rem) / 6)), 100%), 1fr))';
 
 const ToolkitMarketplace = () => {
   const { t, i18n } = useTranslation();
@@ -626,7 +628,7 @@ const ToolkitMarketplace = () => {
             {displayTools.length > 0 ? (
               <Grid
                 ref={gridRef}
-                gridTemplateColumns={'repeat(auto-fill, minmax(min(260px, 100%), 1fr))'}
+                gridTemplateColumns={TOOL_GRID_TEMPLATE_COLUMNS}
                 gridGap={5}
                 alignItems={'stretch'}
               >


### PR DESCRIPTION
## Summary
- keep marketplace grids using automatic column filling
- cap the tool card grid at 6 columns on wide viewports

## Verification
- corepack pnpm exec prettier --check projects/app/src/pages/config/tool/marketplace.tsx projects/marketplace/src/pages/index.tsx
- corepack pnpm exec eslint projects/app/src/pages/config/tool/marketplace.tsx projects/marketplace/src/pages/index.tsx (0 errors; marketplace file is ignored by current eslint config)
- git diff --check upstream/main...HEAD