### PR TITLE
fix: avoid double-encoding avatar URLs

### DIFF
--- a/projects/app/src/pages/api/system/img/[...id].ts
+++ b/projects/app/src/pages/api/system/img/[...id].ts
@@ -22,10 +22,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return;
     }
 
-    // Encode URL to handle special characters (e.g., Chinese characters)
     const publicUrl = getS3AvatarSource().createPublicUrl(joined);
-    const encodedUrl = encodeURI(publicUrl);
-    res.redirect(301, encodedUrl);
+    res.redirect(301, publicUrl);
   } catch (error) {
     jsonRes(res, {
       code: 500,

--- a/projects/app/test/api/system/img.test.ts
+++ b/projects/app/test/api/system/img.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import handler from '@/pages/api/system/img/[...id]';
+
+const mocks = vi.hoisted(() => ({
+  createPublicUrl: vi.fn(),
+  isObjectIdValid: vi.fn(() => false)
+}));
+
+vi.mock('@fastgpt/service/common/s3/sources/avatar', () => ({
+  getS3AvatarSource: vi.fn(() => ({
+    createPublicUrl: mocks.createPublicUrl
+  }))
+}));
+
+vi.mock('@fastgpt/service/common/file/image/controller', () => ({
+  readMongoImg: vi.fn()
+}));
+
+vi.mock('@fastgpt/service/common/mongo', () => ({
+  Types: {
+    ObjectId: {
+      isValid: mocks.isObjectIdValid
+    }
+  }
+}));
+
+describe('system image redirect', () => {
+  const key = 'avatar/team-id/g0A71O-人事咨询小助手.png';
+  const encodedPublicUrl =
+    'https://cdn.example.com/avatar/team-id/g0A71O-%E4%BA%BA%E4%BA%8B%E5%92%A8%E8%AF%A2%E5%B0%8F%E5%8A%A9%E6%89%8B.png';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createPublicUrl.mockReturnValue(encodedPublicUrl);
+  });
+
+  it('does not double-encode an already encoded object URL', async () => {
+    const req = {
+      query: {
+        id: key.split('/')
+      }
+    } as any;
+    const res = {
+      redirect: vi.fn()
+    } as any;
+
+    await handler(req, res);
+
+    expect(mocks.createPublicUrl).toHaveBeenCalledWith(key);
+    expect(res.redirect).toHaveBeenCalledWith(301, encodedPublicUrl);
+  });
+});


### PR DESCRIPTION
Object storage adapters already encode non-ASCII key segments when building public URLs. The app image redirect route was encoding that URL a second time, turning %E4... into %25E4... and causing Chinese avatar filenames to 404 even when the object exists.

This PR removes the duplicate encoding in the app route, adds a regression test, and updates the Pro submodule to the matching fix.

Depends on: labring/fastgpt-pro#1031

Validation:
- pnpm --filter @fastgpt/app exec vitest run -c vitest.config.ts test/api/system/img.test.ts
- pnpm --filter @fastgpt-sdk/storage exec vitest run -c vitest.config.ts test/unit/utils.test.ts test/unit/adapters/aws-s3.adapter.test.ts test/unit/adapters/cos.adapter.test.ts test/unit/adapters/oss.adapter.test.ts
- pnpm --filter @fastgpt/app typecheck
- pnpm --dir pro/admin run typecheck