### PR TITLE
fix(dataset): translate image parse node response

### DIFF
--- a/packages/service/core/workflow/dispatch/dataset/nodeResponse.ts
+++ b/packages/service/core/workflow/dispatch/dataset/nodeResponse.ts
@@ -81,7 +81,7 @@ export const createImageCaptionChildNodeResponse = ({
     requestIds,
     usage,
     seconds,
-    moduleName: i18nT('account_usage:image_parse'),
+    moduleName: i18nT('chat:image_parse'),
     textOutput: queries.join('\n')
   });
 

--- a/packages/service/test/core/workflow/dispatch/ai/agent/sub/dataset.test.ts
+++ b/packages/service/test/core/workflow/dispatch/ai/agent/sub/dataset.test.ts
@@ -441,7 +441,7 @@ describe('dispatchAgentDatasetSearch', () => {
     expect(result.nodeResponse?.childrenResponses).toEqual([
       expect.objectContaining({
         id: 'req_image_caption',
-        moduleName: 'account_usage:image_parse',
+        moduleName: 'chat:image_parse',
         llmRequestIds: ['req_image_caption'],
         totalPoints: 0.12,
         textOutput: 'image caption'

--- a/packages/service/test/core/workflow/dispatch/dataset/search.test.ts
+++ b/packages/service/test/core/workflow/dispatch/dataset/search.test.ts
@@ -267,7 +267,7 @@ describe('dispatchDatasetSearch', () => {
       id: 'req_image_caption_1',
       nodeId: 'req_image_caption_1',
       moduleType: FlowNodeTypeEnum.datasetSearchNode,
-      moduleName: 'account_usage:image_parse',
+      moduleName: 'chat:image_parse',
       moduleLogo: 'core/workflow/template/datasetSearch',
       runningTime: 1.5,
       model: 'gpt-vision name',

--- a/packages/web/i18n/en/chat.json
+++ b/packages/web/i18n/en/chat.json
@@ -52,6 +52,7 @@
   "home.chat_app": "HomeChat-{{name}}",
   "home.select_tools": "Select Tool",
   "home.tools": "Tool: {{num}}",
+  "image_parse": "Image parsing",
   "in_progress": "In Progress",
   "input_guide": "Input Guide",
   "input_placeholder_phone": "Please enter your question",

--- a/packages/web/i18n/zh-CN/chat.json
+++ b/packages/web/i18n/zh-CN/chat.json
@@ -52,6 +52,7 @@
   "home.chat_app": "首页聊天",
   "home.select_tools": "选择工具",
   "home.tools": "工具：{{num}}",
+  "image_parse": "图片解析",
   "in_progress": "进行中",
   "input_guide": "输入引导",
   "input_placeholder_phone": "发消息给FastGPT",

--- a/packages/web/i18n/zh-Hant/chat.json
+++ b/packages/web/i18n/zh-Hant/chat.json
@@ -52,6 +52,7 @@
   "home.chat_app": "首页聊天",
   "home.select_tools": "選擇工具",
   "home.tools": "工具：{{num}}",
+  "image_parse": "圖片解析",
   "in_progress": "進行中",
   "input_guide": "輸入導引",
   "input_placeholder_phone": "請輸入問題",


### PR DESCRIPTION
## What changed

- Use the `chat:image_parse` translation key for the image parsing child node response in dataset search.
- Add Simplified Chinese, Traditional Chinese, and English translations for the node name.
- Update dataset search and Agent dataset search assertions while keeping billing usage names under `account_usage:image_parse`.

## Why

Chat and app debug pages do not load the `account_usage` namespace. The image parsing child node response used `account_usage:image_parse`, so its node name was rendered as an untranslated key.

## Impact

Image parsing child responses now display a localized node name in chat details and workflow debugging. Billing labels are unchanged.

## Validation

- `node scripts/test/withMongo.mjs pnpm --dir packages/service test test/core/workflow/dispatch/dataset/search.test.ts test/core/workflow/dispatch/ai/agent/sub/dataset.test.ts`
- 2 test files passed, 10 tests passed.
- Commit hooks passed ESLint and Prettier.
