### PR TITLE
fix(wecom): track purchased license capacity

### DIFF
--- a/packages/global/support/user/type.ts
+++ b/packages/global/support/user/type.ts
@@ -60,7 +60,8 @@ export const TeamMetaSchema = z.object({
   wecom: z
     .object({
       permanentCode: z.string(),
-      corpId: z.string()
+      corpId: z.string(),
+      licenseCapacity: z.int().min(0).default(0)
     })
     .optional()
 });


### PR DESCRIPTION
## What

- Add meta.wecom.licenseCapacity with a default value of 0.
- Update the pro submodule to purchase only the missing capacity.
- Keep capacity unchanged when switching between Basic and Advanced plans.

## Related PR

- https://github.com/labring/fastgpt-pro/pull/1015

## Verification

- pnpm --filter @fastgpt/admin test test/service/support/wecom/license/utils.test.ts
- pnpm --filter @fastgpt/admin typecheck
- TeamMetaSchema default-value runtime check
- Prettier and git diff checks