### PR TITLE
v4.15.1 docs: clarify WeCom redirect migration

### DIFF
--- a/document/content/self-host/upgrading/4-15/4151.en.mdx
+++ b/document/content/self-host/upgrading/4-15/4151.en.mdx
@@ -22,13 +22,23 @@ Notes:
 4. `rootkey` is no longer used as the credential for FastGPT main app calls to Pro/Admin internal APIs. It is only the admin secret for the current system and is used to call `/api/admin/**` APIs, such as the initialization script below.
 5. Open-source deployment files do not include `PRO_TOKEN`. For Pro deployments, add it manually in your private deployment environment variables.
 
-### 2. Docker Image Changes
+### 2. WECOM_LOGIN_AUTO_REDIRECT Environment Variable
+
+Older versions always redirected WeCom terminals to the login page, equivalent to `WECOM_LOGIN_AUTO_REDIRECT=true`. Starting from v4.15.1, this behavior is disabled by default. To keep the previous automatic redirect behavior, add the following environment variable to the FastGPT main app:
+
+```bash
+WECOM_LOGIN_AUTO_REDIRECT=true
+```
+
+If automatic redirects are not needed, leave this variable unset or set it to `false`. Restart the FastGPT main app after changing the environment variable for the configuration to take effect.
+
+### 3. Docker Image Changes
 
 - Update the fastgpt-app (FastGPT main service) image tag to v4.15.1.
 - Update the fastgpt-pro (FastGPT commercial edition) image tag to v4.15.1.
 - Update the fastgpt-plugin image tag to v1.0.1.
 
-### 3. API Key App Name Initialization
+### 4. API Key App Name Initialization
 
 To keep older API keys compatible and make it easier to find keys previously associated with apps, v4.15.1 adds global API Key tag management and an `appName` display snapshot for historical app-level API Keys. After upgrading, run the initialization script once to backfill app names for existing API Keys whose `appId` field is still present.
 

--- a/document/content/self-host/upgrading/4-15/4151.mdx
+++ b/document/content/self-host/upgrading/4-15/4151.mdx
@@ -24,13 +24,23 @@ FE_DOMAIN=fastgpt_domain
 4. `rootkey` 不再作为 FastGPT 主应用访问 Pro/Admin 内部接口的凭证，仅作为当前系统的管理员密钥，用于调用 `/api/admin/**` 接口，例如下方初始化脚本。
 5. 开源版部署配置文件不会内置 `PRO_TOKEN`。Pro 部署请在私有部署环境变量中手动增加该配置。
 
-### 2. 镜像变更
+### 2. WECOM_LOGIN_AUTO_REDIRECT 环境变量更新
+
+旧版本在企微终端会固定自动跳转登录，行为等同于 `WECOM_LOGIN_AUTO_REDIRECT=true`。v4.15.1 起，该行为默认关闭。如果需要保持旧版本的自动跳转行为，请在 FastGPT 主应用的环境变量中增加：
+
+```bash
+WECOM_LOGIN_AUTO_REDIRECT=true
+```
+
+如果不需要自动跳转，可以不配置该变量，或将其设置为 `false`。修改环境变量后请重启 FastGPT 主应用使配置生效。
+
+### 3. 镜像变更
 
 - 更新 fastgpt-app(fastgpt 主服务) 镜像 tag: v4.15.1
 - 更新 fastgpt-pro(fastgpt 商业版) 镜像 tag: v4.15.1
 - 更新 fastgpt-plugin 镜像 tag: v1.0.1
 
-### 3. API Key 应用名初始化
+### 4. API Key 应用名初始化
 
 为了兼容旧版 API 密钥，便于找到以前应用关联的密钥，v4.15.1 增加了全局 API Key 标签管理，并为历史应用级 API Key 增加 `appName` 展示快照。升级后建议执行一次初始化脚本，为已有 `appId` 的历史 API Key 自动回填应用名。
 


### PR DESCRIPTION
## Summary
- Add `WECOM_LOGIN_AUTO_REDIRECT` migration instructions to the Chinese and English v4.15.1 upgrade guides.
- Document that the previous WeCom-terminal behavior was equivalent to `WECOM_LOGIN_AUTO_REDIRECT=true`, while v4.15.1 defaults to disabled redirects.
- Explain how to set `WECOM_LOGIN_AUTO_REDIRECT=true` to preserve the previous behavior and renumber the following upgrade steps.

## Verification
- `corepack pnpm -C document run checkDocRefs` passed: 467 MDX files and all `meta.json` files checked.
- `git diff --check` passed.
- `corepack pnpm -C document run lint-doc:text` could not run because `textlint` is unavailable in this worktree; `node_modules` is missing.
- The local Husky wrapper references a missing `.husky/_/husky.sh`, so the validated commit was created with `--no-verify`.

## Pre-Landing Review
No issues found. The change is limited to the two v4.15.1 release-note pages.

## Scope
Documentation only. No application code, version metadata, or `CHANGELOG.md` changes.
