### PR TITLE
fix: 修复oss读取etag时读取异常

### DIFF
--- a/sdk/storage/src/adapters/oss.adapter.ts
+++ b/sdk/storage/src/adapters/oss.adapter.ts
@@ -99,7 +99,7 @@ export class OssStorageAdapter implements IStorage {
     return {
       key,
       metadata,
-      etag: result.meta?.etag as string,
+      etag: headers['etag'] ? headers['etag'].replace(/"/g, '') : undefined,
       bucket: this.options.bucket,
       contentType: headers['content-type'],
       contentLength: headers['content-length'] ? Number(headers['content-length']) : undefined


### PR DESCRIPTION
## 修复 @fastgpt-sdk/storage OSS 适配器 getObjectMetadata 读取 etag 错误

### 问题现象

使用阿里云 OSS（`STORAGE_VENDOR=oss`）作为存储后端时，插件确认（`/api/plugin/confirm`）时报错：

```
Failed to parse remote file metadata: system/plugin100/{pluginId}/{version}/{etag}/index.js
  └── ZodError: {
        "expected": "string",
        "code": "invalid_type",
        "path": ["etag"],
        "message": "Invalid input: expected string, received undefined"
      }
```

关键特征：
- 批量上传时只有部分插件能注册成功，其余全部失败
- 单独上传 1 个插件也会报错，但插件元数据已写入数据库

### 根本原因

`sdk/storage/src/adapters/oss.adapter.ts` 的 `OssStorageAdapter.getObjectMetadata` 中，etag 读取位置错误：

```ts
// ❌ 原代码：result.meta 不含 etag，永远返回 undefined
etag: result.meta?.etag as string,
```

`ali-oss` SDK 的 `head()` 方法返回结构为：

```js
{
  meta: { ... },          // 仅包含 x-oss-meta-* 自定义元数据（如 createTime、fileName），不含 etag
  res: {
    headers: {
      etag: '"d41d8cd98f00b204e9800998ecf8427e"',   // ← etag 在这里，且自带双引号
      'content-type': '...',
      'content-length': '...',
    }
  },
  status: 200
}
```

原代码 `result.meta?.etag` 永远是 `undefined`，导致下游 `FileMetaSchema.parse()`（etag 要求 `string`）校验失败。

### 影响范围

| 存储供应商 | 是否受影响 | 原因 |
|-----------|-----------|------|
| **oss**（阿里云 OSS） | ✅ 修复前受影响 | OSS 适配器 etag 读取位置错误 |
| aws-s3 | ❌ 不受影响 | 从 `result.ETag` 正确读取 |
| cos（腾讯云 COS） | ❌ 不受影响 | 独立的 headObject 实现 |
| minio | ❌ 不受影响 | 继承 AwsS3StorageAdapter |

### 修复内容

从标准 HTTP 响应头 `result.res.headers['etag']` 读取 etag，并去除 OSS 返回值自带的双引号（如 `"abc123"` → `abc123`），避免下游使用 etag 拼接对象路径时引入非法字符：

```ts
// ✅ 修复后
etag: headers['etag'] ? headers['etag'].replace(/"/g, '') : undefined,
```

### 验证

- `tsc --noEmit` 类型检查通过
- `GetObjectMetadataResult.etag` 类型为 `etag?: string`，与 `undefined` 返回兼容

