### PR TITLE
fix(security): harden archive parsing and CI actions

### DIFF
--- a/.forgejo/workflows/build-agent-sandbox.yml
+++ b/.forgejo/workflows/build-agent-sandbox.yml
@@ -69,7 +69,7 @@ jobs:
           EOF
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: |
             network=host
@@ -96,7 +96,7 @@ jobs:
           echo "SOURCE_URL=${{ github.server_url }}/${{ github.repository }}" >> "$GITHUB_ENV"
 
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -104,7 +104,7 @@ jobs:
 
       - name: Build for ${{ matrix.arch }}
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         env:
           GODEBUG: madvdontneed=0
         with:
@@ -181,7 +181,7 @@ jobs:
           EOF
 
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -200,7 +200,7 @@ jobs:
           path: ${{ runner.temp }}/digests
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: |
             network=host
@@ -290,7 +290,7 @@ jobs:
           EOF
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: |
             network=host
@@ -317,7 +317,7 @@ jobs:
           echo "SOURCE_URL=${{ github.server_url }}/${{ github.repository }}" >> "$GITHUB_ENV"
 
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -325,7 +325,7 @@ jobs:
 
       - name: Build for ${{ matrix.arch }}
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         env:
           GODEBUG: madvdontneed=0
         with:
@@ -403,7 +403,7 @@ jobs:
           EOF
 
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -422,7 +422,7 @@ jobs:
           path: ${{ runner.temp }}/digests
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: |
             network=host

--- a/.forgejo/workflows/build-code-sandbox.yml
+++ b/.forgejo/workflows/build-code-sandbox.yml
@@ -89,7 +89,7 @@ jobs:
           EOF
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: |
             network=host
@@ -116,7 +116,7 @@ jobs:
           echo "SOURCE_URL=${{ github.server_url }}/${{ github.repository }}" >> "$GITHUB_ENV"
 
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -124,7 +124,7 @@ jobs:
 
       - name: Build for ${{ matrix.arch }}
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         env:
           GODEBUG: madvdontneed=0
         with:
@@ -201,7 +201,7 @@ jobs:
           EOF
 
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -220,7 +220,7 @@ jobs:
           path: ${{ runner.temp }}/digests
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: |
             network=host

--- a/.forgejo/workflows/build-fastgpt-ide-agent.yml
+++ b/.forgejo/workflows/build-fastgpt-ide-agent.yml
@@ -80,7 +80,7 @@ jobs:
           EOF
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: |
             network=host
@@ -107,7 +107,7 @@ jobs:
           echo "SOURCE_URL=${{ github.server_url }}/${{ github.repository }}" >> "$GITHUB_ENV"
 
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -115,7 +115,7 @@ jobs:
 
       - name: Build for ${{ matrix.arch }}
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         env:
           GODEBUG: madvdontneed=0
         with:
@@ -199,7 +199,7 @@ jobs:
           EOF
 
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -218,7 +218,7 @@ jobs:
           path: ${{ runner.temp }}/digests
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: |
             network=host

--- a/.forgejo/workflows/build-fastgpt.yml
+++ b/.forgejo/workflows/build-fastgpt.yml
@@ -95,7 +95,7 @@ jobs:
           EOF
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: |
             network=host
@@ -123,7 +123,7 @@ jobs:
 
       # login docker
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -131,7 +131,7 @@ jobs:
 
       - name: Build for ${{ matrix.archs.arch }}
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         env:
           GODEBUG: madvdontneed=0
         with:
@@ -215,7 +215,7 @@ jobs:
           EOF
 
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -234,7 +234,7 @@ jobs:
           path: ${{ runner.temp }}/digests
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: |
             network=host

--- a/.forgejo/workflows/build-marketplace.yml
+++ b/.forgejo/workflows/build-marketplace.yml
@@ -52,7 +52,7 @@ jobs:
           EOF
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: |
             network=host
@@ -80,7 +80,7 @@ jobs:
 
       # login docker
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -88,7 +88,7 @@ jobs:
 
       - name: Build for ${{ matrix.arch }}
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         env:
           GODEBUG: madvdontneed=0
         with:
@@ -165,7 +165,7 @@ jobs:
           EOF
 
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -184,7 +184,7 @@ jobs:
           path: ${{ runner.temp }}/digests
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: |
             network=host

--- a/.forgejo/workflows/build-mcp-server.yml
+++ b/.forgejo/workflows/build-mcp-server.yml
@@ -69,7 +69,7 @@ jobs:
           EOF
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: |
             network=host
@@ -97,7 +97,7 @@ jobs:
 
       # login docker
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: Build for ${{ matrix.arch }}
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         env:
           GODEBUG: madvdontneed=0
         with:
@@ -181,7 +181,7 @@ jobs:
           EOF
 
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -200,7 +200,7 @@ jobs:
           path: ${{ runner.temp }}/digests
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: |
             network=host

--- a/.forgejo/workflows/test-fastgpt.yaml
+++ b/.forgejo/workflows/test-fastgpt.yaml
@@ -38,7 +38,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name ||
             github.repository }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@v4
         with:
@@ -69,7 +69,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name ||
             github.repository }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@v4
         with:
@@ -124,7 +124,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name ||
             github.repository }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@v4
         with:

--- a/.forgejo/workflows/test-rust-agent.yaml
+++ b/.forgejo/workflows/test-rust-agent.yaml
@@ -28,12 +28,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy, rustfmt
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: "fastgpt-rust-agent-cache"
           workspaces: |

--- a/.forgejo/workflows/test-sandbox.yaml
+++ b/.forgejo/workflows/test-sandbox.yaml
@@ -18,7 +18,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/build-admin.yml
+++ b/.github/workflows/build-admin.yml
@@ -67,7 +67,7 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: network=host
 
@@ -82,7 +82,7 @@ jobs:
 
       # login docker (GHCR only; Ali tags are pushed in release job via imagetools)
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -90,7 +90,7 @@ jobs:
 
       - name: Build for ${{ matrix.archs.arch }}
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: pro/admin/Dockerfile
@@ -136,13 +136,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Ali Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: registry.cn-hangzhou.aliyuncs.com
           username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
@@ -156,7 +156,7 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Set image name and tag
         run: |

--- a/.github/workflows/build-agent-sandbox.yml
+++ b/.github/workflows/build-agent-sandbox.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: network=host
       - name: Cache Docker layers
@@ -57,7 +57,7 @@ jobs:
             ${{ runner.os }}-agent-sandbox-buildx-
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Build for ${{ matrix.arch }}
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: projects/agent-sandbox/Dockerfile
@@ -101,19 +101,19 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Ali Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: registry.cn-hangzhou.aliyuncs.com
           username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
           password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKER_HUB_NAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
@@ -126,7 +126,7 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Set image name and tag
         run: |
@@ -188,7 +188,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: network=host
       - name: Cache Docker layers
@@ -200,7 +200,7 @@ jobs:
             ${{ runner.os }}-volume-manager-buildx-
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -208,7 +208,7 @@ jobs:
 
       - name: Build for ${{ matrix.arch }}
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: projects/volume-manager/Dockerfile
@@ -245,19 +245,19 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Ali Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: registry.cn-hangzhou.aliyuncs.com
           username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
           password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKER_HUB_NAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
@@ -270,7 +270,7 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Set image name and tag
         run: |

--- a/.github/workflows/build-browser-sandbox.yml
+++ b/.github/workflows/build-browser-sandbox.yml
@@ -64,7 +64,7 @@ jobs:
           fi
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.33.4
 
@@ -126,7 +126,7 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: network=host
 
@@ -139,7 +139,7 @@ jobs:
             ${{ runner.os }}-browser-sandbox-buildx-
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -147,7 +147,7 @@ jobs:
 
       - name: Build for ${{ matrix.arch }}
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: pro/browser-sandbox/Dockerfile
@@ -205,21 +205,21 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Ali Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: registry.cn-hangzhou.aliyuncs.com
           username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
           password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKER_HUB_NAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
@@ -232,7 +232,7 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Set image name and tag
         run: |

--- a/.github/workflows/build-code-sandbox.yml
+++ b/.github/workflows/build-code-sandbox.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: network=host
       - name: Cache Docker layers
@@ -77,7 +77,7 @@ jobs:
 
       # ghcr + any extra names in outputs (Ali is pushed only in release via imagetools)
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -85,7 +85,7 @@ jobs:
 
       - name: Build for ${{ matrix.arch }}
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: projects/code-sandbox/Dockerfile
@@ -121,13 +121,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Ali Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: registry.cn-hangzhou.aliyuncs.com
           username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
@@ -140,7 +140,7 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Set image name and tag
         run: |

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -103,7 +103,7 @@ jobs:
           flavor: latest=false
 
       - name: Login to Aliyun
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: registry.cn-hangzhou.aliyuncs.com
           username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
@@ -114,7 +114,7 @@ jobs:
 
       - name: Build and push Docker images (CN)
         if: matrix.domain_config.suffix == 'cn'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./document
           file: ./document/Dockerfile
@@ -129,7 +129,7 @@ jobs:
 
       - name: Build and push Docker images (IO)
         if: matrix.domain_config.suffix == 'io'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./document
           file: ./document/Dockerfile

--- a/.github/workflows/build-fastgpt-ide-agent.yml
+++ b/.github/workflows/build-fastgpt-ide-agent.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: network=host
       - name: Cache Docker layers
@@ -65,7 +65,7 @@ jobs:
 
       # Push per-arch images by digest first; the release job publishes the final manifest tag.
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -73,7 +73,7 @@ jobs:
 
       - name: Build for ${{ matrix.arch }}
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -114,14 +114,14 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Ali Hub
         if: matrix.image == 'fastgpt-agent-sandbox-proxy'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: registry.cn-hangzhou.aliyuncs.com
           username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
@@ -134,7 +134,7 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Set image name and tag
         run: |

--- a/.github/workflows/build-fastgpt.yml
+++ b/.github/workflows/build-fastgpt.yml
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: network=host
 
@@ -71,7 +71,7 @@ jobs:
 
       # login docker
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Build for ${{ matrix.archs.arch }}
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: projects/app/Dockerfile
@@ -123,19 +123,19 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Ali Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: registry.cn-hangzhou.aliyuncs.com
           username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
           password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKER_HUB_NAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
@@ -148,7 +148,7 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Set image name and tag
         run: |

--- a/.github/workflows/build-marketplace.yml
+++ b/.github/workflows/build-marketplace.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: network=host
       - name: Cache Docker layers
@@ -35,7 +35,7 @@ jobs:
 
       # login docker
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build for ${{ matrix.arch }}
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: projects/marketplace/Dockerfile
@@ -79,13 +79,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Ali Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: registry.cn-hangzhou.aliyuncs.com
           username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
@@ -99,7 +99,7 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Generate random tag
         id: tag

--- a/.github/workflows/build-mcp-server.yml
+++ b/.github/workflows/build-mcp-server.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: network=host
       - name: Cache Docker layers
@@ -57,7 +57,7 @@ jobs:
 
       # login docker
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Build for ${{ matrix.arch }}
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: projects/mcp_server/Dockerfile
@@ -101,19 +101,19 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Ali Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: registry.cn-hangzhou.aliyuncs.com
           username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
           password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKER_HUB_NAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
@@ -126,7 +126,7 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Set image name and tag
         run: |

--- a/.github/workflows/build-sso-service-image.yml
+++ b/.github/workflows/build-sso-service-image.yml
@@ -52,9 +52,9 @@ jobs:
         run: |
           sudo apt update && sudo apt install -y nodejs npm
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: network=host
       - name: Cache Docker layers
@@ -65,13 +65,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: labring
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Ali Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: registry.cn-hangzhou.aliyuncs.com
           username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}

--- a/.github/workflows/preview-admin-build.yml
+++ b/.github/workflows/preview-admin-build.yml
@@ -52,10 +52,10 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build Docker image (no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: pro/admin/Dockerfile

--- a/.github/workflows/preview-admin-push.yml
+++ b/.github/workflows/preview-admin-push.yml
@@ -42,10 +42,10 @@ jobs:
         run: docker load --input /tmp/fastgpt-pro-image.tar
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/preview-docs-build.yml
+++ b/.github/workflows/preview-docs-build.yml
@@ -26,13 +26,13 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Prepare Docker workspace catalog
         run: cp pnpm-workspace.yaml document/pnpm-workspace.yaml
 
       - name: Build Docker image (no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./document
           file: ./document/Dockerfile

--- a/.github/workflows/preview-docs-push.yml
+++ b/.github/workflows/preview-docs-push.yml
@@ -103,10 +103,10 @@ jobs:
         run: docker load --input /tmp/docs-image.tar
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/preview-fastgpt-build.yml
+++ b/.github/workflows/preview-fastgpt-build.yml
@@ -105,10 +105,10 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build Docker image (no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/preview-fastgpt-push.yml
+++ b/.github/workflows/preview-fastgpt-push.yml
@@ -135,10 +135,10 @@ jobs:
         run: docker load --input /tmp/${{ matrix.image_name }}-image.tar
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/test-fastgpt-pro.yaml
+++ b/.github/workflows/test-fastgpt-pro.yaml
@@ -35,7 +35,6 @@ jobs:
 
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -64,7 +63,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@v4
         with:
@@ -76,9 +75,33 @@ jobs:
         env:
           INVOKE_TOKEN_SECRET: fastgpt_test_invoke_token_secret_32
         run: pnpm test:admin
-      - name: Report Coverage
+      - name: Upload Coverage
         if: always() && hashFiles('pro/admin/coverage/coverage-summary.json') != ''
-        uses: davelosert/vitest-coverage-report-action@v2
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-fastgpt-pro
+          path: |
+            pro/admin/coverage/coverage-final.json
+            pro/admin/coverage/coverage-summary.json
+          retention-days: 1
+
+  report-coverage:
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Download Coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-fastgpt-pro
+          path: pro/admin/coverage
+        continue-on-error: true
+      - name: Report Coverage
+        if: hashFiles('pro/admin/coverage/coverage-summary.json') != ''
+        uses: davelosert/vitest-coverage-report-action@3c054a2d2e2ca45446417ad5d6d5eb33092af8f1 # v2
         with:
           json-final-path: pro/admin/coverage/coverage-final.json
           json-summary-path: pro/admin/coverage/coverage-summary.json

--- a/.github/workflows/test-fastgpt.yaml
+++ b/.github/workflows/test-fastgpt.yaml
@@ -107,7 +107,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name ||
             github.repository }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@v4
         with:
@@ -141,7 +141,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name ||
             github.repository }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@v4
         with:
@@ -175,7 +175,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name ||
             github.repository }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test-rust-agent.yaml
+++ b/.github/workflows/test-rust-agent.yaml
@@ -28,12 +28,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy, rustfmt
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: "fastgpt-rust-agent-cache"
           workspaces: |

--- a/.github/workflows/test-sandbox.yaml
+++ b/.github/workflows/test-sandbox.yaml
@@ -18,7 +18,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@v4
         with:

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -36,7 +36,6 @@
     "cookie": "^0.7.1",
     "date-fns": "catalog:",
     "dayjs": "catalog:",
-    "decompress": "^4.2.1",
     "domino-ext": "^2.1.4",
     "encoding": "^0.1.13",
     "file-type": "catalog:",
@@ -77,12 +76,12 @@
     "undici": "catalog:",
     "winston": "^3.17.0",
     "xlsx": "0.18.5",
+    "yauzl": "^3.4.0",
     "zod": "catalog:"
   },
   "devDependencies": {
     "@types/async-retry": "^1.4.9",
     "@types/cookie": "^0.5.2",
-    "@types/decompress": "^4.2.7",
     "@types/jsonwebtoken": "catalog:",
     "@types/lodash": "catalog:",
     "@types/mime-types": "catalog:",
@@ -94,6 +93,7 @@
     "@types/proxy-addr": "catalog:",
     "@types/proxy-from-env": "^1.0.4",
     "@types/tunnel": "^0.0.4",
-    "@types/turndown": "^5.0.4"
+    "@types/turndown": "^5.0.4",
+    "@types/yauzl": "^2.10.3"
   }
 }

--- a/packages/service/test/worker/readFile/parseOffice.test.ts
+++ b/packages/service/test/worker/readFile/parseOffice.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import JSZip from 'jszip';
+import { detectFileEncoding } from '@fastgpt/global/common/file/tools';
+import { parseOffice } from '@fastgpt/service/worker/readFile/parseOffice';
+
+type PptxEntry = {
+  path: string;
+  content: string;
+  unixPermissions?: number;
+};
+
+const createPptxWithEntries = async (entries: PptxEntry[]) => {
+  const zip = new JSZip();
+  entries.forEach(({ path, content, unixPermissions }) => {
+    zip.file(path, content, { unixPermissions });
+  });
+
+  return zip.generateAsync({
+    type: 'nodebuffer',
+    platform: 'UNIX'
+  });
+};
+
+const createPptx = async ({ path, content, unixPermissions }: PptxEntry) =>
+  createPptxWithEntries([{ path, content, unixPermissions }]);
+
+const parsePptx = (buffer: Buffer) =>
+  parseOffice({
+    buffer,
+    encoding: 'utf-8',
+    extension: 'pptx'
+  });
+
+const findZipRecord = (buffer: Buffer, signature: number, fromEnd = false) => {
+  const signatureBuffer = Buffer.allocUnsafe(4);
+  signatureBuffer.writeUInt32LE(signature);
+  const offset = fromEnd ? buffer.lastIndexOf(signatureBuffer) : buffer.indexOf(signatureBuffer);
+
+  expect(offset).toBeGreaterThanOrEqual(0);
+  return offset;
+};
+
+describe('parseOffice', () => {
+  it('解析合法 PPTX slide XML', async () => {
+    const buffer = await createPptx({
+      path: 'ppt/slides/slide1.xml',
+      content: '<a:p><a:t>Hello</a:t><a:t> FastGPT</a:t></a:p>'
+    });
+    const encoding = detectFileEncoding(buffer) as BufferEncoding;
+
+    await expect(
+      parseOffice({
+        buffer,
+        encoding,
+        extension: 'pptx'
+      })
+    ).resolves.toBe('Hello FastGPT');
+  });
+
+  it('按页码解析多个 slide 和 notes XML', async () => {
+    const buffer = await createPptxWithEntries([
+      {
+        path: 'ppt/slides/slide2.xml',
+        content: '<a:p><a:t>Slide 2</a:t></a:p>'
+      },
+      {
+        path: 'ppt/slides/slide1.xml',
+        content: '<a:p><a:t>Slide 1</a:t></a:p>'
+      },
+      {
+        path: 'ppt/notesSlides/notesSlide1.xml',
+        content: '<a:p><a:t>Note 1</a:t></a:p>'
+      }
+    ]);
+
+    await expect(parsePptx(buffer)).resolves.toBe('Slide 1\nNote 1\nSlide 2');
+  });
+
+  it('合法 slide XML 没有文本节点时返回空字符串', async () => {
+    const buffer = await createPptx({
+      path: 'ppt/slides/slide1.xml',
+      content: '<a:p></a:p>'
+    });
+
+    await expect(parsePptx(buffer)).resolves.toBe('');
+  });
+
+  it('拒绝伪装成 slide XML 的 symlink entry', async () => {
+    const buffer = await createPptx({
+      path: 'ppt/slides/slide1.xml',
+      content: '/etc/passwd',
+      unixPermissions: 0o120777
+    });
+
+    await expect(parsePptx(buffer)).rejects.toBe('解析 PPT 失败');
+  });
+
+  it('拒绝仅包含嵌套伪装路径的归档', async () => {
+    const buffer = await createPptx({
+      path: 'outside/ppt/slides/slide1.xml',
+      content: '<a:p><a:t>hidden</a:t></a:p>'
+    });
+
+    await expect(parsePptx(buffer)).rejects.toBe('解析 PPT 失败');
+  });
+
+  it('拒绝经 JSZip 规范化后伪装成 slide XML 的 traversal entry', async () => {
+    const buffer = await createPptx({
+      path: '../ppt/slides/slide1.xml',
+      content: '<a:p><a:t>hidden</a:t></a:p>'
+    });
+
+    await expect(parsePptx(buffer)).rejects.toThrow();
+  });
+
+  it('拒绝伪造 uncompressedSize 的高膨胀归档', async () => {
+    const zip = new JSZip();
+    zip.file('ppt/slides/slide1.xml', `<a:p><a:t>${'x'.repeat(10 * 1024 * 1024 + 1)}</a:t></a:p>`);
+    const buffer = await zip.generateAsync({
+      type: 'nodebuffer',
+      platform: 'UNIX',
+      compression: 'DEFLATE',
+      compressionOptions: { level: 9 }
+    });
+    const forgedBuffer = Buffer.from(buffer);
+    const centralDirectoryOffset = findZipRecord(forgedBuffer, 0x02014b50, true);
+    forgedBuffer.writeUInt32LE(1, centralDirectoryOffset + 24);
+
+    await expect(parsePptx(forgedBuffer)).rejects.toThrow();
+  }, 15000);
+
+  it('在读取 entry 前拒绝超过数量限制的归档', async () => {
+    const buffer = await createPptx({
+      path: 'ppt/slides/slide1.xml',
+      content: '<a:p><a:t>Hello</a:t></a:p>'
+    });
+    const forgedBuffer = Buffer.from(buffer);
+    const endRecordOffset = findZipRecord(forgedBuffer, 0x06054b50, true);
+    forgedBuffer.writeUInt16LE(10001, endRecordOffset + 8);
+    forgedBuffer.writeUInt16LE(10001, endRecordOffset + 10);
+
+    await expect(parsePptx(forgedBuffer)).rejects.toBe('解析 PPT 失败');
+  });
+
+  it('拒绝损坏的 PPTX 归档', async () => {
+    await expect(parsePptx(Buffer.from('not-a-zip'))).rejects.toThrow();
+  });
+
+  it('拒绝不支持的 Office 扩展名', async () => {
+    await expect(
+      parseOffice({
+        buffer: Buffer.alloc(0),
+        encoding: 'utf-8',
+        extension: 'docx'
+      })
+    ).rejects.toBe('只能读取 .pptx 文件');
+  });
+});

--- a/packages/service/worker/readFile/parseOffice.ts
+++ b/packages/service/worker/readFile/parseOffice.ts
@@ -1,50 +1,139 @@
-import { getNanoid } from '@fastgpt/global/common/string/tools';
-import fs from 'fs';
-import decompress from 'decompress';
 import { DOMParser } from '@xmldom/xmldom';
-import { clearDirFiles } from '../../common/file/utils';
-import { getLogger, LogCategories } from '../../common/logger';
+import { type Entry, fromBuffer, type ZipFile } from 'yauzl';
 
-const DEFAULTDECOMPRESSSUBLOCATION = '/tmp';
-const logger = getLogger(LogCategories.INFRA.WORKER);
-
-function getNewFileName(ext: string) {
-  return `${DEFAULTDECOMPRESSSUBLOCATION}/${getNanoid()}.${ext}`;
-}
-
-const parseString = (xml: string) => {
-  let parser = new DOMParser();
-  return parser.parseFromString(xml, 'text/xml');
-};
+const powerPointXmlPathRegex = /^ppt\/(?:notesSlides\/notesSlide|slides\/slide)\d+\.xml$/;
+const powerPointSlidePathRegex = /^ppt\/slides\/slide\d+\.xml$/;
+const maxPowerPointEntries = 10000;
+const maxPowerPointXmlFileBytes = 10 * 1024 * 1024;
+const maxPowerPointXmlBytes = 100 * 1024 * 1024;
 
 const parsePowerPoint = async ({
-  filepath,
-  decompressPath,
+  buffer,
   encoding
 }: {
-  filepath: string;
-  decompressPath: string;
+  buffer: Buffer;
   encoding: BufferEncoding;
 }) => {
-  // Files regex that hold our content of interest
-  const allFilesRegex = /ppt\/(notesSlides|slides)\/(notesSlide|slide)\d+.xml/g;
-  const slidesRegex = /ppt\/slides\/slide\d+.xml/g;
+  const decodeXml = (data: Buffer) => {
+    try {
+      return data.toString(encoding);
+    } catch {
+      // 上游按整个压缩包探测编码时可能得到 Node.js 不支持的编码名。
+      return data.toString('utf-8');
+    }
+  };
 
-  /** The decompress location which contains the filename in it */
-
-  const files = await decompress(filepath, decompressPath, {
-    filter: (x) => !!x.path.match(allFilesRegex)
+  const zip = await new Promise<ZipFile>((resolve, reject) => {
+    fromBuffer(
+      buffer,
+      {
+        lazyEntries: true,
+        decodeStrings: true,
+        validateEntrySizes: true,
+        strictFileNames: true
+      },
+      (error, zipFile) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(zipFile);
+      }
+    );
   });
 
-  // Verify if atleast the slides xml files exist in the extracted files list.
-  if (
-    files.length == 0 ||
-    !files.map((file) => file.path).some((filename) => filename.match(slidesRegex))
-  ) {
-    return Promise.reject('解析 PPT 失败');
-  }
+  const files = await new Promise<{ path: string; content: string }[]>((resolve, reject) => {
+    const result: { path: string; content: string }[] = [];
+    let entriesRead = 0;
+    let totalXmlBytes = 0;
+    let settled = false;
 
-  // Sort files by slide number to ensure correct order
+    const fail = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      zip.close();
+      reject(error);
+    };
+
+    const readEntryContent = (entry: Entry) => {
+      zip.openReadStream(entry, (error, stream) => {
+        if (error) {
+          fail(error);
+          return;
+        }
+
+        const chunks: Buffer[] = [];
+        let entryBytes = 0;
+        stream.on('data', (chunk: Buffer) => {
+          entryBytes += chunk.length;
+          totalXmlBytes += chunk.length;
+
+          // 元数据可被伪造，必须按流中真实输出字节中止解压。
+          if (entryBytes > maxPowerPointXmlFileBytes || totalXmlBytes > maxPowerPointXmlBytes) {
+            stream.destroy(new Error('解析 PPT 失败'));
+            return;
+          }
+          chunks.push(chunk);
+        });
+        stream.once('error', fail);
+        stream.once('end', () => {
+          if (settled) return;
+          result.push({
+            path: entry.fileName,
+            content: decodeXml(Buffer.concat(chunks, entryBytes))
+          });
+          zip.readEntry();
+        });
+      });
+    };
+
+    zip.once('error', fail);
+    zip.on('entry', (entry: Entry) => {
+      entriesRead += 1;
+      if (entriesRead > maxPowerPointEntries) {
+        fail('解析 PPT 失败');
+        return;
+      }
+
+      const createdOnUnix = entry.versionMadeBy >>> 8 === 3;
+      const unixMode = entry.externalFileAttributes >>> 16;
+      const unixFileType = unixMode & 0xf000;
+      const isRegularFile =
+        !entry.fileName.endsWith('/') &&
+        (!createdOnUnix || unixFileType === 0 || unixFileType === 0x8000);
+
+      // yauzl 在 entry 事件前校验原始路径；这里只读取锚定 OOXML 路径下的普通文件。
+      if (!isRegularFile || !powerPointXmlPathRegex.test(entry.fileName)) {
+        zip.readEntry();
+        return;
+      }
+
+      if (
+        entry.uncompressedSize > maxPowerPointXmlFileBytes ||
+        totalXmlBytes + entry.uncompressedSize > maxPowerPointXmlBytes
+      ) {
+        fail('解析 PPT 失败');
+        return;
+      }
+      readEntryContent(entry);
+    });
+    zip.once('end', () => {
+      if (settled) return;
+      settled = true;
+      if (!result.some((file) => powerPointSlidePathRegex.test(file.path))) {
+        reject('解析 PPT 失败');
+        return;
+      }
+      resolve(result);
+    });
+
+    if (zip.entryCount > maxPowerPointEntries) {
+      fail('解析 PPT 失败');
+      return;
+    }
+    zip.readEntry();
+  });
+
   const sortedFiles = files.sort((a, b) => {
     const getSlideNumber = (path: string) => {
       const match = path.match(/\d+/);
@@ -52,44 +141,32 @@ const parsePowerPoint = async ({
     };
     return getSlideNumber(a.path) - getSlideNumber(b.path);
   });
+  const parser = new DOMParser();
 
-  // Returning an array of all the xml contents read using fs.readFileSync
-  const xmlContentArray = await Promise.all(
-    sortedFiles.map(async (file) => {
-      try {
-        return await fs.promises.readFile(`${decompressPath}/${file.path}`, encoding);
-      } catch (err) {
-        return await fs.promises.readFile(`${decompressPath}/${file.path}`, 'utf-8');
-      }
-    })
-  );
+  return sortedFiles
+    .map(({ content }) => {
+      const xmlParagraphNodesList = parser
+        .parseFromString(content, 'text/xml')
+        .getElementsByTagName('a:p');
 
-  let responseArr: string[] = [];
-
-  xmlContentArray.forEach((xmlContent) => {
-    /** Find text nodes with a:p tags */
-    const xmlParagraphNodesList = parseString(xmlContent).getElementsByTagName('a:p');
-
-    /** Store all the text content to respond */
-    responseArr.push(
-      Array.from(xmlParagraphNodesList)
-        // Filter paragraph nodes than do not have any text nodes which are identifiable by a:t tag
+      return Array.from(xmlParagraphNodesList)
         .filter((paragraphNode) => paragraphNode.getElementsByTagName('a:t').length != 0)
         .map((paragraphNode) => {
-          /** Find text nodes with a:t tags */
           const xmlTextNodeList = paragraphNode.getElementsByTagName('a:t');
           return Array.from(xmlTextNodeList)
             .filter((textNode) => textNode.childNodes[0] && textNode.childNodes[0].nodeValue)
             .map((textNode) => textNode.childNodes[0].nodeValue)
             .join('');
         })
-        .join('\n')
-    );
-  });
-
-  return responseArr.join('\n');
+        .join('\n');
+    })
+    .join('\n');
 };
 
+/**
+ * 解析受支持的 Office 文件文本。
+ * PPTX 归档按 entry 流式读取，只解压固定 OOXML 路径下且满足大小限制的普通 XML 文件。
+ */
 export const parseOffice = async ({
   buffer,
   encoding,
@@ -99,43 +176,10 @@ export const parseOffice = async ({
   encoding: BufferEncoding;
   extension: string;
 }) => {
-  // Prepare file for processing
-  // create temp file subdirectory if it does not exist
-  if (!fs.existsSync(DEFAULTDECOMPRESSSUBLOCATION)) {
-    fs.mkdirSync(DEFAULTDECOMPRESSSUBLOCATION, { recursive: true });
+  switch (extension) {
+    case 'pptx':
+      return parsePowerPoint({ buffer, encoding });
+    default:
+      return Promise.reject('只能读取 .pptx 文件');
   }
-
-  // temp file name
-  const filepath = getNewFileName(extension);
-  const decompressPath = `${DEFAULTDECOMPRESSSUBLOCATION}/${getNanoid()}`;
-  //   const decompressPath = `${DEFAULTDECOMPRESSSUBLOCATION}/test`;
-
-  // write new file
-  try {
-    fs.writeFileSync(filepath, buffer, {
-      encoding
-    });
-  } catch (err) {
-    fs.writeFileSync(filepath, buffer, {
-      encoding: 'utf-8'
-    });
-  }
-
-  const text = await (async () => {
-    try {
-      switch (extension) {
-        case 'pptx':
-          return parsePowerPoint({ filepath, decompressPath, encoding });
-        default:
-          return Promise.reject('只能读取 .pptx 文件');
-      }
-    } catch (error) {
-      logger.error('Failed to parse pptx file', { extension, error });
-    }
-    return '';
-  })();
-
-  fs.unlinkSync(filepath);
-  clearDirFiles(decompressPath);
-  return text;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -538,9 +538,6 @@ importers:
       dayjs:
         specifier: 'catalog:'
         version: 1.11.19
-      decompress:
-        specifier: ^4.2.1
-        version: 4.2.1
       domino-ext:
         specifier: ^2.1.4
         version: 2.1.4
@@ -661,6 +658,9 @@ importers:
       xlsx:
         specifier: 0.18.5
         version: 0.18.5
+      yauzl:
+        specifier: ^3.4.0
+        version: 3.4.0
       zod:
         specifier: 'catalog:'
         version: 4.1.12
@@ -671,9 +671,6 @@ importers:
       '@types/cookie':
         specifier: ^0.5.2
         version: 0.5.4
-      '@types/decompress':
-        specifier: ^4.2.7
-        version: 4.2.7
       '@types/jsonwebtoken':
         specifier: 'catalog:'
         version: 9.0.9
@@ -710,6 +707,9 @@ importers:
       '@types/turndown':
         specifier: ^5.0.4
         version: 5.0.5
+      '@types/yauzl':
+        specifier: ^2.10.3
+        version: 2.10.3
 
   packages/web:
     dependencies:
@@ -6665,9 +6665,6 @@ packages:
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
-  '@types/decompress@4.2.7':
-    resolution: {integrity: sha512-9z+8yjKr5Wn73Pt17/ldnmQToaFHZxK0N1GHysuk/JIPT8RIdQeoInM01wWPgypRcvb6VH1drjuFpQ4zmY437g==}
-
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -7605,9 +7602,6 @@ packages:
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
-  bl@1.2.3:
-    resolution: {integrity: sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==}
-
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -7674,12 +7668,6 @@ packages:
     resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
     engines: {node: '>=16.20.1'}
 
-  buffer-alloc-unsafe@1.1.0:
-    resolution: {integrity: sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==}
-
-  buffer-alloc@1.2.0:
-    resolution: {integrity: sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==}
-
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
@@ -7689,9 +7677,6 @@ packages:
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
-
-  buffer-fill@1.0.0:
-    resolution: {integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -8503,26 +8488,6 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
-  decompress-tar@4.1.1:
-    resolution: {integrity: sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==}
-    engines: {node: '>=4'}
-
-  decompress-tarbz2@4.1.1:
-    resolution: {integrity: sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==}
-    engines: {node: '>=4'}
-
-  decompress-targz@4.1.1:
-    resolution: {integrity: sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==}
-    engines: {node: '>=4'}
-
-  decompress-unzip@4.0.1:
-    resolution: {integrity: sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==}
-    engines: {node: '>=4'}
-
-  decompress@4.2.1:
-    resolution: {integrity: sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==}
-    engines: {node: '>=4'}
-
   deep-equal@1.1.2:
     resolution: {integrity: sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==}
     engines: {node: '>= 0.4'}
@@ -9231,18 +9196,6 @@ packages:
     resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
     engines: {node: '>=20'}
 
-  file-type@3.9.0:
-    resolution: {integrity: sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==}
-    engines: {node: '>=0.10.0'}
-
-  file-type@5.2.0:
-    resolution: {integrity: sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==}
-    engines: {node: '>=4'}
-
-  file-type@6.2.0:
-    resolution: {integrity: sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==}
-    engines: {node: '>=4'}
-
   file-uri-to-path@2.0.0:
     resolution: {integrity: sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==}
     engines: {node: '>= 6'}
@@ -9576,10 +9529,6 @@ packages:
   get-stdin@5.0.1:
     resolution: {integrity: sha512-jZV7n6jGE3Gt7fgSTJoz91Ak5MuTLwMwkoYdjxuJ/AmjIsE1UC03y/IWkZCQGEvVNS9qoRNwy5BCqxImv0FVeA==}
     engines: {node: '>=0.12.0'}
-
-  get-stream@2.3.1:
-    resolution: {integrity: sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==}
-    engines: {node: '>=0.10.0'}
 
   get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
@@ -10236,9 +10185,6 @@ packages:
     resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
     engines: {node: '>= 0.4'}
 
-  is-natural-number@4.0.1:
-    resolution: {integrity: sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==}
-
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
@@ -10307,10 +10253,6 @@ packages:
   is-shared-array-buffer@1.0.4:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
-
-  is-stream@1.1.0:
-    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
-    engines: {node: '>=0.10.0'}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -10943,10 +10885,6 @@ packages:
 
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
-
-  make-dir@1.3.0:
-    resolution: {integrity: sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==}
-    engines: {node: '>=4'}
 
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -13160,10 +13098,6 @@ packages:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
 
-  seek-bzip@1.0.6:
-    resolution: {integrity: sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==}
-    hasBin: true
-
   semver-diff@4.0.0:
     resolution: {integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==}
     engines: {node: '>=12'}
@@ -13592,9 +13526,6 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
-  strip-dirs@2.1.0:
-    resolution: {integrity: sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==}
-
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -13710,10 +13641,6 @@ packages:
 
   tar-fs@3.1.2:
     resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
-
-  tar-stream@1.6.2:
-    resolution: {integrity: sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==}
-    engines: {node: '>= 0.8.0'}
 
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
@@ -13874,9 +13801,6 @@ packages:
 
   to-arraybuffer@1.0.1:
     resolution: {integrity: sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA==}
-
-  to-buffer@1.1.1:
-    resolution: {integrity: sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -14831,6 +14755,10 @@ packages:
 
   yauzl@3.2.0:
     resolution: {integrity: sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==}
+    engines: {node: '>=12'}
+
+  yauzl@3.4.0:
+    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
     engines: {node: '>=12'}
 
   yjs@13.6.24:
@@ -21151,10 +21079,6 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
-  '@types/decompress@4.2.7':
-    dependencies:
-      '@types/node': 20.17.24
-
   '@types/deep-eql@4.0.2': {}
 
   '@types/dns-packet@5.6.5':
@@ -21433,7 +21357,6 @@ snapshots:
   '@types/yauzl@2.10.3':
     dependencies:
       '@types/node': 20.17.24
-    optional: true
 
   '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)':
     dependencies:
@@ -22295,11 +22218,6 @@ snapshots:
 
   birpc@4.0.0: {}
 
-  bl@1.2.3:
-    dependencies:
-      readable-stream: 2.3.8
-      safe-buffer: 5.2.1
-
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -22399,20 +22317,11 @@ snapshots:
 
   bson@6.10.4: {}
 
-  buffer-alloc-unsafe@1.1.0: {}
-
-  buffer-alloc@1.2.0:
-    dependencies:
-      buffer-alloc-unsafe: 1.1.0
-      buffer-fill: 1.0.0
-
   buffer-crc32@0.2.13: {}
 
   buffer-crc32@1.0.0: {}
 
   buffer-equal-constant-time@1.0.1: {}
-
-  buffer-fill@1.0.0: {}
 
   buffer-from@1.1.2: {}
 
@@ -23263,44 +23172,6 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
-
-  decompress-tar@4.1.1:
-    dependencies:
-      file-type: 5.2.0
-      is-stream: 1.1.0
-      tar-stream: 1.6.2
-
-  decompress-tarbz2@4.1.1:
-    dependencies:
-      decompress-tar: 4.1.1
-      file-type: 6.2.0
-      is-stream: 1.1.0
-      seek-bzip: 1.0.6
-      unbzip2-stream: 1.4.3
-
-  decompress-targz@4.1.1:
-    dependencies:
-      decompress-tar: 4.1.1
-      file-type: 5.2.0
-      is-stream: 1.1.0
-
-  decompress-unzip@4.0.1:
-    dependencies:
-      file-type: 3.9.0
-      get-stream: 2.3.1
-      pify: 2.3.0
-      yauzl: 2.10.0
-
-  decompress@4.2.1:
-    dependencies:
-      decompress-tar: 4.1.1
-      decompress-tarbz2: 4.1.1
-      decompress-targz: 4.1.1
-      decompress-unzip: 4.0.1
-      graceful-fs: 4.2.11
-      make-dir: 1.3.0
-      pify: 2.3.0
-      strip-dirs: 2.1.0
 
   deep-equal@1.1.2:
     dependencies:
@@ -24444,12 +24315,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  file-type@3.9.0: {}
-
-  file-type@5.2.0: {}
-
-  file-type@6.2.0: {}
-
   file-uri-to-path@2.0.0:
     optional: true
 
@@ -24830,11 +24695,6 @@ snapshots:
   get-ready@1.0.0: {}
 
   get-stdin@5.0.1: {}
-
-  get-stream@2.3.1:
-    dependencies:
-      object-assign: 4.1.1
-      pinkie-promise: 2.0.1
 
   get-stream@5.2.0:
     dependencies:
@@ -25679,8 +25539,6 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
 
-  is-natural-number@4.0.1: {}
-
   is-negative-zero@2.0.3: {}
 
   is-npm@6.0.0: {}
@@ -25726,8 +25584,6 @@ snapshots:
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
-
-  is-stream@1.1.0: {}
 
   is-stream@2.0.1: {}
 
@@ -26331,10 +26187,6 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
-
-  make-dir@1.3.0:
-    dependencies:
-      pify: 3.0.0
 
   make-dir@3.1.0:
     dependencies:
@@ -29361,10 +29213,6 @@ snapshots:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
 
-  seek-bzip@1.0.6:
-    dependencies:
-      commander: 2.20.3
-
   semver-diff@4.0.0:
     dependencies:
       semver: 7.8.0
@@ -29905,10 +29753,6 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
-  strip-dirs@2.1.0:
-    dependencies:
-      is-natural-number: 4.0.1
-
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
@@ -30048,16 +29892,6 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
-
-  tar-stream@1.6.2:
-    dependencies:
-      bl: 1.2.3
-      buffer-alloc: 1.2.0
-      end-of-stream: 1.4.4
-      fs-constants: 1.0.0
-      readable-stream: 2.3.8
-      to-buffer: 1.1.1
-      xtend: 4.0.2
 
   tar-stream@2.2.0:
     dependencies:
@@ -30271,8 +30105,6 @@ snapshots:
       tldts-core: 7.4.3
 
   to-arraybuffer@1.0.1: {}
-
-  to-buffer@1.1.1: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -31344,6 +31176,10 @@ snapshots:
   yauzl@3.2.0:
     dependencies:
       buffer-crc32: 0.2.13
+      pend: 1.2.0
+
+  yauzl@3.4.0:
+    dependencies:
       pend: 1.2.0
 
   yjs@13.6.24:


### PR DESCRIPTION
## Summary

- Replace PPTX archive extraction with lazy, streaming `yauzl` parsing and reject traversal paths, symlinks, and non-regular entries.
- Enforce archive limits at three layers: 10,000 entries, 10 MB per XML file, and 100 MB cumulative XML output, measured from actual streamed bytes.
- Pin 129 GitHub and Forgejo action references to immutable 40-character SHAs while preserving version comments.
- Split Pro coverage reporting into an artifact consumer job so the test job only has `contents: read`; the privileged report job does not check out PR source.

## Verification

- PPTX parser tests: 10/10 passed, including traversal, symlink, forged size, and entry-count cases.
- Service suite: 230 files, 3131 tests passed, 35 skipped.
- Isolated TypeScript check passed.
- Frozen-lockfile install passed.
- Parsed all 31 workflow YAML files successfully.
- Verified all 129 action pins.
- `git diff --check` passed.
- `pnpm audit --prod` confirms `GHSA-mp2f-45pm-3cg9` and `GHSA-gmq8-994r-jv83` are absent. Existing dependency baseline remains: 11 critical, 78 high, 125 moderate, 24 low.

## Accepted risks

- Existing fixed deployment credential handling remains unchanged.
- Existing `pull_request_target` paths may still execute code from collaborator or owner PR branches; fork-originated untrusted PR code is outside this accepted path.