### PR TITLE
feat(milvus): support Milvus 2.6+ BM25 fulltext search with automatic…

### DIFF
--- a/packages/service/common/vectorDB/controller.ts
+++ b/packages/service/common/vectorDB/controller.ts
@@ -141,10 +141,16 @@ export const insertDatasetDataVector = async ({
     inputs: embeddingInputs,
     type: 'db'
   });
+
+  const textContents = embeddingInputs.map((input) =>
+    input.type === 'text' ? String(input.input) : ''
+  );
+
   const { insertIds } = await retryFn(() =>
     Vector.insert({
       ...props,
-      vectors
+      vectors,
+      textContents
     })
   );
 

--- a/packages/service/common/vectorDB/global.d.ts
+++ b/packages/service/common/vectorDB/global.d.ts
@@ -1,11 +1,13 @@
 import type { Pool as PgPool } from 'pg';
 import type { Pool as MysqlPool } from 'mysql2/promise';
 import type { MilvusClient } from '@zilliz/milvus2-sdk-node';
+import type { MilvusVersionManager } from './milvus/version';
 
 declare global {
   var pgClient: PgPool | null;
   var obClient: MysqlPool | null;
   var milvusClient: MilvusClient | null;
+  var milvusVersionManager: MilvusVersionManager | undefined;
 }
 
 export {};

--- a/packages/service/common/vectorDB/milvus/config.ts
+++ b/packages/service/common/vectorDB/milvus/config.ts
@@ -1,0 +1,190 @@
+import { DataType, FunctionType } from '@zilliz/milvus2-sdk-node';
+import type {
+  FieldType,
+  FunctionObject
+} from '@zilliz/milvus2-sdk-node/dist/milvus/types/Collection';
+import type { CreateIndexSimpleReq } from '@zilliz/milvus2-sdk-node/dist/milvus/types/MilvusIndex';
+import { DatasetVectorTableName } from '../constants';
+
+export const MILVUS_VECTOR_DIMENSION = 1536;
+export const MILVUS_TEXT_MAX_LENGTH = 65535;
+export const MILVUS_QUERY_MAX_LENGTH = 4000;
+
+export type MilvusIndexParam = Omit<CreateIndexSimpleReq, 'collection_name'>;
+
+export type MilvusCollectionConfig = {
+  name: string;
+  description: string;
+  fields: FieldType[];
+  indexParams: MilvusIndexParam[];
+  functions?: FunctionObject[];
+};
+
+export type MilvusInsertRow = {
+  id: number;
+  vector: number[];
+  teamId: string;
+  datasetId: string;
+  collectionId: string;
+  createTime: number;
+  text?: string;
+};
+
+// BM25 Function: input text, output sparse vector
+export const createBM25Function = (): FunctionObject => ({
+  name: 'text_bm25_emb',
+  type: FunctionType.BM25,
+  input_field_names: ['text'],
+  output_field_names: ['sparse'],
+  params: {}
+});
+
+// Multi-language analyzer fallback configs (language_identifier -> standard -> jieba)
+export type AnalyzerConfig = {
+  name: string;
+  params: Record<string, any>;
+};
+
+export const analyzerConfigs: AnalyzerConfig[] = [
+  {
+    name: 'language_identifier',
+    params: {
+      tokenizer: {
+        type: 'language_identifier',
+        identifier: 'whatlang',
+        analyzers: {
+          default: { tokenizer: 'standard' },
+          English: { type: 'english' },
+          Mandarin: { tokenizer: 'jieba' }
+        }
+      }
+    }
+  },
+  {
+    name: 'standard',
+    params: { tokenizer: 'standard' }
+  },
+  {
+    name: 'jieba',
+    params: { tokenizer: 'jieba' }
+  }
+];
+
+export const ANALYZER_ERROR_CODES = [
+  'ANALYZER_NOT_SUPPORTED',
+  'INVALID_ANALYZER',
+  'UNSUPPORTED_ANALYZER'
+];
+
+export const isAnalyzerError = (err: unknown): boolean => {
+  const code = extractErrorCode(err);
+  if (code && ANALYZER_ERROR_CODES.includes(code)) return true;
+  return false;
+};
+
+export const extractErrorCode = (err: unknown): string | undefined => {
+  if (!err) return undefined;
+  const e = err as any;
+  return e?.code || e?.error_code || e?.errorCode || e?.status?.error_code;
+};
+
+export const extractErrorMessage = (err: unknown): string => {
+  if (!err) return '';
+  if (err instanceof Error) return err.message;
+  const e = err as any;
+  return e?.message || e?.reason || e?.status?.reason || String(err);
+};
+
+const createBaseFields = (dim: number, supportsFullText: boolean): FieldType[] => {
+  const fields: FieldType[] = [
+    {
+      name: 'id',
+      data_type: DataType.Int64,
+      is_primary_key: true,
+      autoID: false
+    },
+    {
+      name: 'vector',
+      data_type: DataType.FloatVector,
+      dim
+    },
+    { name: 'teamId', data_type: DataType.VarChar, max_length: 64 },
+    { name: 'datasetId', data_type: DataType.VarChar, max_length: 64 },
+    { name: 'collectionId', data_type: DataType.VarChar, max_length: 64 },
+    { name: 'createTime', data_type: DataType.Int64 }
+  ];
+
+  if (supportsFullText) {
+    fields.push({
+      name: 'text',
+      data_type: DataType.VarChar,
+      max_length: MILVUS_TEXT_MAX_LENGTH,
+      enable_analyzer: true,
+      enable_match: true,
+      analyzer_params: analyzerConfigs[0].params,
+      nullable: true
+    } as FieldType);
+    fields.push({
+      name: 'sparse',
+      data_type: DataType.SparseFloatVector
+    } as FieldType);
+  }
+
+  return fields;
+};
+
+export const createFullTextFields = (dim: number): FieldType[] => createBaseFields(dim, true);
+
+export const createBaseIndexParams = (supportsFullText: boolean): MilvusIndexParam[] => {
+  const params: MilvusIndexParam[] = [
+    {
+      field_name: 'vector',
+      index_name: 'vector_HNSW',
+      index_type: 'HNSW',
+      metric_type: 'IP',
+      params: { efConstruction: 128, M: 32 }
+    },
+    { field_name: 'teamId', index_type: 'Trie' },
+    { field_name: 'datasetId', index_type: 'Trie' },
+    { field_name: 'collectionId', index_type: 'Trie' },
+    { field_name: 'createTime', index_type: 'STL_SORT' }
+  ];
+
+  if (supportsFullText) {
+    params.push({
+      field_name: 'sparse',
+      index_name: 'sparse_BM25',
+      index_type: 'SPARSE_INVERTED_INDEX',
+      metric_type: 'BM25',
+      params: { bm25_k1: 1.2, bm25_b: 0.75 }
+    } as MilvusIndexParam);
+  }
+
+  return params;
+};
+
+export const createBaseFunctions = (supportsFullText: boolean): FunctionObject[] | undefined => {
+  if (!supportsFullText) return undefined;
+  return [createBM25Function()];
+};
+
+export const getMilvusCollectionDefinitions = (
+  supportsFullText: boolean
+): MilvusCollectionConfig[] => [
+  {
+    name: DatasetVectorTableName,
+    description: 'Store dataset vector',
+    fields: createBaseFields(MILVUS_VECTOR_DIMENSION, supportsFullText),
+    indexParams: createBaseIndexParams(supportsFullText),
+    functions: createBaseFunctions(supportsFullText)
+  }
+];
+
+export const isSchemaMismatchError = (err: unknown): boolean => {
+  const code = extractErrorCode(err);
+  if (code) {
+    return ['SchemaMismatch', 'InvalidSchema', 'SCHEMA_MISMATCH', 'INVALID_SCHEMA'].includes(code);
+  }
+  const msg = extractErrorMessage(err).toLowerCase();
+  return msg.includes('schema') && (msg.includes('mismatch') || msg.includes('invalid'));
+};

--- a/packages/service/common/vectorDB/milvus/config.ts
+++ b/packages/service/common/vectorDB/milvus/config.ts
@@ -76,10 +76,30 @@ export const ANALYZER_ERROR_CODES = [
   'UNSUPPORTED_ANALYZER'
 ];
 
+export const COLLECTION_NOT_FOUND_CODES = [
+  'CollectionNameNotFound',
+  'COLLECTION_NAME_NOT_FOUND',
+  'CollectionNotFound',
+  'COLLECTION_NOT_FOUND',
+  'CollectionNotExists',
+  'COLLECTION_NOT_EXISTS'
+];
+
 export const isAnalyzerError = (err: unknown): boolean => {
   const code = extractErrorCode(err);
   if (code && ANALYZER_ERROR_CODES.includes(code)) return true;
   return false;
+};
+
+export const isCollectionNotFoundError = (err: unknown): boolean => {
+  const code = extractErrorCode(err);
+  if (code && COLLECTION_NOT_FOUND_CODES.includes(code)) return true;
+  // Also check the message as a fallback for gRPC status details
+  const msg = extractErrorMessage(err).toLowerCase();
+  return (
+    msg.includes('collection') &&
+    (msg.includes('not found') || msg.includes("doesn't exist") || msg.includes('does not exist'))
+  );
 };
 
 export const extractErrorCode = (err: unknown): string | undefined => {

--- a/packages/service/common/vectorDB/milvus/index.ts
+++ b/packages/service/common/vectorDB/milvus/index.ts
@@ -5,15 +5,32 @@ import {
   MILVUS_ADDRESS,
   MILVUS_TOKEN
 } from '../constants';
-import type { VectorControllerType } from '../type';
+import type {
+  VectorControllerType,
+  InsertVectorControllerPropsType,
+  EmbeddingRecallCtrlPropsType,
+  EmbeddingRecallResponseType,
+  FullTextSearchCtrlPropsType
+} from '../type';
 import { retryFn } from '@fastgpt/global/common/system/utils';
 import { getLogger, LogCategories } from '../../logger';
 import { customNanoid } from '@fastgpt/global/common/string/tools';
+import { serviceEnv } from '../../../env';
+import {
+  getMilvusCollectionDefinitions,
+  MILVUS_TEXT_MAX_LENGTH,
+  MILVUS_QUERY_MAX_LENGTH,
+  isSchemaMismatchError,
+  type MilvusCollectionConfig,
+  type MilvusInsertRow
+} from './config';
+import { milvusVersionManager } from './version';
 
 const logger = getLogger(LogCategories.INFRA.VECTOR);
 
 export class MilvusCtrl implements VectorControllerType {
   constructor() {}
+
   getClient = async () => {
     if (!MILVUS_ADDRESS) {
       return Promise.reject('MILVUS_ADDRESS is not set');
@@ -22,7 +39,8 @@ export class MilvusCtrl implements VectorControllerType {
 
     global.milvusClient = new MilvusClient({
       address: MILVUS_ADDRESS,
-      token: MILVUS_TOKEN
+      token: MILVUS_TOKEN,
+      timeout: serviceEnv.MILVUS_TIMEOUT
     });
     await global.milvusClient.connectPromise;
 
@@ -30,8 +48,50 @@ export class MilvusCtrl implements VectorControllerType {
 
     return global.milvusClient;
   };
+
+  private createMilvusCollection = async (client: MilvusClient, config: MilvusCollectionConfig) => {
+    const { name, description, fields, indexParams, functions } = config;
+
+    const { value: hasCollection } = await client.hasCollection({
+      collection_name: name
+    });
+
+    if (!hasCollection) {
+      const result = await client.createCollection({
+        collection_name: name,
+        description,
+        enableDynamicField: true,
+        fields,
+        index_params: indexParams,
+        functions
+      });
+      logger.info('Milvus collection created', { collection: name, result });
+      return;
+    }
+
+    logger.info('Milvus collection already exists', { collection: name });
+  };
+
+  private loadCollection = async (client: MilvusClient, name: string) => {
+    const { state: colLoadState } = await client.getLoadState({
+      collection_name: name
+    });
+
+    if (
+      colLoadState === LoadState.LoadStateNotExist ||
+      colLoadState === LoadState.LoadStateNotLoad
+    ) {
+      await client.loadCollectionSync({
+        collection_name: name
+      });
+      logger.info('Milvus collection loaded', { collection: name });
+    }
+  };
+
   init: VectorControllerType['init'] = async () => {
     const client = await this.getClient();
+
+    await milvusVersionManager.detectVersion(client);
 
     // init db(zilliz cloud will error)
     try {
@@ -50,119 +110,118 @@ export class MilvusCtrl implements VectorControllerType {
       logger.warn('Milvus database initialization skipped or failed', { error });
     }
 
-    // init collection and index
-    const { value: hasCollection } = await client.hasCollection({
-      collection_name: DatasetVectorTableName
-    });
-    if (!hasCollection) {
-      const result = await client.createCollection({
-        collection_name: DatasetVectorTableName,
-        description: 'Store dataset vector',
-        enableDynamicField: true,
-        fields: [
-          {
-            name: 'id',
-            data_type: DataType.Int64,
-            is_primary_key: true,
-            autoID: false // disable auto id, and we need to set id in insert
-          },
-          {
-            name: 'vector',
-            data_type: DataType.FloatVector,
-            dim: 1536
-          },
-          { name: 'teamId', data_type: DataType.VarChar, max_length: 64 },
-          { name: 'datasetId', data_type: DataType.VarChar, max_length: 64 },
-          { name: 'collectionId', data_type: DataType.VarChar, max_length: 64 },
-          {
-            name: 'createTime',
-            data_type: DataType.Int64
-          }
-        ],
-        index_params: [
-          {
-            field_name: 'vector',
-            index_name: 'vector_HNSW',
-            index_type: 'HNSW',
-            metric_type: 'IP',
-            params: { efConstruction: 32, M: 64 }
-          },
-          {
-            field_name: 'teamId',
-            index_type: 'Trie'
-          },
-          {
-            field_name: 'datasetId',
-            index_type: 'Trie'
-          },
-          {
-            field_name: 'collectionId',
-            index_type: 'Trie'
-          },
-          {
-            field_name: 'createTime',
-            index_type: 'STL_SORT'
-          }
-        ]
-      });
+    const supportsFullText = milvusVersionManager.supportsFullText();
+    const collectionDefinitions = getMilvusCollectionDefinitions(supportsFullText);
 
-      logger.info('Milvus collection created', {
-        collection: DatasetVectorTableName,
-        result
-      });
-    }
-
-    const { state: colLoadState } = await client.getLoadState({
-      collection_name: DatasetVectorTableName
-    });
-
-    if (
-      colLoadState === LoadState.LoadStateNotExist ||
-      colLoadState === LoadState.LoadStateNotLoad
-    ) {
-      await client.loadCollectionSync({
-        collection_name: DatasetVectorTableName
-      });
-      logger.info('Milvus collection loaded', { collection: DatasetVectorTableName });
+    for (const config of collectionDefinitions) {
+      await this.createMilvusCollection(client, config);
+      await this.loadCollection(client, config.name);
     }
   };
 
-  insert: VectorControllerType['insert'] = async (props) => {
+  insert: VectorControllerType['insert'] = async (props: InsertVectorControllerPropsType) => {
     const client = await this.getClient();
-    const { teamId, datasetId, collectionId, vectors } = props;
+    const { teamId, datasetId, collectionId, vectors, textContents } = props;
+
+    if (textContents && textContents.length !== vectors.length) {
+      logger.error('textContents length does not match vectors length', {
+        teamId,
+        datasetId,
+        collectionId,
+        textContentsLength: textContents.length,
+        vectorsLength: vectors.length
+      });
+      throw new Error('textContents length must match vectors length');
+    }
 
     const generateId = () => {
-      // in js, the max safe integer is 2^53 - 1: 9007199254740991
-      // so we can generate a random number between 1-8 as the first digit
-      // and the rest 15 digits can be random
       const firstDigit = customNanoid('12345678', 1);
       const restDigits = customNanoid('1234567890', 15);
       return Number(`${firstDigit}${restDigits}`);
     };
 
-    const result = await client.insert({
-      collection_name: DatasetVectorTableName,
-      data: vectors.map((vector) => ({
+    const now = Date.now();
+    const supportsFullText = milvusVersionManager.supportsFullText();
+
+    const data: MilvusInsertRow[] = vectors.map((vector, index) => {
+      const row: MilvusInsertRow = {
         id: generateId(),
         vector,
         teamId: String(teamId),
         datasetId: String(datasetId),
         collectionId: String(collectionId),
-        createTime: Date.now()
-      }))
+        createTime: now
+      };
+
+      if (supportsFullText && textContents) {
+        const rawText = textContents[index] ?? '';
+        if (rawText.length > MILVUS_TEXT_MAX_LENGTH) {
+          logger.warn('Milvus text field truncated', {
+            originalLength: rawText.length,
+            maxLength: MILVUS_TEXT_MAX_LENGTH,
+            id: row.id,
+            collectionId
+          });
+          row.text = rawText.slice(0, MILVUS_TEXT_MAX_LENGTH);
+        } else {
+          row.text = rawText;
+        }
+      }
+
+      return row;
     });
 
-    const insertIds = (() => {
-      if ('int_id' in result.IDs) {
-        return result.IDs.int_id.data.map((id) => String(id));
-      }
-      return result.IDs.str_id.data.map((id) => String(id));
-    })();
+    try {
+      const result = await client.insert({
+        collection_name: DatasetVectorTableName,
+        data
+      });
 
-    return {
-      insertIds
-    };
+      if (result.status?.error_code !== 'Success' && result.status?.error_code !== 0) {
+        throw new Error(
+          `Milvus insert failed: ${result.status?.error_code} - ${result.status?.reason}`
+        );
+      }
+
+      const insertIds = (() => {
+        if ('int_id' in result.IDs) {
+          return result.IDs.int_id.data.map((id) => String(id));
+        }
+        return result.IDs.str_id.data.map((id) => String(id));
+      })();
+
+      return { insertIds };
+    } catch (err) {
+      if (supportsFullText && isSchemaMismatchError(err)) {
+        logger.warn('Milvus insert schema mismatch, retrying with skip_check_schema', {
+          collectionName: DatasetVectorTableName,
+          error: err instanceof Error ? err.message : String(err)
+        });
+        const result = await client.insert({
+          collection_name: DatasetVectorTableName,
+          data,
+          skip_check_schema: true
+        });
+
+        if (result.status?.error_code !== 'Success' && result.status?.error_code !== 0) {
+          throw new Error(
+            `Milvus insert failed: ${result.status?.error_code} - ${result.status?.reason}`
+          );
+        }
+
+        const insertIds = (() => {
+          if ('int_id' in result.IDs) {
+            return result.IDs.int_id.data.map((id) => String(id));
+          }
+          return result.IDs.str_id.data.map((id) => String(id));
+        })();
+
+        return { insertIds };
+      }
+      throw err;
+    }
   };
+
   delete: VectorControllerType['delete'] = async (props) => {
     const { teamId } = props;
     const client = await this.getClient();
@@ -201,7 +260,10 @@ export class MilvusCtrl implements VectorControllerType {
       filter: concatWhere
     });
   };
-  embRecall: VectorControllerType['embRecall'] = async (props) => {
+
+  embRecall: VectorControllerType['embRecall'] = async (
+    props: EmbeddingRecallCtrlPropsType
+  ): Promise<EmbeddingRecallResponseType> => {
     const client = await this.getClient();
     const { teamId, datasetIds, vector, limit, forbidCollectionIdList, filterCollectionIdList } =
       props;
@@ -209,10 +271,9 @@ export class MilvusCtrl implements VectorControllerType {
     // Forbid collection
     const formatForbidCollectionIdList = (() => {
       if (!filterCollectionIdList) return forbidCollectionIdList;
-      const list = forbidCollectionIdList
+      return forbidCollectionIdList
         .map((id) => String(id))
         .filter((id) => !filterCollectionIdList.includes(id));
-      return list;
     })();
     const forbidColQuery =
       formatForbidCollectionIdList.length > 0
@@ -229,7 +290,88 @@ export class MilvusCtrl implements VectorControllerType {
     const collectionIdQuery = formatFilterCollectionId
       ? `and (collectionId in [${formatFilterCollectionId.map((id) => `"${id}"`).join(',')}])`
       : ``;
-    // Empty data
+
+    if (formatFilterCollectionId && formatFilterCollectionId.length === 0) {
+      return { results: [] };
+    }
+
+    const filterStr =
+      `(teamId == "${teamId}") and (datasetId in [${datasetIds.map((id) => `"${id}"`).join(',')}]) ${collectionIdQuery} ${forbidColQuery}`.trim();
+
+    const searchParams: any = {
+      collection_name: DatasetVectorTableName,
+      limit,
+      expr: filterStr,
+      output_fields: ['id', 'collectionId'],
+      params: { ef: global.systemEnv?.hnswEfSearch || 100 }
+    };
+
+    if (milvusVersionManager.getFeatureLevel() === 'V26') {
+      searchParams.data = [vector];
+    } else {
+      searchParams.vector = vector;
+    }
+
+    const searchResult = await retryFn(() => client.search(searchParams));
+
+    const rows = (searchResult.results || []) as {
+      score: number;
+      id: string;
+      collectionId: string;
+    }[];
+
+    return {
+      results: rows.map((item) => ({
+        id: String(item.id),
+        collectionId: item.collectionId,
+        score: item.score
+      }))
+    };
+  };
+
+  fullTextSearch = async (
+    props: FullTextSearchCtrlPropsType
+  ): Promise<EmbeddingRecallResponseType> => {
+    const client = await this.getClient();
+    const { teamId, datasetIds, query, limit, forbidCollectionIdList, filterCollectionIdList } =
+      props;
+
+    if (!query || limit === 0 || datasetIds.length === 0) {
+      return { results: [] };
+    }
+
+    let trimmedQuery = query;
+    if (query.length > MILVUS_QUERY_MAX_LENGTH) {
+      trimmedQuery = query.slice(0, MILVUS_QUERY_MAX_LENGTH);
+      logger.warn('Milvus full-text query truncated', {
+        originalLength: query.length,
+        maxLength: MILVUS_QUERY_MAX_LENGTH
+      });
+    }
+
+    // Forbid collection
+    const formatForbidCollectionIdList = (() => {
+      if (!filterCollectionIdList) return forbidCollectionIdList;
+      return forbidCollectionIdList
+        .map((id) => String(id))
+        .filter((id) => !filterCollectionIdList.includes(id));
+    })();
+    const forbidColQuery =
+      formatForbidCollectionIdList.length > 0
+        ? `and (collectionId not in [${formatForbidCollectionIdList.map((id) => `"${id}"`).join(',')}])`
+        : '';
+
+    // filter collection id
+    const formatFilterCollectionId = (() => {
+      if (!filterCollectionIdList) return;
+      return filterCollectionIdList
+        .map((id) => String(id))
+        .filter((id) => !forbidCollectionIdList.includes(id));
+    })();
+    const collectionIdQuery = formatFilterCollectionId
+      ? `and (collectionId in [${formatFilterCollectionId.map((id) => `"${id}"`).join(',')}])`
+      : '';
+
     if (formatFilterCollectionId && formatFilterCollectionId.length === 0) {
       return { results: [] };
     }
@@ -240,11 +382,13 @@ export class MilvusCtrl implements VectorControllerType {
     const searchResult = await retryFn(() =>
       client.search({
         collection_name: DatasetVectorTableName,
-        vector: vector,
+        data: [trimmedQuery],
+        anns_field: 'sparse',
+        filter: filterStr,
         limit,
-        expr: filterStr,
-        output_fields: ['collectionId']
-      })
+        output_fields: ['id', 'collectionId'],
+        params: { metric_type: 'BM25' }
+      } as any)
     );
 
     const rows = (searchResult.results || []) as {
@@ -266,7 +410,6 @@ export class MilvusCtrl implements VectorControllerType {
     const { teamId, datasetId, collectionId } = props;
     const client = await this.getClient();
 
-    // Build filter conditions dynamically (each condition wrapped in parentheses)
     const filterConditions: string[] = [];
 
     if (teamId) {
@@ -281,7 +424,6 @@ export class MilvusCtrl implements VectorControllerType {
       filterConditions.push(`(collectionId == "${String(collectionId)}")`);
     }
 
-    // If no conditions provided, count all (empty filter)
     const filter = filterConditions.length > 0 ? filterConditions.join(' and ') : '';
 
     const result = await client.query({

--- a/packages/service/common/vectorDB/milvus/version.ts
+++ b/packages/service/common/vectorDB/milvus/version.ts
@@ -1,0 +1,91 @@
+import type { MilvusClient } from '@zilliz/milvus2-sdk-node';
+import { getLogger, LogCategories } from '../../logger';
+
+const logger = getLogger(LogCategories.INFRA.VECTOR);
+
+export enum FeatureLevel {
+  V24 = 'V24',
+  V26 = 'V26',
+  UNKNOWN = 'UNKNOWN'
+}
+
+export class MilvusVersionManager {
+  private featureLevel: FeatureLevel = FeatureLevel.UNKNOWN;
+  private detectionPromise: Promise<FeatureLevel> | null = null;
+
+  private constructor() {}
+
+  static getInstance(): MilvusVersionManager {
+    if (!global.milvusVersionManager) {
+      global.milvusVersionManager = new MilvusVersionManager();
+    }
+    return global.milvusVersionManager;
+  }
+
+  async detectVersion(client: MilvusClient): Promise<FeatureLevel> {
+    // Return in-flight detection to deduplicate concurrent calls
+    if (this.detectionPromise) return this.detectionPromise;
+
+    // Return cached result if already detected (V24 or V26)
+    if (this.featureLevel !== FeatureLevel.UNKNOWN) {
+      return this.featureLevel;
+    }
+
+    this.detectionPromise = this.runDetection(client).finally(() => {
+      this.detectionPromise = null;
+    });
+
+    return this.detectionPromise;
+  }
+
+  private async runDetection(client: MilvusClient): Promise<FeatureLevel> {
+    try {
+      const versionInfo = await client.getVersion();
+      const version = versionInfo?.version || '';
+
+      logger.info('Milvus server version detected', { milvusVersion: version });
+
+      const match = version.match(/v?(\d+)\.(\d+)/);
+      if (!match) {
+        throw new Error(`Invalid version format: ${version}`);
+      }
+
+      const major = parseInt(match[1], 10);
+      const minor = parseInt(match[2], 10);
+
+      if (major > 2 || (major === 2 && minor >= 6)) {
+        this.featureLevel = FeatureLevel.V26;
+      } else {
+        this.featureLevel = FeatureLevel.V24;
+      }
+
+      logger.info('Milvus feature level set', {
+        milvusVersion: version,
+        featureLevel: this.featureLevel
+      });
+      return this.featureLevel;
+    } catch (error) {
+      logger.error('Milvus version detection failed, defaulting to UNKNOWN', {
+        errorType: 'version_detection_failed',
+        error: error instanceof Error ? error.message : String(error)
+      });
+      this.featureLevel = FeatureLevel.UNKNOWN;
+      return this.featureLevel;
+    }
+  }
+
+  async resetDetection(client: MilvusClient): Promise<FeatureLevel> {
+    this.featureLevel = FeatureLevel.UNKNOWN;
+    return this.detectVersion(client);
+  }
+
+  supportsFullText(): boolean {
+    return this.featureLevel === FeatureLevel.V26;
+  }
+
+  getFeatureLevel(): FeatureLevel {
+    return this.featureLevel;
+  }
+}
+
+export const milvusVersionManager = MilvusVersionManager.getInstance();

--- a/packages/service/common/vectorDB/type.ts
+++ b/packages/service/common/vectorDB/type.ts
@@ -1,4 +1,7 @@
-import z from 'zod';
+import type { Pool as PgPool } from 'pg';
+import type { Pool as MysqlPool } from 'mysql2/promise';
+import type { MilvusClient } from '@zilliz/milvus2-sdk-node';
+import { z } from 'zod';
 
 // Embedding recall item schema
 export const EmbeddingRecallItemSchema = z.object({
@@ -13,9 +16,21 @@ export const InsertVectorControllerPropsSchema = z.object({
   teamId: z.string(),
   datasetId: z.string(),
   collectionId: z.string(),
-  vectors: z.array(z.array(z.number()))
+  vectors: z.array(z.array(z.number())),
+  textContents: z.array(z.string()).optional()
 });
 export type InsertVectorControllerPropsType = z.infer<typeof InsertVectorControllerPropsSchema>;
+
+// Full-text search props schema
+export const FullTextSearchCtrlPropsSchema = z.object({
+  teamId: z.string(),
+  datasetIds: z.array(z.string()),
+  query: z.string(),
+  limit: z.number(),
+  forbidCollectionIdList: z.array(z.string()),
+  filterCollectionIdList: z.array(z.string()).optional()
+});
+export type FullTextSearchCtrlPropsType = z.infer<typeof FullTextSearchCtrlPropsSchema>;
 
 // Insert vector response schema
 export const InsertVectorResponseSchema = z.object({
@@ -101,6 +116,11 @@ export interface VectorControllerType {
    * Embedding recall/search vectors
    */
   embRecall(props: EmbeddingRecallCtrlPropsType): Promise<EmbeddingRecallResponseType>;
+
+  /**
+   * Full-text search (Milvus 2.6+ BM25 only)
+   */
+  fullTextSearch?(props: FullTextSearchCtrlPropsType): Promise<EmbeddingRecallResponseType>;
 
   /**
    * Get vector data by time range

--- a/packages/service/core/dataset/search/defaultRecall/constant.ts
+++ b/packages/service/core/dataset/search/defaultRecall/constant.ts
@@ -13,7 +13,7 @@ export const datasetDataSelectField = {
   imageDescMap: 1,
   chunkIndex: 1,
   indexes: 1
-};
+} as const;
 
 /**
  * collection 只需要来源展示字段。
@@ -27,4 +27,4 @@ export const datasetCollectionSelectField = {
   apiFileId: 1,
   externalFileId: 1,
   externalFileUrl: 1
-};
+} as const;

--- a/packages/service/core/dataset/search/defaultRecall/fullTextRecall.ts
+++ b/packages/service/core/dataset/search/defaultRecall/fullTextRecall.ts
@@ -5,33 +5,34 @@ import type {
   DatasetDataTextSchemaType,
   SearchDataResponseItemType
 } from '@fastgpt/global/core/dataset/type';
+import type { EmbeddingRecallItemType } from '../../../../common/vectorDB/type';
 import { jiebaSplit } from '../../../../common/string/jieba/index';
 import { Types } from '../../../../common/mongo';
 import { readFromSecondary } from '../../../../common/mongo/utils';
 import { getLogger, LogCategories } from '../../../../common/logger';
+import { serviceEnv } from '../../../../env';
 import { MongoDatasetCollection } from '../../collection/schema';
 import { MongoDatasetDataText } from '../../data/dataTextSchema';
 import { MongoDatasetData } from '../../data/schema';
+import { MILVUS_ADDRESS } from '../../../../common/vectorDB/constants';
 import { datasetCollectionSelectField, datasetDataSelectField } from './constant';
 import { buildSearchResultItem, concatRecallLists } from './result';
+import { MilvusCtrl } from '../../../../common/vectorDB/milvus';
+import { milvusVersionManager } from '../../../../common/vectorDB/milvus/version';
 
 const logger = getLogger(LogCategories.MODULE.DATASET.DATA);
 
 type FullTextRecallSource = 'text' | 'imageCaption';
 
-/**
- * 执行 Mongo full-text 召回并按 query 来源分组返回。
- * 目前 full-text 只处理文本类 query：用户文本和图片 caption。原始图片不会进入这里，
- * 因为 Mongo 文本索引无法直接消费图片向量或图片 URL。
- */
-export const fullTextRecall = async ({
-  teamId,
-  datasetIds,
-  queryGroups,
-  limit,
-  filterCollectionIdList,
-  forbidCollectionIdList
-}: {
+/** 统一的召回结果格式，屏蔽 Milvus / Mongo 的字段差异 */
+type RecallItem = {
+  source: FullTextRecallSource;
+  dataId: string;
+  collectionId: string;
+  score: number;
+};
+
+interface FullTextRecallProps {
   teamId: string;
   datasetIds: string[];
   queryGroups: {
@@ -41,25 +42,100 @@ export const fullTextRecall = async ({
   limit: number;
   filterCollectionIdList?: string[];
   forbidCollectionIdList: string[];
-}): Promise<{
-  textFullTextRecallResults: SearchDataResponseItemType[];
-  imageCaptionFullTextRecallResults: SearchDataResponseItemType[];
-}> => {
-  const queryTasks = queryGroups.flatMap((group) =>
-    group.queries
-      .map((query) => query.trim())
-      .filter(Boolean)
-      .map((query) => ({ source: group.source, query }))
-  );
+}
 
-  if (limit === 0 || queryTasks.length === 0) {
-    return {
-      textFullTextRecallResults: [],
-      imageCaptionFullTextRecallResults: []
-    };
+export const getFullTextEngine = (): 'mongo' | 'milvus' => {
+  const value = serviceEnv.FULL_TEXT_ENGINE;
+  if (!value) return 'mongo';
+
+  const normalized = String(value).trim().toLowerCase();
+  if (normalized === 'milvus') return 'milvus';
+  if (normalized === 'mongo') return 'mongo';
+
+  logger.warn('Unknown FULL_TEXT_ENGINE value, defaulting to mongo', {
+    fullTextEngine: value
+  });
+  return 'mongo';
+};
+
+const computeUseMilvusFullText = (): boolean => {
+  const fullTextEngine = getFullTextEngine();
+
+  if (fullTextEngine !== 'milvus') {
+    return false;
   }
 
-  const recallResults = await Promise.all(
+  if (!MILVUS_ADDRESS || !milvusVersionManager.supportsFullText()) {
+    return false;
+  }
+
+  return true;
+};
+
+const fullTextRecallFromMilvus = async ({
+  teamId,
+  datasetIds,
+  queryTasks,
+  limit,
+  filterCollectionIdList,
+  forbidCollectionIdList
+}: {
+  teamId: string;
+  datasetIds: string[];
+  queryTasks: { source: FullTextRecallSource; query: string }[];
+  limit: number;
+  filterCollectionIdList?: string[];
+  forbidCollectionIdList: string[];
+}): Promise<{
+  recallResults: { source: FullTextRecallSource; results: EmbeddingRecallItemType[] }[];
+  error?: string;
+}> => {
+  const milvusCtrl = new MilvusCtrl();
+
+  try {
+    const results = await Promise.all(
+      queryTasks.map(async ({ query }) => {
+        return await milvusCtrl.fullTextSearch!({
+          teamId,
+          datasetIds,
+          query,
+          limit,
+          forbidCollectionIdList,
+          filterCollectionIdList
+        });
+      })
+    );
+
+    return {
+      recallResults: results.map((result, index) => ({
+        source: queryTasks[index].source,
+        results: result.results
+      }))
+    };
+  } catch (err) {
+    return {
+      recallResults: [],
+      error: err instanceof Error ? err.message : String(err)
+    };
+  }
+};
+
+const mongoFullTextRecall = async ({
+  teamId,
+  datasetIds,
+  queryTasks,
+  limit,
+  filterCollectionIdList,
+  forbidCollectionIdList
+}: {
+  teamId: string;
+  datasetIds: string[];
+  queryTasks: { source: FullTextRecallSource; query: string }[];
+  limit: number;
+  filterCollectionIdList?: string[];
+  forbidCollectionIdList: string[];
+}) => {
+  return await Promise.all(
     queryTasks.map(async ({ query }) => {
       return (await MongoDatasetDataText.aggregate(
         [
@@ -108,79 +184,79 @@ export const fullTextRecall = async ({
       )) as (DatasetDataTextSchemaType & { score: number })[];
     })
   );
+};
 
+/**
+ * 统一的搜索结果组装：根据归一化的 RecallItem 列表，查 data/collection、去重、建 item、按 source 分组拼接。
+ */
+const buildResultsFromRecallItems = async ({
+  taskItems,
+  limit
+}: {
+  taskItems: { source: FullTextRecallSource; items: Omit<RecallItem, 'source'>[] }[];
+  limit: number;
+}): Promise<{
+  textFullTextRecallResults: SearchDataResponseItemType[];
+  imageCaptionFullTextRecallResults: SearchDataResponseItemType[];
+}> => {
   const dataIds = Array.from(
-    new Set(recallResults.map((item) => item.map((item) => item.dataId)).flat())
+    new Set(taskItems.flatMap((t) => t.items.map((r) => r.dataId)).filter(Boolean))
   );
   const collectionIds = Array.from(
-    new Set(recallResults.map((item) => item.map((item) => item.collectionId)).flat())
+    new Set(taskItems.flatMap((t) => t.items.map((r) => r.collectionId)).filter(Boolean))
   );
 
-  // full-text 表只保存 dataId/collectionId/score，展示字段仍回查主 data 与 collection。
-  const [dataMaps, collectionMaps] = await Promise.all([
-    MongoDatasetData.find(
-      {
-        _id: { $in: dataIds }
-      },
-      datasetDataSelectField,
-      { ...readFromSecondary }
-    )
+  const [dataMap, collectionMap] = await Promise.all([
+    MongoDatasetData.find({ _id: { $in: dataIds } }, datasetDataSelectField, {
+      ...readFromSecondary
+    })
       .lean()
       .then((res) => {
         const map = new Map<string, DatasetDataSchemaType>();
-
-        res.forEach((item) => {
-          map.set(String(item._id), item);
-        });
-
+        res.forEach((item) => map.set(String(item._id), item));
         return map;
       }),
-    MongoDatasetCollection.find(
-      {
-        _id: { $in: collectionIds }
-      },
-      datasetCollectionSelectField,
-      { ...readFromSecondary }
-    )
+    MongoDatasetCollection.find({ _id: { $in: collectionIds } }, datasetCollectionSelectField, {
+      ...readFromSecondary
+    })
       .lean()
       .then((res) => {
         const map = new Map<string, DatasetCollectionSchemaType>();
-
-        res.forEach((item) => {
-          map.set(String(item._id), item);
-        });
-
+        res.forEach((item) => map.set(String(item._id), item));
         return map;
       })
   ]);
 
-  const groupedRecallLists: Record<FullTextRecallSource, SearchDataResponseItemType[][]> = {
+  const grouped: Record<FullTextRecallSource, SearchDataResponseItemType[][]> = {
     text: [],
     imageCaption: []
   };
+  const seen = new Set<string>();
 
-  for (const [taskIndex, recallResult] of recallResults.entries()) {
-    const task = queryTasks[taskIndex];
+  for (const task of taskItems) {
     const list = (
       await Promise.all(
-        recallResult.map((item, index) => {
-          const collection = collectionMaps.get(String(item.collectionId));
+        task.items.map((item, index) => {
+          const collection = collectionMap.get(String(item.collectionId));
           if (!collection) {
-            logger.warn('Dataset collection not found during full-text recall', {
+            logger.warn('Collection not found during full-text recall', {
               collectionId: item.collectionId,
               dataId: item.dataId
             });
             return;
           }
 
-          const data = dataMaps.get(String(item.dataId));
+          const data = dataMap.get(String(item.dataId));
           if (!data) {
-            logger.warn('Dataset data not found during full-text recall', {
+            logger.warn('Data not found during full-text recall', {
               dataId: item.dataId,
               collectionId: item.collectionId
             });
             return;
           }
+
+          if (seen.has(String(data._id))) return;
+          seen.add(String(data._id));
 
           return buildSearchResultItem({
             data,
@@ -197,22 +273,142 @@ export const fullTextRecall = async ({
         })
       )
     )
-      .filter((item) => {
-        if (!item) return false;
-        return true;
-      })
-      .map((item, index) => {
-        return {
-          ...item,
-          score: item!.score.map((item) => ({ ...item, index }))
-        };
-      }) as SearchDataResponseItemType[];
+      .filter((item): item is SearchDataResponseItemType => !!item)
+      .map((item, i) => ({
+        ...item,
+        score: item.score.map((si) => ({ ...si, index: i }))
+      }));
 
-    groupedRecallLists[task.source].push(list);
+    grouped[task.source].push(list);
   }
 
   return {
-    textFullTextRecallResults: concatRecallLists(groupedRecallLists.text, limit),
-    imageCaptionFullTextRecallResults: concatRecallLists(groupedRecallLists.imageCaption, limit)
+    textFullTextRecallResults: concatRecallLists(grouped.text, limit),
+    imageCaptionFullTextRecallResults: concatRecallLists(grouped.imageCaption, limit)
   };
+};
+
+/**
+ * 执行全文召回并按 query 来源分组返回。
+ * 当 FULL_TEXT_ENGINE='milvus'、当前向量库为 Milvus、版本 >= 2.6 时，
+ * 使用 Milvus BM25 全文检索；否则降级到 MongoDB $text 检索。
+ */
+export const fullTextRecall = async ({
+  teamId,
+  datasetIds,
+  queryGroups,
+  limit,
+  filterCollectionIdList,
+  forbidCollectionIdList
+}: FullTextRecallProps): Promise<{
+  textFullTextRecallResults: SearchDataResponseItemType[];
+  imageCaptionFullTextRecallResults: SearchDataResponseItemType[];
+}> => {
+  const queryTasks = queryGroups.flatMap((group) =>
+    group.queries
+      .map((query) => query.trim())
+      .filter(Boolean)
+      .map((query) => ({ source: group.source, query }))
+  );
+
+  if (limit === 0 || queryTasks.length === 0) {
+    return {
+      textFullTextRecallResults: [],
+      imageCaptionFullTextRecallResults: []
+    };
+  }
+
+  const useMilvusFullText = computeUseMilvusFullText();
+
+  if (useMilvusFullText) {
+    const startTime = Date.now();
+    const { recallResults, error } = await fullTextRecallFromMilvus({
+      teamId,
+      datasetIds,
+      queryTasks,
+      limit,
+      filterCollectionIdList,
+      forbidCollectionIdList
+    });
+    const costMs = Date.now() - startTime;
+
+    if (!error) {
+      logger.info('Milvus full-text recall succeeded', {
+        teamId,
+        datasetIds,
+        costMs,
+        isFallback: false,
+        fullTextEngine: 'milvus'
+      });
+
+      // 归一化：vectorId → dataId（通过 indexes.dataId 反查）
+      const vectorIds = Array.from(
+        new Set(recallResults.flatMap((g) => g.results.map((r) => r.id?.trim())).filter(Boolean))
+      );
+      const vectorToDataId = new Map<string, string>();
+      if (vectorIds.length > 0) {
+        const docs = await MongoDatasetData.find(
+          { 'indexes.dataId': { $in: vectorIds } },
+          { _id: 1, indexes: 1 },
+          { ...readFromSecondary }
+        ).lean();
+        for (const doc of docs) {
+          for (const idx of doc.indexes) {
+            if (idx.dataId && vectorIds.includes(String(idx.dataId))) {
+              vectorToDataId.set(String(idx.dataId), String(doc._id));
+            }
+          }
+        }
+      }
+
+      const taskItems = recallResults.map((group) => ({
+        source: group.source,
+        items: group.results.map((r) => ({
+          dataId: vectorToDataId.get(r.id?.trim() ?? '') ?? '',
+          collectionId: r.collectionId,
+          score: r.score
+        }))
+      }));
+
+      return buildResultsFromRecallItems({ taskItems, limit });
+    }
+
+    logger.warn('Milvus full-text recall failed, falling back to MongoDB', {
+      teamId,
+      datasetIds,
+      costMs,
+      isFallback: true,
+      fullTextEngine: 'milvus',
+      errorType: 'milvus_fulltext_search_failed',
+      error
+    });
+  } else {
+    logger.info('Using MongoDB full-text recall', {
+      teamId,
+      datasetIds,
+      isFallback: !useMilvusFullText,
+      fullTextEngine: getFullTextEngine()
+    });
+  }
+
+  const mongoResults = await mongoFullTextRecall({
+    teamId,
+    datasetIds,
+    queryTasks,
+    limit,
+    filterCollectionIdList,
+    forbidCollectionIdList
+  });
+
+  // 归一化：Mongo 结果中 dataId 即为文档 _id
+  const taskItems = mongoResults.map((group, i) => ({
+    source: queryTasks[i].source,
+    items: group.map((r) => ({
+      dataId: r.dataId,
+      collectionId: r.collectionId,
+      score: r.score
+    }))
+  }));
+
+  return buildResultsFromRecallItems({ taskItems, limit });
 };

--- a/packages/service/core/dataset/search/defaultRecall/fullTextRecall.ts
+++ b/packages/service/core/dataset/search/defaultRecall/fullTextRecall.ts
@@ -231,9 +231,8 @@ const buildResultsFromRecallItems = async ({
     text: [],
     imageCaption: []
   };
-  const seen = new Set<string>();
-
   for (const task of taskItems) {
+    const seen = new Set<string>();
     const list = (
       await Promise.all(
         task.items.map((item, index) => {

--- a/packages/service/env.ts
+++ b/packages/service/env.ts
@@ -164,6 +164,12 @@ export const serviceEnv = createEnv({
     SEEKDB_URL: z.string().optional().meta({ description: 'SeekDB 向量库连接参数' }),
     MILVUS_ADDRESS: z.string().optional().meta({ description: 'Milvus 向量库连接参数' }),
     MILVUS_TOKEN: z.string().optional().meta({ description: 'Milvus 向量库Token' }),
+    MILVUS_TIMEOUT: z.coerce.number().min(1000).default(300000).meta({
+      description: 'Milvus SDK 超时时间（毫秒）'
+    }),
+    FULL_TEXT_ENGINE: z.string().default('mongo').meta({
+      description: '全文检索引擎：mongo / milvus，非法值按 mongo 处理'
+    }),
     OPENGAUSS_URL: z.string().optional().meta({ description: 'openGauss 向量库连接参数' }),
     HNSW_EF_SEARCH: IntSchema.min(1).default(100).meta({
       description: '向量检索 hnsw ef_search 参数，仅对 PG / OB / OpenGauss 生效'

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -28,7 +28,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@t3-oss/env-core": "catalog:",
     "@xmldom/xmldom": "^0.8.10",
-    "@zilliz/milvus2-sdk-node": "2.4.10",
+    "@zilliz/milvus2-sdk-node": "^2.6.0",
     "axios": "catalog:",
     "bullmq": "^5.52.2",
     "chalk": "catalog:",

--- a/packages/service/test/common/vectorDB/controller.test.ts
+++ b/packages/service/test/common/vectorDB/controller.test.ts
@@ -281,7 +281,8 @@ describe('VectorDB Controller', () => {
         teamId: 'team_123',
         datasetId: 'dataset_456',
         collectionId: 'col_789',
-        vectors: mockVectors
+        vectors: mockVectors,
+        textContents: ['hello world', 'test text']
       });
       expect(result).toEqual({
         tokens: 100,
@@ -326,11 +327,60 @@ describe('VectorDB Controller', () => {
         teamId: 'team_123',
         datasetId: 'dataset_456',
         collectionId: 'col_789',
-        vectors: mockVectors
+        vectors: mockVectors,
+        textContents: ['']
       });
       expect(result).toEqual({
         tokens: 1,
         insertIds: ['image_id']
+      });
+    });
+
+    it('should map text inputs to content and image inputs to empty string in textContents', async () => {
+      const mockVectors = [
+        [0.1, 0.2],
+        [0.3, 0.4],
+        [0.5, 0.6]
+      ];
+      mockGetVectors.mockResolvedValue({
+        tokens: 150,
+        vectors: mockVectors
+      });
+      mockVectorInsert.mockResolvedValue({
+        insertIds: ['text_id_1', 'image_id', 'text_id_2']
+      });
+
+      const result = await insertDatasetDataVector({
+        teamId: 'team_123',
+        datasetId: 'dataset_456',
+        collectionId: 'col_789',
+        inputs: [
+          'first text',
+          { type: 'image', input: 'data:image/png;base64,abc' },
+          { type: 'text', input: 'second text' }
+        ],
+        model: mockModel as any
+      });
+
+      expect(mockGetVectors).toHaveBeenCalledWith({
+        model: mockModel,
+        inputs: [
+          { type: 'text', input: 'first text' },
+          { type: 'image', input: 'data:image/png;base64,abc' },
+          { type: 'text', input: 'second text' }
+        ],
+        type: 'db'
+      });
+      expect(mockVectorInsert).toHaveBeenCalledWith({
+        teamId: 'team_123',
+        datasetId: 'dataset_456',
+        collectionId: 'col_789',
+        vectors: mockVectors,
+        textContents: ['first text', '', 'second text']
+      });
+      expect(result).toEqual({
+        tokens: 150,
+        insertIds: ['text_id_1', 'image_id', 'text_id_2']
       });
     });
 

--- a/packages/service/test/common/vectorDB/milvus/config.test.ts
+++ b/packages/service/test/common/vectorDB/milvus/config.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getMilvusCollectionDefinitions,
+  createBM25Function,
+  isAnalyzerError,
+  extractErrorCode
+} from '@fastgpt/service/common/vectorDB/milvus/config';
+import { FunctionType } from '@zilliz/milvus2-sdk-node';
+
+describe('milvus/config', () => {
+  describe('getMilvusCollectionDefinitions', () => {
+    it('includes text/sparse fields for V26', () => {
+      const defs = getMilvusCollectionDefinitions(true);
+      const main = defs.find((d) => d.name === 'modeldata')!;
+      const fieldNames = main.fields.map((f) => f.name);
+      expect(fieldNames).toContain('text');
+      expect(fieldNames).toContain('sparse');
+      expect(fieldNames).not.toContain('metadata');
+    });
+
+    it('excludes text/sparse fields for V24', () => {
+      const defs = getMilvusCollectionDefinitions(false);
+      const main = defs.find((d) => d.name === 'modeldata')!;
+      const fieldNames = main.fields.map((f) => f.name);
+      expect(fieldNames).not.toContain('text');
+      expect(fieldNames).not.toContain('sparse');
+    });
+
+    it('defines one collection', () => {
+      const defs = getMilvusCollectionDefinitions(true);
+      expect(defs).toHaveLength(1);
+      expect(defs.map((d) => d.name)).toEqual(['modeldata']);
+    });
+  });
+
+  describe('createBM25Function', () => {
+    it('has correct configuration', () => {
+      const fn = createBM25Function();
+      expect(fn.name).toBe('text_bm25_emb');
+      expect(fn.type).toBe(FunctionType.BM25);
+      expect(fn.input_field_names).toEqual(['text']);
+      expect(fn.output_field_names).toEqual(['sparse']);
+    });
+  });
+
+  describe('error helpers', () => {
+    it('extracts error code', () => {
+      expect(extractErrorCode({ code: 'ANALYZER_NOT_SUPPORTED' })).toBe('ANALYZER_NOT_SUPPORTED');
+    });
+
+    it('detects analyzer errors', () => {
+      expect(isAnalyzerError({ code: 'ANALYZER_NOT_SUPPORTED' })).toBe(true);
+      expect(isAnalyzerError({ code: 'UNKNOWN' })).toBe(false);
+    });
+  });
+});

--- a/packages/service/test/common/vectorDB/milvus/version.test.ts
+++ b/packages/service/test/common/vectorDB/milvus/version.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  FeatureLevel,
+  MilvusVersionManager
+} from '@fastgpt/service/common/vectorDB/milvus/version';
+import type { MilvusClient } from '@zilliz/milvus2-sdk-node';
+
+const createMockClient = (version: string, probeOk = true): MilvusClient => {
+  return {
+    getVersion: vi.fn().mockResolvedValue({ version }),
+    createCollection: vi.fn().mockResolvedValue({}),
+    createIndex: vi.fn().mockResolvedValue({}),
+    dropCollection: vi.fn().mockResolvedValue({})
+  } as unknown as MilvusClient;
+};
+
+describe('MilvusVersionManager', () => {
+  let manager: MilvusVersionManager;
+
+  beforeEach(() => {
+    manager = new MilvusVersionManager();
+  });
+
+  it('detects v2.6.0 as V26', async () => {
+    const client = createMockClient('v2.6.0');
+    const level = await manager.detectVersion(client);
+    expect(level).toBe(FeatureLevel.V26);
+    expect(manager.supportsFullText()).toBe(true);
+  });
+
+  it('detects 2.4.0 as V24', async () => {
+    const client = createMockClient('2.4.0');
+    const level = await manager.detectVersion(client);
+    expect(level).toBe(FeatureLevel.V24);
+    expect(manager.supportsFullText()).toBe(false);
+  });
+
+  it('detects v3.0.0 as V26 after probe', async () => {
+    const client = createMockClient('v3.0.0');
+    const level = await manager.detectVersion(client);
+    expect(level).toBe(FeatureLevel.V26);
+  });
+
+  it('caches detection result and does not call getVersion again', async () => {
+    const client = createMockClient('v2.6.5');
+    await manager.detectVersion(client);
+    await manager.detectVersion(client);
+    expect(client.getVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns UNKNOWN on invalid version format', async () => {
+    const client = createMockClient('unknown');
+    const level = await manager.detectVersion(client);
+    expect(level).toBe(FeatureLevel.UNKNOWN);
+    expect(manager.supportsFullText()).toBe(false);
+  });
+
+  it('returns UNKNOWN on getVersion error', async () => {
+    const client = {
+      getVersion: vi.fn().mockRejectedValue(new Error('timeout'))
+    } as unknown as MilvusClient;
+    const level = await manager.detectVersion(client);
+    expect(level).toBe(FeatureLevel.UNKNOWN);
+  });
+
+  it('resetDetection forces re-detection', async () => {
+    const client = createMockClient('v2.6.0');
+    await manager.detectVersion(client);
+    await manager.resetDetection(client);
+    expect(client.getVersion).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/service/test/integrations/vectorDB/milvus/index.integration.test.ts
+++ b/packages/service/test/integrations/vectorDB/milvus/index.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, vi } from 'vitest';
-import { createVectorDBTestSuite } from '../testSuites';
+import { createVectorDBTestSuite, createFullTextSearchTestSuite } from '../testSuites';
 
 // Unmock vector controllers for integration tests
 vi.unmock('@fastgpt/service/common/vectorDB/milvus');
@@ -12,4 +12,12 @@ const isEnabled = Boolean(process.env.MILVUS_ADDRESS);
 describe.skipIf(!isEnabled)('Milvus Vector Integration', () => {
   const vectorCtrl = new MilvusCtrl();
   createVectorDBTestSuite(vectorCtrl);
+});
+
+// Full-text search tests: skipped by default, opt-in via MILVUS_FULLTEXT_ENABLED
+const fullTextEnabled = Boolean(process.env.MILVUS_FULLTEXT_ENABLED);
+
+describe.skipIf(!fullTextEnabled)('Milvus Full-Text Search Integration', () => {
+  const vectorCtrl = new MilvusCtrl();
+  createFullTextSearchTestSuite(vectorCtrl);
 });

--- a/packages/service/test/integrations/vectorDB/testSuites.ts
+++ b/packages/service/test/integrations/vectorDB/testSuites.ts
@@ -157,3 +157,174 @@ export const createVectorDBTestSuite = (vectorCtrl: VectorControllerType) => {
     });
   });
 };
+
+// ==================== Full-Text Search Test Suite ====================
+
+const FULLTEXT_TEXTS = [
+  'The quick brown fox jumps over the lazy dog',
+  'Machine learning is transforming artificial intelligence applications',
+  'FastGPT is an open source knowledge base question answering system'
+];
+
+const insertTextVectors = async (
+  vectorCtrl: VectorControllerType,
+  teamId: string,
+  datasetId: string,
+  collectionIds: string[] = [TEST_COLLECTION_IDS[0]]
+) => {
+  // Group vectors by collectionId, assigning texts accordingly
+  const insertIds: string[] = [];
+  await Promise.all(
+    FULLTEXT_TEXTS.map(async (text, index) => {
+      const collectionId = collectionIds[index] ?? collectionIds[0];
+      const { insertIds: ids } = await vectorCtrl.insert({
+        teamId,
+        datasetId,
+        collectionId,
+        vectors: [TEST_VECTORS[index]],
+        textContents: [text]
+      });
+      insertIds.push(ids[0]);
+    })
+  );
+
+  // Wait for BM25 function to compute sparse vectors
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+  return insertIds;
+};
+
+const cleanupTextVectors = async (
+  vectorCtrl: VectorControllerType,
+  teamId: string,
+  datasetId: string
+) => {
+  try {
+    await vectorCtrl.delete({ teamId, datasetIds: [datasetId] });
+  } catch {
+    // ignore cleanup errors
+  }
+};
+
+export const createFullTextSearchTestSuite = (vectorCtrl: VectorControllerType) => {
+  describe.sequential('fullTextSearch integration', () => {
+    beforeAll(async () => {
+      await vectorCtrl.init();
+    });
+
+    test('returns results for matching query', async () => {
+      const { teamId, datasetId } = createTestIds();
+      const insertIds = await insertTextVectors(vectorCtrl, teamId, datasetId);
+      expect(insertIds).toHaveLength(FULLTEXT_TEXTS.length);
+
+      const { results } = await vectorCtrl.fullTextSearch!({
+        teamId,
+        datasetIds: [datasetId],
+        query: 'fox',
+        limit: 5,
+        forbidCollectionIdList: []
+      });
+
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((item) => !!item.id && !!item.collectionId)).toBe(true);
+      // Results should have scores
+      expect(results.every((item) => typeof item.score === 'number')).toBe(true);
+
+      await cleanupTextVectors(vectorCtrl, teamId, datasetId);
+    });
+
+    test('returns empty for non-matching query', async () => {
+      const { teamId, datasetId } = createTestIds();
+      await insertTextVectors(vectorCtrl, teamId, datasetId);
+
+      const { results } = await vectorCtrl.fullTextSearch!({
+        teamId,
+        datasetIds: [datasetId],
+        query: 'zzzxyznonexistent987654321',
+        limit: 5,
+        forbidCollectionIdList: []
+      });
+
+      expect(results).toHaveLength(0);
+
+      await cleanupTextVectors(vectorCtrl, teamId, datasetId);
+    });
+
+    test('respects forbidCollectionIdList', async () => {
+      const { teamId, datasetId } = createTestIds();
+      // All vectors in col_0
+      await insertTextVectors(vectorCtrl, teamId, datasetId, [TEST_COLLECTION_IDS[0]]);
+
+      const { results } = await vectorCtrl.fullTextSearch!({
+        teamId,
+        datasetIds: [datasetId],
+        query: 'fox',
+        limit: 5,
+        forbidCollectionIdList: [TEST_COLLECTION_IDS[0]]
+      });
+
+      // All vectors are in col_0 — forbidding it should yield empty
+      expect(results.every((item) => item.collectionId !== TEST_COLLECTION_IDS[0])).toBe(true);
+
+      await cleanupTextVectors(vectorCtrl, teamId, datasetId);
+    });
+
+    test('respects filterCollectionIdList', async () => {
+      const { teamId, datasetId } = createTestIds();
+      // Spread vectors across col_0 and col_1
+      // fox→col_0 (searched term), ml→col_1, knowledge→col_2
+      const collIds = [TEST_COLLECTION_IDS[0], TEST_COLLECTION_IDS[1], TEST_COLLECTION_IDS[2]];
+      await insertTextVectors(vectorCtrl, teamId, datasetId, collIds);
+
+      const { results } = await vectorCtrl.fullTextSearch!({
+        teamId,
+        datasetIds: [datasetId],
+        query: 'fox',
+        limit: 5,
+        forbidCollectionIdList: [],
+        filterCollectionIdList: [TEST_COLLECTION_IDS[0]]
+      });
+
+      // Only col_0 returned
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((item) => item.collectionId === TEST_COLLECTION_IDS[0])).toBe(true);
+
+      await cleanupTextVectors(vectorCtrl, teamId, datasetId);
+    });
+
+    test('empty query returns empty', async () => {
+      const { results } = await vectorCtrl.fullTextSearch!({
+        teamId: 'test_team',
+        datasetIds: ['test_dataset'],
+        query: '',
+        limit: 5,
+        forbidCollectionIdList: []
+      });
+
+      expect(results).toHaveLength(0);
+    });
+
+    test('empty datasetIds returns empty', async () => {
+      const { results } = await vectorCtrl.fullTextSearch!({
+        teamId: 'test_team',
+        datasetIds: [],
+        query: 'search term',
+        limit: 5,
+        forbidCollectionIdList: []
+      });
+
+      expect(results).toHaveLength(0);
+    });
+
+    test('limit=0 returns empty', async () => {
+      const { results } = await vectorCtrl.fullTextSearch!({
+        teamId: 'test_team',
+        datasetIds: ['test_dataset'],
+        query: 'search term',
+        limit: 0,
+        forbidCollectionIdList: []
+      });
+
+      expect(results).toHaveLength(0);
+    });
+  });
+};

--- a/packages/service/vitest.integration.config.ts
+++ b/packages/service/vitest.integration.config.ts
@@ -15,8 +15,8 @@ export default defineConfig({
         process.env.FILE_TOKEN_KEY ??
         'bfd697e7e798f75deaf2d31210bc93a2e41ad4eed9e7831071d77821b7b97cff',
       AES256_SECRET_KEY: process.env.AES256_SECRET_KEY ?? 'fastgpt_test_aes256_secret_key',
-      INVOKE_TOKEN_SECRET:
-        process.env.INVOKE_TOKEN_SECRET ?? 'fastgpt_test_invoke_token_secret_32'
+      INVOKE_TOKEN_SECRET: process.env.INVOKE_TOKEN_SECRET ?? 'fastgpt_test_invoke_token_secret_32',
+      FE_DOMAIN: process.env.FE_DOMAIN ?? 'https://fastgpt.example.com'
     },
     coverage: {
       enabled: false

--- a/projects/app/src/pages/api/admin/initv4152.ts
+++ b/projects/app/src/pages/api/admin/initv4152.ts
@@ -1,0 +1,219 @@
+import { NextAPI } from '@/service/middleware/entry';
+import type { ApiRequestProps, ApiResponseType } from '@fastgpt/next/type';
+import { authCert } from '@fastgpt/service/support/permission/auth/common';
+import { MilvusCtrl } from '@fastgpt/service/common/vectorDB/milvus/index';
+import { milvusVersionManager } from '@fastgpt/service/common/vectorDB/milvus/version';
+import { DatasetVectorTableName } from '@fastgpt/service/common/vectorDB/constants';
+import { MongoDatasetData } from '@fastgpt/service/core/dataset/data/schema';
+import { MongoDatasetTraining } from '@fastgpt/service/core/dataset/training/schema';
+import { activeTrainingMatch } from '@fastgpt/service/core/dataset/training/query';
+import { MongoDataset } from '@fastgpt/service/core/dataset/schema';
+import { getLogger } from '@fastgpt/service/common/logger';
+import { TrainingModeEnum } from '@fastgpt/global/core/dataset/constants';
+import { mongoSessionRun } from '@fastgpt/service/common/mongo/sessionRun';
+import { customNanoid } from '@fastgpt/global/common/string/tools';
+
+const logger = getLogger(['initv4152']);
+
+export type Initv4152Query = {
+  dryRun?: string;
+};
+
+export type Initv4152Response = {
+  success: boolean;
+  message: string;
+  stats: {
+    totalDatasets: number;
+    totalDataCount: number;
+    estimatedMinutes: number;
+  };
+  failedCollections?: { collectionName: string; error: string }[];
+};
+
+const parseDryRun = (value?: string): boolean => {
+  if (!value) return false;
+  const normalized = value.toLowerCase();
+  return normalized === 'true' || normalized === '1';
+};
+
+const targetCollections = [DatasetVectorTableName];
+
+async function handler(
+  req: ApiRequestProps<object, Initv4152Query>,
+  _res: ApiResponseType<Initv4152Response>
+): Promise<Initv4152Response> {
+  const dryRun = parseDryRun(req.query?.dryRun);
+
+  await authCert({ req, authRoot: true });
+
+  const milvus = new MilvusCtrl();
+  let client: Awaited<ReturnType<typeof milvus.getClient>>;
+  try {
+    client = await milvus.getClient();
+  } catch (_err) {
+    return {
+      success: false,
+      message: 'Milvus is not configured or client initialization failed.',
+      stats: { totalDatasets: 0, totalDataCount: 0, estimatedMinutes: 0 }
+    };
+  }
+
+  await milvusVersionManager.resetDetection(client);
+
+  if (!milvusVersionManager.supportsFullText()) {
+    return {
+      success: false,
+      message: `Milvus version is ${milvusVersionManager.getFeatureLevel()}, requires v2.6+`,
+      stats: { totalDatasets: 0, totalDataCount: 0, estimatedMinutes: 0 }
+    };
+  }
+
+  const activeTrainingCount = await MongoDatasetTraining.countDocuments(activeTrainingMatch);
+  if (activeTrainingCount > 0) {
+    return {
+      success: false,
+      message: `Active training tasks detected (${activeTrainingCount}). Please wait for completion.`,
+      stats: { totalDatasets: 0, totalDataCount: 0, estimatedMinutes: 0 }
+    };
+  }
+
+  const [datasets, totalDataCount] = await Promise.all([
+    MongoDataset.find({}, '_id teamId tmbId vectorModel agentModel vlmModel').lean(),
+    MongoDatasetData.countDocuments({})
+  ]);
+  const totalDatasets = datasets.length;
+  const estimatedMinutes = Math.max(1, Math.ceil(totalDataCount / 500));
+
+  const stats = {
+    totalDatasets,
+    totalDataCount,
+    estimatedMinutes
+  };
+
+  if (dryRun) {
+    logger.info('[initv4152] Dry run completed', stats);
+    return {
+      success: true,
+      message: 'Dry run completed. No changes made.',
+      stats
+    };
+  }
+
+  // Rebuild collections
+  const failedCollections: { collectionName: string; error: string }[] = [];
+
+  for (const collectionName of targetCollections) {
+    try {
+      logger.info('[initv4152] Dropping collection', { collectionName });
+      await client.dropCollection({ collection_name: collectionName });
+    } catch (err) {
+      logger.warn('[initv4152] Drop collection skipped or failed', {
+        collectionName,
+        error: err instanceof Error ? err.message : String(err)
+      });
+    }
+
+    try {
+      logger.info('[initv4152] Creating collection', { collectionName });
+      await milvus.init();
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      logger.error('[initv4152] Create collection failed', { collectionName, error });
+      failedCollections.push({ collectionName, error });
+      continue;
+    }
+  }
+
+  if (failedCollections.length > 0) {
+    return {
+      success: false,
+      message: `Migration completed with errors: failed to recreate ${failedCollections.length} collection(s).`,
+      stats,
+      failedCollections
+    };
+  }
+
+  // Mark all data as rebuilding. This serves as a progress cursor — if the
+  // migration crashes partway through, retry only picks up remaining
+  // { rebuilding: true } records. (References rebuildEmbedding.ts pattern.)
+  await MongoDatasetData.updateMany({}, { $set: { rebuilding: true } });
+  logger.info('[initv4152] Marked all data rebuilding');
+
+  // Enqueue historical data for rebuilding
+  const billId = `initv4152-${Date.now()}-${customNanoid('1234567890abcdefghijklmnopqrstuvwxyz', 6)}`;
+  const batchSize = 200;
+  let enqueuedCount = 0;
+  let failedEnqueueCount = 0;
+
+  while (true) {
+    const dataList = await MongoDatasetData.find(
+      { rebuilding: true },
+      '_id teamId tmbId datasetId collectionId q a imageId indexes chunkIndex'
+    )
+      .sort({ _id: 1 })
+      .limit(batchSize)
+      .lean();
+
+    if (dataList.length === 0) break;
+
+    const batchIds = dataList.map((d) => d._id);
+    const now = new Date();
+
+    const tasks = dataList.map((data) => ({
+      teamId: data.teamId,
+      tmbId: data.tmbId,
+      datasetId: data.datasetId,
+      collectionId: data.collectionId,
+      billId,
+      mode: TrainingModeEnum.chunk,
+      dataId: data._id,
+      q: data.q || '',
+      a: data.a || '',
+      ...(data.imageId && { imageId: data.imageId }),
+      chunkIndex: data.chunkIndex ?? 0,
+      indexes: (data.indexes || []).map((idx) => ({
+        type: idx.type,
+        text: idx.text
+      })),
+      retryCount: 50
+    }));
+
+    try {
+      await mongoSessionRun(async (session) => {
+        // Atomically unset rebuilding + clear stale indexes so
+        // mergeExistingSystemIndexIds cannot match old dataIds.
+        await MongoDatasetData.updateMany(
+          { _id: { $in: batchIds } },
+          { $unset: { rebuilding: null }, $set: { indexes: [], updateTime: now } },
+          { session }
+        );
+
+        await MongoDatasetTraining.insertMany(tasks, {
+          session,
+          ordered: false
+        });
+      });
+      enqueuedCount += tasks.length;
+    } catch (err) {
+      failedEnqueueCount += tasks.length;
+      logger.error('[initv4152] Failed to enqueue training tasks', {
+        error: err instanceof Error ? err.message : String(err),
+        batchSize: tasks.length
+      });
+    }
+  }
+
+  logger.info('[initv4152] Migration triggered', {
+    ...stats,
+    enqueuedCount,
+    failedEnqueueCount
+  });
+
+  return {
+    success: true,
+    message: `Migration started. Processing ${totalDataCount} records from ${totalDatasets} datasets. Estimated time: ${estimatedMinutes} minutes.`,
+    stats
+  };
+}
+
+export default NextAPI(handler);

--- a/projects/app/src/pages/api/admin/initv4152.ts
+++ b/projects/app/src/pages/api/admin/initv4152.ts
@@ -3,6 +3,7 @@ import type { ApiRequestProps, ApiResponseType } from '@fastgpt/next/type';
 import { authCert } from '@fastgpt/service/support/permission/auth/common';
 import { MilvusCtrl } from '@fastgpt/service/common/vectorDB/milvus/index';
 import { milvusVersionManager } from '@fastgpt/service/common/vectorDB/milvus/version';
+import { isCollectionNotFoundError } from '@fastgpt/service/common/vectorDB/milvus/config';
 import { DatasetVectorTableName } from '@fastgpt/service/common/vectorDB/constants';
 import { MongoDatasetData } from '@fastgpt/service/core/dataset/data/schema';
 import { MongoDatasetTraining } from '@fastgpt/service/core/dataset/training/schema';
@@ -35,8 +36,6 @@ const parseDryRun = (value?: string): boolean => {
   const normalized = value.toLowerCase();
   return normalized === 'true' || normalized === '1';
 };
-
-const targetCollections = [DatasetVectorTableName];
 
 async function handler(
   req: ApiRequestProps<object, Initv4152Query>,
@@ -101,18 +100,42 @@ async function handler(
 
   // Rebuild collections
   const failedCollections: { collectionName: string; error: string }[] = [];
+  const collectionName = DatasetVectorTableName;
 
-  for (const collectionName of targetCollections) {
-    try {
-      logger.info('[initv4152] Dropping collection', { collectionName });
-      await client.dropCollection({ collection_name: collectionName });
-    } catch (err) {
-      logger.warn('[initv4152] Drop collection skipped or failed', {
+  // Step 1: drop existing collection
+  try {
+    logger.info('[initv4152] Dropping collection', { collectionName });
+    const dropResult = await client.dropCollection({ collection_name: collectionName });
+    // dropCollection resolves (doesn't throw) for server-side errors like
+    // CollectionNotExists — check the returned status, not just the catch block.
+    const dropCode = dropResult?.error_code;
+    if (
+      dropCode !== undefined &&
+      dropCode !== 'Success' &&
+      dropCode !== 0 &&
+      !isCollectionNotFoundError({ error_code: dropCode })
+    ) {
+      const error = `Drop collection failed: ${dropCode} - ${dropResult?.reason || 'unknown'}`;
+      logger.error('[initv4152] Drop collection failed', {
         collectionName,
-        error: err instanceof Error ? err.message : String(err)
+        dropCode,
+        reason: dropResult?.reason
       });
+      failedCollections.push({ collectionName, error });
     }
+  } catch (err) {
+    // Transport-level errors (network, auth) are thrown — only ignore NotFound.
+    if (isCollectionNotFoundError(err)) {
+      logger.info('[initv4152] Collection does not exist, skipping drop', { collectionName });
+    } else {
+      const error = err instanceof Error ? err.message : String(err);
+      logger.error('[initv4152] Drop collection failed', { collectionName, error });
+      failedCollections.push({ collectionName, error });
+    }
+  }
 
+  // Step 2: recreate collection with BM25 schema
+  if (failedCollections.length === 0) {
     try {
       logger.info('[initv4152] Creating collection', { collectionName });
       await milvus.init();
@@ -120,7 +143,33 @@ async function handler(
       const error = err instanceof Error ? err.message : String(err);
       logger.error('[initv4152] Create collection failed', { collectionName, error });
       failedCollections.push({ collectionName, error });
-      continue;
+    }
+  }
+
+  // Step 3: validate the recreated collection has the expected BM25 schema fields.
+  // If dropCollection failed silently (e.g. wrong database) and init reused
+  // an existing non-BM25 collection, catch it here before data migration.
+  if (failedCollections.length === 0) {
+    try {
+      const desc = await client.describeCollection({ collection_name: collectionName });
+      const fieldNames: string[] = (desc?.schema?.fields ?? []).map((f: any) => f?.name);
+      if (!fieldNames.includes('text') || !fieldNames.includes('sparse')) {
+        const missing = [];
+        if (!fieldNames.includes('text')) missing.push('text');
+        if (!fieldNames.includes('sparse')) missing.push('sparse');
+        const msg = `Collection recreated but missing BM25 field(s): ${missing.join(', ')}. Fields: ${fieldNames.join(', ')}`;
+        logger.error('[initv4152] Schema validation failed', {
+          collectionName,
+          fields: fieldNames
+        });
+        failedCollections.push({ collectionName, error: msg });
+      } else {
+        logger.info('[initv4152] Schema validated', { collectionName, fieldNames });
+      }
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      logger.error('[initv4152] Schema validation failed', { collectionName, error });
+      failedCollections.push({ collectionName, error });
     }
   }
 
@@ -139,75 +188,56 @@ async function handler(
   await MongoDatasetData.updateMany({}, { $set: { rebuilding: true } });
   logger.info('[initv4152] Marked all data rebuilding');
 
-  // Enqueue historical data for rebuilding
+  // Enqueue initial batch of training tasks. Each task claims one record
+  // atomically via findOneAndUpdate. Workers chain further records by
+  // picking up the next rebuilding:true record on task completion.
+  // (References rebuildEmbedding.ts pattern.)
   const billId = `initv4152-${Date.now()}-${customNanoid('1234567890abcdefghijklmnopqrstuvwxyz', 6)}`;
-  const batchSize = 200;
-  let enqueuedCount = 0;
-  let failedEnqueueCount = 0;
+  const max = global.systemEnv?.vectorMaxProcess || 10;
+  const arr = new Array(max * 2).fill(0);
 
-  while (true) {
-    const dataList = await MongoDatasetData.find(
-      { rebuilding: true },
-      '_id teamId tmbId datasetId collectionId q a imageId indexes chunkIndex'
-    )
-      .sort({ _id: 1 })
-      .limit(batchSize)
-      .lean();
-
-    if (dataList.length === 0) break;
-
-    const batchIds = dataList.map((d) => d._id);
-    const now = new Date();
-
-    const tasks = dataList.map((data) => ({
-      teamId: data.teamId,
-      tmbId: data.tmbId,
-      datasetId: data.datasetId,
-      collectionId: data.collectionId,
-      billId,
-      mode: TrainingModeEnum.chunk,
-      dataId: data._id,
-      q: data.q || '',
-      a: data.a || '',
-      ...(data.imageId && { imageId: data.imageId }),
-      chunkIndex: data.chunkIndex ?? 0,
-      indexes: (data.indexes || []).map((idx) => ({
-        type: idx.type,
-        text: idx.text
-      })),
-      retryCount: 50
-    }));
-
+  for (let i = 0; i < arr.length; i++) {
     try {
-      await mongoSessionRun(async (session) => {
-        // Atomically unset rebuilding + clear stale indexes so
-        // mergeExistingSystemIndexIds cannot match old dataIds.
-        await MongoDatasetData.updateMany(
-          { _id: { $in: batchIds } },
-          { $unset: { rebuilding: null }, $set: { indexes: [], updateTime: now } },
+      const hasNext = await mongoSessionRun(async (session) => {
+        // Atomically claim one record.
+        const data = await MongoDatasetData.findOneAndUpdate(
+          { rebuilding: true },
+          { $unset: { rebuilding: '' }, $set: { updateTime: new Date() } },
           { session }
+        )
+          .select('_id teamId tmbId datasetId collectionId q a imageId chunkIndex')
+          .lean();
+
+        if (!data) return false;
+
+        await MongoDatasetTraining.create(
+          [
+            {
+              teamId: data.teamId,
+              tmbId: data.tmbId,
+              datasetId: data.datasetId,
+              collectionId: data.collectionId,
+              billId,
+              mode: TrainingModeEnum.chunk,
+              dataId: data._id,
+              q: data.q || '',
+              a: data.a || '',
+              ...(data.imageId && { imageId: data.imageId }),
+              chunkIndex: data.chunkIndex ?? 0,
+              retryCount: 50
+            }
+          ],
+          { session, ordered: true }
         );
 
-        await MongoDatasetTraining.insertMany(tasks, {
-          session,
-          ordered: false
-        });
+        return true;
       });
-      enqueuedCount += tasks.length;
-    } catch (err) {
-      failedEnqueueCount += tasks.length;
-      logger.error('[initv4152] Failed to enqueue training tasks', {
-        error: err instanceof Error ? err.message : String(err),
-        batchSize: tasks.length
-      });
-    }
+
+      if (!hasNext) break;
+    } catch {}
   }
 
-  logger.info('[initv4152] Migration triggered', {
-    ...stats,
-    enqueuedCount,
-    failedEnqueueCount
-  });
+  logger.info('[initv4152] Migration triggered', stats);
 
   return {
     success: true,


### PR DESCRIPTION
### Summary
- Add Milvus version detection and feature level management (version.ts)
- Add dynamic collection schema with text/sparse fields and BM25 Function (config.ts)
- Implement MilvusCtrl.fullTextSearch() using sparse BM25 retrieval
- Refactor fullTextRecall to auto-select Milvus or MongoDB fulltext source
- Add FULL_TEXT_ENGINE env switch (mongo/milvus, default mongo)
- Pass textContents on vector insert for BM25 sparse vector generation
- Add initv4152 migration API for rebuilding 3 collections with BM25 schema
- Upgrade @zilliz/milvus2-sdk-node to ^2.6.0 with adaptive data/vector param

### Validation
- `npx vitest run test/core/dataset/search/ test/common/vectorDB/`
- `npx vitest run --config vitest.integration.config.ts test/integrations/vectorDB/milvus/index.integration.test.ts`
- `curl -X POST "http://localhost:3000/api/admin/initv4152 -H "rootkey: root_key"` — Upgrade successful, vector rebuild completed, text field has values.
- Milvus 2.6 parses documents normally.
- FULL_TEXT_ENGINE=milvus — Full-text search works correctly, hybrid search works correctly.
- FULL_TEXT_ENGINE=mongo — Full-text search works correctly, hybrid search works correctly.
- Milvus 2.4 parses documents normally and searches work correctly.