### PR TITLE
fix(volume-manager): default pvc storage class to empty

### DIFF
--- a/projects/volume-manager/README.md
+++ b/projects/volume-manager/README.md
@@ -68,14 +68,14 @@ DELETE /v1/volumes/:sessionId
 | `VM_VOLUME_NAME_PREFIX` | | `fastgpt-session` | 卷名前缀 |
 | `VM_DOCKER_SOCKET` | | `/var/run/docker.sock` | Docker socket 路径（docker 模式） |
 | `VM_K8S_NAMESPACE` | | `opensandbox` | PVC 所在命名空间（k8s 模式） |
-| `VM_K8S_PVC_STORAGE_CLASS` | | `standard` | PVC StorageClass（k8s 模式） |
+| `VM_K8S_PVC_STORAGE_CLASS` | | `''` | PVC StorageClass（k8s 模式） |
 | `VM_K8S_PVC_STORAGE_SIZE` | | `1Gi` | PVC 容量（k8s 模式） |
 
 ## Kubernetes 部署要求
 
 ### StorageClass
 
-volume-manager 默认使用 StorageClass `fastgpt-local`（可通过 `VM_K8S_PVC_STORAGE_CLASS` 覆盖）。参考配置：
+volume-manager 默认将 `storageClassName` 置为空字符串；如需指定 StorageClass，可通过 `VM_K8S_PVC_STORAGE_CLASS` 覆盖。参考配置：
 
 ```yaml
 apiVersion: storage.k8s.io/v1
@@ -112,7 +112,7 @@ volume-manager 使用集群内 ServiceAccount 认证，无需挂载外部 kubeco
 ### 部署检查清单
 
 - [ ] 命名空间 `opensandbox`（或自定义值）已存在
-- [ ] StorageClass `fastgpt-local`（或自定义值）已创建并可用
+- [ ] 如配置 `VM_K8S_PVC_STORAGE_CLASS`，对应 StorageClass 已创建并可用
 - [ ] ServiceAccount + Role + RoleBinding 已创建
 - [ ] Secret 中包含有效的 `VM_AUTH_TOKEN`
 

--- a/projects/volume-manager/src/env.ts
+++ b/projects/volume-manager/src/env.ts
@@ -7,7 +7,7 @@ const schema = z.object({
   VM_DOCKER_SOCKET: z.string().default('/var/run/docker.sock'),
   VM_DOCKER_API_VERSION: z.string().default('v1.44'),
   VM_K8S_NAMESPACE: z.string().default('opensandbox'),
-  VM_K8S_PVC_STORAGE_CLASS: z.string().default('standard'),
+  VM_K8S_PVC_STORAGE_CLASS: z.string().default(''),
   VM_K8S_PVC_STORAGE_SIZE: z.string().default('1Gi'),
   VM_VOLUME_NAME_PREFIX: z.string().default('fastgpt-session'),
   VM_LOG_LEVEL: z.enum(['debug', 'info', 'none']).default('info')

--- a/projects/volume-manager/test/unit/K8sVolumeDriver.test.ts
+++ b/projects/volume-manager/test/unit/K8sVolumeDriver.test.ts
@@ -7,7 +7,7 @@ vi.mock('../../src/env', () => ({
   env: {
     VM_K8S_NAMESPACE: 'opensandbox',
     VM_VOLUME_NAME_PREFIX: 'fastgpt-session',
-    VM_K8S_PVC_STORAGE_CLASS: 'standard',
+    VM_K8S_PVC_STORAGE_CLASS: '',
     VM_K8S_PVC_STORAGE_SIZE: '1Gi'
   }
 }));
@@ -47,7 +47,11 @@ describe('K8sVolumeDriver', () => {
     const { K8sVolumeDriver } = await import('../../src/drivers/K8sVolumeDriver');
     const driver = new K8sVolumeDriver();
     const result = await driver.ensure(VALID_ID);
+    const [, createOpts] = fetchMock.mock.calls[1];
+    const body = JSON.parse((createOpts as any).body);
+
     expect(result).toEqual({ claimName: VOLUME_NAME, created: true });
+    expect(body.spec.storageClassName).toBe('');
   });
 
   it('ensure throws on unexpected GET error', async () => {


### PR DESCRIPTION
Summary: change volume-manager VM_K8S_PVC_STORAGE_CLASS default from standard to an empty string, update README, and assert the generated PVC uses an empty storageClassName. Tests: pnpm --filter @fastgpt/volume-manager test passed; git diff --check passed; pnpm test currently fails before running tests because turbo cannot find workspace package @fastgpt/admin.