### PR TITLE
fix: restore v1 completion value type compatibility

### DIFF
--- a/projects/app/src/pages/api/v1/chat/completions.ts
+++ b/projects/app/src/pages/api/v1/chat/completions.ts
@@ -470,7 +470,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       const formatResponseContent = removeAIResponseCite(assistantResponses, jsonRetainDatasetCite);
       const formattdResponse = formatCompletionResponseContent({
         responseContent: formatResponseContent,
-        detail
+        detail,
+        includeLegacyType: true
       });
 
       const error =

--- a/projects/app/src/service/core/chat/utils.ts
+++ b/projects/app/src/service/core/chat/utils.ts
@@ -6,6 +6,7 @@ export type PublicCompletionInteractive = Pick<WorkflowInteractiveResponseType, 
 
 export type CompletionDetailValueItem = Omit<AIChatItemValueItemType, 'interactive'> & {
   interactive?: PublicCompletionInteractive;
+  type?: 'text' | 'file' | 'tool' | 'interactive' | 'reasoning';
 };
 
 export type CompletionResponseContent =
@@ -23,10 +24,12 @@ export type CompletionResponseContent =
  */
 export const formatCompletionResponseContent = ({
   responseContent,
-  detail
+  detail,
+  includeLegacyType = false
 }: {
   responseContent: AIChatItemValueItemType[];
   detail: boolean;
+  includeLegacyType?: boolean;
 }): CompletionResponseContent => {
   const MAX_COMPLETION_INTERACTIVE_EXTRACT_DEPTH = 20;
 
@@ -79,13 +82,24 @@ export const formatCompletionResponseContent = ({
     };
   };
 
-  const formatDetailValueList = (responseContent: AIChatItemValueItemType[]) =>
-    responseContent.map((item) => ({
+  const formatDetailValueList = (responseContent: AIChatItemValueItemType[]) => {
+    const getLegacyValueType = (item: AIChatItemValueItemType) => {
+      if (item.text) return 'text' as const;
+      if ('file' in item) return 'file' as const;
+      if ('tool' in item || 'tools' in item) return 'tool' as const;
+      if (item.interactive) return 'interactive' as const;
+      if (item.reasoning) return 'reasoning' as const;
+      return 'text' as const;
+    };
+
+    return responseContent.map((item) => ({
       ...item,
+      ...(includeLegacyType && { type: getLegacyValueType(item) }),
       ...(item.interactive && {
         interactive: formatPublicCompletionInteractive(item.interactive)
       })
     }));
+  };
 
   const shouldReturnDetailValueList = ({
     responseContent,

--- a/projects/app/test/service/core/chat/completionResponse.test.ts
+++ b/projects/app/test/service/core/chat/completionResponse.test.ts
@@ -145,4 +145,50 @@ describe('formatCompletionResponseContent', () => {
       content: 'hello\nworld'
     });
   });
+
+  it('adds legacy value types only when explicitly enabled', () => {
+    const responseContent: AIChatItemValueItemType[] = [
+      {
+        reasoning: { content: 'thinking' },
+        text: { content: 'hello' }
+      },
+      {
+        tools: [
+          {
+            id: 'call-1',
+            toolName: 'Search',
+            toolAvatar: '',
+            functionName: 'search',
+            params: '{}',
+            response: 'result'
+          }
+        ]
+      }
+    ];
+
+    expect(
+      formatCompletionResponseContent({
+        detail: true,
+        responseContent,
+        includeLegacyType: true
+      })
+    ).toEqual([
+      {
+        reasoning: { content: 'thinking' },
+        text: { content: 'hello' },
+        type: 'text'
+      },
+      {
+        tools: responseContent[1].tools,
+        type: 'tool'
+      }
+    ]);
+
+    expect(
+      formatCompletionResponseContent({
+        detail: true,
+        responseContent
+      })
+    ).toEqual(responseContent);
+  });
 });


### PR DESCRIPTION
## What changed

- Restore legacy `type` discriminators on structured `choices[].message.content` items returned by `/v1/chat/completions`.
- Keep `/v2/chat/completions` unchanged by making the compatibility behavior opt-in and enabling it only in v1.
- Preserve the legacy precedence used by chat records: `text`, `file`, `tool`, `interactive`, then `reasoning`.
- Add coverage for both the v1 compatibility mode and the unchanged default behavior used by v2.

## Why

The unified Agent Loop now emits field-keyed values such as `{ text, reasoning }` and `{ tools }` without the historical `type` field. v1 clients may rely on `type` for compatibility.

## Validation

- `git diff --check`
- Prettier 3.8.3 check passed for all changed files
- Confirmed only the v1 route enables `includeLegacyType`
- Targeted Vitest could not run because dependency installation repeatedly failed on npm registry HTTP 502 responses