### PR TITLE
fix(service): set default expiration for invoked file uploads

### DIFF
--- a/packages/service/support/invoke/invoke.ts
+++ b/packages/service/support/invoke/invoke.ts
@@ -16,6 +16,7 @@ import { getUserDetail } from '../user/controller';
 import { MongoTeam } from '../user/team/teamSchema';
 import { InvokeFileUploadSchema, InvokeSessionSchema, type InvokeFileUploadType } from './type';
 import type { InvokeSessionType } from './type';
+import { addHours } from 'date-fns';
 
 const INVOKE_TOKEN_EXPIRES_IN = 60 * 60;
 
@@ -72,7 +73,7 @@ export class InvokeProcessor {
 
     const { appId, chatId, uId } = InvokeSessionSchema.parse(this._session);
 
-    const { filename, body, contentType, expiredTime } = InvokeFileUploadSchema.parse(params);
+    const { filename, body, contentType } = InvokeFileUploadSchema.parse(params);
     const result = await getS3ChatSource().uploadChatFile({
       sourceType: ChatSourceTypeEnum.app,
       sourceId: appId,
@@ -81,7 +82,7 @@ export class InvokeProcessor {
       filename,
       body,
       contentType,
-      expiredTime
+      expiredTime: addHours(new Date(), 365)
     });
 
     return {

--- a/packages/service/support/invoke/type.ts
+++ b/packages/service/support/invoke/type.ts
@@ -16,8 +16,7 @@ export type InvokeSessionType = z.infer<typeof InvokeSessionSchema>;
 export const InvokeFileUploadSchema = z.object({
   filename: UploadFileByBodySchema.shape.filename,
   body: UploadFileByBodySchema.shape.body,
-  contentType: UploadFileByBodySchema.shape.contentType,
-  expiredTime: UploadFileByBodySchema.shape.expiredTime
+  contentType: UploadFileByBodySchema.shape.contentType
 });
 
 export type InvokeFileUploadType = z.infer<typeof InvokeFileUploadSchema>;

--- a/packages/service/test/support/invoke/invoke.test.ts
+++ b/packages/service/test/support/invoke/invoke.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PluginPermissionEnum } from '@fastgpt/global/sdk/fastgpt-plugin';
 import { ChatSourceTypeEnum } from '@fastgpt/global/core/chat/constants';
 
@@ -29,6 +29,8 @@ const createProcessor = () =>
 describe('InvokeProcessor.handleFileUpload', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
     mockGetToolFilePrefix.mockReturnValue('chat/app-1/user-1/chat-1');
     mockUploadChatFile.mockResolvedValue({
       key: 'chat/app-1/user-1/chat-1/image.png',
@@ -38,6 +40,10 @@ describe('InvokeProcessor.handleFileUpload', () => {
         url: 'https://example.com/api/system/file/download/token?filename=image.png'
       }
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('上传文件内容并返回最终访问 URL', async () => {
@@ -56,7 +62,7 @@ describe('InvokeProcessor.handleFileUpload', () => {
       filename: 'image.png',
       body,
       contentType: 'image/png',
-      expiredTime: undefined
+      expiredTime: new Date('2026-01-16T05:00:00.000Z')
     });
     expect(mockCreateUploadChatFileURL).not.toHaveBeenCalled();
     expect(result).toEqual({


### PR DESCRIPTION
Update the invoke file upload logic to ignore the client-provided
expiration time and enforce a fixed 365-day expiry, ensuring consistent
storage cleanup behavior.
