### PR TITLE
fix(agent): recognize internal runtime tools

### DIFF
--- a/packages/service/core/ai/llm/agentLoop/provider/fastAgent/loop/index.ts
+++ b/packages/service/core/ai/llm/agentLoop/provider/fastAgent/loop/index.ts
@@ -182,7 +182,11 @@ export const runFastAgentMainLoop = async <TChildrenResponse = unknown>({
     toolCatalog: normalized
   };
 
-  const hasRuntimeTools = normalized.runtimeTools.length > 0;
+  const hasRuntimeTools =
+    normalized.runtimeTools.length > 0 ||
+    (normalized.sandboxTools?.length ?? 0) > 0 ||
+    !!normalized.readFileTool ||
+    !!normalized.datasetSearchTool;
 
   let pendingAsk:
     | {

--- a/packages/service/core/ai/llm/agentLoop/provider/piAgent/run.ts
+++ b/packages/service/core/ai/llm/agentLoop/provider/piAgent/run.ts
@@ -403,7 +403,11 @@ export const runPiAgentLoop = async <TChildrenResponse = unknown>({
       ? input.systemPrompt || ''
       : getMainAgentSystemPrompt({
           systemPrompt: input.systemPrompt,
-          hasRuntimeTools: runtime.toolCatalog.runtimeTools.length > 0
+          hasRuntimeTools:
+            runtime.toolCatalog.runtimeTools.length > 0 ||
+            runtime.systemTools?.sandbox?.enabled === true ||
+            runtime.systemTools?.readFile?.enabled === true ||
+            runtime.systemTools?.datasetSearch?.enabled === true
         });
   const agent = new Agent({
     initialState: {

--- a/packages/service/test/core/ai/llm/agentLoop/fastAgentLoop.test.ts
+++ b/packages/service/test/core/ai/llm/agentLoop/fastAgentLoop.test.ts
@@ -165,6 +165,58 @@ describe('runFastAgentMainLoop', () => {
     expect(mainAgentPrompt).toContain('options：2 到 5 个');
   });
 
+  it.each([
+    {
+      name: 'no runtime-capable tools',
+      toolCatalog: { runtimeTools: [] },
+      expectedConstraint: true
+    },
+    {
+      name: 'sandbox tools only',
+      toolCatalog: { runtimeTools: [], sandboxTools: [tool('sandbox_shell')] },
+      expectedConstraint: false
+    },
+    {
+      name: 'read file tool only',
+      toolCatalog: { runtimeTools: [], readFileTool: tool('read_files') },
+      expectedConstraint: false
+    },
+    {
+      name: 'dataset search tool only',
+      toolCatalog: { runtimeTools: [], datasetSearchTool: tool('dataset_search') },
+      expectedConstraint: false
+    }
+  ] satisfies Array<{
+    name: string;
+    toolCatalog: AgentLoopRuntime['toolCatalog'];
+    expectedConstraint: boolean;
+  }>)(
+    'sets the runtime tool constraint correctly with $name',
+    async ({ toolCatalog, expectedConstraint }) => {
+      mockCreateLLMResponseQueue(createLLMResponseMock, [
+        text({
+          requestId: 'req_runtime_tool_constraint',
+          content: 'direct answer'
+        })
+      ]);
+
+      await runFastAgentMainLoop({
+        runtime: createRuntime({ toolCatalog }),
+        input: {
+          messages: [
+            {
+              role: ChatCompletionRequestMessageRoleEnum.User,
+              content: 'hello'
+            }
+          ]
+        }
+      });
+
+      const mainAgentPrompt = createLLMResponseMock.mock.calls[0][0].body.messages[0].content;
+      expect(mainAgentPrompt.includes('<tool_constraint>')).toBe(expectedConstraint);
+    }
+  );
+
   it('creates an active plan through set_plan', async () => {
     const events: any[] = [];
     mockCreateLLMResponseQueue(createLLMResponseMock, [

--- a/packages/service/test/core/ai/llm/agentLoop/piAgentProvider.test.ts
+++ b/packages/service/test/core/ai/llm/agentLoop/piAgentProvider.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LLMModelItemType } from '@fastgpt/global/core/ai/model.schema';
 import { ModelTypeEnum } from '@fastgpt/global/core/ai/constants';
+import type { AgentLoopSystemTools } from '@fastgpt/service/core/ai/llm/agentLoop/domain';
 
 const {
   agentPromptMock,
@@ -365,6 +366,73 @@ describe('runPiAgentLoop', () => {
       })
     ]);
   });
+
+  it.each([
+    {
+      name: 'no runtime-capable tools',
+      systemTools: undefined,
+      expectedConstraint: true
+    },
+    {
+      name: 'sandbox tools only',
+      systemTools: {
+        sandbox: {
+          enabled: true,
+          client: {} as any
+        }
+      },
+      expectedConstraint: false
+    },
+    {
+      name: 'read file tool only',
+      systemTools: {
+        readFile: {
+          enabled: true,
+          maxFileAmount: 20,
+          execute: vi.fn()
+        }
+      },
+      expectedConstraint: false
+    },
+    {
+      name: 'dataset search tool only',
+      systemTools: {
+        datasetSearch: {
+          enabled: true,
+          execute: vi.fn()
+        }
+      },
+      expectedConstraint: false
+    }
+  ] satisfies Array<{
+    name: string;
+    systemTools?: AgentLoopSystemTools;
+    expectedConstraint: boolean;
+  }>)(
+    'sets the runtime tool constraint correctly with $name',
+    async ({ systemTools, expectedConstraint }) => {
+      await runPiAgentLoop({
+        input: {
+          messages: [{ role: 'user', content: 'hello' }]
+        },
+        runtime: {
+          llmParams: {
+            model: 'gpt-5'
+          },
+          systemTools,
+          toolCatalog: {
+            runtimeTools: []
+          },
+          executeTool: vi.fn(),
+          checkIsStopping: vi.fn(() => false)
+        }
+      });
+
+      expect(
+        agentConstructorArgs.at(-1).initialState.systemPrompt.includes('<tool_constraint>')
+      ).toBe(expectedConstraint);
+    }
+  );
 
   it('preserves multimodal content in the current user prompt', async () => {
     await runPiAgentLoop({


### PR DESCRIPTION
## What changed

- Count sandbox, read-file, and dataset-search system tools when deciding whether runtime tools are available.
- Keep plan and ask tools excluded from that availability check.
- Add regression coverage for fastAgent and piAgent with no tools and with each internal runtime tool enabled independently.

## Why

The main agent prompt previously checked only user-selected `runtimeTools`. When sandbox was enabled without another tool, the model received both the sandbox capability prompt and a contradictory constraint saying that no runtime tools were available. The same mismatch also applied to read-file and dataset-search system tools.

## Impact

Agents that only enable sandbox, read-file, or dataset-search no longer receive the incorrect no-runtime-tools constraint. Tool registration and execution paths are unchanged.

## Validation

- Targeted agent-loop tests: 46 passed.
- Service test suite: 3434 tests passed; the one suite initially blocked by a missing local `packages/next` dependency link passed after restoring that worktree link.
- `git diff --check` passed.
