### PR TITLE
fix: respect configured chat upload limit

### DIFF
--- a/projects/app/src/components/core/app/FileSelect.tsx
+++ b/projects/app/src/components/core/app/FileSelect.tsx
@@ -26,6 +26,7 @@ import MyTag from '@fastgpt/web/components/common/Tag/index';
 import { defaultAppSelectFileConfig } from '@fastgpt/global/core/app/constants';
 import InputSlider from '@fastgpt/web/components/common/MySlider/InputSlider';
 import { FileTypeSelectorPanel } from '@fastgpt/web/components/core/app/FileTypeSelector';
+import { resolveFileSelectConfigMaxFiles } from './fileSelectConfig';
 
 const FileSelect = ({
   forbidVision = false,
@@ -42,11 +43,11 @@ const FileSelect = ({
   const { teamPlanStatus } = useUserStore();
   const { isOpen, onOpen, onClose } = useDisclosure();
 
-  // 文件数量限制：团队套餐 || 系统配置 || 默认值（这里是指对话中，最多上传多少文件）
-  const maxSelectFiles = Math.min(
-    teamPlanStatus?.standard?.maxUploadFileCount || feConfigs.uploadFileMaxAmount,
-    50
-  );
+  // 对话可配置的文件数量不能超过团队套餐；未配置套餐时沿用系统上传上限。
+  const maxSelectFiles = resolveFileSelectConfigMaxFiles({
+    teamPlanMaxFiles: teamPlanStatus?.standard?.maxUploadFileCount,
+    systemMaxFiles: feConfigs.uploadFileMaxAmount
+  });
 
   const [localValue, setLocalValue] = useState(value);
 

--- a/projects/app/src/components/core/app/fileSelectConfig.ts
+++ b/projects/app/src/components/core/app/fileSelectConfig.ts
@@ -1,0 +1,12 @@
+/**
+ * 解析工作流对话可配置的最大文件数。
+ * 团队套餐是更严格的业务上限；套餐未配置该字段时，才回退到系统上传数量配置。
+ * 该函数单独导出用于覆盖无套餐和套餐限制的回归测试。
+ */
+export const resolveFileSelectConfigMaxFiles = ({
+  teamPlanMaxFiles,
+  systemMaxFiles
+}: {
+  teamPlanMaxFiles?: number;
+  systemMaxFiles: number;
+}) => teamPlanMaxFiles ?? systemMaxFiles;

--- a/projects/app/test/components/core/app/fileSelectConfig.test.ts
+++ b/projects/app/test/components/core/app/fileSelectConfig.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { resolveFileSelectConfigMaxFiles } from '@/components/core/app/fileSelectConfig';
+
+describe('resolveFileSelectConfigMaxFiles', () => {
+  it('uses the system upload limit when the team plan has no file limit', () => {
+    expect(
+      resolveFileSelectConfigMaxFiles({
+        systemMaxFiles: 100
+      })
+    ).toBe(100);
+  });
+
+  it('uses the team plan limit when it is configured', () => {
+    expect(
+      resolveFileSelectConfigMaxFiles({
+        teamPlanMaxFiles: 20,
+        systemMaxFiles: 100
+      })
+    ).toBe(20);
+  });
+
+  it('does not replace an explicit zero limit with the system limit', () => {
+    expect(
+      resolveFileSelectConfigMaxFiles({
+        teamPlanMaxFiles: 0,
+        systemMaxFiles: 100
+      })
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

- remove the hard-coded 50-file cap from workflow chat file configuration
- use the team plan limit when configured and otherwise fall back to the system upload limit
- add regression tests for system, plan, and explicit zero limits

## Testing

- pnpm --filter @fastgpt/app test test/components/core/app/fileSelectConfig.test.ts test/components/core/chat/ChatContainer/ChatBox/chatValue.test.ts
- ESLint passed for changed files