### PR TITLE
fix(sandbox): move migration staging out of workspace

### DIFF
--- a/packages/global/common/system/utils.ts
+++ b/packages/global/common/system/utils.ts
@@ -40,31 +40,42 @@ export const withTimeout = async <T>(
   }
 };
 
-/** 按固定并发执行任务；waitForAll 仅用于调用方必须等待所有 worker 收敛后再抛错的场景。 */
+/** 按固定并发执行任务；任一任务失败时立即向调用方抛出该错误。 */
 export const batchRun = async <T, R>(
   arr: T[],
   fn: (item: T, index: number) => Promise<R>,
-  batchSize = 10,
-  options: { waitForAll?: boolean } = {}
+  batchSize = 10
 ): Promise<R[]> => {
   const result: R[] = new Array(arr.length);
-  const errors: Array<{ index: number; error: unknown }> = [];
   let nextIndex = 0;
   const batchFn = async () => {
     while (nextIndex < arr.length) {
       const currentIndex = nextIndex++;
-      try {
-        result[currentIndex] = await fn(arr[currentIndex], currentIndex);
-      } catch (error) {
-        if (!options.waitForAll) throw error;
-        errors.push({ index: currentIndex, error });
-      }
+      result[currentIndex] = await fn(arr[currentIndex], currentIndex);
     }
   };
   await Promise.all(Array.from({ length: Math.min(batchSize, arr.length) }, () => batchFn()));
-  if (errors.length > 0) {
-    errors.sort((a, b) => a.index - b.index);
-    throw errors[0].error;
-  }
   return result;
 };
+
+export type BatchRunSettledResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: unknown };
+
+/** 按固定并发执行全部任务，并按输入顺序返回每项成功或失败结果。 */
+export const batchRunSettled = async <T, R>(
+  arr: T[],
+  fn: (item: T, index: number) => Promise<R>,
+  batchSize = 10
+): Promise<BatchRunSettledResult<R>[]> =>
+  batchRun(
+    arr,
+    async (item, index) => {
+      try {
+        return { success: true, data: await fn(item, index) } as const;
+      } catch (error) {
+        return { success: false, error } as const;
+      }
+    },
+    batchSize
+  );

--- a/packages/global/test/common/system/utils.test.ts
+++ b/packages/global/test/common/system/utils.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { delay, retryFn, batchRun, withTimeout } from '@fastgpt/global/common/system/utils';
+import {
+  batchRun,
+  batchRunSettled,
+  delay,
+  retryFn,
+  withTimeout
+} from '@fastgpt/global/common/system/utils';
 
 describe('system utils', () => {
   afterEach(() => {
@@ -321,21 +327,25 @@ describe('system utils', () => {
       expect(fn).toHaveBeenCalledTimes(1);
     });
 
-    it('should wait for every worker before rejecting when waitForAll is enabled', async () => {
-      const completed: number[] = [];
+    it('should return every settled result in input order', async () => {
+      const firstError = new Error('first failed');
+      const thirdError = new Error('third failed');
       const fn = vi.fn(async (item: number) => {
-        if (item === 1) throw new Error('first failed');
-        await delay(item);
-        completed.push(item);
-        return item;
+        await delay((5 - item) * 2);
+        if (item === 1) throw firstError;
+        if (item === 3) throw thirdError;
+        return item * 10;
       });
 
-      await expect(batchRun([1, 2, 3, 4], fn, 2, { waitForAll: true })).rejects.toThrow(
-        'first failed'
-      );
+      const results = await batchRunSettled([1, 2, 3, 4], fn, 2);
 
       expect(fn).toHaveBeenCalledTimes(4);
-      expect(completed.sort((a, b) => a - b)).toEqual([2, 3, 4]);
+      expect(results).toEqual([
+        { success: false, error: firstError },
+        { success: true, data: 20 },
+        { success: false, error: thirdError },
+        { success: true, data: 40 }
+      ]);
     });
   });
 });

--- a/packages/service/core/ai/sandbox/application/legacyMigration/cleanup.ts
+++ b/packages/service/core/ai/sandbox/application/legacyMigration/cleanup.ts
@@ -1,8 +1,9 @@
 /** Legacy Sandbox 归档前清理和 Source 删除清理。 */
 import { getErrText } from '@fastgpt/global/common/error/utils';
-import { batchRun } from '@fastgpt/global/common/system/utils';
+import { batchRunSettled } from '@fastgpt/global/common/system/utils';
 import { SandboxStatusEnum } from '@fastgpt/global/core/ai/sandbox/constants';
 import { ChatSourceTypeEnum } from '@fastgpt/global/core/chat/constants';
+import { getLogger, LogCategories } from '../../../../../common/logger';
 import { getS3SandboxSource } from '../../../../../common/s3/sources/sandbox';
 import {
   completeLegacySandboxArchive,
@@ -25,6 +26,7 @@ import { getLegacyMigrationPhase, toLegacyResource } from './utils';
 
 const APP_SANDBOX_MIGRATION_CONCURRENCY = 5;
 const SOURCE_DELETE_CONCURRENCY = 10;
+const logger = getLogger(LogCategories.MODULE.AI.SANDBOX);
 
 export class LegacySandboxCleanupError extends Error {
   constructor(
@@ -185,6 +187,41 @@ async function cleanupLegacyInstanceForSourceDeletion(params: {
   });
 }
 
+/** 清理同一 Source 的 Legacy 资源；全部任务收敛后记录每个失败实例。 */
+async function cleanupLegacyInstancesForSourceDeletion(params: {
+  legacy: LegacySandboxInstanceSchemaType[];
+  sourceType: ChatSourceTypeEnum;
+  sourceId: string;
+  assertLeaseValid: () => void;
+  concurrency: number;
+}) {
+  const { legacy, sourceType, sourceId, assertLeaseValid, concurrency } = params;
+  const results = await batchRunSettled(
+    legacy,
+    (doc) => cleanupLegacyInstanceForSourceDeletion({ doc, assertLeaseValid }),
+    concurrency
+  );
+  const failures = results.flatMap((result, index) => {
+    if (result.success) return [];
+    return [
+      {
+        sandboxId: legacy[index].sandboxId,
+        ...(result.error instanceof LegacySandboxCleanupError ? { step: result.error.step } : {}),
+        error: getErrText(result.error, 'Unknown Legacy Sandbox cleanup error')
+      }
+    ];
+  });
+  if (failures.length === 0) return;
+
+  logger.error('Failed to clean up Legacy Sandbox resources', {
+    sourceType,
+    sourceId,
+    failureCount: failures.length,
+    failures
+  });
+  throw new Error(`Failed to clean up ${failures.length} Legacy Sandbox resources`);
+}
+
 /** App 删除在 Source Lease 内同时清理 v2 和 Legacy 资源。 */
 export async function deleteAppSandboxesForAppDeletion(appId: string): Promise<void> {
   await withSandboxSourceMutationLease({
@@ -202,19 +239,20 @@ export async function deleteAppSandboxesForAppDeletion(appId: string): Promise<v
         sourceType: ChatSourceTypeEnum.app,
         sourceId: appId
       });
-      await batchRun(
+      await cleanupLegacyInstancesForSourceDeletion({
         legacy,
-        (doc) => cleanupLegacyInstanceForSourceDeletion({ doc, assertLeaseValid: assertValid }),
-        APP_SANDBOX_MIGRATION_CONCURRENCY,
-        { waitForAll: true }
-      );
+        sourceType: ChatSourceTypeEnum.app,
+        sourceId: appId,
+        assertLeaseValid: assertValid,
+        concurrency: APP_SANDBOX_MIGRATION_CONCURRENCY
+      });
     }
   });
 }
 
 /** Skill 删除按 source 串行清理 v2 和 Legacy 资源。 */
 export async function deleteSkillEditSandboxesForSkillDeletion(skillIds: string[]) {
-  await batchRun(
+  const results = await batchRunSettled(
     skillIds,
     async (skillId) => {
       await withSandboxSourceMutationLease({
@@ -232,16 +270,33 @@ export async function deleteSkillEditSandboxesForSkillDeletion(skillIds: string[
             sourceType: ChatSourceTypeEnum.skillEdit,
             sourceId: skillId
           });
-          await batchRun(
+          await cleanupLegacyInstancesForSourceDeletion({
             legacy,
-            (doc) => cleanupLegacyInstanceForSourceDeletion({ doc, assertLeaseValid: assertValid }),
-            SOURCE_DELETE_CONCURRENCY,
-            { waitForAll: true }
-          );
+            sourceType: ChatSourceTypeEnum.skillEdit,
+            sourceId: skillId,
+            assertLeaseValid: assertValid,
+            concurrency: SOURCE_DELETE_CONCURRENCY
+          });
         }
       });
     },
-    SOURCE_DELETE_CONCURRENCY,
-    { waitForAll: true }
+    SOURCE_DELETE_CONCURRENCY
   );
+
+  const failures = results.flatMap((result, index) => {
+    if (result.success) return [];
+    return [
+      {
+        skillId: skillIds[index],
+        error: getErrText(result.error, 'Unknown Skill Sandbox cleanup error')
+      }
+    ];
+  });
+  if (failures.length === 0) return;
+
+  logger.error('Failed to clean up Skill Sandbox sources', {
+    failureCount: failures.length,
+    failures
+  });
+  throw new Error(`Failed to clean up ${failures.length} Skill Sandbox sources`);
 }

--- a/packages/service/core/ai/sandbox/application/legacyMigration/workspace.ts
+++ b/packages/service/core/ai/sandbox/application/legacyMigration/workspace.ts
@@ -10,6 +10,7 @@ import type { LegacySandboxInstanceSchemaType } from '../../infrastructure/insta
 import { SandboxMetadataSchema, type SandboxProviderType } from '../../type';
 import { getSandboxRuntimePaths, getSandboxSessionPathSegment, joinSandboxPath } from '../../utils';
 import { restoreSandboxWorkspaceArchiveForMigration } from '../archive';
+import { resolveSandboxHome } from '../runtime/home';
 import type { LegacyMigrationTarget } from './types';
 import { toV2Metadata } from './utils';
 
@@ -69,10 +70,16 @@ async function mergeLegacyWorkspaceArchive(params: {
   removeAppRuntimeSkillCaches: boolean;
 }) {
   const { target, legacySandboxId, archiveBody, targetDirectory } = params;
-  const { workspaceRoot } = target.getRuntimePaths();
+  const homeDirectory = await resolveSandboxHome(target.provider);
+  if (!homeDirectory) {
+    throw new Error('Failed to resolve sandbox HOME for migration staging directory');
+  }
   const stagingName = createHash('sha256').update(legacySandboxId).digest('hex').slice(0, 40);
   const stagingDirectory = joinSandboxPath(
-    joinSandboxPath(workspaceRoot, '.migration'),
+    homeDirectory,
+    '.fastgpt',
+    'tmp',
+    'migration',
     stagingName
   );
   await restoreSandboxWorkspaceArchiveForMigration({
@@ -142,7 +149,8 @@ export const installLegacyWorkspaceArchive = (params: {
     legacySandboxId: params.legacySandboxId,
     archiveBody: params.archiveBody,
     targetDirectory: joinSandboxPath(
-      joinSandboxPath(workspaceRoot, 'sessions'),
+      workspaceRoot,
+      'sessions',
       getSandboxSessionPathSegment(params.chatId)
     ),
     removeAppRuntimeSkillCaches: true

--- a/packages/service/core/ai/sandbox/application/resource.ts
+++ b/packages/service/core/ai/sandbox/application/resource.ts
@@ -3,7 +3,8 @@
  *
  * 所有远端 stop/delete 都在 provider 无关的 Lifecycle Lease 内先抢占 Mongo operation。
  */
-import { batchRun } from '@fastgpt/global/common/system/utils';
+import { getErrText } from '@fastgpt/global/common/error/utils';
+import { batchRun, batchRunSettled } from '@fastgpt/global/common/system/utils';
 import { ChatSourceTypeEnum } from '@fastgpt/global/core/chat/constants';
 import { subMinutes } from 'date-fns';
 import { getLogger, LogCategories } from '../../../../common/logger';
@@ -197,24 +198,45 @@ export async function deleteSandbox(params: DeleteSandboxParams): Promise<void> 
   await deleteSandboxResource(instance);
 }
 
+/** 删除一批 Sandbox 资源；全部任务收敛后统一记录失败资源并阻止后续清理阶段。 */
+const deleteSandboxResourceBatch = async (instances: SandboxResourceRef[]) => {
+  const results = await batchRunSettled(
+    instances,
+    (instance) => deleteSandboxResource(instance),
+    10
+  );
+  const failures = results.flatMap((result, index) => {
+    if (result.success) return [];
+    return [
+      {
+        sandboxId: instances[index].sandboxId,
+        error: getErrText(result.error, 'Unknown sandbox deletion error')
+      }
+    ];
+  });
+  if (failures.length === 0) return;
+
+  logger.error('Failed to delete sandbox resources', {
+    failureCount: failures.length,
+    failures
+  });
+  throw new Error(`Failed to delete ${failures.length} sandbox resources`);
+};
+
 /** 调用方持有 Source Mutation Lease 时，清理某个 App 的全部 v2 资源。 */
 export const deleteAppSandboxes = async (appId: string) => {
   const instances = await findSandboxResourcesBySource({
     sourceType: ChatSourceTypeEnum.app,
     sourceId: appId
   });
-  await batchRun(instances, (instance) => deleteSandboxResource(instance), 10, {
-    waitForAll: true
-  });
+  await deleteSandboxResourceBatch(instances);
 };
 
 /** 调用方持有各 Skill Source Mutation Lease 时，清理 Skill Edit v2 资源。 */
 export const deleteSkillEditSandboxes = async (skillIds: string[]) => {
   if (skillIds.length === 0) return;
   const instances = await findSkillRelatedSandboxResources(skillIds);
-  await batchRun(instances, (instance) => deleteSandboxResource(instance), 10, {
-    waitForAll: true
-  });
+  await deleteSandboxResourceBatch(instances);
 };
 
 /** cron 批量 stop；单条失败会记录并允许同批其他资源继续。 */

--- a/packages/service/core/ai/sandbox/application/skillEdit/runtime.ts
+++ b/packages/service/core/ai/sandbox/application/skillEdit/runtime.ts
@@ -457,7 +457,7 @@ export async function packageSkillInSandbox(params: {
     if (!homeDirectory) {
       throw new Error('Failed to resolve sandbox HOME for package temp directory');
     }
-    const packageTempDir = joinSandboxPath(joinSandboxPath(homeDirectory, '.fastgpt'), 'tmp');
+    const packageTempDir = joinSandboxPath(homeDirectory, '.fastgpt', 'tmp');
     const packageZipFilename = `skill-package-${Date.now()}-${Math.random()
       .toString(36)
       .slice(2)}.zip`;

--- a/packages/service/core/ai/sandbox/infrastructure/provider/runtimeProfile/utils.ts
+++ b/packages/service/core/ai/sandbox/infrastructure/provider/runtimeProfile/utils.ts
@@ -11,7 +11,7 @@ export const getSandboxSkillsRootPath = (workDirectory: string) =>
 
 /** 内置 Skill 注入到 sandbox 用户主目录，不属于用户可编辑 workspace。 */
 export const getSandboxBuiltinSkillsRootPath = (homeDirectory: string) =>
-  joinSandboxPath(joinSandboxPath(homeDirectory, '.fastgpt'), 'skills');
+  joinSandboxPath(homeDirectory, '.fastgpt', 'skills');
 
 /**
  * 合并环境变量时让业务场景入参覆盖已有 createConfig。

--- a/packages/service/core/ai/sandbox/utils/index.ts
+++ b/packages/service/core/ai/sandbox/utils/index.ts
@@ -12,9 +12,12 @@ type HashContent = string | Buffer | Uint8Array;
 export const trimSandboxPathRight = (value: string) =>
   value === '/' ? '' : value.replace(/\/+$/, '');
 
-/** 用 sandbox 语义拼接路径，避免不同 provider 工作目录末尾斜杠导致双斜杠。 */
-export const joinSandboxPath = (basePath: string, path: string) =>
-  `${trimSandboxPathRight(basePath)}/${path}`;
+/** 用 sandbox 语义拼接一段或多段路径，避免不同 provider 工作目录末尾斜杠导致双斜杠。 */
+export const joinSandboxPath = (basePath: string, path: string, ...paths: string[]) =>
+  [path, ...paths].reduce(
+    (currentPath, nextPath) => `${trimSandboxPathRight(currentPath)}/${nextPath}`,
+    basePath
+  );
 
 /** 将 chatId 转成稳定的单个目录名；常规 NanoID 保持原值，异常输入使用 URL 编码。 */
 export const getSandboxSessionPathSegment = (chatId: string) => {
@@ -58,7 +61,8 @@ export const getSandboxRuntimePaths = ({
       workspaceRoot,
       runtimeSkillsRoot,
       sessionWorkDirectory: joinSandboxPath(
-        joinSandboxPath(workspaceRoot, 'sessions'),
+        workspaceRoot,
+        'sessions',
         getSandboxSessionPathSegment(chatId ?? '')
       )
     };

--- a/packages/service/test/core/ai/sandbox/application/legacyMigration/service.test.ts
+++ b/packages/service/test/core/ai/sandbox/application/legacyMigration/service.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   buildRuntimeSandboxAdapter: vi.fn(),
   buildSandboxResourceAdapter: vi.fn(),
   ensureConnectedSandboxRunning: vi.fn(),
+  resolveSandboxHome: vi.fn(),
   deleteSessionVolume: vi.fn(),
   getSessionVolumeConfig: vi.fn(),
   downloadLegacyWorkspaceArchive: vi.fn(),
@@ -74,6 +75,10 @@ vi.mock('@fastgpt/service/core/ai/sandbox/infrastructure/provider/config', () =>
 
 vi.mock('@fastgpt/service/core/ai/sandbox/infrastructure/provider/lifecycle', () => ({
   ensureConnectedSandboxRunning: mocks.ensureConnectedSandboxRunning
+}));
+
+vi.mock('@fastgpt/service/core/ai/sandbox/application/runtime/home', () => ({
+  resolveSandboxHome: mocks.resolveSandboxHome
 }));
 
 vi.mock('@fastgpt/service/core/ai/sandbox/infrastructure/provider/runtimeProfile', () => ({
@@ -209,6 +214,7 @@ describe('legacy sandbox migration', () => {
     mocks.completeSandboxOperation.mockResolvedValue({ status: 'running' });
     mocks.markSandboxOperationFailed.mockResolvedValue(undefined);
     mocks.ensureConnectedSandboxRunning.mockResolvedValue(undefined);
+    mocks.resolveSandboxHome.mockResolvedValue('/home/sandbox');
     mocks.getSessionVolumeConfig.mockResolvedValue(undefined);
     mocks.deleteSessionVolume.mockResolvedValue(undefined);
     mocks.downloadLegacyWorkspaceArchive.mockResolvedValue(Buffer.from('zip'));
@@ -259,14 +265,41 @@ describe('legacy sandbox migration', () => {
       expect(mocks.restoreSandboxWorkspaceArchiveForMigration).toHaveBeenCalledWith(
         expect.objectContaining({
           sandbox: target.provider,
-          workDirectory: expect.stringMatching(/^\/workspace\/\.migration\/[0-9a-f]{40}$/),
+          workDirectory: expect.stringMatching(
+            /^\/home\/sandbox\/\.fastgpt\/tmp\/migration\/[0-9a-f]{40}$/
+          ),
           sandboxId: 'migration-test-old-1'
         })
       );
+      expect(mocks.resolveSandboxHome).toHaveBeenCalledWith(target.provider);
       const commitCommand = target.provider.execute.mock.calls[0][0] as string;
       expect(commitCommand).toContain("target='/workspace/sessions/chat%2F2'");
       expect(commitCommand).toContain('merge_without_overwrite');
       expect(commitCommand).toContain('[ ! -e "$target_path" ]');
+    });
+
+    it('rejects migration before restore when Sandbox HOME cannot be resolved', async () => {
+      const target = {
+        provider: createTargetProvider(),
+        getRuntimePaths: () => ({
+          workspaceRoot: '/workspace',
+          runtimeSkillsRoot: '/workspace/projects',
+          sessionWorkDirectory: '/workspace/sessions/chat-1'
+        })
+      } as any;
+      mocks.resolveSandboxHome.mockResolvedValueOnce(undefined);
+
+      await expect(
+        installLegacyWorkspaceArchive({
+          target,
+          legacySandboxId: 'migration-test-home-missing',
+          chatId: 'chat-1',
+          archiveBody: Buffer.from('zip')
+        })
+      ).rejects.toThrow('Failed to resolve sandbox HOME for migration staging directory');
+
+      expect(mocks.restoreSandboxWorkspaceArchiveForMigration).not.toHaveBeenCalled();
+      expect(target.provider.execute).not.toHaveBeenCalled();
     });
   });
 
@@ -621,7 +654,9 @@ describe('legacy sandbox migration', () => {
       );
       expect(mocks.restoreSandboxWorkspaceArchiveForMigration).toHaveBeenCalledWith(
         expect.objectContaining({
-          workDirectory: expect.stringMatching(/^\/workspace\/\.migration\/[0-9a-f]{40}$/),
+          workDirectory: expect.stringMatching(
+            /^\/home\/sandbox\/\.fastgpt\/tmp\/migration\/[0-9a-f]{40}$/
+          ),
           sandboxId: 'migration-test-skill-1'
         })
       );
@@ -652,7 +687,9 @@ describe('legacy sandbox migration', () => {
         userId: ChatSourceTypeEnum.skillEdit
       });
       const workspaceRoot = await mkdtemp(path.join(tmpdir(), 'fastgpt-skill-migration-'));
+      const homeDirectory = await mkdtemp(path.join(tmpdir(), 'fastgpt-skill-migration-home-'));
       mocks.runtimeWorkDirectory.value = workspaceRoot;
+      mocks.resolveSandboxHome.mockResolvedValue(homeDirectory);
       await writeFile(path.join(workspaceRoot, 'shared.txt'), 'current');
       await mkdir(path.join(workspaceRoot, 'nested'), { recursive: true });
       await writeFile(path.join(workspaceRoot, 'nested', 'shared.txt'), 'current-nested');
@@ -704,6 +741,7 @@ describe('legacy sandbox migration', () => {
         );
       } finally {
         await rm(workspaceRoot, { recursive: true, force: true });
+        await rm(homeDirectory, { recursive: true, force: true });
       }
     });
   });

--- a/packages/service/test/core/ai/sandbox/application/resource.test.ts
+++ b/packages/service/test/core/ai/sandbox/application/resource.test.ts
@@ -264,6 +264,33 @@ describe('sandbox resource lifecycle', () => {
     expect(mocks.withSandboxLifecycleLease).toHaveBeenCalledTimes(2);
   });
 
+  it('records every failed resource after bulk deletion settles', async () => {
+    const resources = [
+      createResource({ sandboxId: 'sandbox-a' }),
+      createResource({ sandboxId: 'sandbox-b' }),
+      createResource({ sandboxId: 'sandbox-c' })
+    ];
+    mocks.findSandboxResourcesBySource.mockResolvedValueOnce(resources);
+    mocks.withSandboxLifecycleLease.mockImplementation(async ({ sandboxId, fn }: any) => {
+      if (sandboxId === 'sandbox-a') throw new Error('delete a failed');
+      if (sandboxId === 'sandbox-b') throw new Error('delete b failed');
+      return fn({ signal: new AbortController().signal, assertValid });
+    });
+
+    await expect(deleteAppSandboxes('app-1')).rejects.toThrow(
+      'Failed to delete 2 sandbox resources'
+    );
+
+    expect(mocks.withSandboxLifecycleLease).toHaveBeenCalledTimes(3);
+    expect(mocks.logger.error).toHaveBeenCalledWith('Failed to delete sandbox resources', {
+      failureCount: 2,
+      failures: [
+        { sandboxId: 'sandbox-a', error: 'delete a failed' },
+        { sandboxId: 'sandbox-b', error: 'delete b failed' }
+      ]
+    });
+  });
+
   it('isolates failures while stopping a cron batch', async () => {
     mocks.buildSandboxResourceAdapter.mockReturnValueOnce({
       stop: vi.fn(async () => {


### PR DESCRIPTION
## What

- move legacy migration staging to `$HOME/.fastgpt/tmp/migration`
- support multi-segment `joinSandboxPath` and replace nested calls
- fail before archive restore when sandbox HOME cannot be resolved

## Tests

- `pnpm test`