### PR TITLE
feat: add direct sandbox workspace preview

### DIFF
--- a/.agents/design/core/ai/sandbox/workspace-direct-preview.md
+++ b/.agents/design/core/ai/sandbox/workspace-direct-preview.md
@@ -1,0 +1,145 @@
+# Agent Sandbox Workspace Direct Preview
+
+## 1. Goal
+
+Replace sandbox file S3 export with a short-lived, read-only URL:
+
+```text
+https://agent-proxy.fastgpt.cn/preview/{token}/test/preview.html
+```
+
+The token authenticates one sandbox workspace. The remaining URL is resolved as a workspace-relative
+path. File bytes flow from the sandbox IDE agent through `agent-sandbox-proxy`; FastGPT only authenticates
+the business session, signs the token, and resolves the provider endpoint.
+
+## 2. Scope
+
+- Replace HTML S3 preview with direct workspace preview.
+- Replace `sandbox_get_file_url` S3 uploads with direct workspace URLs.
+- Support `GET`, `HEAD`, content type, content length, ETag, and single byte ranges.
+- Preserve relative HTML references such as `./assets/app.js` and `../images/a.png`.
+- Keep existing `fs` and `terminal` WebSocket behavior unchanged.
+- Support provider endpoint resolution through `ISandbox.getEndpoint`.
+
+The existing S3 workspace archive lifecycle is unrelated and remains unchanged.
+
+## 3. Architecture
+
+```text
+Browser / model
+  -> GET /preview/{token}/{workspacePath}
+  -> agent-sandbox-proxy
+       1. verifies HMAC token locally
+       2. resolves the sandbox endpoint through FastGPT verifyTicket using an internal header
+       3. proxies an authenticated HTTP request to port 1319
+  -> fastgpt-ide-agent preview listener
+       1. validates the internal agent password
+       2. confines the path to FASTGPT_WORKDIR
+       3. streams the file response
+```
+
+## 4. Token Contract
+
+Preview tokens reuse `AGENT_SANDBOX_PROXY_SECRET` and the existing business identity claims:
+
+```ts
+{
+  sourceType,
+  sourceId,
+  userId,
+  chatId,
+  teamId,
+  channel: 'preview',
+  permission: 'read',
+  exp
+}
+```
+
+The token never contains provider endpoints or the IDE agent password. The default lifetime remains two
+hours to preserve the existing `sandbox_get_file_url` contract.
+
+## 5. HTTP Contracts
+
+### 5.1 Public proxy
+
+```text
+GET|HEAD /preview/{token}/{*path}
+```
+
+- `token` is one base64url JWT path segment.
+- `path` is workspace-relative.
+- Other methods return `405`.
+- The upstream host and port always come from FastGPT ticket resolution.
+
+### 5.2 Sandbox preview listener
+
+```text
+GET|HEAD /preview/{*path}
+X-FastGPT-Agent-Token: {agentPassword}
+```
+
+- Binds to `IDE_AGENT_PREVIEW_BIND_ADDR`, default `0.0.0.0:1319`.
+- Uses `FASTGPT_WORKDIR` as the root.
+- Does not expose directory listings.
+- Rejects absolute paths, traversal, invalid encodings, and symlinks escaping the workspace.
+
+## 6. FastGPT Changes
+
+- Add reusable preview token signing and URL construction in the sandbox application layer.
+- Derive the public HTTP proxy URL from `AGENT_SANDBOX_PROXY_URL` (`ws -> http`, `wss -> https`).
+- Change `getHtmlPreviewLink` to validate the session and return a preview URL without reading/uploading
+  the HTML file.
+- Change `sandbox_get_file_url` to return preview URLs without reading/uploading the files.
+- Extend internal ticket verification with `channel=preview` and endpoint port `1319`.
+- Thread `teamId` through sandbox tool execution so preview claims retain the real tenant identity.
+- Update OpenAPI descriptions and tool descriptions to remove S3 semantics.
+
+## 7. Resource Reference Behavior
+
+Given:
+
+```text
+/preview/{token}/test/preview.html
+```
+
+- `./assets/app.js` resolves to `/preview/{token}/test/assets/app.js` and works.
+- `../images/a.png` resolves to `/preview/{token}/images/a.png` and works.
+- `/assets/app.js` loses the token prefix and is intentionally unsupported in this path-based version.
+
+The sandbox system prompt must require relative asset paths for generated previews.
+
+## 8. Security
+
+- A preview URL is a bearer capability for read-only access to the token's whole workspace.
+- Preview content uses the existing proxy origin, which must remain separate from the FastGPT app origin.
+- Responses set `Referrer-Policy: no-referrer`, `X-Content-Type-Options: nosniff`, and
+  `Cache-Control: private, no-store`.
+- Proxy and ingress logs must redact the token path segment.
+- The proxy sends tickets to FastGPT in `X-Sandbox-Ticket`, not the query string, so the main app's
+  request logs do not contain bearer tokens. FastGPT temporarily accepts the old query transport for rollout.
+- The proxy does not accept an upstream URL, host, scheme, or port from the client.
+- Cached endpoint resolution uses SHA-256 token keys and never bypasses local token expiration checks.
+
+## 9. Compatibility And Rollout
+
+- Sandbox runtime images must include the preview listener before FastGPT starts issuing preview URLs.
+- Old sandboxes without port 1319 return a clear proxy error; local integration uses a freshly built image.
+- Upgrade FastGPT before agent-sandbox-proxy: the app accepts both old query tickets and new header tickets,
+  while the new proxy only uses the non-logging header transport.
+- `fs`, `terminal`, editor upload/download, and workspace S3 archive paths remain unchanged.
+- Local verification builds worktree images and runs them against the existing Docker dependencies.
+
+## 10. TODO
+
+- [x] Implement and test the IDE agent preview HTTP listener.
+- [x] Implement and test proxy preview routing and streaming relay.
+- [x] Add preview token signing, ticket verification, and URL helpers.
+- [x] Replace HTML preview S3 upload.
+- [x] Replace `sandbox_get_file_url` S3 upload.
+- [x] Thread `teamId` through sandbox tool calls.
+- [x] Update OpenAPI, environment/runtime contracts, prompt, and rollout notes.
+- [x] Build local sandbox and proxy images.
+- [x] Run TypeScript and Rust unit tests.
+- [x] Run an OpenSandbox end-to-end test with HTML, CSS, image, HEAD, Range, expiry, auth, and missing files.
+- [x] Cover traversal and escaping symlinks in unit tests.
+- [x] Run repository-wide final validation.

--- a/packages/global/core/ai/sandbox/constants.ts
+++ b/packages/global/core/ai/sandbox/constants.ts
@@ -51,4 +51,5 @@ export const SANDBOX_SYSTEM_PROMPT = `## 沙盒能力
 - 使用 ${SANDBOX_EDIT_FILE_TOOL_NAME} 对已有文件做精确查找替换
 - 使用 ${SANDBOX_SEARCH_TOOL_NAME} 搜索沙盒内的文件路径
 - 默认将生成文件保存在当前 sandbox 工作目录；若本轮 system-reminder 指定了更具体的产物目录或禁止目录，必须优先遵守
+- HTML 等多文件预览产物必须使用相对资源路径（例如 ./assets/app.js），不要使用 /assets/app.js 这类根路径
 - 若需要将生成的文件链接，可使用 ${SANDBOX_GET_FILE_URL_TOOL_NAME} 获取临时访问链接`;

--- a/packages/global/core/ai/sandbox/tools/getFileUrl.ts
+++ b/packages/global/core/ai/sandbox/tools/getFileUrl.ts
@@ -13,7 +13,7 @@ export const SANDBOX_GET_FILE_URL_TOOL: ChatCompletionTool = {
   type: 'function',
   function: {
     name: SANDBOX_GET_FILE_URL_TOOL_NAME,
-    description: '从虚拟机读取指定文件，上传至云存储，返回 2 小时有效期的访问链接',
+    description: '为虚拟机 workspace 中的指定文件返回 2 小时有效期的直连访问链接',
     parameters: {
       type: 'object',
       properties: {
@@ -21,9 +21,9 @@ export const SANDBOX_GET_FILE_URL_TOOL: ChatCompletionTool = {
           type: 'array',
           items: {
             type: 'string',
-            description: '文件访问路径，例如: output.csv'
+            description: 'workspace 文件路径，例如: output.csv'
           },
-          description: '文件访问路径，例如: ["output.csv", "output.txt"]'
+          description: 'workspace 文件路径，例如: ["output.csv", "output.txt"]'
         }
       },
       required: ['paths']

--- a/packages/global/openapi/core/ai/sandbox/api.ts
+++ b/packages/global/openapi/core/ai/sandbox/api.ts
@@ -116,12 +116,21 @@ export type SandboxGetTicketResponse = z.infer<typeof SandboxGetTicketResponseSc
  */
 export const SandboxGetHtmlPreviewLinkBodyRawSchema = createOutLinkChatTargetInputSchema({
   ...SandboxBaseShape,
-  filePath: z.string().describe('文件路径')
+  filePath: z.string().meta({
+    example: 'dist/index.html',
+    description: 'HTML 文件路径，相对于沙盒 workspace 根目录'
+  })
 });
 export const SandboxGetHtmlPreviewLinkBodySchema = withSandboxTarget({
-  filePath: z.string().describe('文件路径')
+  filePath: z.string().meta({
+    example: 'dist/index.html',
+    description: 'HTML 文件路径，相对于沙盒 workspace 根目录'
+  })
 });
-export const SandboxGetHtmlPreviewLinkResponseSchema = z.string().describe('HTML 预览链接');
+export const SandboxGetHtmlPreviewLinkResponseSchema = z.string().url().meta({
+  example: 'https://agent-proxy.example.com/preview/token/dist/index.html',
+  description: '由 agent-proxy 直接读取 sandbox workspace 的短期 HTML 预览链接'
+});
 export type SandboxGetHtmlPreviewLinkBody = z.input<typeof SandboxGetHtmlPreviewLinkBodySchema>;
 export type SandboxGetHtmlPreviewLinkRuntimeBody = z.output<
   typeof SandboxGetHtmlPreviewLinkBodySchema

--- a/packages/global/openapi/core/ai/sandbox/index.ts
+++ b/packages/global/openapi/core/ai/sandbox/index.ts
@@ -70,7 +70,8 @@ export const SandboxPath: OpenAPIPath = {
   '/core/ai/sandbox/getHtmlPreviewLink': {
     post: {
       summary: '获取 HTML 文件预览链接',
-      description: '返回用于在浏览器中预览 HTML 文件的链接（S3 托管）',
+      description:
+        '校验文件后签发短期只读链接，由 agent-proxy 直接转发 sandbox workspace 内容，不复制到对象存储',
       tags: [DevApiTagsMap.sandbox],
       requestBody: {
         content: {

--- a/packages/service/core/ai/sandbox/application/preview.ts
+++ b/packages/service/core/ai/sandbox/application/preview.ts
@@ -1,0 +1,135 @@
+/**
+ * 沙盒业务层：签发并解析 workspace 只读预览链接。
+ *
+ * Preview token 只携带业务归属，不包含 provider endpoint 或 IDE Agent 内部口令。文件路径
+ * 必须落在当前 provider 的 workDirectory 内，并以 URL path segment 形式传给 agent-proxy。
+ */
+import jwt from 'jsonwebtoken';
+import z from 'zod';
+import { ChatSourceTypeEnum } from '@fastgpt/global/core/chat/constants';
+import { serviceEnv } from '../../../../env';
+import { resolveSandboxWorkspacePath } from './file';
+import { getSandboxRuntimeProfile } from '../infrastructure/provider/runtimeProfile';
+import { trimSandboxPathRight } from '../utils';
+
+export const SANDBOX_PREVIEW_CHANNEL = 'preview' as const;
+export const SANDBOX_PREVIEW_PERMISSION = 'read' as const;
+export const SANDBOX_PREVIEW_TOKEN_EXPIRES_SECONDS = 2 * 60 * 60;
+
+export const SandboxPreviewTicketContextSchema = z.object({
+  sourceType: z.enum(ChatSourceTypeEnum),
+  sourceId: z.string().min(1),
+  userId: z.string(),
+  chatId: z.string().min(1),
+  teamId: z.string().min(1)
+});
+export type SandboxPreviewTicketContext = z.infer<typeof SandboxPreviewTicketContextSchema>;
+
+export const SandboxPreviewTicketClaimsSchema = SandboxPreviewTicketContextSchema.extend({
+  channel: z.literal(SANDBOX_PREVIEW_CHANNEL),
+  permission: z.literal(SANDBOX_PREVIEW_PERMISSION),
+  iat: z.number().int().nonnegative(),
+  exp: z.number().int().positive()
+});
+export type SandboxPreviewTicketClaims = z.infer<typeof SandboxPreviewTicketClaimsSchema>;
+
+const getPreviewSecret = () => {
+  const secret = serviceEnv.AGENT_SANDBOX_PROXY_SECRET;
+  if (!secret) {
+    throw new Error('AGENT_SANDBOX_PROXY_SECRET environment variable is missing');
+  }
+  return secret;
+};
+
+/** 签发一个可读取当前 sandbox workspace 的短期 bearer token。 */
+export function createSandboxPreviewTicket(context: SandboxPreviewTicketContext): string {
+  const parsedContext = SandboxPreviewTicketContextSchema.parse(context);
+  return jwt.sign(
+    {
+      ...parsedContext,
+      channel: SANDBOX_PREVIEW_CHANNEL,
+      permission: SANDBOX_PREVIEW_PERMISSION
+    },
+    getPreviewSecret(),
+    { expiresIn: SANDBOX_PREVIEW_TOKEN_EXPIRES_SECONDS }
+  );
+}
+
+/** 校验 preview token，并返回已收窄的业务 claims。 */
+export function verifySandboxPreviewTicket(token: string): SandboxPreviewTicketClaims {
+  return SandboxPreviewTicketClaimsSchema.parse(jwt.verify(token, getPreviewSecret()));
+}
+
+/**
+ * 将工具/API 输入路径规整为 provider 绝对路径和 workspace 相对路径。
+ *
+ * 内部工具历史上允许传入 `/workspace/file` 绝对路径，因此这里兼容 workspace 内绝对路径；
+ * workspace 外路径、空路径、反斜杠、控制字符和非规范 segment 一律拒绝。
+ */
+export function resolveSandboxPreviewPath(filePath: string): {
+  providerPath: string;
+  relativePath: string;
+} {
+  if (!filePath || filePath.includes('\\') || /[\u0000-\u001F\u007F]/.test(filePath)) {
+    throw new Error('Invalid sandbox preview path');
+  }
+
+  const workDirectory = trimSandboxPathRight(getSandboxRuntimeProfile().workDirectory);
+  const providerPath = resolveSandboxWorkspacePath(filePath, workDirectory || '/', {
+    allowAbsolutePath: true
+  });
+  const relativePath = providerPath.slice(workDirectory.length).replace(/^\/+/, '');
+  const segments = relativePath.split('/');
+  if (
+    !relativePath ||
+    segments.some((segment) => !segment || segment === '.' || segment === '..')
+  ) {
+    throw new Error('Invalid sandbox preview path');
+  }
+
+  return { providerPath, relativePath };
+}
+
+const getSandboxPreviewProxyBaseUrl = () => {
+  const rawUrl = serviceEnv.AGENT_SANDBOX_PROXY_URL;
+  if (!rawUrl) {
+    throw new Error('AGENT_SANDBOX_PROXY_URL environment variable is missing');
+  }
+
+  const url = new URL(rawUrl);
+  url.protocol = (() => {
+    if (url.protocol === 'ws:') return 'http:';
+    if (url.protocol === 'wss:') return 'https:';
+    throw new Error('AGENT_SANDBOX_PROXY_URL must start with ws:// or wss://');
+  })();
+  url.search = '';
+  url.hash = '';
+  return url.toString().replace(/\/+$/, '');
+};
+
+/** 使用已签发的 token 构建一个 workspace 文件 URL。 */
+export function buildSandboxPreviewFileUrl({
+  ticket,
+  filePath
+}: {
+  ticket: string;
+  filePath: string;
+}): string {
+  const { relativePath } = resolveSandboxPreviewPath(filePath);
+  const encodedPath = relativePath.split('/').map(encodeURIComponent).join('/');
+  return `${getSandboxPreviewProxyBaseUrl()}/preview/${encodeURIComponent(ticket)}/${encodedPath}`;
+}
+
+/** 为一个 workspace 文件签发 token 并返回完整 direct preview URL。 */
+export function createSandboxPreviewFileUrl({
+  context,
+  filePath
+}: {
+  context: SandboxPreviewTicketContext;
+  filePath: string;
+}): string {
+  return buildSandboxPreviewFileUrl({
+    ticket: createSandboxPreviewTicket(context),
+    filePath
+  });
+}

--- a/packages/service/core/ai/sandbox/application/toolCall/getFileUrl.tool.ts
+++ b/packages/service/core/ai/sandbox/application/toolCall/getFileUrl.tool.ts
@@ -1,15 +1,17 @@
 /**
  * 沙盒业务层：定义 sandbox 文件临时下载链接工具。
  *
- * 只负责把 sandbox 文件流转存到 chat S3 临时对象，不处理运行态生命周期。
+ * 只负责确认 workspace 文件存在并返回 agent-proxy 直连链接，不处理运行态生命周期。
  */
 import z from 'zod';
 import path from 'path';
-import { Readable } from 'stream';
-import { addHours } from 'date-fns';
 import { defineTool } from './type';
-import { getS3ChatSource } from '../../../../../common/s3/sources/chat';
 import { SANDBOX_GET_FILE_URL_TOOL_NAME } from '@fastgpt/global/core/ai/sandbox/tools';
+import {
+  buildSandboxPreviewFileUrl,
+  createSandboxPreviewTicket,
+  resolveSandboxPreviewPath
+} from '../preview';
 
 const SandboxGetFileUrlToolSchema = z.object({
   paths: z.array(z.string())
@@ -17,34 +19,32 @@ const SandboxGetFileUrlToolSchema = z.object({
 
 export const sandboxGetFileUrlTool = defineTool({
   zodSchema: SandboxGetFileUrlToolSchema,
-  execute: async ({ sourceType, sourceId, userId, chatId, sandboxInstance, params }) => {
-    const result = await Promise.all(
-      params.paths.map(async (filePath) => {
-        const filename = path.basename(filePath);
-        const stream = sandboxInstance.provider.readFileStream(filePath);
-        const readable = Readable.from(stream);
-
-        const chatBucket = getS3ChatSource();
-        const expiredTime = addHours(new Date(), 2);
-        const { key } = await chatBucket.uploadChatFile({
-          sourceType,
-          sourceId,
-          chatId,
-          uId: userId,
-          filename,
-          body: readable,
-          expiredTime
-        });
-        const { url: fileUrl } = await chatBucket.createGetChatFileURL({
-          key,
-          expiredHours: 2,
-          external: true,
-          mode: 'presigned'
-        });
-
-        return { fileUrl, filename };
-      })
+  execute: async ({ sourceType, sourceId, userId, chatId, teamId, sandboxInstance, params }) => {
+    const files = params.paths.map((filePath) => ({
+      filePath,
+      ...resolveSandboxPreviewPath(filePath)
+    }));
+    const fileInfoMap = await sandboxInstance.provider.getFileInfo(
+      files.map(({ providerPath }) => providerPath)
     );
+    for (const { providerPath } of files) {
+      const fileInfo = fileInfoMap.get(providerPath);
+      if (!fileInfo || fileInfo.isDirectory) {
+        throw new Error(`Sandbox preview file not found: ${providerPath}`);
+      }
+    }
+
+    const ticket = createSandboxPreviewTicket({
+      sourceType,
+      sourceId,
+      userId,
+      chatId,
+      teamId
+    });
+    const result = files.map(({ filePath, relativePath }) => ({
+      fileUrl: buildSandboxPreviewFileUrl({ ticket, filePath }),
+      filename: path.posix.basename(relativePath)
+    }));
 
     return { response: JSON.stringify(result) };
   }

--- a/packages/service/core/ai/sandbox/application/toolCall/index.ts
+++ b/packages/service/core/ai/sandbox/application/toolCall/index.ts
@@ -48,6 +48,7 @@ export const runSandboxTools = async ({
   sourceId,
   userId,
   chatId,
+  teamId,
   toolName,
   args,
   sandboxClient
@@ -56,6 +57,7 @@ export const runSandboxTools = async ({
   sourceId: string;
   userId: string;
   chatId: string;
+  teamId: string;
   toolName: string;
   args: string;
   sandboxClient?: SandboxClient;
@@ -109,6 +111,7 @@ export const runSandboxTools = async ({
     sourceId,
     userId,
     chatId,
+    teamId,
     sandboxInstance: instance,
     params: parsedArgs.data as any
   });

--- a/packages/service/core/ai/sandbox/application/toolCall/type.ts
+++ b/packages/service/core/ai/sandbox/application/toolCall/type.ts
@@ -12,6 +12,7 @@ type ToolExecuteContext<P> = {
   sourceId: string;
   userId: string;
   chatId: string;
+  teamId: string;
   sandboxInstance: SandboxClient;
   params: P;
 };

--- a/packages/service/core/ai/sandbox/infrastructure/provider/config.ts
+++ b/packages/service/core/ai/sandbox/infrastructure/provider/config.ts
@@ -121,6 +121,7 @@ export function getSandboxAdapterConfig({
           sessionId,
           workDirectory: profile.workDirectory,
           ideAgentBindAddr: serviceEnv.IDE_AGENT_BIND_ADDR,
+          ideAgentPreviewBindAddr: serviceEnv.IDE_AGENT_PREVIEW_BIND_ADDR,
           ideAgentMaxFileBytes: getAgentSandboxMaxFileBytes(),
           ideAgentWsLimits: {
             maxMessageBytes: serviceEnv.AGENT_SANDBOX_WS_MAX_MESSAGE_BYTES,

--- a/packages/service/core/ai/sandbox/infrastructure/provider/runtimeProfile/utils.ts
+++ b/packages/service/core/ai/sandbox/infrastructure/provider/runtimeProfile/utils.ts
@@ -57,12 +57,14 @@ export function buildBaseSandboxRuntimeEnv({
   sessionId,
   workDirectory,
   ideAgentBindAddr,
+  ideAgentPreviewBindAddr,
   ideAgentMaxFileBytes,
   ideAgentWsLimits
 }: {
   sessionId: string;
   workDirectory: string;
   ideAgentBindAddr: string;
+  ideAgentPreviewBindAddr: string;
   ideAgentMaxFileBytes: number;
   ideAgentWsLimits: {
     maxMessageBytes: number;
@@ -74,6 +76,7 @@ export function buildBaseSandboxRuntimeEnv({
     FASTGPT_WORKDIR: workDirectory,
     IDE_AGENT_ENABLED: 'true',
     IDE_AGENT_BIND_ADDR: ideAgentBindAddr,
+    IDE_AGENT_PREVIEW_BIND_ADDR: ideAgentPreviewBindAddr,
     FASTGPT_IDE_MAX_FILE_BYTES: String(ideAgentMaxFileBytes),
     FASTGPT_IDE_WS_MAX_MESSAGE_BYTES: String(ideAgentWsLimits.maxMessageBytes),
     FASTGPT_IDE_WS_MAX_FRAME_BYTES: String(ideAgentWsLimits.maxFrameBytes)

--- a/packages/service/core/workflow/dispatch/ai/agent/sub/sandbox/tool.ts
+++ b/packages/service/core/workflow/dispatch/ai/agent/sub/sandbox/tool.ts
@@ -20,6 +20,7 @@ export const dispatchSandboxTool = async ({
   sourceId,
   userId,
   chatId,
+  teamId,
   lang,
   sandboxClient
 }: {
@@ -29,6 +30,7 @@ export const dispatchSandboxTool = async ({
   sourceId: string;
   userId: string;
   chatId: string;
+  teamId: string;
   lang?: localeType;
   sandboxClient?: SandboxClient;
 }): Promise<DispatchSubAppResponse> => {
@@ -39,6 +41,7 @@ export const dispatchSandboxTool = async ({
     sourceId,
     userId,
     chatId,
+    teamId,
     sandboxClient
   });
 

--- a/packages/service/core/workflow/dispatch/ai/agent/utils.ts
+++ b/packages/service/core/workflow/dispatch/ai/agent/utils.ts
@@ -263,6 +263,7 @@ export const getExecuteTool = ({
             sourceId: runningAppInfo.sourceId,
             userId: uid,
             chatId,
+            teamId: runningUserInfo.teamId,
             lang,
             sandboxClient
           });

--- a/packages/service/core/workflow/dispatch/ai/toolcall/hooks/useToolRunner.ts
+++ b/packages/service/core/workflow/dispatch/ai/toolcall/hooks/useToolRunner.ts
@@ -144,6 +144,7 @@ export const useToolRunner = ({
           sourceId: workflowProps.runningAppInfo.sourceId,
           userId: workflowProps.uid,
           chatId: workflowProps.chatId,
+          teamId: workflowProps.runningUserInfo.teamId,
           ...(sandboxClient ? { sandboxClient } : {})
         };
         const { input, response, durationSeconds } = await runSandboxTools(sandboxToolParams);

--- a/packages/service/env.ts
+++ b/packages/service/env.ts
@@ -68,6 +68,7 @@ export const serviceEnv = createEnv({
     // Agent sandbox
     AGENT_SANDBOX_PROVIDER: z.enum(agentSandboxProviderList).optional(),
     IDE_AGENT_BIND_ADDR: z.string().default('0.0.0.0:1318'),
+    IDE_AGENT_PREVIEW_BIND_ADDR: z.string().default('0.0.0.0:1319'),
     // E2B配置
     AGENT_SANDBOX_E2B_API_KEY: z.string().optional(),
     // Sealos配置

--- a/packages/service/test/core/ai/sandbox/application/preview.test.ts
+++ b/packages/service/test/core/ai/sandbox/application/preview.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ChatSourceTypeEnum } from '@fastgpt/global/core/chat/constants';
+import { serviceEnv } from '@fastgpt/service/env';
+
+import {
+  buildSandboxPreviewFileUrl,
+  createSandboxPreviewTicket,
+  resolveSandboxPreviewPath,
+  verifySandboxPreviewTicket
+} from '@fastgpt/service/core/ai/sandbox/application/preview';
+
+const originalProxySecret = serviceEnv.AGENT_SANDBOX_PROXY_SECRET;
+const originalProxyUrl = serviceEnv.AGENT_SANDBOX_PROXY_URL;
+const originalProvider = serviceEnv.AGENT_SANDBOX_PROVIDER;
+
+describe('sandbox preview application', () => {
+  beforeEach(() => {
+    serviceEnv.AGENT_SANDBOX_PROXY_SECRET = 'preview-secret-1234567890-1234567890';
+    serviceEnv.AGENT_SANDBOX_PROXY_URL = 'wss://agent-proxy.example.com/base/';
+    serviceEnv.AGENT_SANDBOX_PROVIDER = 'opensandbox';
+  });
+
+  afterEach(() => {
+    serviceEnv.AGENT_SANDBOX_PROXY_SECRET = originalProxySecret;
+    serviceEnv.AGENT_SANDBOX_PROXY_URL = originalProxyUrl;
+    serviceEnv.AGENT_SANDBOX_PROVIDER = originalProvider;
+  });
+
+  it('signs and verifies read-only preview claims', () => {
+    const ticket = createSandboxPreviewTicket({
+      sourceType: ChatSourceTypeEnum.app,
+      sourceId: 'app-1',
+      userId: 'user-1',
+      chatId: 'chat-1',
+      teamId: 'team-1'
+    });
+
+    expect(verifySandboxPreviewTicket(ticket)).toMatchObject({
+      sourceType: ChatSourceTypeEnum.app,
+      sourceId: 'app-1',
+      userId: 'user-1',
+      chatId: 'chat-1',
+      teamId: 'team-1',
+      channel: 'preview',
+      permission: 'read'
+    });
+  });
+
+  it('builds an HTTPS proxy URL and encodes each workspace path segment', () => {
+    expect(
+      buildSandboxPreviewFileUrl({
+        ticket: 'header.payload.signature',
+        filePath: '/workspace/test dir/预览.html'
+      })
+    ).toBe(
+      'https://agent-proxy.example.com/base/preview/header.payload.signature/test%20dir/%E9%A2%84%E8%A7%88.html'
+    );
+  });
+
+  it('normalizes relative and workspace absolute paths', () => {
+    expect(resolveSandboxPreviewPath('./dir/file.txt')).toEqual({
+      providerPath: '/workspace/dir/file.txt',
+      relativePath: 'dir/file.txt'
+    });
+    expect(resolveSandboxPreviewPath('/workspace/dir/file.txt')).toEqual({
+      providerPath: '/workspace/dir/file.txt',
+      relativePath: 'dir/file.txt'
+    });
+  });
+
+  it('rejects workspace roots, traversal, outside absolute paths and noncanonical segments', () => {
+    expect(() => resolveSandboxPreviewPath('.')).toThrow('Invalid sandbox preview path');
+    expect(() => resolveSandboxPreviewPath('../secret')).toThrow('Path traversal detected');
+    expect(() => resolveSandboxPreviewPath('/etc/passwd')).toThrow(
+      'Sandbox path is outside workspace'
+    );
+    expect(() => resolveSandboxPreviewPath('dir//file')).toThrow('Invalid sandbox preview path');
+    expect(() => resolveSandboxPreviewPath('dir\\file')).toThrow('Invalid sandbox preview path');
+  });
+});

--- a/packages/service/test/core/ai/sandbox/application/toolCall/getFileUrl.tool.test.ts
+++ b/packages/service/test/core/ai/sandbox/application/toolCall/getFileUrl.tool.test.ts
@@ -1,36 +1,49 @@
-import { Readable } from 'stream';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatSourceTypeEnum } from '@fastgpt/global/core/chat/constants';
 
-const s3Mock = vi.hoisted(() => ({
-  uploadChatFile: vi.fn(),
-  createGetChatFileURL: vi.fn()
+const previewMock = vi.hoisted(() => ({
+  buildSandboxPreviewFileUrl: vi.fn(),
+  createSandboxPreviewTicket: vi.fn(),
+  resolveSandboxPreviewPath: vi.fn()
 }));
 
-vi.mock('@fastgpt/service/common/s3/sources/chat', () => ({
-  getS3ChatSource: () => ({
-    uploadChatFile: s3Mock.uploadChatFile,
-    createGetChatFileURL: s3Mock.createGetChatFileURL
-  })
-}));
+vi.mock('@fastgpt/service/core/ai/sandbox/application/preview', () => previewMock);
 
 import { sandboxGetFileUrlTool } from '@fastgpt/service/core/ai/sandbox/application/toolCall/getFileUrl.tool';
 
+const getFileInfo = vi.fn();
 const createSandboxInstance = () =>
   ({
     provider: {
-      readFileStream: vi.fn(() => Readable.from(['file-content']))
+      getFileInfo
     }
   }) as any;
 
 describe('sandboxGetFileUrlTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    s3Mock.uploadChatFile.mockResolvedValue({ key: 'chat/file.txt' });
-    s3Mock.createGetChatFileURL.mockResolvedValue({ url: 'signed-url' });
+    previewMock.createSandboxPreviewTicket.mockReturnValue('preview-ticket');
+    previewMock.resolveSandboxPreviewPath
+      .mockReturnValueOnce({
+        providerPath: '/workspace/file.txt',
+        relativePath: 'file.txt'
+      })
+      .mockReturnValueOnce({
+        providerPath: '/workspace/report/data.csv',
+        relativePath: 'report/data.csv'
+      });
+    previewMock.buildSandboxPreviewFileUrl.mockImplementation(
+      ({ filePath }: { filePath: string }) => `preview:${filePath}`
+    );
+    getFileInfo.mockResolvedValue(
+      new Map([
+        ['/workspace/file.txt', { path: '/workspace/file.txt', isDirectory: false }],
+        ['/workspace/report/data.csv', { path: '/workspace/report/data.csv', isDirectory: false }]
+      ])
+    );
   });
 
-  it('uploads sandbox files and returns signed urls', async () => {
+  it('returns direct preview urls without uploading file content', async () => {
     const sandbox = createSandboxInstance();
 
     const result = await sandboxGetFileUrlTool.execute({
@@ -38,26 +51,44 @@ describe('sandboxGetFileUrlTool', () => {
       sourceId: 'app',
       userId: 'user',
       chatId: 'chat',
+      teamId: 'team',
       sandboxInstance: sandbox,
-      params: { paths: ['/workspace/file.txt'] }
+      params: { paths: ['/workspace/file.txt', 'report/data.csv'] }
     });
 
-    expect(JSON.parse(result.response)).toEqual([{ fileUrl: 'signed-url', filename: 'file.txt' }]);
-    expect(sandbox.provider.readFileStream).toHaveBeenCalledWith('/workspace/file.txt');
-    expect(s3Mock.uploadChatFile).toHaveBeenCalledWith(
-      expect.objectContaining({
+    expect(JSON.parse(result.response)).toEqual([
+      { fileUrl: 'preview:/workspace/file.txt', filename: 'file.txt' },
+      { fileUrl: 'preview:report/data.csv', filename: 'data.csv' }
+    ]);
+    expect(getFileInfo).toHaveBeenCalledWith(['/workspace/file.txt', '/workspace/report/data.csv']);
+    expect(previewMock.createSandboxPreviewTicket).toHaveBeenCalledWith({
+      sourceType: ChatSourceTypeEnum.app,
+      sourceId: 'app',
+      userId: 'user',
+      chatId: 'chat',
+      teamId: 'team'
+    });
+    expect(previewMock.buildSandboxPreviewFileUrl).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects missing files before issuing a preview ticket', async () => {
+    previewMock.resolveSandboxPreviewPath.mockReset().mockReturnValue({
+      providerPath: '/workspace/missing.txt',
+      relativePath: 'missing.txt'
+    });
+    getFileInfo.mockResolvedValue(new Map());
+
+    await expect(
+      sandboxGetFileUrlTool.execute({
         sourceType: ChatSourceTypeEnum.app,
         sourceId: 'app',
+        userId: 'user',
         chatId: 'chat',
-        uId: 'user',
-        filename: 'file.txt'
+        teamId: 'team',
+        sandboxInstance: createSandboxInstance(),
+        params: { paths: ['missing.txt'] }
       })
-    );
-    expect(s3Mock.createGetChatFileURL).toHaveBeenCalledWith({
-      key: 'chat/file.txt',
-      expiredHours: 2,
-      external: true,
-      mode: 'presigned'
-    });
+    ).rejects.toThrow('Sandbox preview file not found');
+    expect(previewMock.createSandboxPreviewTicket).not.toHaveBeenCalled();
   });
 });

--- a/packages/service/test/core/ai/sandbox/application/toolCall/index.test.ts
+++ b/packages/service/test/core/ai/sandbox/application/toolCall/index.test.ts
@@ -19,11 +19,6 @@ const mirrorMock = vi.hoisted(() => ({
   prepareSandboxRuntimeMirrors: vi.fn()
 }));
 
-const s3Mock = vi.hoisted(() => ({
-  uploadChatFile: vi.fn(),
-  createGetChatFileURL: vi.fn()
-}));
-
 vi.mock('@fastgpt/service/core/ai/sandbox/application/runtime/client', () => ({
   getSandboxClient: runtimeMock.getSandboxClient
 }));
@@ -38,13 +33,6 @@ vi.mock('@fastgpt/service/core/ai/sandbox/application/runtime/mirrors', () => ({
 
 vi.mock('@fastgpt/service/core/ai/sandbox/infrastructure/provider/runtimeProfile', () => ({
   getSandboxRuntimeProfile: () => ({ workDirectory: '/workspace' })
-}));
-
-vi.mock('@fastgpt/service/common/s3/sources/chat', () => ({
-  getS3ChatSource: () => ({
-    uploadChatFile: s3Mock.uploadChatFile,
-    createGetChatFileURL: s3Mock.createGetChatFileURL
-  })
 }));
 
 import {
@@ -65,14 +53,13 @@ const createSandboxInstance = () =>
 describe('sandbox toolCall index', () => {
   const appSource = {
     sourceType: ChatSourceTypeEnum.app,
-    sourceId: 'app'
+    sourceId: 'app',
+    teamId: 'team'
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
     runtimeMock.getSandboxClient.mockResolvedValue(createSandboxInstance());
-    s3Mock.uploadChatFile.mockResolvedValue({ key: 'chat/file.txt' });
-    s3Mock.createGetChatFileURL.mockResolvedValue({ url: 'signed-url' });
   });
 
   it('executes known tools through a fetched sandbox client', async () => {

--- a/packages/service/test/core/ai/sandbox/infrastructure/provider/config.test.ts
+++ b/packages/service/test/core/ai/sandbox/infrastructure/provider/config.test.ts
@@ -188,6 +188,7 @@ describe('sandbox provider config', () => {
         FASTGPT_WORKDIR: '/home/devbox/workspace',
         IDE_AGENT_ENABLED: 'true',
         IDE_AGENT_BIND_ADDR: '0.0.0.0:1318',
+        IDE_AGENT_PREVIEW_BIND_ADDR: '0.0.0.0:1319',
         FASTGPT_IDE_MAX_FILE_BYTES: '536870912',
         FASTGPT_IDE_WS_MAX_MESSAGE_BYTES: '67108864',
         FASTGPT_IDE_WS_MAX_FRAME_BYTES: '16777216'

--- a/packages/service/test/core/ai/sandbox/infrastructure/provider/runtimeProfile.test.ts
+++ b/packages/service/test/core/ai/sandbox/infrastructure/provider/runtimeProfile.test.ts
@@ -101,6 +101,7 @@ describe('sandbox runtime profile', () => {
           sessionId: 'session-1',
           workDirectory: runtimeProfile.workDirectory,
           ideAgentBindAddr: '0.0.0.0:1318',
+          ideAgentPreviewBindAddr: '0.0.0.0:1319',
           ideAgentMaxFileBytes: 10 * 1024 * 1024,
           ideAgentWsLimits: {
             maxMessageBytes: 64 * 1024 * 1024,
@@ -119,6 +120,7 @@ describe('sandbox runtime profile', () => {
         FASTGPT_WORKDIR: '/custom/devbox/workspace',
         IDE_AGENT_ENABLED: 'true',
         IDE_AGENT_BIND_ADDR: '0.0.0.0:1318',
+        IDE_AGENT_PREVIEW_BIND_ADDR: '0.0.0.0:1319',
         FASTGPT_IDE_MAX_FILE_BYTES: '10485760',
         FASTGPT_IDE_WS_MAX_MESSAGE_BYTES: '67108864',
         FASTGPT_IDE_WS_MAX_FRAME_BYTES: '16777216'

--- a/packages/service/test/core/workflow/dispatch/ai/toolcall/hooks/useToolRunner.test.ts
+++ b/packages/service/test/core/workflow/dispatch/ai/toolcall/hooks/useToolRunner.test.ts
@@ -198,6 +198,7 @@ describe('useToolRunner', () => {
       sourceId: 'app_1',
       userId: 'user_1',
       chatId: 'chat_1',
+      teamId: 'team_1',
       sandboxClient
     });
     expect(result).toEqual({

--- a/projects/agent-sandbox-proxy/.env.template
+++ b/projects/agent-sandbox-proxy/.env.template
@@ -5,7 +5,7 @@
 PORT=1006
 
 # 2. JWT 验签与内网握手密钥 (必须与 NextJS 主站的 AGENT_SANDBOX_PROXY_SECRET 保持完全一致)
-# 用于 Proxy 在边缘直接拦截所有非法 WebSocket 握手请求，并作为 X-Proxy-Token Header 进行内网安全身份回源校验。
+# 用于 Proxy 在边缘拦截非法 WebSocket/Preview 请求，并作为 X-Proxy-Token Header 进行内网安全身份回源校验。
 # 生产环境必须配置为高强度随机值，不能使用示例占位。
 AGENT_SANDBOX_PROXY_SECRET=
 
@@ -18,6 +18,9 @@ FASTGPT_APP_URL=http://localhost:3000
 # 5. Proxy 回源主站请求超时时间（秒）。需覆盖主站冷启动沙盒、读取 agent password 和 endpoint 查询。
 FASTGPT_APP_REQUEST_TIMEOUT_SECS=10
 
-# 6. 将主站返回的 localhost 上游地址改写为容器可访问的 Host。
+# 6. Preview 文件资源的 sandbox endpoint 解析缓存（秒）。每个请求仍会独立校验 JWT 过期时间。
+AGENT_SANDBOX_PROXY_ADDRESS_CACHE_TTL_SECS=30
+
+# 7. 将主站返回的 localhost 上游地址改写为容器可访问的 Host。
 # dev compose 通常填 host.docker.internal；生产环境一般留空。
 AGENT_SANDBOX_PROXY_REWRITE_HOST=

--- a/projects/agent-sandbox-proxy/Cargo.lock
+++ b/projects/agent-sandbox-proxy/Cargo.lock
@@ -389,6 +389,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -448,6 +449,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,9 +484,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1265,6 +1274,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1285,12 +1295,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -1818,6 +1830,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,6 +2107,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/projects/agent-sandbox-proxy/Cargo.toml
+++ b/projects/agent-sandbox-proxy/Cargo.toml
@@ -14,5 +14,6 @@ serde_json = "1.0.150"
 dotenvy = "0.15.7"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
-reqwest = { version = "0.13.4", default-features = false, features = ["json", "query", "rustls"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["json", "query", "rustls", "stream"] }
 jsonwebtoken = { version = "10.4.0", default-features = false, features = ["rust_crypto"] }
+sha2 = "0.10.9"

--- a/projects/agent-sandbox-proxy/src/auth.rs
+++ b/projects/agent-sandbox-proxy/src/auth.rs
@@ -1,8 +1,11 @@
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
 use std::env;
 use std::sync::{LazyLock, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
 use tracing::{debug, error};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -59,9 +62,19 @@ static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
 });
 
 static PROXY_SECRET: OnceLock<String> = OnceLock::new();
+static SANDBOX_ADDRESS_CACHE: LazyLock<RwLock<HashMap<[u8; 32], CachedSandboxAddress>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
 
 const DEFAULT_APP_REQUEST_TIMEOUT_SECS: u64 = 10;
+const DEFAULT_ADDRESS_CACHE_TTL_SECS: u64 = 30;
+const MAX_ADDRESS_CACHE_ENTRIES: usize = 2_000;
 const MIN_PROXY_SECRET_BYTES: usize = 32;
+
+#[derive(Clone)]
+struct CachedSandboxAddress {
+    address: SandboxAddress,
+    expires_at: Instant,
+}
 
 fn get_app_request_timeout() -> Duration {
     let seconds = env::var("FASTGPT_APP_REQUEST_TIMEOUT_SECS")
@@ -90,6 +103,11 @@ pub fn get_proxy_secret() -> &'static str {
         }
         secret
     })
+}
+
+#[cfg(test)]
+pub fn init_test_proxy_secret() {
+    let _ = PROXY_SECRET.set("test-secret-key-1234567890-very-long-32".to_string());
 }
 
 /// 在代理层边缘进行本地 JWT 验签防刷，直接在第一道闸口过滤非法请求
@@ -121,12 +139,13 @@ pub async fn resolve_sandbox_address(ticket: &str) -> Result<SandboxAddress, Str
         request_url
     );
 
-    // 2. 发起内网 HTTP GET 请求 (复用全局共享的 TCP 连接池，自动处理 Keep-Alive 与 URL 编码)
+    // 2. ticket 放在内网 header，避免主站 access log 记录 bearer token。
     let client = get_http_client();
-    let mut request = client.get(&request_url).query(&[("ticket", ticket)]);
-
-    // 3. 安全二次加固：必须携带正确的 AGENT_SANDBOX_PROXY_SECRET，在 Header 中注入安全防刷握手 Token
-    request = request.header("X-Proxy-Token", get_proxy_secret());
+    let request = client
+        .get(&request_url)
+        .header("X-Sandbox-Ticket", ticket)
+        // 3. 共享密钥只用于 proxy 到主站的反向通道认证。
+        .header("X-Proxy-Token", get_proxy_secret());
 
     let response = request
         .send()
@@ -166,6 +185,64 @@ pub async fn resolve_sandbox_address(ticket: &str) -> Result<SandboxAddress, Str
 
     debug!("[Auth] Ticket resolved successfully.");
     Ok(address)
+}
+
+fn get_address_cache_ttl() -> Duration {
+    let seconds = env::var("AGENT_SANDBOX_PROXY_ADDRESS_CACHE_TTL_SECS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_ADDRESS_CACHE_TTL_SECS);
+    Duration::from_secs(seconds)
+}
+
+fn get_ticket_cache_key(ticket: &str) -> [u8; 32] {
+    Sha256::digest(ticket.as_bytes()).into()
+}
+
+/**
+ * Resolves a preview ticket with a short address cache.
+ *
+ * JWT validity is checked by the caller on every request. This cache only avoids repeating the
+ * FastGPT back-channel lookup and sandbox password read for each resource in one HTML page.
+ */
+pub async fn resolve_cached_sandbox_address(ticket: &str) -> Result<SandboxAddress, String> {
+    let now = Instant::now();
+    let cache_key = get_ticket_cache_key(ticket);
+    if let Some(cached) = SANDBOX_ADDRESS_CACHE.read().await.get(&cache_key)
+        && cached.expires_at > now
+    {
+        return Ok(cached.address.clone());
+    }
+
+    let address = resolve_sandbox_address(ticket).await?;
+    let resolved_at = Instant::now();
+    let mut cache = SANDBOX_ADDRESS_CACHE.write().await;
+    cache.retain(|_, cached| cached.expires_at > resolved_at);
+    if cache.len() >= MAX_ADDRESS_CACHE_ENTRIES
+        && let Some(oldest_key) = cache
+            .iter()
+            .min_by_key(|(_, cached)| cached.expires_at)
+            .map(|(key, _)| *key)
+    {
+        cache.remove(&oldest_key);
+    }
+    cache.insert(
+        cache_key,
+        CachedSandboxAddress {
+            address: address.clone(),
+            expires_at: resolved_at + get_address_cache_ttl(),
+        },
+    );
+
+    Ok(address)
+}
+
+pub async fn invalidate_cached_sandbox_address(ticket: &str) {
+    SANDBOX_ADDRESS_CACHE
+        .write()
+        .await
+        .remove(&get_ticket_cache_key(ticket));
 }
 
 #[cfg(test)]
@@ -284,5 +361,17 @@ mod tests {
         assert!(res.is_err());
         let err = res.unwrap_err();
         assert!(err.contains("ExpiredSignature") || err.contains("validation failed"));
+    }
+
+    #[test]
+    fn test_ticket_cache_key_is_stable_without_retaining_token() {
+        assert_eq!(
+            get_ticket_cache_key("ticket-a"),
+            get_ticket_cache_key("ticket-a")
+        );
+        assert_ne!(
+            get_ticket_cache_key("ticket-a"),
+            get_ticket_cache_key("ticket-b")
+        );
     }
 }

--- a/projects/agent-sandbox-proxy/src/main.rs
+++ b/projects/agent-sandbox-proxy/src/main.rs
@@ -1,8 +1,9 @@
 use axum::{
     Router,
-    extract::{Query, ws::WebSocketUpgrade},
-    http::StatusCode,
-    response::IntoResponse,
+    body::Body,
+    extract::{Path, Query, ws::WebSocketUpgrade},
+    http::{HeaderMap, Method, StatusCode},
+    response::{IntoResponse, Response},
     routing::get,
 };
 use serde::Deserialize;
@@ -10,14 +11,24 @@ use std::net::SocketAddr;
 use tracing::{error, info};
 
 mod auth;
+mod preview;
 mod relay;
 
-use auth::resolve_sandbox_address;
+use auth::{
+    invalidate_cached_sandbox_address, resolve_cached_sandbox_address, resolve_sandbox_address,
+};
+use preview::{bad_gateway_response, preview_error_response, proxy_preview_file};
 use relay::handle_relay;
 
 #[derive(Deserialize)]
 struct WsQuery {
     ticket: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct PreviewPath {
+    ticket: String,
+    path: String,
 }
 
 #[tokio::main]
@@ -35,7 +46,11 @@ async fn main() {
     let app = Router::new()
         .route("/health", get(health_check))
         .route("/fs", get(fs_handler))
-        .route("/terminal", get(terminal_handler));
+        .route("/terminal", get(terminal_handler))
+        .route(
+            "/preview/{ticket}/{*path}",
+            get(preview_handler).head(preview_handler),
+        );
 
     let port: u16 = std::env::var("PORT")
         .ok()
@@ -80,32 +95,10 @@ async fn verify_and_resolve_auth(
         }
     };
 
-    let claims = auth::verify_jwt_ticket(&ticket).map_err(|err| {
+    let claims = verify_ticket_for_channel(&ticket, expected_channel).map_err(|err| {
         error!("[Auth] Local JWT verification failed: {}", err);
         (StatusCode::UNAUTHORIZED, format!("Unauthorized: {}", err))
     })?;
-
-    if claims.channel != expected_channel {
-        error!(
-            "[Auth] JWT channel mismatch. expected: {}, actual: {}",
-            expected_channel, claims.channel
-        );
-        return Err((
-            StatusCode::UNAUTHORIZED,
-            "Unauthorized: ticket channel mismatch".to_string(),
-        ));
-    }
-
-    if expected_channel == "terminal" && claims.permission != "write" {
-        error!(
-            "[Auth] JWT terminal permission mismatch. actual: {}",
-            claims.permission
-        );
-        return Err((
-            StatusCode::UNAUTHORIZED,
-            "Unauthorized: terminal ticket requires write permission".to_string(),
-        ));
-    }
 
     let address = resolve_sandbox_address(&ticket).await.map_err(|err| {
         error!("[Auth] Ticket resolution failed: {}", err);
@@ -113,6 +106,23 @@ async fn verify_and_resolve_auth(
     })?;
 
     Ok((address, claims))
+}
+
+fn verify_ticket_for_channel(
+    ticket: &str,
+    expected_channel: &'static str,
+) -> Result<auth::Claims, String> {
+    let claims = auth::verify_jwt_ticket(ticket)?;
+    if claims.channel != expected_channel {
+        return Err("ticket channel mismatch".to_string());
+    }
+    if expected_channel == "terminal" && claims.permission != "write" {
+        return Err("terminal ticket requires write permission".to_string());
+    }
+    if expected_channel == "preview" && claims.permission != "read" {
+        return Err("preview ticket requires read permission".to_string());
+    }
+    Ok(claims)
 }
 
 async fn fs_handler(ws: WebSocketUpgrade, Query(query): Query<WsQuery>) -> impl IntoResponse {
@@ -144,5 +154,95 @@ async fn terminal_handler(ws: WebSocketUpgrade, Query(query): Query<WsQuery>) ->
                 .into_response()
         }
         Err((status, err_msg)) => (status, err_msg).into_response(),
+    }
+}
+
+async fn preview_handler(
+    Path(params): Path<PreviewPath>,
+    method: Method,
+    headers: HeaderMap,
+) -> Response<Body> {
+    if let Err(error) = verify_ticket_for_channel(&params.ticket, "preview") {
+        error!("[Preview] Ticket verification failed: {}", error);
+        return preview_error_response(StatusCode::UNAUTHORIZED, "Unauthorized preview ticket");
+    }
+
+    let address = match resolve_cached_sandbox_address(&params.ticket).await {
+        Ok(address) => address,
+        Err(error) => {
+            error!("[Preview] Ticket resolution failed: {}", error);
+            return preview_error_response(
+                StatusCode::FORBIDDEN,
+                "Preview ticket resolution failed",
+            );
+        }
+    };
+
+    match proxy_preview_file(&address, &params.path, &method, &headers).await {
+        Ok(response) => response,
+        Err(first_error) => {
+            error!("[Preview] Cached upstream request failed: {}", first_error);
+            invalidate_cached_sandbox_address(&params.ticket).await;
+
+            let fresh_address = match resolve_cached_sandbox_address(&params.ticket).await {
+                Ok(address) => address,
+                Err(error) => {
+                    error!("[Preview] Upstream re-resolution failed: {}", error);
+                    return bad_gateway_response();
+                }
+            };
+            proxy_preview_file(&fresh_address, &params.path, &method, &headers)
+                .await
+                .unwrap_or_else(|error| {
+                    error!("[Preview] Upstream retry failed: {}", error);
+                    bad_gateway_response()
+                })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonwebtoken::{EncodingKey, Header, encode};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn preview_ticket(permission: &str) -> String {
+        auth::init_test_proxy_secret();
+        let exp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 60;
+        encode(
+            &Header::default(),
+            &auth::Claims {
+                source_type: "app".to_string(),
+                source_id: "app-id".to_string(),
+                user_id: "user-id".to_string(),
+                chat_id: "chat-id".to_string(),
+                team_id: "team-id".to_string(),
+                channel: "preview".to_string(),
+                permission: permission.to_string(),
+                exp,
+            },
+            &EncodingKey::from_secret(auth::get_proxy_secret().as_bytes()),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn accepts_read_only_preview_tickets() {
+        let ticket = preview_ticket("read");
+        let claims = verify_ticket_for_channel(&ticket, "preview").unwrap();
+        assert_eq!(claims.channel, "preview");
+        assert_eq!(claims.permission, "read");
+    }
+
+    #[test]
+    fn rejects_preview_write_permission_and_channel_mismatch() {
+        let ticket = preview_ticket("write");
+        assert!(verify_ticket_for_channel(&ticket, "preview").is_err());
+        assert!(verify_ticket_for_channel(&ticket, "fs").is_err());
     }
 }

--- a/projects/agent-sandbox-proxy/src/preview.rs
+++ b/projects/agent-sandbox-proxy/src/preview.rs
@@ -1,0 +1,309 @@
+use std::{sync::LazyLock, time::Duration};
+
+use axum::{
+    body::Body,
+    http::{
+        HeaderMap, HeaderName, Method, StatusCode,
+        header::{
+            ACCEPT_RANGES, CACHE_CONTROL, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, ETAG,
+            IF_NONE_MATCH, RANGE, REFERRER_POLICY, X_CONTENT_TYPE_OPTIONS,
+        },
+    },
+    response::Response,
+};
+
+use crate::{auth::SandboxAddress, relay::build_http_preview_url};
+
+static PREVIEW_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .pool_idle_timeout(Duration::from_secs(90))
+        .build()
+        .expect("Failed to initialize preview HTTP client")
+});
+
+const FORWARDED_REQUEST_HEADERS: [HeaderName; 2] = [RANGE, IF_NONE_MATCH];
+const AGENT_TOKEN_HEADER: &str = "x-fastgpt-agent-token";
+const PREVIEW_METHOD_HEADER: &str = "x-fastgpt-preview-method";
+const FORWARDED_RESPONSE_HEADERS: [HeaderName; 5] = [
+    CONTENT_TYPE,
+    CONTENT_LENGTH,
+    CONTENT_RANGE,
+    ACCEPT_RANGES,
+    ETAG,
+];
+
+pub fn preview_error_response(status: StatusCode, message: &'static str) -> Response<Body> {
+    let mut response = Response::new(Body::from(message));
+    *response.status_mut() = status;
+    response.headers_mut().insert(
+        CONTENT_TYPE,
+        axum::http::HeaderValue::from_static("text/plain; charset=utf-8"),
+    );
+    response.headers_mut().insert(
+        CACHE_CONTROL,
+        axum::http::HeaderValue::from_static("private, no-store"),
+    );
+    response.headers_mut().insert(
+        REFERRER_POLICY,
+        axum::http::HeaderValue::from_static("no-referrer"),
+    );
+    response.headers_mut().insert(
+        X_CONTENT_TYPE_OPTIONS,
+        axum::http::HeaderValue::from_static("nosniff"),
+    );
+    response
+}
+
+/**
+ * Proxies one authenticated public preview request to the fixed IDE agent preview service.
+ *
+ * Only a small HTTP header allowlist crosses the trust boundary. The client cannot influence the
+ * upstream host, port, authorization token, or HTTP method beyond GET/HEAD.
+ */
+pub async fn proxy_preview_file(
+    address: &SandboxAddress,
+    path: &str,
+    method: &Method,
+    request_headers: &HeaderMap,
+) -> Result<Response<Body>, String> {
+    let sandbox_url = address
+        .sandbox_url
+        .as_deref()
+        .filter(|url| !url.is_empty())
+        .ok_or_else(|| "Sandbox endpoint is missing".to_string())?;
+    let agent_token = address
+        .agent_token
+        .as_deref()
+        .filter(|token| !token.is_empty())
+        .ok_or_else(|| "Agent token is missing".to_string())?;
+    let target_url = build_http_preview_url(sandbox_url, path)?;
+
+    let is_head = method == Method::HEAD;
+    let reqwest_method = if is_head {
+        reqwest::Method::GET
+    } else {
+        reqwest::Method::from_bytes(method.as_str().as_bytes())
+            .map_err(|error| format!("Invalid preview method: {error}"))?
+    };
+    let mut request = PREVIEW_CLIENT
+        .request(reqwest_method, target_url)
+        .header(AGENT_TOKEN_HEADER, agent_token);
+    if is_head {
+        request = request.header(PREVIEW_METHOD_HEADER, "HEAD");
+    }
+    for header_name in FORWARDED_REQUEST_HEADERS {
+        if let Some(value) = request_headers.get(&header_name) {
+            request = request.header(header_name, value);
+        }
+    }
+
+    let upstream = request
+        .send()
+        .await
+        .map_err(|error| format!("Failed to connect sandbox preview service: {error}"))?;
+    let status = StatusCode::from_u16(upstream.status().as_u16())
+        .map_err(|error| format!("Invalid upstream status: {error}"))?;
+    if matches!(
+        status,
+        StatusCode::UNAUTHORIZED
+            | StatusCode::BAD_GATEWAY
+            | StatusCode::SERVICE_UNAVAILABLE
+            | StatusCode::GATEWAY_TIMEOUT
+    ) {
+        return Err(format!("Sandbox preview upstream returned {status}"));
+    }
+    let upstream_headers = upstream.headers().clone();
+    let body = if is_head {
+        Body::empty()
+    } else {
+        Body::from_stream(upstream.bytes_stream())
+    };
+    let mut response = Response::new(body);
+    *response.status_mut() = status;
+
+    for header_name in FORWARDED_RESPONSE_HEADERS {
+        if let Some(value) = upstream_headers.get(&header_name) {
+            response.headers_mut().insert(header_name, value.clone());
+        }
+    }
+    response.headers_mut().insert(
+        REFERRER_POLICY,
+        axum::http::HeaderValue::from_static("no-referrer"),
+    );
+    response.headers_mut().insert(
+        X_CONTENT_TYPE_OPTIONS,
+        axum::http::HeaderValue::from_static("nosniff"),
+    );
+    response.headers_mut().insert(
+        CACHE_CONTROL,
+        axum::http::HeaderValue::from_static("private, no-store"),
+    );
+
+    Ok(response)
+}
+
+pub fn bad_gateway_response() -> Response<Body> {
+    preview_error_response(StatusCode::BAD_GATEWAY, "Sandbox preview is unavailable")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Router, body::to_bytes, extract::Path, http::HeaderValue, routing::get};
+
+    async fn upstream_handler(Path(path): Path<String>, headers: HeaderMap) -> Response<Body> {
+        assert_eq!(headers.get(AGENT_TOKEN_HEADER).unwrap(), "agent-password");
+        assert_eq!(headers.get(RANGE).unwrap(), "bytes=1-3");
+        let mut response = Response::new(Body::from(path));
+        response
+            .headers_mut()
+            .insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        response
+            .headers_mut()
+            .insert(CONTENT_RANGE, HeaderValue::from_static("bytes 1-3/10"));
+        *response.status_mut() = StatusCode::PARTIAL_CONTENT;
+        response
+    }
+
+    async fn head_upstream_handler(headers: HeaderMap) -> Response<Body> {
+        assert_eq!(headers.get(AGENT_TOKEN_HEADER).unwrap(), "agent-password");
+        assert_eq!(headers.get(PREVIEW_METHOD_HEADER).unwrap(), "HEAD");
+        let mut response = Response::new(Body::from("body-must-not-be-forwarded"));
+        response
+            .headers_mut()
+            .insert(CONTENT_LENGTH, HeaderValue::from_static("26"));
+        response
+    }
+
+    async fn unavailable_upstream_handler() -> StatusCode {
+        StatusCode::SERVICE_UNAVAILABLE
+    }
+
+    #[tokio::test]
+    async fn streams_preview_response_and_forwards_safe_headers() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(
+                listener,
+                Router::new().route("/base/preview/{*path}", get(upstream_handler)),
+            )
+            .await
+            .unwrap();
+        });
+
+        let mut request_headers = HeaderMap::new();
+        request_headers.insert(RANGE, HeaderValue::from_static("bytes=1-3"));
+        let response = proxy_preview_file(
+            &SandboxAddress {
+                sandbox_url: Some(format!("http://{address}/base")),
+                agent_token: Some("agent-password".to_string()),
+                ws_limits: Default::default(),
+            },
+            "dir/file.txt",
+            &Method::GET,
+            &request_headers,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT);
+        assert_eq!(
+            response.headers().get(CONTENT_RANGE).unwrap(),
+            "bytes 1-3/10"
+        );
+        assert_eq!(
+            response.headers().get(REFERRER_POLICY).unwrap(),
+            "no-referrer"
+        );
+        let body = to_bytes(response.into_body(), 1024).await.unwrap();
+        assert_eq!(&body[..], b"dir/file.txt");
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_upstream_credentials() {
+        let response = proxy_preview_file(
+            &SandboxAddress {
+                sandbox_url: None,
+                agent_token: None,
+                ws_limits: Default::default(),
+            },
+            "file.txt",
+            &Method::GET,
+            &HeaderMap::new(),
+        )
+        .await;
+
+        assert!(
+            response
+                .unwrap_err()
+                .contains("Sandbox endpoint is missing")
+        );
+    }
+
+    #[tokio::test]
+    async fn tunnels_head_through_get_without_forwarding_a_body() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(
+                listener,
+                Router::new().route("/base/preview/{*path}", get(head_upstream_handler)),
+            )
+            .await
+            .unwrap();
+        });
+
+        let response = proxy_preview_file(
+            &SandboxAddress {
+                sandbox_url: Some(format!("http://{address}/base")),
+                agent_token: Some("agent-password".to_string()),
+                ws_limits: Default::default(),
+            },
+            "dir/file.txt",
+            &Method::HEAD,
+            &HeaderMap::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers().get(CONTENT_LENGTH).unwrap(), "26");
+        assert!(
+            to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn surfaces_retryable_upstream_statuses_as_relay_errors() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(
+                listener,
+                Router::new().route("/base/preview/{*path}", get(unavailable_upstream_handler)),
+            )
+            .await
+            .unwrap();
+        });
+
+        let error = proxy_preview_file(
+            &SandboxAddress {
+                sandbox_url: Some(format!("http://{address}/base")),
+                agent_token: Some("agent-password".to_string()),
+                ws_limits: Default::default(),
+            },
+            "dir/file.txt",
+            &Method::GET,
+            &HeaderMap::new(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.contains("503 Service Unavailable"));
+    }
+}

--- a/projects/agent-sandbox-proxy/src/relay.rs
+++ b/projects/agent-sandbox-proxy/src/relay.rs
@@ -63,6 +63,50 @@ fn build_ws_upstream_base_url_with_rewrite(
     Ok(endpoint.as_str().trim_end_matches('/').to_string())
 }
 
+/// 构建只读 preview HTTP 上游地址，并把 workspace 相对路径安全追加到 provider endpoint。
+pub(crate) fn build_http_preview_url(raw_endpoint: &str, path: &str) -> Result<String, String> {
+    let rewrite_host = env::var(LOOPBACK_REWRITE_HOST_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    build_http_preview_url_with_rewrite(raw_endpoint, path, rewrite_host.as_deref())
+}
+
+fn build_http_preview_url_with_rewrite(
+    raw_endpoint: &str,
+    path: &str,
+    rewrite_host: Option<&str>,
+) -> Result<String, String> {
+    if path.is_empty() || path.starts_with('/') || path.contains('\\') || path.contains('\0') {
+        return Err("Invalid workspace preview path".to_string());
+    }
+
+    let path_segments = path.split('/').collect::<Vec<_>>();
+    if path_segments
+        .iter()
+        .any(|segment| segment.is_empty() || *segment == "." || *segment == "..")
+    {
+        return Err("Invalid workspace preview path".to_string());
+    }
+
+    let mut endpoint = parse_sandbox_endpoint(raw_endpoint)?;
+    rewrite_loopback_host(&mut endpoint, rewrite_host)?;
+    use_http_scheme(&mut endpoint)?;
+    endpoint.set_fragment(None);
+
+    {
+        let mut segments = endpoint
+            .path_segments_mut()
+            .map_err(|_| "Sandbox endpoint cannot be used as a base URL".to_string())?;
+        segments.pop_if_empty();
+        segments.push("preview");
+        segments.extend(path_segments);
+    }
+
+    Ok(endpoint.to_string())
+}
+
 fn parse_sandbox_endpoint(raw_endpoint: &str) -> Result<Url, String> {
     let endpoint = raw_endpoint.trim().trim_end_matches('/');
     if endpoint.is_empty() {
@@ -110,70 +154,16 @@ fn use_websocket_scheme(endpoint: &mut Url) -> Result<(), String> {
         .map_err(|_| format!("Failed to set sandbox endpoint scheme to {}", ws_scheme))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::build_ws_upstream_base_url_with_rewrite;
+fn use_http_scheme(endpoint: &mut Url) -> Result<(), String> {
+    let http_scheme = match endpoint.scheme() {
+        "http" | "ws" => "http",
+        "https" | "wss" => "https",
+        scheme => return Err(format!("Unsupported sandbox endpoint scheme: {}", scheme)),
+    };
 
-    #[test]
-    fn rewrites_scheme_less_loopback_endpoint() {
-        let url = build_ws_upstream_base_url_with_rewrite(
-            "localhost:8090/sandboxes/demo/proxy/1318",
-            Some("host.docker.internal"),
-        )
-        .unwrap();
-
-        assert_eq!(
-            url,
-            "ws://host.docker.internal:8090/sandboxes/demo/proxy/1318"
-        );
-    }
-
-    #[test]
-    fn rewrites_http_loopback_endpoint() {
-        let url = build_ws_upstream_base_url_with_rewrite(
-            "http://127.0.0.1:8090/sandboxes/demo/proxy/1318/",
-            Some("host.docker.internal"),
-        )
-        .unwrap();
-
-        assert_eq!(
-            url,
-            "ws://host.docker.internal:8090/sandboxes/demo/proxy/1318"
-        );
-    }
-
-    #[test]
-    fn preserves_non_loopback_host() {
-        let url = build_ws_upstream_base_url_with_rewrite(
-            "http://opensandbox-server:8090/sandboxes/demo/proxy/1318",
-            Some("host.docker.internal"),
-        )
-        .unwrap();
-
-        assert_eq!(
-            url,
-            "ws://opensandbox-server:8090/sandboxes/demo/proxy/1318"
-        );
-    }
-
-    #[test]
-    fn preserves_secure_websocket_scheme() {
-        let url = build_ws_upstream_base_url_with_rewrite(
-            "https://sandbox.example.com/sandboxes/demo/proxy/1318",
-            None,
-        )
-        .unwrap();
-
-        assert_eq!(url, "wss://sandbox.example.com/sandboxes/demo/proxy/1318");
-    }
-
-    #[test]
-    fn rejects_unsupported_scheme() {
-        let err = build_ws_upstream_base_url_with_rewrite("ftp://localhost/sandboxes/demo", None)
-            .unwrap_err();
-
-        assert!(err.contains("Unsupported sandbox endpoint scheme"));
-    }
+    endpoint
+        .set_scheme(http_scheme)
+        .map_err(|_| format!("Failed to set sandbox endpoint scheme to {}", http_scheme))
 }
 
 /// 连接沙盒内的 IDE Agent，允许 agent 冷启动时出现短暂端口不可用。
@@ -770,5 +760,93 @@ fn tungstenite_to_axum(msg: WsMsg) -> Result<AxumMsg, ()> {
             }
         }))),
         _ => Err(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_http_preview_url_with_rewrite, build_ws_upstream_base_url_with_rewrite};
+
+    #[test]
+    fn rewrites_scheme_less_loopback_endpoint() {
+        let url = build_ws_upstream_base_url_with_rewrite(
+            "localhost:8090/sandboxes/demo/proxy/1318",
+            Some("host.docker.internal"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            url,
+            "ws://host.docker.internal:8090/sandboxes/demo/proxy/1318"
+        );
+    }
+
+    #[test]
+    fn rewrites_http_loopback_endpoint() {
+        let url = build_ws_upstream_base_url_with_rewrite(
+            "http://127.0.0.1:8090/sandboxes/demo/proxy/1318/",
+            Some("host.docker.internal"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            url,
+            "ws://host.docker.internal:8090/sandboxes/demo/proxy/1318"
+        );
+    }
+
+    #[test]
+    fn preserves_non_loopback_host() {
+        let url = build_ws_upstream_base_url_with_rewrite(
+            "http://opensandbox-server:8090/sandboxes/demo/proxy/1318",
+            Some("host.docker.internal"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            url,
+            "ws://opensandbox-server:8090/sandboxes/demo/proxy/1318"
+        );
+    }
+
+    #[test]
+    fn preserves_secure_websocket_scheme() {
+        let url = build_ws_upstream_base_url_with_rewrite(
+            "https://sandbox.example.com/sandboxes/demo/proxy/1318",
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(url, "wss://sandbox.example.com/sandboxes/demo/proxy/1318");
+    }
+
+    #[test]
+    fn rejects_unsupported_scheme() {
+        let err = build_ws_upstream_base_url_with_rewrite("ftp://localhost/sandboxes/demo", None)
+            .unwrap_err();
+
+        assert!(err.contains("Unsupported sandbox endpoint scheme"));
+    }
+
+    #[test]
+    fn builds_http_preview_url_with_encoded_workspace_segments() {
+        let url = build_http_preview_url_with_rewrite(
+            "http://127.0.0.1:8090/sandboxes/demo/proxy/1319",
+            "test dir/预览.html",
+            Some("host.docker.internal"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            url,
+            "http://host.docker.internal:8090/sandboxes/demo/proxy/1319/preview/test%20dir/%E9%A2%84%E8%A7%88.html"
+        );
+    }
+
+    #[test]
+    fn rejects_preview_path_traversal_and_unsupported_scheme() {
+        assert!(build_http_preview_url_with_rewrite("http://sandbox", "../secret", None).is_err());
+        assert!(build_http_preview_url_with_rewrite("http://sandbox", "dir//file", None).is_err());
+        assert!(build_http_preview_url_with_rewrite("ftp://sandbox", "file.txt", None).is_err());
     }
 }

--- a/projects/app/src/pageComponents/chat/SandboxEditor/api.ts
+++ b/projects/app/src/pageComponents/chat/SandboxEditor/api.ts
@@ -112,7 +112,7 @@ export const checkSandboxExist = async (data: SandboxCheckExistClientBody) =>
   POST<SandboxCheckExistResponse>('/core/ai/sandbox/checkExist', normalizeSandboxRequest(data));
 
 /**
- * 获取 HTML 预览链接 (S3 托管)
+ * 获取 HTML 预览链接（agent-proxy 直连 sandbox workspace）
  */
 export const getHtmlPreviewLink = (data: SandboxGetHtmlPreviewLinkClientBody) =>
   POST<SandboxGetHtmlPreviewLinkResponse>(

--- a/projects/app/src/pages/api/core/ai/sandbox/getHtmlPreviewLink.ts
+++ b/projects/app/src/pages/api/core/ai/sandbox/getHtmlPreviewLink.ts
@@ -6,13 +6,18 @@ import {
   authSandboxSession,
   buildSandboxClientQueryFromChatSource
 } from '@/service/core/sandbox/auth';
-import { SandboxGetHtmlPreviewLinkBodySchema } from '@fastgpt/global/openapi/core/ai/sandbox/api';
-import { S3PrivateBucket } from '@fastgpt/service/common/s3/buckets/private';
-import { getFileS3Key } from '@fastgpt/service/common/s3/utils';
-import { addMinutes } from 'date-fns';
+import {
+  SandboxGetHtmlPreviewLinkBodySchema,
+  SandboxGetHtmlPreviewLinkResponseSchema
+} from '@fastgpt/global/openapi/core/ai/sandbox/api';
 import { getSandboxClient } from '@fastgpt/service/core/ai/sandbox/interface/runtime';
-import { getSandboxFileContent } from '@fastgpt/service/core/ai/sandbox/interface/file';
 import { parseApiInput } from '@fastgpt/service/common/zod/requestParseError';
+import {
+  createSandboxPreviewFileUrl,
+  resolveSandboxPreviewPath
+} from '@fastgpt/service/core/ai/sandbox/application/preview';
+import { ReadPermissionVal } from '@fastgpt/global/support/permission/constant';
+import mime from 'mime';
 
 async function handler(req: ApiRequestProps, res: NextApiResponse): Promise<void> {
   const { sourceType, sourceId, chatId, filePath, outLinkAuthData } = parseApiInput({
@@ -31,10 +36,11 @@ async function handler(req: ApiRequestProps, res: NextApiResponse): Promise<void
     sourceType,
     sourceId,
     chatId,
-    outLinkAuthData
+    outLinkAuthData,
+    per: ReadPermissionVal
   });
 
-  // 2. 从沙箱读取实际文件内容，避免客户端传入任意 HTML
+  // 2. 只检查目标文件，不把 sandbox 内容复制到主站或对象存储。
   const sandbox = await getSandboxClient(
     buildSandboxClientQueryFromChatSource({
       sourceType: resolvedSourceType,
@@ -46,26 +52,29 @@ async function handler(req: ApiRequestProps, res: NextApiResponse): Promise<void
       failedArchivePolicy: 'clearAndContinue'
     }
   );
-  const { content, contentType } = await getSandboxFileContent(sandbox, filePath, true);
+  const { providerPath } = resolveSandboxPreviewPath(filePath);
+  const fileInfo = (await sandbox.provider.getFileInfo([providerPath])).get(providerPath);
 
-  if (!contentType.startsWith('text/html')) {
+  if (!fileInfo || fileInfo.isDirectory) {
+    return jsonRes(res, { code: 400, message: 'HTML file does not exist' });
+  }
+  if (mime.getType(providerPath) !== 'text/html') {
     return jsonRes(res, { code: 400, message: 'File is not an HTML file' });
   }
 
-  // 3. 保持 HTML 原始内容上传到 S3，避免预览时移除或禁用脚本逻辑。
-  const bucket = new S3PrivateBucket();
-  const { fileKey } = getFileS3Key.temp({ teamId, filename: 'preview.html' });
-  const expiredTime = addMinutes(new Date(), 30);
-
-  const {
-    accessUrl: { url }
-  } = await bucket.uploadFileByBody({
-    key: fileKey,
-    body: content,
-    filename: 'preview.html',
-    contentType: 'text/html; charset=utf-8',
-    expiredTime
-  });
+  // 3. token 仅描述 sandbox 归属，provider endpoint 和内部口令由 proxy 按请求解析。
+  const url = SandboxGetHtmlPreviewLinkResponseSchema.parse(
+    createSandboxPreviewFileUrl({
+      context: {
+        sourceType: resolvedSourceType,
+        sourceId: resolvedSourceId,
+        userId: uid,
+        chatId,
+        teamId
+      },
+      filePath: providerPath
+    })
+  );
 
   return jsonRes(res, {
     data: url

--- a/projects/app/src/pages/api/core/ai/sandbox/verifyTicket.ts
+++ b/projects/app/src/pages/api/core/ai/sandbox/verifyTicket.ts
@@ -16,13 +16,19 @@ import {
 import { serviceEnv } from '@fastgpt/service/env';
 import { ChatSourceTypeEnum } from '@fastgpt/global/core/chat/constants';
 import { buildSandboxClientQueryFromChatSource } from '@/service/core/sandbox/auth';
+import {
+  SANDBOX_PREVIEW_CHANNEL,
+  SandboxPreviewTicketClaimsSchema
+} from '@fastgpt/service/core/ai/sandbox/application/preview';
 
 const DEFAULT_IDE_AGENT_PORT = 1318;
+const DEFAULT_IDE_AGENT_PREVIEW_PORT = 1319;
 const IDE_AGENT_PASSWORD_READ_COMMAND = 'sh -c "cat ~/.fastgpt-ide-agent-password"';
 
 const VerifyTicketQuerySchema = z.object({
-  ticket: z.string()
+  ticket: z.string().min(1).optional()
 });
+const SANDBOX_TICKET_HEADER = 'x-sandbox-ticket';
 
 const SandboxVerifyTicketResponseSchema = z.object({
   sandbox_url: z.string().min(1),
@@ -45,13 +51,22 @@ const SandboxTicketClaimsSchema = BaseSandboxTicketClaimsSchema.extend({
   sourceType: z.enum(ChatSourceTypeEnum),
   sourceId: z.string()
 });
+const SandboxProxyTicketClaimsSchema = z.union([
+  SandboxTicketClaimsSchema,
+  SandboxPreviewTicketClaimsSchema
+]);
 
-const getIdeAgentPort = () => {
-  const bindAddr = serviceEnv.IDE_AGENT_BIND_ADDR;
-  if (!bindAddr) return DEFAULT_IDE_AGENT_PORT;
+/** 根据 ticket 通道选择 IDE Agent 的内部监听端口。 */
+const getIdeAgentPort = (channel: z.infer<typeof SandboxProxyTicketClaimsSchema>['channel']) => {
+  const isPreview = channel === SANDBOX_PREVIEW_CHANNEL;
+  const bindAddr = isPreview
+    ? serviceEnv.IDE_AGENT_PREVIEW_BIND_ADDR
+    : serviceEnv.IDE_AGENT_BIND_ADDR;
+  const defaultPort = isPreview ? DEFAULT_IDE_AGENT_PREVIEW_PORT : DEFAULT_IDE_AGENT_PORT;
+  if (!bindAddr) return defaultPort;
 
   const port = parseInt(bindAddr.split(':').pop() || '', 10);
-  return Number.isFinite(port) ? port : DEFAULT_IDE_AGENT_PORT;
+  return Number.isFinite(port) ? port : defaultPort;
 };
 
 async function readIdeAgentPassword(sandbox: SandboxClient) {
@@ -87,14 +102,19 @@ async function readIdeAgentPassword(sandbox: SandboxClient) {
 async function handler(req: ApiRequestProps): Promise<SandboxVerifyTicketResponse> {
   const secret = authAgentSandboxProxy(req);
 
-  const { ticket } = parseApiInput({
+  const { ticket: queryTicket } = parseApiInput({
     req,
     querySchema: VerifyTicketQuerySchema
   }).query;
+  const headerTicket = req.headers[SANDBOX_TICKET_HEADER];
+  const ticket = z
+    .string()
+    .min(1)
+    .parse((typeof headerTicket === 'string' ? headerTicket : undefined) ?? queryTicket);
 
-  let decoded: z.infer<typeof SandboxTicketClaimsSchema>;
+  let decoded: z.infer<typeof SandboxProxyTicketClaimsSchema>;
   try {
-    decoded = SandboxTicketClaimsSchema.parse(jwt.verify(ticket, secret));
+    decoded = SandboxProxyTicketClaimsSchema.parse(jwt.verify(ticket, secret));
   } catch (err: any) {
     throw new Error('Invalid ticket signature: ' + err.message);
   }
@@ -111,7 +131,7 @@ async function handler(req: ApiRequestProps): Promise<SandboxVerifyTicketRespons
   );
   const agentPassword = await readIdeAgentPassword(sandbox);
 
-  const endpoint = await sandbox.provider.getEndpoint(getIdeAgentPort());
+  const endpoint = await sandbox.provider.getEndpoint(getIdeAgentPort(decoded.channel));
 
   return SandboxVerifyTicketResponseSchema.parse({
     sandbox_url: endpoint.url,

--- a/projects/app/test/api/core/ai/sandbox/getHtmlPreviewLink.test.ts
+++ b/projects/app/test/api/core/ai/sandbox/getHtmlPreviewLink.test.ts
@@ -1,0 +1,139 @@
+import { ChatSourceTypeEnum } from '@fastgpt/global/core/chat/constants';
+import { ReadPermissionVal } from '@fastgpt/global/support/permission/constant';
+import { jsonRes } from '@fastgpt/service/common/response';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  authSandboxSession: vi.fn(),
+  buildSandboxClientQueryFromChatSource: vi.fn(),
+  createSandboxPreviewFileUrl: vi.fn(),
+  getFileInfo: vi.fn(),
+  getSandboxClient: vi.fn(),
+  resolveSandboxPreviewPath: vi.fn()
+}));
+
+vi.mock('@/service/middleware/entry', () => ({
+  NextAPI: vi.fn((handler) => handler)
+}));
+
+vi.mock('@/service/core/sandbox/auth', () => ({
+  authSandboxSession: mocks.authSandboxSession,
+  buildSandboxClientQueryFromChatSource: mocks.buildSandboxClientQueryFromChatSource
+}));
+
+vi.mock('@fastgpt/service/core/ai/sandbox/interface/runtime', () => ({
+  getSandboxClient: mocks.getSandboxClient
+}));
+
+vi.mock('@fastgpt/service/core/ai/sandbox/application/preview', () => ({
+  createSandboxPreviewFileUrl: mocks.createSandboxPreviewFileUrl,
+  resolveSandboxPreviewPath: mocks.resolveSandboxPreviewPath
+}));
+
+import handler from '@/pages/api/core/ai/sandbox/getHtmlPreviewLink';
+
+const mockJsonRes = vi.mocked(jsonRes);
+
+const createReq = (filePath = 'dist/index.html') =>
+  ({
+    body: {
+      appId: '507f1f77bcf86cd799439011',
+      chatId: 'chat-1',
+      filePath
+    }
+  }) as any;
+
+const createRes = () => {
+  const res = { status: vi.fn(), json: vi.fn() };
+  res.status.mockReturnValue(res);
+  return res as any;
+};
+
+describe('sandbox getHtmlPreviewLink API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authSandboxSession.mockResolvedValue({
+      uid: 'user-1',
+      teamId: 'team-1',
+      sourceType: ChatSourceTypeEnum.app,
+      sourceId: '507f1f77bcf86cd799439011'
+    });
+    mocks.buildSandboxClientQueryFromChatSource.mockReturnValue({ sandboxId: 'sandbox-1' });
+    mocks.resolveSandboxPreviewPath.mockReturnValue({
+      providerPath: '/workspace/dist/index.html',
+      relativePath: 'dist/index.html'
+    });
+    mocks.getFileInfo.mockResolvedValue(
+      new Map([['/workspace/dist/index.html', { isDirectory: false, isFile: true }]])
+    );
+    mocks.getSandboxClient.mockResolvedValue({ provider: { getFileInfo: mocks.getFileInfo } });
+    mocks.createSandboxPreviewFileUrl.mockReturnValue(
+      'https://agent-proxy.example.com/preview/ticket/dist/index.html'
+    );
+  });
+
+  it('returns a direct proxy URL without reading or uploading the HTML file', async () => {
+    const req = createReq();
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(mocks.authSandboxSession).toHaveBeenCalledWith({
+      req,
+      sourceType: ChatSourceTypeEnum.app,
+      sourceId: '507f1f77bcf86cd799439011',
+      chatId: 'chat-1',
+      outLinkAuthData: undefined,
+      per: ReadPermissionVal
+    });
+    expect(mocks.getFileInfo).toHaveBeenCalledWith(['/workspace/dist/index.html']);
+    expect(mocks.createSandboxPreviewFileUrl).toHaveBeenCalledWith({
+      context: {
+        sourceType: ChatSourceTypeEnum.app,
+        sourceId: '507f1f77bcf86cd799439011',
+        userId: 'user-1',
+        chatId: 'chat-1',
+        teamId: 'team-1'
+      },
+      filePath: '/workspace/dist/index.html'
+    });
+    expect(mockJsonRes).toHaveBeenCalledWith(res, {
+      data: 'https://agent-proxy.example.com/preview/ticket/dist/index.html'
+    });
+  });
+
+  it('rejects missing files, directories and non-HTML file extensions', async () => {
+    const missingRes = createRes();
+    mocks.getFileInfo.mockResolvedValueOnce(new Map());
+    await handler(createReq(), missingRes);
+    expect(mockJsonRes).toHaveBeenNthCalledWith(1, missingRes, {
+      code: 400,
+      message: 'HTML file does not exist'
+    });
+
+    const directoryRes = createRes();
+    mocks.getFileInfo.mockResolvedValueOnce(
+      new Map([['/workspace/dist/index.html', { isDirectory: true }]])
+    );
+    await handler(createReq(), directoryRes);
+    expect(mockJsonRes).toHaveBeenNthCalledWith(2, directoryRes, {
+      code: 400,
+      message: 'HTML file does not exist'
+    });
+
+    const textRes = createRes();
+    mocks.resolveSandboxPreviewPath.mockReturnValueOnce({
+      providerPath: '/workspace/dist/readme.txt',
+      relativePath: 'dist/readme.txt'
+    });
+    mocks.getFileInfo.mockResolvedValueOnce(
+      new Map([['/workspace/dist/readme.txt', { isDirectory: false, isFile: true }]])
+    );
+    await handler(createReq('dist/readme.txt'), textRes);
+    expect(mockJsonRes).toHaveBeenNthCalledWith(3, textRes, {
+      code: 400,
+      message: 'File is not an HTML file'
+    });
+    expect(mocks.createSandboxPreviewFileUrl).not.toHaveBeenCalled();
+  });
+});

--- a/projects/app/test/api/core/ai/sandbox/verifyTicket.test.ts
+++ b/projects/app/test/api/core/ai/sandbox/verifyTicket.test.ts
@@ -1,0 +1,107 @@
+import { ChatSourceTypeEnum } from '@fastgpt/global/core/chat/constants';
+import { serviceEnv } from '@fastgpt/service/env';
+import jwt from 'jsonwebtoken';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  authAgentSandboxProxy: vi.fn(),
+  buildSandboxClientQueryFromChatSource: vi.fn(),
+  exec: vi.fn(),
+  getEndpoint: vi.fn(),
+  getSandboxClient: vi.fn()
+}));
+
+vi.mock('@/service/middleware/entry', () => ({
+  NextAPI: vi.fn((handler) => handler)
+}));
+
+vi.mock('@/service/core/sandbox/auth', () => ({
+  authAgentSandboxProxy: mocks.authAgentSandboxProxy,
+  buildSandboxClientQueryFromChatSource: mocks.buildSandboxClientQueryFromChatSource
+}));
+
+vi.mock('@fastgpt/service/core/ai/sandbox/interface/runtime', () => ({
+  getSandboxClient: mocks.getSandboxClient
+}));
+
+import handler from '@/pages/api/core/ai/sandbox/verifyTicket';
+
+const secret = 'preview-secret-1234567890-1234567890';
+const originalIdeBindAddr = serviceEnv.IDE_AGENT_BIND_ADDR;
+const originalPreviewBindAddr = serviceEnv.IDE_AGENT_PREVIEW_BIND_ADDR;
+
+const createTicket = (channel: 'fs' | 'terminal' | 'preview', permission = 'read') =>
+  jwt.sign(
+    {
+      sourceType: ChatSourceTypeEnum.app,
+      sourceId: 'app-1',
+      userId: 'user-1',
+      chatId: 'chat-1',
+      teamId: 'team-1',
+      channel,
+      permission
+    },
+    secret,
+    { expiresIn: 60 }
+  );
+
+const createReq = (ticket: string) => ({ query: { ticket }, headers: {} }) as any;
+const createHeaderReq = (ticket: string) =>
+  ({ query: {}, headers: { 'x-sandbox-ticket': ticket } }) as any;
+
+describe('sandbox verifyTicket API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    serviceEnv.IDE_AGENT_BIND_ADDR = '0.0.0.0:2318';
+    serviceEnv.IDE_AGENT_PREVIEW_BIND_ADDR = '0.0.0.0:2319';
+    mocks.authAgentSandboxProxy.mockReturnValue(secret);
+    mocks.buildSandboxClientQueryFromChatSource.mockReturnValue({ sandboxId: 'sandbox-1' });
+    mocks.exec.mockResolvedValue({ stdout: 'agent-password\n', stderr: '', exitCode: 0 });
+    mocks.getEndpoint.mockResolvedValue({ url: 'http://sandbox.internal' });
+    mocks.getSandboxClient.mockResolvedValue({
+      exec: mocks.exec,
+      provider: { getEndpoint: mocks.getEndpoint }
+    });
+  });
+
+  afterEach(() => {
+    serviceEnv.IDE_AGENT_BIND_ADDR = originalIdeBindAddr;
+    serviceEnv.IDE_AGENT_PREVIEW_BIND_ADDR = originalPreviewBindAddr;
+  });
+
+  it('resolves preview tickets to the read-only HTTP listener', async () => {
+    await expect(handler(createHeaderReq(createTicket('preview')))).resolves.toMatchObject({
+      sandbox_url: 'http://sandbox.internal',
+      agent_token: 'agent-password'
+    });
+
+    expect(mocks.getEndpoint).toHaveBeenCalledWith(2319);
+  });
+
+  it('keeps WebSocket tickets on the existing IDE Agent listener', async () => {
+    await handler(createReq(createTicket('fs')));
+    expect(mocks.getEndpoint).toHaveBeenCalledWith(2318);
+  });
+
+  it('prefers the internal header over the legacy query transport', async () => {
+    const req = createHeaderReq(createTicket('preview'));
+    req.query.ticket = 'invalid-legacy-ticket';
+
+    await expect(handler(req)).resolves.toMatchObject({
+      sandbox_url: 'http://sandbox.internal'
+    });
+    expect(mocks.getEndpoint).toHaveBeenCalledWith(2319);
+  });
+
+  it('rejects write permission on preview tickets', async () => {
+    await expect(handler(createHeaderReq(createTicket('preview', 'write')))).rejects.toThrow(
+      'Invalid ticket signature'
+    );
+    expect(mocks.getSandboxClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests without a ticket in either transport', async () => {
+    await expect(handler({ query: {}, headers: {} } as any)).rejects.toThrow();
+    expect(mocks.getSandboxClient).not.toHaveBeenCalled();
+  });
+});

--- a/projects/fastgpt-ide-agent/Cargo.lock
+++ b/projects/fastgpt-ide-agent/Cargo.lock
@@ -9,6 +9,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,8 +160,10 @@ dependencies = [
 name = "fastgpt-ide-agent"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "base64",
  "futures-util",
+ "mime_guess",
  "notify",
  "notify-debouncer-full",
  "path-security",
@@ -120,6 +174,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-tungstenite",
+ "tokio-util",
+ "tower",
 ]
 
 [[package]]
@@ -146,6 +202,15 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -235,10 +300,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "inotify"
@@ -311,10 +440,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "mio"
@@ -416,6 +567,12 @@ checksum = "82874a773db60c7c36782df468314e634ad34440df8cb72c36109cdfea02a4fd"
 dependencies = [
  "anyhow",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -649,6 +806,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
 name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,6 +831,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tempfile"
@@ -762,6 +931,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +991,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/projects/fastgpt-ide-agent/Cargo.toml
+++ b/projects/fastgpt-ide-agent/Cargo.toml
@@ -7,6 +7,8 @@ rust-version = "1.95"
 [dependencies]
 tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread", "net", "time", "sync", "fs", "io-util", "process"] }
 tokio-tungstenite = { version = "0.29.0", default-features = false, features = ["handshake"] }
+tokio-util = { version = "0.7.18", features = ["io"] }
+axum = { version = "0.8.9", default-features = false, features = ["http1", "tokio"] }
 portable-pty = "0.9.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
@@ -16,6 +18,8 @@ path-security = "0.2.0"
 notify = "9.0.0-rc.4"
 notify-debouncer-full = "0.8.0-rc.2"
 sha2 = "0.10.9"
+mime_guess = "2.0.5"
 
 [dev-dependencies]
 tempfile = "3.27.0"
+tower = { version = "0.5.3", features = ["util"] }

--- a/projects/fastgpt-ide-agent/Dockerfile
+++ b/projects/fastgpt-ide-agent/Dockerfile
@@ -38,6 +38,6 @@ RUN chmod +x /usr/local/bin/fastgpt-ide-agent \
 
 USER fastgpt
 
-EXPOSE 1318
+EXPOSE 1318 1319
 
 CMD ["fastgpt-ide-agent"]

--- a/projects/fastgpt-ide-agent/src/main.rs
+++ b/projects/fastgpt-ide-agent/src/main.rs
@@ -5,6 +5,7 @@ use tokio::net::TcpListener;
 mod connection;
 mod fs;
 mod password;
+mod preview;
 mod protocol;
 mod terminal;
 mod workspace;
@@ -35,26 +36,45 @@ async fn main() {
 
     let bind_addr =
         std::env::var("IDE_AGENT_BIND_ADDR").unwrap_or_else(|_| "0.0.0.0:1318".to_string());
-    let listener = TcpListener::bind(&bind_addr)
+    let ws_listener = TcpListener::bind(&bind_addr)
         .await
         .unwrap_or_else(|_| panic!("Failed to bind to {}", bind_addr));
     println!("FastGPT IDE Agent listening on {}", bind_addr);
 
-    loop {
-        match listener.accept().await {
-            Ok((stream, _)) => {
-                let expected_password = Arc::clone(&password);
-                tokio::spawn(async move {
-                    handle_connection(stream, expected_password).await;
-                });
-            }
-            Err(e) => {
-                eprintln!(
-                    "Accept connection error: {:?}. Temporary pause for 50ms...",
-                    e
-                );
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let preview_bind_addr =
+        std::env::var("IDE_AGENT_PREVIEW_BIND_ADDR").unwrap_or_else(|_| "0.0.0.0:1319".to_string());
+    let preview_listener = TcpListener::bind(&preview_bind_addr)
+        .await
+        .unwrap_or_else(|_| panic!("Failed to bind to {}", preview_bind_addr));
+    println!(
+        "FastGPT IDE Agent preview server listening on {}",
+        preview_bind_addr
+    );
+
+    let serve_ws = async {
+        loop {
+            match ws_listener.accept().await {
+                Ok((stream, _)) => {
+                    let expected_password = Arc::clone(&password);
+                    tokio::spawn(async move {
+                        handle_connection(stream, expected_password).await;
+                    });
+                }
+                Err(e) => {
+                    eprintln!(
+                        "Accept connection error: {:?}. Temporary pause for 50ms...",
+                        e
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
             }
         }
-    }
+    };
+
+    tokio::select! {
+        _ = serve_ws => {}
+        result = preview::serve_preview(preview_listener, Arc::clone(&password)) => {
+            panic!("Preview server stopped unexpectedly: {result:?}");
+        }
+    };
 }

--- a/projects/fastgpt-ide-agent/src/preview.rs
+++ b/projects/fastgpt-ide-agent/src/preview.rs
@@ -1,0 +1,504 @@
+use std::{
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use axum::{
+    Router,
+    body::Body,
+    extract::{Path, State},
+    http::{
+        HeaderMap, HeaderValue, Method, StatusCode,
+        header::{
+            ACCEPT_RANGES, CACHE_CONTROL, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, ETAG,
+            IF_NONE_MATCH, RANGE, REFERRER_POLICY, X_CONTENT_TYPE_OPTIONS,
+        },
+    },
+    response::Response,
+    routing::get,
+};
+use tokio::{
+    fs::File,
+    io::{AsyncReadExt, AsyncSeekExt, SeekFrom},
+    net::TcpListener,
+};
+use tokio_util::io::ReaderStream;
+
+use crate::workspace::sanitize_path;
+
+#[derive(Clone)]
+struct PreviewState {
+    password: Arc<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ByteRange {
+    start: u64,
+    end: u64,
+}
+
+const AGENT_TOKEN_HEADER: &str = "x-fastgpt-agent-token";
+const PREVIEW_METHOD_HEADER: &str = "x-fastgpt-preview-method";
+
+fn parse_byte_range(value: &str, file_size: u64) -> Result<ByteRange, ()> {
+    if file_size == 0 || !value.starts_with("bytes=") {
+        return Err(());
+    }
+
+    let raw_range = &value[6..];
+    if raw_range.contains(',') {
+        return Err(());
+    }
+
+    let (raw_start, raw_end) = raw_range.split_once('-').ok_or(())?;
+    if raw_start.is_empty() {
+        let suffix_length = raw_end.parse::<u64>().map_err(|_| ())?;
+        if suffix_length == 0 {
+            return Err(());
+        }
+        let length = suffix_length.min(file_size);
+        return Ok(ByteRange {
+            start: file_size - length,
+            end: file_size - 1,
+        });
+    }
+
+    let start = raw_start.parse::<u64>().map_err(|_| ())?;
+    if start >= file_size {
+        return Err(());
+    }
+
+    let end = if raw_end.is_empty() {
+        file_size - 1
+    } else {
+        raw_end.parse::<u64>().map_err(|_| ())?.min(file_size - 1)
+    };
+    if end < start {
+        return Err(());
+    }
+
+    Ok(ByteRange { start, end })
+}
+
+fn apply_security_headers(headers: &mut HeaderMap) {
+    headers.insert(REFERRER_POLICY, HeaderValue::from_static("no-referrer"));
+    headers.insert(X_CONTENT_TYPE_OPTIONS, HeaderValue::from_static("nosniff"));
+    headers.insert(CACHE_CONTROL, HeaderValue::from_static("private, no-store"));
+}
+
+fn text_response(status: StatusCode, message: &'static str) -> Response<Body> {
+    let mut response = Response::new(Body::from(message));
+    *response.status_mut() = status;
+    response.headers_mut().insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static("text/plain; charset=utf-8"),
+    );
+    apply_security_headers(response.headers_mut());
+    response
+}
+
+fn is_authorized(headers: &HeaderMap, password: &str) -> bool {
+    headers
+        .get(AGENT_TOKEN_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value == password)
+}
+
+fn build_etag(file_size: u64, modified_at: SystemTime) -> String {
+    let modified_millis = modified_at
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default();
+    format!("W/\"{file_size:x}-{modified_millis:x}\"")
+}
+
+fn content_type_for_path(path: &std::path::Path) -> String {
+    let mime = mime_guess::from_path(path).first_or_octet_stream();
+    if mime.type_() == mime_guess::mime::TEXT {
+        format!("{}; charset=utf-8", mime.essence_str())
+    } else {
+        mime.essence_str().to_string()
+    }
+}
+
+/**
+ * Streams one authenticated workspace file over HTTP.
+ *
+ * The public preview ticket is never accepted here. The sandbox-local listener only trusts the
+ * IDE agent password supplied by agent-sandbox-proxy and confines every path to FASTGPT_WORKDIR.
+ */
+async fn preview_file_handler(
+    State(state): State<PreviewState>,
+    Path(path): Path<String>,
+    method: Method,
+    headers: HeaderMap,
+) -> Response<Body> {
+    if !is_authorized(&headers, &state.password) {
+        return text_response(StatusCode::UNAUTHORIZED, "Unauthorized");
+    }
+    let is_head = method == Method::HEAD
+        || (method == Method::GET
+            && headers
+                .get(PREVIEW_METHOD_HEADER)
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| value.eq_ignore_ascii_case("HEAD")));
+
+    let mut clean_path = match sanitize_path(&path).await {
+        Ok(path) => path,
+        Err(_) => return text_response(StatusCode::FORBIDDEN, "Forbidden workspace path"),
+    };
+    let mut metadata = match tokio::fs::metadata(&clean_path).await {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return text_response(StatusCode::NOT_FOUND, "File not found");
+        }
+        Err(_) => return text_response(StatusCode::INTERNAL_SERVER_ERROR, "Failed to read file"),
+    };
+
+    if metadata.is_dir() {
+        let index_path = format!("{}/index.html", path.trim_end_matches('/'));
+        clean_path = match sanitize_path(&index_path).await {
+            Ok(path) => path,
+            Err(_) => return text_response(StatusCode::FORBIDDEN, "Forbidden workspace path"),
+        };
+        metadata = match tokio::fs::metadata(&clean_path).await {
+            Ok(metadata) if metadata.is_file() => metadata,
+            Ok(_) => return text_response(StatusCode::FORBIDDEN, "Directory listing is disabled"),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return text_response(StatusCode::NOT_FOUND, "File not found");
+            }
+            Err(_) => {
+                return text_response(StatusCode::INTERNAL_SERVER_ERROR, "Failed to read file");
+            }
+        };
+    }
+
+    if !metadata.is_file() {
+        return text_response(StatusCode::FORBIDDEN, "Unsupported workspace entry");
+    }
+
+    let file_size = metadata.len();
+    let etag = build_etag(
+        file_size,
+        metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+    );
+    if headers
+        .get(IF_NONE_MATCH)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value == etag)
+    {
+        let mut response = Response::new(Body::empty());
+        *response.status_mut() = StatusCode::NOT_MODIFIED;
+        response
+            .headers_mut()
+            .insert(ETAG, HeaderValue::from_str(&etag).unwrap());
+        apply_security_headers(response.headers_mut());
+        return response;
+    }
+
+    let requested_range = match headers.get(RANGE).and_then(|value| value.to_str().ok()) {
+        Some(value) => match parse_byte_range(value, file_size) {
+            Ok(range) => Some(range),
+            Err(_) => {
+                let mut response = text_response(
+                    StatusCode::RANGE_NOT_SATISFIABLE,
+                    "Requested range is not satisfiable",
+                );
+                response.headers_mut().insert(
+                    CONTENT_RANGE,
+                    HeaderValue::from_str(&format!("bytes */{file_size}")).unwrap(),
+                );
+                return response;
+            }
+        },
+        None => None,
+    };
+    let response_range = requested_range.unwrap_or(ByteRange {
+        start: 0,
+        end: file_size.saturating_sub(1),
+    });
+    let response_length = if file_size == 0 {
+        0
+    } else {
+        response_range.end - response_range.start + 1
+    };
+
+    let body = if is_head || response_length == 0 {
+        Body::empty()
+    } else {
+        let mut file = match File::open(&clean_path).await {
+            Ok(file) => file,
+            Err(_) => {
+                return text_response(StatusCode::INTERNAL_SERVER_ERROR, "Failed to open file");
+            }
+        };
+        if response_range.start > 0
+            && file
+                .seek(SeekFrom::Start(response_range.start))
+                .await
+                .is_err()
+        {
+            return text_response(StatusCode::INTERNAL_SERVER_ERROR, "Failed to seek file");
+        }
+        Body::from_stream(ReaderStream::new(file.take(response_length)))
+    };
+
+    let mut response = Response::new(body);
+    *response.status_mut() = if requested_range.is_some() {
+        StatusCode::PARTIAL_CONTENT
+    } else {
+        StatusCode::OK
+    };
+    let response_headers = response.headers_mut();
+    response_headers.insert(ACCEPT_RANGES, HeaderValue::from_static("bytes"));
+    response_headers.insert(
+        CONTENT_TYPE,
+        HeaderValue::from_str(&content_type_for_path(&clean_path)).unwrap(),
+    );
+    response_headers.insert(
+        CONTENT_LENGTH,
+        HeaderValue::from_str(&response_length.to_string()).unwrap(),
+    );
+    response_headers.insert(ETAG, HeaderValue::from_str(&etag).unwrap());
+    if requested_range.is_some() {
+        response_headers.insert(
+            CONTENT_RANGE,
+            HeaderValue::from_str(&format!(
+                "bytes {}-{}/{}",
+                response_range.start, response_range.end, file_size
+            ))
+            .unwrap(),
+        );
+    }
+    apply_security_headers(response_headers);
+
+    response
+}
+
+fn preview_router(password: Arc<String>) -> Router {
+    Router::new()
+        .route(
+            "/preview/{*path}",
+            get(preview_file_handler).head(preview_file_handler),
+        )
+        .with_state(PreviewState { password })
+}
+
+pub async fn serve_preview(listener: TcpListener, password: Arc<String>) -> std::io::Result<()> {
+    axum::serve(listener, preview_router(password)).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::to_bytes,
+        http::{Request, header::CONTENT_RANGE},
+    };
+    use tower::ServiceExt;
+
+    use crate::workspace::init_test_workspace;
+
+    fn authorized_request(uri: &str) -> Request<Body> {
+        Request::builder()
+            .uri(uri)
+            .header(AGENT_TOKEN_HEADER, "preview-password")
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[test]
+    fn parses_supported_single_byte_ranges() {
+        assert_eq!(
+            parse_byte_range("bytes=2-5", 10),
+            Ok(ByteRange { start: 2, end: 5 })
+        );
+        assert_eq!(
+            parse_byte_range("bytes=7-", 10),
+            Ok(ByteRange { start: 7, end: 9 })
+        );
+        assert_eq!(
+            parse_byte_range("bytes=-3", 10),
+            Ok(ByteRange { start: 7, end: 9 })
+        );
+        assert_eq!(
+            parse_byte_range("bytes=2-100", 10),
+            Ok(ByteRange { start: 2, end: 9 })
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_or_multiple_byte_ranges() {
+        assert!(parse_byte_range("items=0-1", 10).is_err());
+        assert!(parse_byte_range("bytes=10-11", 10).is_err());
+        assert!(parse_byte_range("bytes=5-2", 10).is_err());
+        assert!(parse_byte_range("bytes=0-1,3-4", 10).is_err());
+        assert!(parse_byte_range("bytes=-0", 10).is_err());
+        assert!(parse_byte_range("bytes=0-", 0).is_err());
+    }
+
+    #[tokio::test]
+    async fn serves_authenticated_files_with_content_headers() {
+        let workspace = init_test_workspace();
+        let file_path = workspace.join("preview_http_index.html");
+        tokio::fs::write(&file_path, "<h1>preview</h1>")
+            .await
+            .unwrap();
+
+        let response = preview_router(Arc::new("preview-password".to_string()))
+            .oneshot(authorized_request("/preview/preview_http_index.html"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(CONTENT_TYPE).unwrap(),
+            "text/html; charset=utf-8"
+        );
+        assert_eq!(
+            response.headers().get(REFERRER_POLICY).unwrap(),
+            "no-referrer"
+        );
+        let body = to_bytes(response.into_body(), 1024).await.unwrap();
+        assert_eq!(&body[..], b"<h1>preview</h1>");
+    }
+
+    #[tokio::test]
+    async fn supports_head_etag_and_range_requests() {
+        let workspace = init_test_workspace();
+        let file_path = workspace.join("preview_http_range.txt");
+        tokio::fs::write(&file_path, "0123456789").await.unwrap();
+        let router = preview_router(Arc::new("preview-password".to_string()));
+
+        let range_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/preview/preview_http_range.txt")
+                    .header(AGENT_TOKEN_HEADER, "preview-password")
+                    .header(RANGE, "bytes=2-5")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(range_response.status(), StatusCode::PARTIAL_CONTENT);
+        assert_eq!(
+            range_response.headers().get(CONTENT_RANGE).unwrap(),
+            "bytes 2-5/10"
+        );
+        let etag = range_response.headers().get(ETAG).unwrap().clone();
+        let body = to_bytes(range_response.into_body(), 1024).await.unwrap();
+        assert_eq!(&body[..], b"2345");
+
+        let head_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::HEAD)
+                    .uri("/preview/preview_http_range.txt")
+                    .header(AGENT_TOKEN_HEADER, "preview-password")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(head_response.status(), StatusCode::OK);
+        assert_eq!(head_response.headers().get(CONTENT_LENGTH).unwrap(), "10");
+        assert!(
+            to_bytes(head_response.into_body(), 1024)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        let tunneled_head_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/preview/preview_http_range.txt")
+                    .header(AGENT_TOKEN_HEADER, "preview-password")
+                    .header(PREVIEW_METHOD_HEADER, "HEAD")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(tunneled_head_response.status(), StatusCode::OK);
+        assert!(
+            to_bytes(tunneled_head_response.into_body(), 1024)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        let not_modified_response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/preview/preview_http_range.txt")
+                    .header(AGENT_TOKEN_HEADER, "preview-password")
+                    .header(IF_NONE_MATCH, etag)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(not_modified_response.status(), StatusCode::NOT_MODIFIED);
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_auth_and_invalid_ranges() {
+        let workspace = init_test_workspace();
+        tokio::fs::write(workspace.join("preview_http_auth.txt"), "content")
+            .await
+            .unwrap();
+        let router = preview_router(Arc::new("preview-password".to_string()));
+
+        let unauthorized = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/preview/preview_http_auth.txt")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+        let invalid_range = router
+            .oneshot(
+                Request::builder()
+                    .uri("/preview/preview_http_auth.txt")
+                    .header(AGENT_TOKEN_HEADER, "preview-password")
+                    .header(RANGE, "bytes=999-")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(invalid_range.status(), StatusCode::RANGE_NOT_SATISFIABLE);
+        assert_eq!(
+            invalid_range.headers().get(CONTENT_RANGE).unwrap(),
+            "bytes */7"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn rejects_directory_index_symlinks_outside_workspace() {
+        let workspace = init_test_workspace();
+        let directory = workspace.join("preview_http_outside_index");
+        let _ = tokio::fs::remove_dir_all(&directory).await;
+        tokio::fs::create_dir_all(&directory).await.unwrap();
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        std::os::unix::fs::symlink(outside.path(), directory.join("index.html")).unwrap();
+
+        let response = preview_router(Arc::new("preview-password".to_string()))
+            .oneshot(authorized_request("/preview/preview_http_outside_index"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+}


### PR DESCRIPTION
## What

- add a read-only IDE Agent HTTP listener rooted at `FASTGPT_WORKDIR`
- add `/preview/{token}/{path}` streaming relay support to `agent-sandbox-proxy`
- issue two-hour preview tickets from FastGPT and resolve sandbox endpoints through the existing authenticated back channel
- replace HTML preview and `sandbox_get_file_url` S3 exports with direct workspace URLs
- preserve existing WebSocket behavior and sandbox archive storage

## Why

HTML previews and generated file links currently copy sandbox files to S3 before they can be opened. This adds latency, duplicates temporary data, and can break relative asset references. The new path keeps the workspace as the source of truth and lets relative HTML resources resolve through one scoped proxy URL.

## Security and behavior

- preview tickets are signed, read-only bearer capabilities scoped to one sandbox workspace
- provider endpoints and IDE Agent passwords never appear in public tickets
- all file paths are confined to the workspace; traversal, escaping symlinks, absolute paths, and directory listings are rejected
- proxy-to-app ticket resolution uses an internal header to avoid query-string logging
- only GET/HEAD and a small request/response header allowlist are relayed
- responses include no-referrer, no-sniff, and no-store headers
- S3-backed sandbox archive/restore remains unchanged

## Checks

- `pnpm --filter @fastgpt/app typecheck`
- focused FastGPT sandbox tests, including preview ticket, HTML API, tool URL, runtime config, and ticket transport coverage
- `cargo test` and `cargo clippy --all-targets -- -D warnings` for both Rust projects
- local Docker/OpenSandbox end-to-end verification for HTML, relative CSS/image assets, MIME, ETag/304, Range/206, HEAD, missing files, internal auth, and token expiry
- repository-wide app/global/service test attempt: global passed; three unrelated 20-second timeout failures under concurrent load all passed when rerun in isolation

The top-level `pnpm test` script cannot run in this checkout because it references the absent `@fastgpt/admin` workspace, so the available app/global/service suites were run directly through Turbo.
