### PR TITLE
feat: track home attribution source during authentication

### DIFF
--- a/packages/global/openapi/support/user/account/login/api.ts
+++ b/packages/global/openapi/support/user/account/login/api.ts
@@ -58,33 +58,31 @@ export const PreLoginResponseSchema = z
 export type PreLoginResponseType = z.infer<typeof PreLoginResponseSchema>;
 
 // ===== Login by password =====
-export const LoginByPasswordBodySchema = z
-  .object({
-    username: z.string().meta({
-      example: 'admin',
-      description: '用户名'
-    }),
-    password: z.string().meta({
-      example: 'hashed_password',
-      description: '密码'
-    }),
-    code: z.string().meta({
-      example: '123456',
-      description: '预登录验证码'
-    }),
-    language: LanguageSchema.optional().default('zh-CN').meta({
-      example: 'zh-CN',
-      description: '用户语言偏好'
-    })
+export const LoginByPasswordBodySchema = TrackRegisterParamsSchema.extend({
+  username: z.string().meta({
+    example: 'admin',
+    description: '用户名'
+  }),
+  password: z.string().meta({
+    example: 'hashed_password',
+    description: '密码'
+  }),
+  code: z.string().meta({
+    example: '123456',
+    description: '预登录验证码'
+  }),
+  language: LanguageSchema.optional().default('zh-CN').meta({
+    example: 'zh-CN',
+    description: '用户语言偏好'
   })
-  .meta({
-    example: {
-      username: 'admin',
-      password: 'hashed_password',
-      code: '123456',
-      language: 'zh-CN'
-    }
-  });
+}).meta({
+  example: {
+    username: 'admin',
+    password: 'hashed_password',
+    code: '123456',
+    language: 'zh-CN'
+  }
+});
 export type LoginByPasswordBodyType = z.infer<typeof LoginByPasswordBodySchema>;
 
 /* ===== Wecom Login ===== */
@@ -107,7 +105,7 @@ export const OauthLoginBodySchema = TrackRegisterParamsSchema.extend({
 export type OauthLoginBodyType = z.infer<typeof OauthLoginBodySchema>;
 
 // ===== Fast Login =====
-export const FastLoginBodySchema = z.object({
+export const FastLoginBodySchema = TrackRegisterParamsSchema.extend({
   token: z.string().meta({ description: 'Token' }),
   code: z.string().meta({ description: 'Code' }),
   language: LanguageSchema.optional().meta({ description: '语言' })

--- a/packages/global/support/marketing/type.ts
+++ b/packages/global/support/marketing/type.ts
@@ -31,20 +31,28 @@ export const FastGPTSourceSchema = z
   .passthrough();
 export type FastGPTSourceType = z.infer<typeof FastGPTSourceSchema>;
 
-export const FastGPT_SEM_Schema = ShortUrlSchema.extend({
+const FastGPTSemBaseSchema = ShortUrlSchema.extend({
   keyword: z.string().optional(),
   search: z.string().optional(),
   source: z.string().optional(),
-  firstsource: FastGPTSourceSchema.optional(),
-  lastsource: FastGPTSourceSchema.optional(),
   sourceDomain: z.string().optional()
 });
+
+export const FastGPT_SEM_Schema = FastGPTSemBaseSchema.extend({
+  firstsource: FastGPTSourceSchema.optional(),
+  lastsource: FastGPTSourceSchema.optional()
+});
 export type FastGPTSemType = z.infer<typeof FastGPT_SEM_Schema>;
+
+export const FastGPTTrackSemSchema = FastGPTSemBaseSchema.extend({
+  home_source: FastGPTSourceSchema.optional()
+});
+export type FastGPTTrackSemType = z.infer<typeof FastGPTTrackSemSchema>;
 
 export const TrackRegisterParamsSchema = z.object({
   inviterId: z.string().optional(),
   bd_vid: z.string().optional(),
   msclkid: z.string().optional(),
-  fastgpt_sem: FastGPT_SEM_Schema.optional()
+  fastgpt_sem: FastGPTTrackSemSchema.optional()
 });
 export type TrackRegisterParams = z.infer<typeof TrackRegisterParamsSchema>;

--- a/packages/global/support/marketing/type.ts
+++ b/packages/global/support/marketing/type.ts
@@ -7,10 +7,34 @@ export const ShortUrlSchema = z.object({
 });
 export type ShortUrlParams = z.infer<typeof ShortUrlSchema>;
 
+export const FastGPTSourceSchema = z
+  .object({
+    visitor_id: z.string().optional(),
+    first_touch_channel: z.string().optional(),
+    first_touch_source: z.string().optional(),
+    first_landing_url: z.string().optional(),
+    first_touch_at: z.string().optional(),
+    last_touch_channel: z.string().optional(),
+    last_touch_source: z.string().optional(),
+    channel_l1: z.string().optional(),
+    channel_l2: z.string().optional(),
+    is_paid: z.boolean().optional(),
+    utm_source: z.string().optional(),
+    utm_medium: z.string().optional(),
+    utm_campaign: z.string().optional(),
+    utm_term: z.string().optional(),
+    utm_content: z.string().optional(),
+    click_id: z.string().optional(),
+    referrer_url: z.string().optional(),
+    fastgpt_source: z.string().optional()
+  })
+  .passthrough();
+export type FastGPTSourceType = z.infer<typeof FastGPTSourceSchema>;
+
 export const FastGPT_SEM_Schema = ShortUrlSchema.extend({
   keyword: z.string().optional(),
   search: z.string().optional(),
-  source: z.string().optional(),
+  source: z.union([z.string(), FastGPTSourceSchema]).optional(),
   sourceDomain: z.string().optional()
 });
 export type FastGPTSemType = z.infer<typeof FastGPT_SEM_Schema>;

--- a/packages/global/support/marketing/type.ts
+++ b/packages/global/support/marketing/type.ts
@@ -34,7 +34,9 @@ export type FastGPTSourceType = z.infer<typeof FastGPTSourceSchema>;
 export const FastGPT_SEM_Schema = ShortUrlSchema.extend({
   keyword: z.string().optional(),
   search: z.string().optional(),
-  source: z.union([z.string(), FastGPTSourceSchema]).optional(),
+  source: z.string().optional(),
+  firstsource: FastGPTSourceSchema.optional(),
+  lastsource: FastGPTSourceSchema.optional(),
   sourceDomain: z.string().optional()
 });
 export type FastGPTSemType = z.infer<typeof FastGPT_SEM_Schema>;

--- a/projects/app/src/pageComponents/login/LoginForm/LoginForm.tsx
+++ b/projects/app/src/pageComponents/login/LoginForm/LoginForm.tsx
@@ -15,6 +15,7 @@ import type { LangEnum } from '@fastgpt/global/common/i18n/type';
 import type { LoginSuccessResponseType } from '@fastgpt/global/openapi/support/user/account/login/api';
 import PolicyTip from './PolicyTip';
 import { getRegisterMethods } from '@/web/common/system/utils';
+import { getFastGPTSemForLogin, onFastGPTLoginSuccess } from '@/web/support/marketing/utils';
 
 type LoginSuccessHandler = (res: LoginSuccessResponseType) => void | Promise<void>;
 
@@ -50,9 +51,10 @@ const LoginForm = ({ setPageType, loginSuccess }: Props) => {
         username,
         password,
         code,
+        fastgpt_sem: getFastGPTSemForLogin(),
         language: i18n.language as LangEnum
       });
-      await loginSuccess(loginResponse);
+      await onFastGPTLoginSuccess(loginSuccess, loginResponse);
     },
     {
       refreshDeps: [loginSuccess],

--- a/projects/app/src/pageComponents/login/LoginForm/LoginForm.tsx
+++ b/projects/app/src/pageComponents/login/LoginForm/LoginForm.tsx
@@ -15,7 +15,7 @@ import type { LangEnum } from '@fastgpt/global/common/i18n/type';
 import type { LoginSuccessResponseType } from '@fastgpt/global/openapi/support/user/account/login/api';
 import PolicyTip from './PolicyTip';
 import { getRegisterMethods } from '@/web/common/system/utils';
-import { getFastGPTSemForLogin, onFastGPTLoginSuccess } from '@/web/support/marketing/utils';
+import { getFastGPTSem, onFastGPTLoginSuccess } from '@/web/support/marketing/utils';
 
 type LoginSuccessHandler = (res: LoginSuccessResponseType) => void | Promise<void>;
 
@@ -51,7 +51,7 @@ const LoginForm = ({ setPageType, loginSuccess }: Props) => {
         username,
         password,
         code,
-        fastgpt_sem: getFastGPTSemForLogin(),
+        fastgpt_sem: getFastGPTSem(),
         language: i18n.language as LangEnum
       });
       await onFastGPTLoginSuccess(loginSuccess, loginResponse);

--- a/projects/app/src/pageComponents/login/LoginForm/WechatForm.tsx
+++ b/projects/app/src/pageComponents/login/LoginForm/WechatForm.tsx
@@ -11,7 +11,7 @@ import Loading from '@fastgpt/web/components/common/MyLoading';
 import MyImage from '@fastgpt/web/components/common/Image/MyImage';
 import {
   getBdVId,
-  getFastGPTSemForLogin,
+  getFastGPTSem,
   getMsclkid,
   getInviterId,
   onFastGPTLoginSuccess
@@ -48,7 +48,7 @@ const WechatForm = ({ setPageType, loginSuccess }: Props) => {
         code: wechatInfo?.code || '',
         bd_vid: getBdVId(),
         msclkid: getMsclkid(),
-        fastgpt_sem: getFastGPTSemForLogin(),
+        fastgpt_sem: getFastGPTSem(),
         language: i18n.language as LangEnum
       }),
     {

--- a/projects/app/src/pageComponents/login/LoginForm/WechatForm.tsx
+++ b/projects/app/src/pageComponents/login/LoginForm/WechatForm.tsx
@@ -11,10 +11,10 @@ import Loading from '@fastgpt/web/components/common/MyLoading';
 import MyImage from '@fastgpt/web/components/common/Image/MyImage';
 import {
   getBdVId,
-  getFastGPTSem,
+  getFastGPTSemForLogin,
   getMsclkid,
-  removeFastGPTSem,
-  getInviterId
+  getInviterId,
+  onFastGPTLoginSuccess
 } from '@/web/support/marketing/utils';
 import PolicyTip from './PolicyTip';
 import type { LoginSuccessResponseType } from '@fastgpt/global/openapi/support/user/account/login/api';
@@ -48,7 +48,7 @@ const WechatForm = ({ setPageType, loginSuccess }: Props) => {
         code: wechatInfo?.code || '',
         bd_vid: getBdVId(),
         msclkid: getMsclkid(),
-        fastgpt_sem: getFastGPTSem(),
+        fastgpt_sem: getFastGPTSemForLogin(),
         language: i18n.language as LangEnum
       }),
     {
@@ -56,8 +56,7 @@ const WechatForm = ({ setPageType, loginSuccess }: Props) => {
       enabled: !!wechatInfo?.code,
       async onSuccess(data: LoginSuccessResponseType | undefined) {
         if (data) {
-          removeFastGPTSem();
-          await loginSuccess(data);
+          await onFastGPTLoginSuccess(loginSuccess, data);
         }
       }
     }

--- a/projects/app/src/pageComponents/login/RegisterForm.tsx
+++ b/projects/app/src/pageComponents/login/RegisterForm.tsx
@@ -13,7 +13,7 @@ import {
   getFastGPTSem,
   getInviterId,
   getMsclkid,
-  removeFastGPTSem
+  onFastGPTLoginSuccess
 } from '@/web/support/marketing/utils';
 import { checkPasswordRule } from '@fastgpt/global/common/string/password';
 import type { LoginSuccessResponseType } from '@fastgpt/global/openapi/support/user/account/login/api';
@@ -64,8 +64,7 @@ const RegisterForm = ({ setPageType, loginSuccess }: Props) => {
         fastgpt_sem: getFastGPTSem(),
         language: i18n.language as LangEnum
       });
-      await loginSuccess(loginResponse);
-      removeFastGPTSem();
+      await onFastGPTLoginSuccess(loginSuccess, loginResponse);
 
       toast({
         status: 'success',

--- a/projects/app/src/pages/api/support/user/account/loginByPassword.ts
+++ b/projects/app/src/pages/api/support/user/account/loginByPassword.ts
@@ -64,10 +64,10 @@ async function handler(
 
   user.lastLoginTmbId = userDetail.team.tmbId;
   user.language = language;
-  if (fastgpt_sem?.lastsource) {
+  if (fastgpt_sem?.home_source) {
     user.fastgpt_sem = {
       ...(user.fastgpt_sem || {}),
-      lastsource: fastgpt_sem.lastsource
+      lastsource: fastgpt_sem.home_source
     };
   }
   await user.save();

--- a/projects/app/src/pages/api/support/user/account/loginByPassword.ts
+++ b/projects/app/src/pages/api/support/user/account/loginByPassword.ts
@@ -26,7 +26,7 @@ async function handler(
   req: ApiRequestProps<LoginByPasswordBodyType>,
   res: ApiResponseType
 ): Promise<LoginSuccessResponseType> {
-  const { username, password, code, language } = parseApiInput({
+  const { username, password, code, language, fastgpt_sem } = parseApiInput({
     req,
     bodySchema: LoginByPasswordBodySchema
   }).body;
@@ -64,6 +64,12 @@ async function handler(
 
   user.lastLoginTmbId = userDetail.team.tmbId;
   user.language = language;
+  if (fastgpt_sem?.lastsource) {
+    user.fastgpt_sem = {
+      ...(user.fastgpt_sem || {}),
+      lastsource: fastgpt_sem.lastsource
+    };
+  }
   await user.save();
 
   const token = await createUserSession({

--- a/projects/app/src/pages/login/fastlogin.tsx
+++ b/projects/app/src/pages/login/fastlogin.tsx
@@ -12,6 +12,7 @@ import { validateRedirectUrl } from '@/web/common/utils/uri';
 import type { LoginSuccessResponseType } from '@fastgpt/global/openapi/support/user/account/login/api';
 import { useLoginRedirectAfterLogin } from '@/web/support/user/loginRedirect';
 import type { LangEnum } from '@fastgpt/global/common/i18n/type';
+import { getFastGPTSemForLogin, onFastGPTLoginSuccess } from '@/web/support/marketing/utils';
 
 const FastLogin = ({
   code,
@@ -55,6 +56,7 @@ const FastLogin = ({
         const res = await postFastLogin({
           code,
           token,
+          fastgpt_sem: getFastGPTSemForLogin(),
           language: i18n.language as LangEnum
         });
         if (!res) {
@@ -66,7 +68,7 @@ const FastLogin = ({
             router.replace('/login');
           }, 1000);
         }
-        await loginSuccess(res);
+        await onFastGPTLoginSuccess(loginSuccess, res);
       } catch (error) {
         toast({
           status: 'warning',

--- a/projects/app/src/pages/login/fastlogin.tsx
+++ b/projects/app/src/pages/login/fastlogin.tsx
@@ -12,7 +12,7 @@ import { validateRedirectUrl } from '@/web/common/utils/uri';
 import type { LoginSuccessResponseType } from '@fastgpt/global/openapi/support/user/account/login/api';
 import { useLoginRedirectAfterLogin } from '@/web/support/user/loginRedirect';
 import type { LangEnum } from '@fastgpt/global/common/i18n/type';
-import { getFastGPTSemForLogin, onFastGPTLoginSuccess } from '@/web/support/marketing/utils';
+import { getFastGPTSem, onFastGPTLoginSuccess } from '@/web/support/marketing/utils';
 
 const FastLogin = ({
   code,
@@ -56,7 +56,7 @@ const FastLogin = ({
         const res = await postFastLogin({
           code,
           token,
-          fastgpt_sem: getFastGPTSemForLogin(),
+          fastgpt_sem: getFastGPTSem(),
           language: i18n.language as LangEnum
         });
         if (!res) {

--- a/projects/app/src/pages/login/provider.tsx
+++ b/projects/app/src/pages/login/provider.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'next-i18next';
 import { OAuthEnum } from '@fastgpt/global/support/user/constant';
 import {
   getBdVId,
-  getFastGPTSemForLogin,
+  getFastGPTSem,
   getInviterId,
   getMsclkid,
   onFastGPTLoginSuccess
@@ -89,7 +89,7 @@ const provider = () => {
           inviterId: getInviterId(),
           bd_vid: getBdVId(),
           msclkid: getMsclkid(),
-          fastgpt_sem: getFastGPTSemForLogin(),
+          fastgpt_sem: getFastGPTSem(),
           language: i18n.language as LangEnum
         });
 

--- a/projects/app/src/pages/login/provider.tsx
+++ b/projects/app/src/pages/login/provider.tsx
@@ -12,10 +12,10 @@ import { useTranslation } from 'next-i18next';
 import { OAuthEnum } from '@fastgpt/global/support/user/constant';
 import {
   getBdVId,
-  getFastGPTSem,
+  getFastGPTSemForLogin,
   getInviterId,
   getMsclkid,
-  removeFastGPTSem
+  onFastGPTLoginSuccess
 } from '@/web/support/marketing/utils';
 import { postAcceptInvitationLink } from '@/web/support/user/team/api';
 import { retryFn } from '@fastgpt/global/common/system/utils';
@@ -89,7 +89,7 @@ const provider = () => {
           inviterId: getInviterId(),
           bd_vid: getBdVId(),
           msclkid: getMsclkid(),
-          fastgpt_sem: getFastGPTSem(),
+          fastgpt_sem: getFastGPTSemForLogin(),
           language: i18n.language as LangEnum
         });
 
@@ -103,8 +103,7 @@ const provider = () => {
           }, 1000);
         }
 
-        removeFastGPTSem();
-        await loginSuccess(res);
+        await onFastGPTLoginSuccess(loginSuccess, res);
       } catch (error) {
         toast({
           status: 'warning',

--- a/projects/app/src/web/context/useInitApp.ts
+++ b/projects/app/src/web/context/useInitApp.ts
@@ -185,7 +185,7 @@ export const useInitApp = () => {
       keyword: k,
       search,
       source: fastgpt_source,
-      firstsource: sourceValue,
+      home_source: sourceValue,
       ...utmParams
     });
 

--- a/projects/app/src/web/context/useInitApp.ts
+++ b/projects/app/src/web/context/useInitApp.ts
@@ -179,12 +179,13 @@ export const useInitApp = () => {
           ...sourceObject,
           ...(fastgpt_source ? { fastgpt_source } : {})
         }
-      : fastgpt_source;
+      : undefined;
 
     setFastGPTSem({
       keyword: k,
       search,
-      source: sourceValue,
+      source: fastgpt_source,
+      firstsource: sourceValue,
       ...utmParams
     });
 

--- a/projects/app/src/web/context/useInitApp.ts
+++ b/projects/app/src/web/context/useInitApp.ts
@@ -11,6 +11,7 @@ import {
   setBdVId,
   setFastGPTSem,
   initFastGPTSemSourceDomain,
+  parseFastGPTSource,
   setInviterId,
   setMsclkid,
   setUtmParams,
@@ -26,6 +27,7 @@ type MarketingQueryParams = {
   msclkid?: string;
   k?: string;
   search?: string;
+  source?: string;
   fastgpt_source?: string;
   sourceDomain?: string;
   utm_source?: string;
@@ -40,6 +42,7 @@ const MARKETING_PARAMS: (keyof MarketingQueryParams)[] = [
   'bd_vid',
   'msclkid',
   'k',
+  'source',
   'fastgpt_source',
   'sourceDomain',
   'utm_source',
@@ -57,6 +60,7 @@ export const useInitApp = () => {
     msclkid,
     k,
     search,
+    source,
     fastgpt_source,
     sourceDomain,
     utm_source,
@@ -157,18 +161,30 @@ export const useInitApp = () => {
     setUtmWorkflow(utm_workflow);
     initFastGPTSemSourceDomain(sourceDomain);
 
+    const sourceObject = parseFastGPTSource(source);
+    const sourceUtmSource = utm_source || sourceObject?.utm_source;
+    const sourceUtmMedium = utm_medium || sourceObject?.utm_medium;
+    const sourceUtmContent = utm_content || sourceObject?.utm_content;
     const utmParams: ShortUrlParams = {
-      ...(utm_source && { shortUrlSource: utm_source }),
-      ...(utm_medium && { shortUrlMedium: utm_medium }),
-      ...(utm_content && { shortUrlContent: utm_content })
+      ...(sourceUtmSource && { shortUrlSource: sourceUtmSource }),
+      ...(sourceUtmMedium && { shortUrlMedium: sourceUtmMedium }),
+      ...(sourceUtmContent && { shortUrlContent: sourceUtmContent })
     };
     if (utm_workflow) {
       setUtmParams(utmParams);
     }
+
+    const sourceValue = sourceObject
+      ? {
+          ...sourceObject,
+          ...(fastgpt_source ? { fastgpt_source } : {})
+        }
+      : fastgpt_source;
+
     setFastGPTSem({
       keyword: k,
       search,
-      source: fastgpt_source,
+      source: sourceValue,
       ...utmParams
     });
 

--- a/projects/app/src/web/support/marketing/utils.ts
+++ b/projects/app/src/web/support/marketing/utils.ts
@@ -1,5 +1,6 @@
 import {
   FastGPTSourceSchema,
+  FastGPTTrackSemSchema,
   type ShortUrlParams,
   type TrackRegisterParams
 } from '@fastgpt/global/support/marketing/type';
@@ -60,11 +61,13 @@ export const removeUtmParams = () => {
   localStorage.removeItem('utm_params');
 };
 
-export const getFastGPTSem = () => {
+export const getFastGPTSem = (): TrackRegisterParams['fastgpt_sem'] => {
   try {
-    return localStorage.getItem('fastgpt_sem')
-      ? JSON.parse(localStorage.getItem('fastgpt_sem')!)
-      : undefined;
+    const value = localStorage.getItem('fastgpt_sem');
+    if (!value) return undefined;
+
+    const result = FastGPTTrackSemSchema.safeParse(JSON.parse(value));
+    return result.success ? result.data : undefined;
   } catch {
     return undefined;
   }
@@ -80,17 +83,6 @@ export const parseFastGPTSource = (source?: string | string[]) => {
   } catch {
     return undefined;
   }
-};
-
-export const getFastGPTSemForLogin = () => {
-  const fastgptSem = getFastGPTSem();
-  if (!fastgptSem?.firstsource) return fastgptSem;
-
-  const { firstsource, ...rest } = fastgptSem;
-  return {
-    ...rest,
-    lastsource: firstsource
-  };
 };
 
 export const onFastGPTLoginSuccess = async <T>(

--- a/projects/app/src/web/support/marketing/utils.ts
+++ b/projects/app/src/web/support/marketing/utils.ts
@@ -1,4 +1,5 @@
 import {
+  FastGPTSourceSchema,
   type ShortUrlParams,
   type TrackRegisterParams
 } from '@fastgpt/global/support/marketing/type';
@@ -68,6 +69,19 @@ export const getFastGPTSem = () => {
     return undefined;
   }
 };
+
+export const parseFastGPTSource = (source?: string | string[]) => {
+  const sourceValue = Array.isArray(source) ? source[0] : source;
+  if (!sourceValue) return undefined;
+
+  try {
+    const result = FastGPTSourceSchema.safeParse(JSON.parse(sourceValue));
+    return result.success ? result.data : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 export const setFastGPTSem = (fastgptSem?: TrackRegisterParams['fastgpt_sem']) => {
   if (!fastgptSem) return;
 

--- a/projects/app/src/web/support/marketing/utils.ts
+++ b/projects/app/src/web/support/marketing/utils.ts
@@ -82,6 +82,25 @@ export const parseFastGPTSource = (source?: string | string[]) => {
   }
 };
 
+export const getFastGPTSemForLogin = () => {
+  const fastgptSem = getFastGPTSem();
+  if (!fastgptSem?.firstsource) return fastgptSem;
+
+  const { firstsource, ...rest } = fastgptSem;
+  return {
+    ...rest,
+    lastsource: firstsource
+  };
+};
+
+export const onFastGPTLoginSuccess = async <T>(
+  loginSuccess: (result: T) => void | Promise<void>,
+  result: T
+) => {
+  await loginSuccess(result);
+  removeFastGPTSem();
+};
+
 export const setFastGPTSem = (fastgptSem?: TrackRegisterParams['fastgpt_sem']) => {
   if (!fastgptSem) return;
 

--- a/projects/app/test/api/support/user/account/loginByPassword.test.ts
+++ b/projects/app/test/api/support/user/account/loginByPassword.test.ts
@@ -49,7 +49,7 @@ describe('loginByPassword API', () => {
   });
 
   it('should login successfully with valid credentials', async () => {
-    const res = await Call<LoginByPasswordBodyType, {}, any>(loginApi.default, {
+    const res = await Call<LoginByPasswordBodyType, Record<string, never>, any>(loginApi.default, {
       body: {
         username: 'testuser',
         password: 'testpassword',
@@ -84,7 +84,7 @@ describe('loginByPassword API', () => {
   });
 
   it('should reject login when username is empty', async () => {
-    const res = await Call<LoginByPasswordBodyType, {}, any>(loginApi.default, {
+    const res = await Call<LoginByPasswordBodyType, Record<string, never>, any>(loginApi.default, {
       body: {
         username: '',
         password: 'testpassword',
@@ -97,7 +97,7 @@ describe('loginByPassword API', () => {
   });
 
   it('should reject login when password is empty', async () => {
-    const res = await Call<LoginByPasswordBodyType, {}, any>(loginApi.default, {
+    const res = await Call<LoginByPasswordBodyType, Record<string, never>, any>(loginApi.default, {
       body: {
         username: 'testuser',
         password: '',
@@ -114,7 +114,7 @@ describe('loginByPassword API', () => {
   it('should reject login when auth code verification fails', async () => {
     vi.mocked(authCode).mockRejectedValueOnce(new Error('Invalid code'));
 
-    const res = await Call<LoginByPasswordBodyType, {}, any>(loginApi.default, {
+    const res = await Call<LoginByPasswordBodyType, Record<string, never>, any>(loginApi.default, {
       body: {
         username: 'testuser',
         password: 'testpassword',
@@ -128,7 +128,7 @@ describe('loginByPassword API', () => {
   });
 
   it('should reject login when user does not exist', async () => {
-    const res = await Call<LoginByPasswordBodyType, {}, any>(loginApi.default, {
+    const res = await Call<LoginByPasswordBodyType, Record<string, never>, any>(loginApi.default, {
       body: {
         username: 'nonexistentuser',
         password: 'testpassword',
@@ -146,7 +146,7 @@ describe('loginByPassword API', () => {
       status: UserStatusEnum.forbidden
     });
 
-    const res = await Call<LoginByPasswordBodyType, {}, any>(loginApi.default, {
+    const res = await Call<LoginByPasswordBodyType, Record<string, never>, any>(loginApi.default, {
       body: {
         username: 'testuser',
         password: 'testpassword',
@@ -160,7 +160,7 @@ describe('loginByPassword API', () => {
   });
 
   it('should reject login when password is incorrect', async () => {
-    const res = await Call<LoginByPasswordBodyType, {}, any>(loginApi.default, {
+    const res = await Call<LoginByPasswordBodyType, Record<string, never>, any>(loginApi.default, {
       body: {
         username: 'testuser',
         password: 'wrongpassword',
@@ -174,7 +174,7 @@ describe('loginByPassword API', () => {
   });
 
   it('should update language on successful login', async () => {
-    const res = await Call<LoginByPasswordBodyType, {}, any>(loginApi.default, {
+    const res = await Call<LoginByPasswordBodyType, Record<string, never>, any>(loginApi.default, {
       body: {
         username: 'testuser',
         password: 'testpassword',
@@ -188,6 +188,32 @@ describe('loginByPassword API', () => {
     const updatedUser = await MongoUser.findById(testUser._id);
     expect(updatedUser?.language).toBe('en');
     expect(updatedUser?.lastLoginTmbId).toEqual(testTmb._id);
+  });
+
+  it('should persist lastsource on successful login', async () => {
+    const lastsource = {
+      visitor_id: 'visitor-1',
+      last_touch_channel: 'search',
+      last_touch_source: 'Google'
+    };
+
+    const res = await Call<LoginByPasswordBodyType, Record<string, never>, any>(loginApi.default, {
+      body: {
+        username: 'testuser',
+        password: 'testpassword',
+        code: '123456',
+        fastgpt_sem: {
+          source: 'home_hero_trial',
+          lastsource
+        },
+        language: 'zh-CN'
+      }
+    });
+
+    expect(res.code).toBe(200);
+
+    const updatedUser = await MongoUser.findById(testUser._id).lean();
+    expect(updatedUser?.fastgpt_sem).toMatchObject({ lastsource });
   });
 
   it('should handle root user login correctly', async () => {
@@ -217,7 +243,7 @@ describe('loginByPassword API', () => {
       lastLoginTmbId: rootTmb._id
     });
 
-    const res = await Call<LoginByPasswordBodyType, {}, any>(loginApi.default, {
+    const res = await Call<LoginByPasswordBodyType, Record<string, never>, any>(loginApi.default, {
       body: {
         username: 'root',
         password: 'rootpassword',
@@ -236,7 +262,7 @@ describe('loginByPassword API', () => {
   describe('NoSQL injection prevention', () => {
     it('should reject password as object with MongoDB operator ($ne)', async () => {
       // GHSA-jxvr-h2vx-p73r Step 2: password: {"$ne": ""} bypasses password check
-      const res = await Call<any, {}, any>(loginApi.default, {
+      const res = await Call<any, Record<string, never>, any>(loginApi.default, {
         body: {
           username: 'testuser',
           password: { $ne: '' },
@@ -252,7 +278,7 @@ describe('loginByPassword API', () => {
     });
 
     it('should reject password with $regex operator', async () => {
-      const res = await Call<any, {}, any>(loginApi.default, {
+      const res = await Call<any, Record<string, never>, any>(loginApi.default, {
         body: {
           username: 'testuser',
           password: { $regex: '.*' },
@@ -265,7 +291,7 @@ describe('loginByPassword API', () => {
     });
 
     it('should reject password with $where injection', async () => {
-      const res = await Call<any, {}, any>(loginApi.default, {
+      const res = await Call<any, Record<string, never>, any>(loginApi.default, {
         body: {
           username: 'testuser',
           password: { $where: 'return true' },
@@ -278,7 +304,7 @@ describe('loginByPassword API', () => {
     });
 
     it('should reject username as object with MongoDB operator', async () => {
-      const res = await Call<any, {}, any>(loginApi.default, {
+      const res = await Call<any, Record<string, never>, any>(loginApi.default, {
         body: {
           username: { $ne: '' },
           password: 'testpassword',
@@ -291,7 +317,7 @@ describe('loginByPassword API', () => {
     });
 
     it('should reject code as object with MongoDB operator', async () => {
-      const res = await Call<any, {}, any>(loginApi.default, {
+      const res = await Call<any, Record<string, never>, any>(loginApi.default, {
         body: {
           username: 'testuser',
           password: 'testpassword',
@@ -304,7 +330,7 @@ describe('loginByPassword API', () => {
     });
 
     it('should reject all fields as injection objects simultaneously', async () => {
-      const res = await Call<any, {}, any>(loginApi.default, {
+      const res = await Call<any, Record<string, never>, any>(loginApi.default, {
         body: {
           username: { $ne: '' },
           password: { $ne: '' },
@@ -317,7 +343,7 @@ describe('loginByPassword API', () => {
     });
 
     it('should reject password as non-string types (array, number)', async () => {
-      const arrayRes = await Call<any, {}, any>(loginApi.default, {
+      const arrayRes = await Call<any, Record<string, never>, any>(loginApi.default, {
         body: {
           username: 'testuser',
           password: ['testpassword'],
@@ -327,7 +353,7 @@ describe('loginByPassword API', () => {
       });
       expect(arrayRes.code).toBe(500);
 
-      const numberRes = await Call<any, {}, any>(loginApi.default, {
+      const numberRes = await Call<any, Record<string, never>, any>(loginApi.default, {
         body: {
           username: 'testuser',
           password: 12345,

--- a/projects/app/test/api/support/user/account/loginByPassword.test.ts
+++ b/projects/app/test/api/support/user/account/loginByPassword.test.ts
@@ -190,8 +190,8 @@ describe('loginByPassword API', () => {
     expect(updatedUser?.lastLoginTmbId).toEqual(testTmb._id);
   });
 
-  it('should persist lastsource on successful login', async () => {
-    const lastsource = {
+  it('should persist home_source as lastsource on successful login', async () => {
+    const homeSource = {
       visitor_id: 'visitor-1',
       last_touch_channel: 'search',
       last_touch_source: 'Google'
@@ -204,7 +204,7 @@ describe('loginByPassword API', () => {
         code: '123456',
         fastgpt_sem: {
           source: 'home_hero_trial',
-          lastsource
+          home_source: homeSource
         },
         language: 'zh-CN'
       }
@@ -213,7 +213,7 @@ describe('loginByPassword API', () => {
     expect(res.code).toBe(200);
 
     const updatedUser = await MongoUser.findById(testUser._id).lean();
-    expect(updatedUser?.fastgpt_sem).toMatchObject({ lastsource });
+    expect(updatedUser?.fastgpt_sem).toMatchObject({ lastsource: homeSource });
   });
 
   it('should handle root user login correctly', async () => {

--- a/projects/app/test/web/support/marketing/utils.test.ts
+++ b/projects/app/test/web/support/marketing/utils.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getFastGPTSem,
   initFastGPTSemSourceDomain,
+  parseFastGPTSource,
   removeFastGPTSem
 } from '@/web/support/marketing/utils';
 
@@ -37,5 +38,25 @@ describe('marketing utils', () => {
     initFastGPTSemSourceDomain('https://example.com');
 
     expect(getFastGPTSem()?.sourceDomain).toBe('https://example.com');
+  });
+
+  it('should parse the source attribution object from the URL', () => {
+    expect(
+      parseFastGPTSource(
+        JSON.stringify({
+          visitor_id: 'visitor-1',
+          first_touch_source: 'ChatGPT',
+          is_paid: false
+        })
+      )
+    ).toMatchObject({
+      visitor_id: 'visitor-1',
+      first_touch_source: 'ChatGPT',
+      is_paid: false
+    });
+  });
+
+  it('should ignore an invalid source attribution object', () => {
+    expect(parseFastGPTSource('{invalid')).toBeUndefined();
   });
 });

--- a/projects/app/test/web/support/marketing/utils.test.ts
+++ b/projects/app/test/web/support/marketing/utils.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getFastGPTSem,
-  getFastGPTSemForLogin,
   initFastGPTSemSourceDomain,
   onFastGPTLoginSuccess,
   parseFastGPTSource,
@@ -63,27 +62,42 @@ describe('marketing utils', () => {
     expect(parseFastGPTSource('{invalid')).toBeUndefined();
   });
 
-  it('should send firstsource as lastsource for login', () => {
+  it('should keep home source independent from first and last source', () => {
     setFastGPTSem({
       source: 'home_hero_trial',
-      firstsource: {
+      home_source: {
         visitor_id: 'visitor-1',
         first_touch_source: 'ChatGPT'
       }
     });
 
-    expect(getFastGPTSemForLogin()).toEqual({
+    expect(getFastGPTSem()).toEqual({
       source: 'home_hero_trial',
-      lastsource: {
+      home_source: {
         visitor_id: 'visitor-1',
         first_touch_source: 'ChatGPT'
       }
     });
   });
 
+  it('should not send persisted first and last source fields from the client', () => {
+    localStorage.setItem(
+      'fastgpt_sem',
+      JSON.stringify({
+        home_source: { visitor_id: 'visitor-current' },
+        firstsource: { visitor_id: 'visitor-first' },
+        lastsource: { visitor_id: 'visitor-last' }
+      })
+    );
+
+    expect(getFastGPTSem()).toEqual({
+      home_source: { visitor_id: 'visitor-current' }
+    });
+  });
+
   it('should clear pending marketing data after login succeeds', async () => {
     setFastGPTSem({
-      firstsource: { visitor_id: 'visitor-1' }
+      home_source: { visitor_id: 'visitor-1' }
     });
     const loginSuccess = vi.fn();
 

--- a/projects/app/test/web/support/marketing/utils.test.ts
+++ b/projects/app/test/web/support/marketing/utils.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getFastGPTSem,
+  getFastGPTSemForLogin,
   initFastGPTSemSourceDomain,
+  onFastGPTLoginSuccess,
   parseFastGPTSource,
-  removeFastGPTSem
+  removeFastGPTSem,
+  setFastGPTSem
 } from '@/web/support/marketing/utils';
 
 const storageMock = () => {
@@ -58,5 +61,35 @@ describe('marketing utils', () => {
 
   it('should ignore an invalid source attribution object', () => {
     expect(parseFastGPTSource('{invalid')).toBeUndefined();
+  });
+
+  it('should send firstsource as lastsource for login', () => {
+    setFastGPTSem({
+      source: 'home_hero_trial',
+      firstsource: {
+        visitor_id: 'visitor-1',
+        first_touch_source: 'ChatGPT'
+      }
+    });
+
+    expect(getFastGPTSemForLogin()).toEqual({
+      source: 'home_hero_trial',
+      lastsource: {
+        visitor_id: 'visitor-1',
+        first_touch_source: 'ChatGPT'
+      }
+    });
+  });
+
+  it('should clear pending marketing data after login succeeds', async () => {
+    setFastGPTSem({
+      firstsource: { visitor_id: 'visitor-1' }
+    });
+    const loginSuccess = vi.fn();
+
+    await onFastGPTLoginSuccess(loginSuccess, { ok: true });
+
+    expect(loginSuccess).toHaveBeenCalledWith({ ok: true });
+    expect(getFastGPTSem()).toBeUndefined();
   });
 });

--- a/projects/app/test/web/support/user/api.test.ts
+++ b/projects/app/test/web/support/user/api.test.ts
@@ -51,6 +51,10 @@ describe('user api', () => {
       fastgpt_sem: {
         keyword: 'sem123',
         source: 'home_hero_trial',
+        home_source: {
+          visitor_id: 'visitor-1',
+          first_touch_source: 'ChatGPT'
+        },
         sourceDomain: 'https://example.com'
       }
     };


### PR DESCRIPTION
## Summary
- Keep `fastgpt_sem.source` as the existing CTA placement string.
- Receive the home attribution payload as a single transport field: `fastgpt_sem.home_source`.
- Separate the client transport schema from persisted user attribution fields, so clients cannot assign `firstsource` or `lastsource`.
- Send the same `home_source` payload for registration, password, OAuth, WeChat, and fast login.
- Map `home_source` to persisted `lastsource` in the open-source password-login endpoint while preserving existing attribution data.
- Keep authentication-success cleanup centralized in `onFastGPTLoginSuccess`.

The registration endpoint is implemented under `proApi` and is not present in this repository. It should map `home_source` to persisted `firstsource` when creating the user. The OAuth, WeChat, and fast-login Pro endpoints should map it to `lastsource`.

## Verification
- Targeted marketing, user API, and password-login tests: 45 passed.
- Changed-file ESLint and Prettier checks passed.
- Type checking reaches only the existing missing `runtimeUpgradeModalBg.jpg` asset error.