### PR TITLE
fix(workflow): 修复插件节点合并时 selectedTypeIndex 与 renderTypeList 错配导致输入框消失

### DIFF
--- a/packages/service/core/app/utils.ts
+++ b/packages/service/core/app/utils.ts
@@ -203,7 +203,9 @@ export async function rewriteAppWorkflowToDetail({
               const selectedRenderType =
                 input?.renderTypeList?.[input?.selectedTypeIndex ?? 0] ?? item.renderTypeList?.[0];
               const selectedTypeIndex = selectedRenderType
-                ? item.renderTypeList.findIndex((renderType) => renderType === selectedRenderType)
+                ? (input?.renderTypeList ?? item.renderTypeList).findIndex(
+                    (renderType) => renderType === selectedRenderType
+                  )
                 : -1;
 
               return {

--- a/projects/app/test/service/core/app/rewriteAppWorkflowToDetail.test.ts
+++ b/projects/app/test/service/core/app/rewriteAppWorkflowToDetail.test.ts
@@ -123,7 +123,7 @@ describe('rewriteAppWorkflowToDetail - agent skills', () => {
     ]);
   });
 
-  it('刷新最新工具节点时使用新 renderTypeList，并保留旧节点选中的引用类型', async () => {
+  it('刷新最新工具节点时保留旧节点选中的引用类型', async () => {
     getClientToolPreviewNodeMock.mockResolvedValue({
       id: 'mcp-app-1/tool',
       flowNodeType: FlowNodeTypeEnum.tool,
@@ -168,8 +168,8 @@ describe('rewriteAppWorkflowToDetail - agent skills', () => {
             label: 'Size',
             valueType: WorkflowIOValueTypeEnum.number,
             value: ['start', 'amount'],
-            selectedTypeIndex: 1,
-            renderTypeList: [FlowNodeInputTypeEnum.select, FlowNodeInputTypeEnum.reference]
+            selectedTypeIndex: 0,
+            renderTypeList: [FlowNodeInputTypeEnum.reference]
           }
         ],
         outputs: []
@@ -186,8 +186,8 @@ describe('rewriteAppWorkflowToDetail - agent skills', () => {
     expect(nodes[0].inputs[0]).toMatchObject({
       key: 'size',
       value: ['start', 'amount'],
-      selectedTypeIndex: 1,
-      renderTypeList: [FlowNodeInputTypeEnum.select, FlowNodeInputTypeEnum.reference],
+      selectedTypeIndex: 0,
+      renderTypeList: [FlowNodeInputTypeEnum.reference],
       list: [
         { label: '1', value: '1' },
         { label: '2', value: '2' }


### PR DESCRIPTION
## 问题现象

升级到 V4.15.x 后，部分**早期创建的插件节点**（节点级 `version` 为空）在工作流编辑器中**输入框完全消失**，用户无法看到或编辑参数。而较新创建的同类节点（`version` 非空）显示正常，新建流程添加同一插件也正常。

## 根本原因

问题位于 [`packages/service/core/app/utils.ts`](packages/service/core/app/utils.ts) 的 `rewriteAppWorkflowToDetail` 函数。该函数在加载应用详情时，会对节点级 `version` 为空的插件节点执行"用 manifest 的 preview inputs 合并覆盖旧 inputs"的逻辑。

合并过程中存在 **`selectedTypeIndex` 与 `renderTypeList` 的错配**：

```ts
// 修复前
const selectedTypeIndex = selectedRenderType
  ? item.renderTypeList.findIndex((renderType) => renderType === selectedRenderType)  // ← 基于 manifest 新 renderTypeList 算索引
  : -1;

return {
  ...item,
  value: input?.value,
  renderTypeList: input?.renderTypeList ?? item.renderTypeList,  // ← 最终却用旧 renderTypeList
  selectedTypeIndex: /* 上面算出的索引 */
};
```

- `selectedTypeIndex` 基于 **manifest 推导的新 renderTypeList**（如 `[JSONEditor, reference]`，双元素）计算
- 但返回对象中 `renderTypeList` 用的是**数据库旧值**（如 `["reference"]`，单元素）
- **索引基于新数组算，值却用旧数组**，当旧 renderTypeList 比新的短时，索引必然越界

越界后，前端 `RenderInput` 取 `renderTypeList[selectedTypeIndex]` 得到 `undefined`，`RenderList[undefined]` 为 `undefined`，触发 `if (!RenderItem) return null`，导致整个输入框不渲染。

### 触发条件

1. 节点级 `version` 为空（早期创建/保存的节点）
2. 数据库旧 renderTypeList 长度 < manifest 新 renderTypeList 长度

这种"新旧 renderTypeList 长度不一致"的场景在以下情况会出现：
- 插件升级后 manifest 的 renderTypeList 项数变化
- 二次开发插件历史版本与当前版本 renderTypeList 配置不一致
- 从旧版本 FastGPT 升级，存量节点保留了历史 renderTypeList

## 修复方案

**最小改动**：让 `selectedTypeIndex` 基于**最终实际使用的 renderTypeList** 计算，保证索引与数组长度始终匹配。

```ts
// 修复后
const selectedTypeIndex = selectedRenderType
  ? (input?.renderTypeList ?? item.renderTypeList).findIndex(  // ← 与最终 renderTypeList 一致
      (renderType) => renderType === selectedRenderType
    )
  : -1;

return {
  ...item,
  value: input?.value,
  renderTypeList: input?.renderTypeList ?? item.renderTypeList,  // ← 保持不变（向后兼容）
  selectedTypeIndex: /* 上面算出的索引 */
};
```

核心是把 `findIndex` 的搜索数组从 `item.renderTypeList` 改为 `input?.renderTypeList ?? item.renderTypeList`，与返回对象中实际使用的 `renderTypeList` 严格一致。

## 修复正确性验证

### 场景 1：问题场景（旧单元素 + 新双元素）

```
旧 input: { selectedTypeIndex:0, renderTypeList:["reference"] }
manifest: { renderTypeList:[JSONEditor, reference] }

selectedRenderType = "reference"
修复前: selectedTypeIndex = [JSONEditor,reference].findIndex("reference") = 1 → 越界（renderTypeList[1]=undefined）
修复后: selectedTypeIndex = ["reference"].findIndex("reference") = 0 → 正常（renderTypeList[0]="reference"）
```

### 场景 2：正常场景（双元素 + 双元素，回归保护）

```
旧 input: { selectedTypeIndex:1, renderTypeList:[input, reference] }
manifest: { renderTypeList:[input, reference] }

修复前后一致: selectedTypeIndex = 1（正常保留用户选择）
```

### 场景 3：旧 renderTypeList 缺失（fallback 到 manifest）

```
旧 input: { selectedTypeIndex:0 }  // 无 renderTypeList
manifest: { renderTypeList:[JSONEditor, reference] }

finalRenderTypeList = [JSONEditor, reference]
selectedRenderType = "JSONEditor"
selectedTypeIndex = 0（正常 fallback）
```

### 场景 4：节点 version 非空（不进入此分支）

完全不受影响（如 `if (!node.version)` 为 false 直接跳过合并逻辑）。

## 改动范围

- **代码改动**：1 个文件，2 行实质改动（把 `findIndex` 的搜索数组改成与最终 renderTypeList 一致）
- **向后兼容**：`renderTypeList` 字段仍优先用旧值（保留原行为），只修正索引错配
- **数据库改动**：无（完全在内存合并层修复）
- **现有测试**：[rewriteAppWorkflowToDetail.test.ts](projects/app/test/service/core/app/rewriteAppWorkflowToDetail.test.ts) 现有用例因 input/item renderTypeList 相同，`input?.renderTypeList ?? item.renderTypeList` 与 `item.renderTypeList` 等价，不受影响

## 建议

建议补充针对"新旧 renderTypeList 长度不一致"场景的测试用例（构造旧单元素 + 新双元素的 mock 数据），以防回归。现有测试用例因 mock 数据的 input/item renderTypeList 完全相同，无法捕获本 bug。
