### PR TITLE
fix(ci): allow trusted fork checkout in pro workflows

### DIFF
--- a/.github/workflows/preview-admin-build.yml
+++ b/.github/workflows/preview-admin-build.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 1
 
       - name: Update submodules

--- a/.github/workflows/test-fastgpt-pro.yaml
+++ b/.github/workflows/test-fastgpt-pro.yaml
@@ -44,6 +44,7 @@ jobs:
           repository: ${{ github.event_name == 'pull_request_target' &&
             github.event.pull_request.head.repo.full_name || github.repository
             }}
+          allow-unsafe-pr-checkout: true
       - name: Update submodules
         env:
           PRO_SUBMODULE_TOKEN: ${{ secrets.PRO_SUBMODULE_TOKEN }}


### PR DESCRIPTION
## Summary

- opt in to fork PR checkout for the Pro test and admin preview workflows
- preserve the existing COLLABORATOR/OWNER actor guard and submodule token handling
- keep the change GitHub-only because these workflows have no Forgejo counterparts

## Why

actions/checkout@v4 now rejects fork code checkout from pull_request_target unless the workflow explicitly opts in. These Pro workflows intentionally need the trusted base context to access the private Pro submodule and already restrict execution to collaborators and owners.

## Validation

- parsed both workflow files as YAML
- passed git diff --check
- confirmed the current actions/checkout@v4 action metadata defines allow-unsafe-pr-checkout

Note: actionlint v1.7.12 still has the pre-update checkout@v4 input list and reports this newly backported input as unknown.