### PR TITLE
fix: clamp uploaded file access url expiration

### DIFF
--- a/packages/service/common/s3/buckets/base.ts
+++ b/packages/service/common/s3/buckets/base.ts
@@ -16,7 +16,7 @@ import { S3ErrEnum } from '@fastgpt/global/common/error/code/s3';
 import { createUploadConstraints } from '../utils/uploadConstraints';
 import path from 'node:path';
 import { MongoS3TTL } from '../models/ttl';
-import { addHours, addMinutes, differenceInSeconds } from 'date-fns';
+import { addHours, addMinutes, differenceInHours, differenceInSeconds } from 'date-fns';
 import { getLogger, LogCategories } from '../../logger';
 import { addS3DelJob } from '../queue/delete';
 import { type UploadFileByBufferParams, UploadFileByBodySchema } from '../contracts/type';
@@ -314,7 +314,7 @@ export class S3BaseBucket {
       key,
       accessUrl: await this.createExternalUrl({
         key,
-        expiredHours: 2
+        expiredHours: Math.max(1, differenceInHours(expiredTime, new Date()))
       })
     };
   }


### PR DESCRIPTION
## Summary
- clamp uploaded-file access URL expiration to at least 1 hour when converting from expiredTime
- sync pro submodule pointer to the latest upstream commits

## Tests
- pnpm --filter @fastgpt/service test test/common/s3/config/constants.test.ts
- git diff --check -- packages/service/common/s3/buckets/base.ts