### PR TITLE
fix(sandbox): align v2 migration and Devbox resource limits

### DIFF
--- a/.agents/design/core/ai/sandbox/user-level-sandbox.md
+++ b/.agents/design/core/ai/sandbox/user-level-sandbox.md
@@ -59,7 +59,7 @@ sessionWorkDirectory = <workspaceRoot>/sessions/<chatId>
 
 - `agent_sandbox_instances_v2` 是新运行时的唯一实例表。
 - 顶层 `status` 是唯一权威生命周期状态。
-- `metadata.operation` 只记录 operation token、持久阶段、心跳和错误，不承担第二套状态判断。
+- `operation` 只记录 operation token、持久阶段、心跳和错误，不承担第二套状态判断。
 - 普通 runtime 不得连接 `legacyMigrating` 或其他过渡态实例。
 - 单个 Chat 删除不删除共享 Sandbox，也不单独清理 `sessions/<chatId>`。
 - App 或 Skill 删除负责清理所属 v2 与 Legacy 资源。
@@ -89,25 +89,18 @@ type SandboxInstance = {
   createdAt: Date;
   limit?: SandboxLimit;
   storage?: SandboxStorage;
-  metadata?: {
-    teamId?: string;
-    tmbId?: string;
-    volumeEnabled?: boolean;
-    image?: SandboxImage;
-    sessionId?: string;
-    skillIds?: string[];
-    skillName?: string;
-    versionId?: string;
-    operation?: {
-      id: string;
-      type: 'provision' | 'legacyMigration' | 'stop' | 'archive' | 'restore' | 'delete';
-      phase: string;
-      previousStatus?: 'running' | 'stopped' | 'archived';
-      startedAt: Date;
-      heartbeatAt: Date;
-      failedAt?: Date;
-      error?: string;
-    };
+  teamId?: string;
+  image?: SandboxImage;
+  versionId?: string;
+  operation?: {
+    id: string;
+    type: 'provision' | 'legacyMigration' | 'stop' | 'archive' | 'restore' | 'delete';
+    phase: string;
+    previousStatus?: 'running' | 'stopped' | 'archived';
+    startedAt: Date;
+    heartbeatAt: Date;
+    failedAt?: Date;
+    error?: string;
   };
 };
 ```
@@ -118,9 +111,9 @@ type SandboxInstance = {
 - `(sourceType, sourceId, userId)` 唯一，约束业务逻辑实例。
 - 稳定态只有 `running/stopped/archived`，稳定态不得残留 operation。
 - 每个过渡态必须匹配唯一 operation 类型。
-- 过渡态接管按 `status + metadata.operation.heartbeatAt` 查询，空闲资源按
+- 过渡态接管按 `status + operation.heartbeatAt` 查询，空闲资源按
   `status + lastActiveAt` 查询。
-- v2 不包含 `chatId`、旧 `appId/type`、`metadata.archive` 或 `metadata.migration`。
+- v2 不包含通用 `metadata` 容器，也不包含 `chatId` 或旧 `appId/type`。
 
 ### 3.2 Legacy 实例
 
@@ -207,7 +200,13 @@ active；删除任务只处理已经持久标记删除的 source。
 
 第 0 阶段结束后必须重新统计 Sandbox 待归一化记录和待清理旧 Debug Chat。两者合计为
 `pendingCount`；只要它不为 0，整次任务就停在该阶段，不得归档 Workspace、删除待迁移物理资源
-或创建 v2 目标。该总数归零后直接进入 Workspace 迁移，不再执行重复的 Legacy 整表 Zod 预检。
+或创建 v2 目标。该总数归零后，先执行一次 Legacy 专属整表预检，再进入 Workspace 迁移；该预检
+不复用 v2 instance schema。
+
+Legacy 预检使用独立的 `LegacySandboxInstanceZodSchema`，不得使用 v2 实例 schema 校验 Legacy
+输入。Legacy metadata 可以包含 `providerCreatedAt`、旧 `storage` 等 Skill 编辑历史字段；这些字段
+由 Legacy schema 读取，在映射到 v2 时显式丢弃。`toV2SandboxFields` 只能按 v2 稳定根字段白名单
+构造结果，避免新的 Legacy 字段通过对象展开泄漏到 v2。
 
 ### 6.2 两阶段迁移
 
@@ -237,6 +236,11 @@ active；删除任务只处理已经持久标记删除的 source。
 - 失败保留目标、Legacy 记录和归档；重试从持久 phase 继续，不重复已经确认的副作用。
 - `completed` 是 Legacy 迁移终态，后续迁移只预检、不重复安装。
 
+旧 Skill Debug Chat 清理沿用 beta6 初始化脚本：扫描当前全部 Skill，排除同 ID 的 App 后逐个
+统计 Legacy Chat；列表包含空 Skill 的检查结果，但正式执行只删除 `chatCount > 0` 的 Skill。
+`matchedSkillCount` 表示排除冲突后的扫描数量，`cleanedSkillCount` 表示实际提交删除的 Skill
+数量，`pendingChatCount` 用于迁移阻塞判断。
+
 Skill 分组并发度为 20；App 分组并发度为 5，组内按 `lastActiveAt` 从新到旧串行安装。
 
 ## 7. 运行时配置收敛
@@ -254,7 +258,7 @@ App Chat 和 Workflow 只在 Agent 或 ToolCall 节点确定本轮实际使用 S
 - Skill Edit 继续由用户显式确认升级并在页面轮询，不复用 App Chat 的静默交互。
 
 迁移过程不新增数据库状态；它复用 archive、restore 和稳定 `archived` 状态。历史记录缺少
-`metadata.image` 时按镜像不一致处理。
+`image` 时按镜像不一致处理。
 
 ## 8. Sandbox 不可用时的 App Chat 降级
 

--- a/packages/service/core/ai/sandbox/application/archive.ts
+++ b/packages/service/core/ai/sandbox/application/archive.ts
@@ -324,7 +324,7 @@ async function archiveSandboxWithinLease(params: {
     return { status: 'skipped', reason: `Sandbox is ${current.status}` };
   }
   if (current.status === SandboxInstanceStatusEnum.archiving) {
-    const operation = current.metadata?.operation;
+    const operation = current.operation;
     const staleBefore = subMinutes(new Date(), SANDBOX_STALE_ARCHIVING_MINUTES);
     // Lease 过期不代表旧 Provider 请求已经终止，隔离窗口内禁止新执行者换 token 接管。
     if (!operation?.error && (!operation?.heartbeatAt || operation.heartbeatAt >= staleBefore)) {
@@ -370,7 +370,7 @@ async function archiveSandboxWithinLease(params: {
         status: SandboxInstanceStatusEnum.archived,
         set: ({ resource: claimed }) => {
           const image = getSandboxRuntimeProfile(claimed.provider).defaultImage;
-          return image ? { 'metadata.image': image } : {};
+          return image ? { image } : {};
         }
       }
     };
@@ -589,10 +589,9 @@ export async function restoreArchivedSandboxBeforeUse(params: {
       }
       if (
         current.status === SandboxInstanceStatusEnum.restoring &&
-        !current.metadata?.operation?.error &&
-        current.metadata?.operation?.heartbeatAt &&
-        current.metadata.operation.heartbeatAt >=
-          subMinutes(new Date(), SANDBOX_STALE_ARCHIVING_MINUTES)
+        !current.operation?.error &&
+        current.operation?.heartbeatAt &&
+        current.operation.heartbeatAt >= subMinutes(new Date(), SANDBOX_STALE_ARCHIVING_MINUTES)
       ) {
         throw new SandboxLifecycleStateError(current.status);
       }
@@ -636,8 +635,7 @@ export async function restoreArchivedSandboxBeforeUse(params: {
               userId: params.userId,
               ...(restoredStorage !== undefined ? { storage: restoredStorage } : {}),
               ...(params.resourceLimit ? { limit: params.resourceLimit } : {}),
-              'metadata.volumeEnabled': Boolean(restoredStorage),
-              ...(runtimeImage ? { 'metadata.image': runtimeImage } : {})
+              ...(runtimeImage ? { image: runtimeImage } : {})
             })
           }
         };

--- a/packages/service/core/ai/sandbox/application/legacyMigration/debugChatCleanup.ts
+++ b/packages/service/core/ai/sandbox/application/legacyMigration/debugChatCleanup.ts
@@ -28,8 +28,10 @@ const getConflictAppSkillIds = async (skillIds: string[]) => {
 };
 
 const getLegacyDebugChatStats = async (skillId: string): Promise<LegacyDebugChatCleanupItem> => {
-  const legacyQuery = buildLegacySkillDebugChatQuery(skillId);
-  const legacyChatList = await MongoChat.find(legacyQuery, 'chatId').lean();
+  const legacyChatList = await MongoChat.find(
+    buildLegacySkillDebugChatQuery(skillId),
+    'chatId'
+  ).lean();
   const legacyChatIds = legacyChatList.map((chat) => chat.chatId).filter(Boolean);
   const legacyChatItemQuery = {
     appId: skillId,
@@ -49,7 +51,7 @@ const getLegacyDebugChatStats = async (skillId: string): Promise<LegacyDebugChat
     chatCount: legacyChatIds.length,
     chatItemCount,
     chatItemResponseCount,
-    deleted: false
+    status: 'pending'
   };
 };
 
@@ -83,7 +85,6 @@ const cleanupLegacySkillDebugChatResources = async (skillId: string) => {
  * 与 App 同 ID 的 Skill 按原脚本规则跳过，避免把无 sourceType 的 App Chat 误删。
  */
 export async function cleanupLegacySkillDebugChats(params: { dryRun: boolean }): Promise<{
-  scannedSkillCount: number;
   cleanup: LegacyDebugChatCleanupResult;
 }> {
   const skillIds = await getAllSkillIds();
@@ -97,7 +98,7 @@ export async function cleanupLegacySkillDebugChats(params: { dryRun: boolean }):
       deletableList.map((item) => cleanupLegacySkillDebugChatResources(item.skillId))
     );
     deletableList.forEach((item) => {
-      item.deleted = true;
+      item.status = 'deleted';
     });
   }
 
@@ -108,15 +109,13 @@ export async function cleanupLegacySkillDebugChats(params: { dryRun: boolean }):
   ).then((counts) => counts.reduce((sum, count) => sum + count, 0));
 
   return {
-    scannedSkillCount: skillIds.length,
     cleanup: {
       conflictAppSkillCount: conflictAppSkillIds.size,
-      cleanupSkillCount: cleanupSkillIds.length,
+      matchedSkillCount: list.length,
       totalLegacyChats: list.reduce((sum, item) => sum + item.chatCount, 0),
       totalChatItems: list.reduce((sum, item) => sum + item.chatItemCount, 0),
       totalChatItemResponses: list.reduce((sum, item) => sum + item.chatItemResponseCount, 0),
-      deletedSkillCount: list.filter((item) => item.deleted).length,
-      skippedEmptyCount: list.filter((item) => item.chatCount === 0).length,
+      cleanedSkillCount: list.filter((item) => item.status === 'deleted').length,
       pendingChatCount,
       list
     }

--- a/packages/service/core/ai/sandbox/application/legacyMigration/normalization.ts
+++ b/packages/service/core/ai/sandbox/application/legacyMigration/normalization.ts
@@ -23,7 +23,7 @@ import type { LegacySandboxNormalizationResult } from './types';
 const LEGACY_SANDBOX_NORMALIZATION_CONCURRENCY = 10;
 type LegacySandboxFieldNormalizationResult = Omit<
   LegacySandboxNormalizationResult,
-  'sandboxPendingCount' | 'scannedSkillCount' | 'legacyDebugChatCleanup'
+  'sandboxPendingCount' | 'legacyDebugChatCleanup'
 >;
 
 /** 按 beta6 兼容规则解析缺失 source 的旧记录；无法解析的记录视为孤儿资源。 */
@@ -168,7 +168,6 @@ export async function normalizeLegacySandboxes(params: {
   return {
     ...sandboxNormalization,
     sandboxPendingCount: sandboxNormalization.pendingCount,
-    scannedSkillCount: debugChatCleanup.scannedSkillCount,
     legacyDebugChatCleanup: debugChatCleanup.cleanup,
     pendingCount: sandboxNormalization.pendingCount + debugChatCleanup.cleanup.pendingChatCount
   };

--- a/packages/service/core/ai/sandbox/application/legacyMigration/service.ts
+++ b/packages/service/core/ai/sandbox/application/legacyMigration/service.ts
@@ -7,7 +7,10 @@ import { subMinutes } from 'date-fns';
 import { pushTrack } from '../../../../../common/middle/tracks/utils';
 import { getS3SandboxSource } from '../../../../../common/s3/sources/sandbox';
 import { getAgentSandboxArchiveMaxBytes } from '../../config';
-import type { LegacySandboxInstanceSchemaType } from '../../infrastructure/instance/legacySchema';
+import {
+  LegacySandboxInstanceZodSchema,
+  type LegacySandboxInstanceSchemaType
+} from '../../infrastructure/instance/legacySchema';
 import {
   findAllLegacySandboxInstanceRecords,
   updateLegacySandboxMigrationState
@@ -45,7 +48,7 @@ import {
 } from './utils';
 import {
   createMigrationTarget,
-  getMigrationTargetMetadata,
+  getMigrationTargetFields,
   installLegacySkillWorkspaceArchive,
   installLegacyWorkspaceArchive
 } from './workspace';
@@ -223,15 +226,15 @@ const migrateLegacySkill = async (item: ResolvedLegacySkill) => {
               provider,
               sandboxId: targetSandboxId,
               sourceId: item.sourceId,
-              metadata: getMigrationTargetMetadata(item.doc.metadata, provider),
+              ...getMigrationTargetFields(item.doc.metadata, provider),
               reclaimHeartbeatBefore: subMinutes(new Date(), SANDBOX_STALE_ARCHIVING_MINUTES)
             });
-            if (!targetDoc?.metadata?.operation?.id) {
+            if (!targetDoc?.operation?.id) {
               throw new Error('Skill sandbox migration target is unavailable or busy');
             }
 
-            const operationId = targetDoc.metadata.operation.id;
-            let operationPhase = targetDoc.metadata.operation.phase;
+            const operationId = targetDoc.operation.id;
+            let operationPhase = targetDoc.operation.phase;
             try {
               assertLeasesValid();
               const target = await createMigrationTarget({
@@ -421,14 +424,14 @@ const migrateAppGroup = async (params: {
               sandboxId: targetSandboxId,
               sourceId: first.sourceId,
               userId: first.userId,
-              metadata: getMigrationTargetMetadata(first.doc.metadata, provider),
+              ...getMigrationTargetFields(first.doc.metadata, provider),
               reclaimHeartbeatBefore: subMinutes(new Date(), SANDBOX_STALE_ARCHIVING_MINUTES)
             });
-            if (!targetDoc?.metadata?.operation?.id) {
+            if (!targetDoc?.operation?.id) {
               throw new Error('App sandbox migration target is unavailable or busy');
             }
-            const operationId = targetDoc.metadata.operation.id;
-            let operationPhase = targetDoc.metadata.operation.phase;
+            const operationId = targetDoc.operation.id;
+            let operationPhase = targetDoc.operation.phase;
 
             try {
               assertLeasesValid();
@@ -576,7 +579,35 @@ const runLegacySandboxMigration = async (
   }
 
   assertLeaseValid?.();
-  const docs = await findAllLegacySandboxInstanceRecords();
+  // 归一化只处理旧归属字段；进入归档前仍需用 Legacy schema 校验完整记录，避免把
+  // 不兼容数据带入远端副作用。Legacy schema 不复用 v2 instance schema。
+  const parseLegacySandboxInstances = (rawDocs: unknown[]): LegacySandboxInstanceSchemaType[] => {
+    const parsedDocs: LegacySandboxInstanceSchemaType[] = [];
+    const failures: string[] = [];
+    for (const rawDoc of rawDocs) {
+      const parsed = LegacySandboxInstanceZodSchema.safeParse(rawDoc);
+      if (parsed.success) {
+        parsedDocs.push(parsed.data);
+        continue;
+      }
+      const doc = rawDoc && typeof rawDoc === 'object' ? (rawDoc as Record<string, unknown>) : {};
+      failures.push(
+        `_id=${String(doc._id ?? 'unknown')}, sandboxId=${String(doc.sandboxId ?? 'unknown')} [${parsed.error.issues
+          .map((issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+          .join('; ')}]`
+      );
+    }
+    if (failures.length > 0) {
+      throw new Error(
+        [
+          `Legacy Sandbox preflight validation failed for ${failures.length} record(s)`,
+          ...failures
+        ].join('\n')
+      );
+    }
+    return parsedDocs;
+  };
+  const docs = parseLegacySandboxInstances(await findAllLegacySandboxInstanceRecords());
   const completedLegacyCount = docs.filter(
     (doc) => getLegacyMigrationPhase(doc) === 'completed'
   ).length;

--- a/packages/service/core/ai/sandbox/application/legacyMigration/types.ts
+++ b/packages/service/core/ai/sandbox/application/legacyMigration/types.ts
@@ -47,17 +47,16 @@ export type LegacyDebugChatCleanupItem = {
   chatCount: number;
   chatItemCount: number;
   chatItemResponseCount: number;
-  deleted: boolean;
+  status: 'pending' | 'deleted';
 };
 
 export type LegacyDebugChatCleanupResult = {
   conflictAppSkillCount: number;
-  cleanupSkillCount: number;
+  matchedSkillCount: number;
   totalLegacyChats: number;
   totalChatItems: number;
   totalChatItemResponses: number;
-  deletedSkillCount: number;
-  skippedEmptyCount: number;
+  cleanedSkillCount: number;
   pendingChatCount: number;
   list: LegacyDebugChatCleanupItem[];
 };
@@ -73,7 +72,6 @@ export type LegacySandboxNormalizationResult = {
   orphanDeletedCount: number;
   orphanFailedCount: number;
   sandboxPendingCount: number;
-  scannedSkillCount: number;
   legacyDebugChatCleanup: LegacyDebugChatCleanupResult;
   pendingCount: number;
   failures: UserSandboxMigrationFailure[];

--- a/packages/service/core/ai/sandbox/application/legacyMigration/utils.ts
+++ b/packages/service/core/ai/sandbox/application/legacyMigration/utils.ts
@@ -2,11 +2,7 @@
 import { generateSandboxId, SandboxStatusEnum } from '@fastgpt/global/core/ai/sandbox/constants';
 import { ChatSourceTypeEnum } from '@fastgpt/global/core/chat/constants';
 import type { LegacySandboxInstanceSchemaType } from '../../infrastructure/instance/legacySchema';
-import {
-  SandboxInstanceStatusEnum,
-  SandboxMetadataSchema,
-  SandboxProviderSchema
-} from '../../type';
+import { SandboxInstanceStatusEnum, SandboxProviderSchema } from '../../type';
 import type { LegacyMigrationPhase } from './types';
 
 export const getLegacyMigrationPhase = (
@@ -22,18 +18,11 @@ export const getLegacyMigrationTargetSandboxId = (doc: LegacySandboxInstanceSche
       doc.sourceType === ChatSourceTypeEnum.skillEdit ? ChatSourceTypeEnum.skillEdit : doc.userId
   });
 
-/** 删除 Legacy 专用 metadata，只保留 v2 schema 接受的稳定字段。 */
-export const toV2Metadata = (metadata?: LegacySandboxInstanceSchemaType['metadata']) => {
-  const {
-    archive: _archive,
-    migration: _migration,
-    provider: _provider,
-    skillId: _skillId,
-    userLevelMigration: _userLevelMigration,
-    ...stableMetadata
-  } = metadata ?? {};
-  return SandboxMetadataSchema.parse(stableMetadata);
-};
+/** 只把 v2 支持的稳定根字段映射到目标实例，Legacy metadata 不会随 rest 泄漏。 */
+export const toV2SandboxFields = (metadata?: LegacySandboxInstanceSchemaType['metadata']) => ({
+  ...(metadata?.teamId !== undefined ? { teamId: metadata.teamId } : {}),
+  ...(metadata?.versionId !== undefined ? { versionId: metadata.versionId } : {})
+});
 
 /** 把 Legacy 记录转换成 Provider archive/delete 接受的物理资源。 */
 export const toLegacyResource = (doc: LegacySandboxInstanceSchemaType) => ({

--- a/packages/service/core/ai/sandbox/application/legacyMigration/workspace.ts
+++ b/packages/service/core/ai/sandbox/application/legacyMigration/workspace.ts
@@ -7,27 +7,27 @@ import { ensureConnectedSandboxRunning } from '../../infrastructure/provider/lif
 import { getSandboxRuntimeProfile } from '../../infrastructure/provider/runtimeProfile';
 import { getSessionVolumeConfig } from '../../infrastructure/volume/service';
 import type { LegacySandboxInstanceSchemaType } from '../../infrastructure/instance/legacySchema';
-import { SandboxMetadataSchema, type SandboxProviderType } from '../../type';
+import type { SandboxProviderType } from '../../type';
 import { getSandboxRuntimePaths, getSandboxSessionPathSegment, joinSandboxPath } from '../../utils';
 import { restoreSandboxWorkspaceArchiveForMigration } from '../archive';
 import { resolveSandboxHome } from '../runtime/home';
 import type { LegacyMigrationTarget } from './types';
-import { toV2Metadata } from './utils';
+import { toV2SandboxFields } from './utils';
 
 const LEGACY_SKILL_VERSION_DIRECTORY_NAME_LENGTH = 24;
 const MIGRATION_COMMAND_TIMEOUT_MS = 10 * 60 * 1000;
 
-/** migration 创建新物理资源时，把当前 Provider runtime image 写入 v2 metadata。 */
-export const getMigrationTargetMetadata = (
+/** migration 创建新物理资源时，把稳定归属字段和当前 runtime image 写入 v2 根字段。 */
+export const getMigrationTargetFields = (
   metadata: LegacySandboxInstanceSchemaType['metadata'],
   provider: SandboxProviderType
 ) => {
-  const stableMetadata = toV2Metadata(metadata);
+  const stableFields = toV2SandboxFields(metadata);
   const image = getSandboxRuntimeProfile(provider).defaultImage;
-  return SandboxMetadataSchema.parse({
-    ...stableMetadata,
+  return {
+    ...stableFields,
     ...(image ? { image } : {})
-  });
+  };
 };
 
 /** 创建 migration 专用 target，不经过可能触发其他业务恢复分支的普通 runtime client。 */

--- a/packages/service/core/ai/sandbox/application/lifecycle/runner.ts
+++ b/packages/service/core/ai/sandbox/application/lifecycle/runner.ts
@@ -72,16 +72,14 @@ export type RunSandboxLifecycleParams = {
 };
 
 const requireOperationId = (resource: SandboxResourceDoc) => {
-  const operationId = resource.metadata?.operation?.id;
+  const operationId = resource.operation?.id;
   if (!operationId) {
-    throw new Error(
-      `Sandbox ${resource.sandboxId} has no ${resource.metadata?.operation?.type} operation`
-    );
+    throw new Error(`Sandbox ${resource.sandboxId} has no ${resource.operation?.type} operation`);
   }
   return operationId;
 };
 
-const getPhase = (resource: SandboxResourceDoc) => resource.metadata?.operation?.phase ?? 'claimed';
+const getPhase = (resource: SandboxResourceDoc) => resource.operation?.phase ?? 'claimed';
 
 /**
  * 执行一条已由调用方重新读取的 Sandbox 生命周期 operation。
@@ -95,8 +93,7 @@ export async function runSandboxLifecycleOperation(
   const { resource, lease, definition } = params;
   if (
     params.alreadyClaimed &&
-    (resource.status !== definition.status ||
-      resource.metadata?.operation?.type !== definition.operationType)
+    (resource.status !== definition.status || resource.operation?.type !== definition.operationType)
   ) {
     throw new Error(
       `Sandbox ${resource.sandboxId} does not own the expected ${definition.operationType} operation`

--- a/packages/service/core/ai/sandbox/application/providerMigration.ts
+++ b/packages/service/core/ai/sandbox/application/providerMigration.ts
@@ -79,16 +79,14 @@ export async function migrateSandboxProviderBeforeUse(params: {
         resource: SandboxResourceDoc
       ): Promise<SandboxResourceDoc> => {
         if (resource.status !== SandboxInstanceStatusEnum.restoring) return resource;
-        const operation = resource.metadata?.operation;
+        const operation = resource.operation;
         const staleBefore = subMinutes(new Date(), SANDBOX_STALE_ARCHIVING_MINUTES);
         if (!operation?.error && operation?.heartbeatAt && operation.heartbeatAt >= staleBefore) {
           throw new SandboxLifecycleStateError(resource.status);
         }
 
         const rollbackFromPhase =
-          resource.metadata?.operation?.phase === 'archiveInstalled'
-            ? 'archiveInstalled'
-            : 'claimed';
+          resource.operation?.phase === 'archiveInstalled' ? 'archiveInstalled' : 'claimed';
         const definition: SandboxLifecycleDefinition = {
           operationType: SandboxOperationTypeEnum.restore,
           status: SandboxInstanceStatusEnum.restoring,

--- a/packages/service/core/ai/sandbox/application/resource.ts
+++ b/packages/service/core/ai/sandbox/application/resource.ts
@@ -62,7 +62,7 @@ const assertDeleteCanFenceCurrentOperation = (resource: SandboxResourceDoc) => {
   const isolationMinutes = deleteIsolationMinutesByStatus[resource.status];
   if (!isolationMinutes) return;
 
-  const operation = resource.metadata?.operation;
+  const operation = resource.operation;
   if (operation?.error) return;
   const staleBefore = subMinutes(new Date(), isolationMinutes);
   if (!operation?.heartbeatAt || operation.heartbeatAt >= staleBefore) {

--- a/packages/service/core/ai/sandbox/application/runtime/client.ts
+++ b/packages/service/core/ai/sandbox/application/runtime/client.ts
@@ -144,10 +144,7 @@ export class SandboxClient {
           memoryMiB: this.opts.resourceLimits.memoryMiB,
           diskGiB: this.opts.resourceLimits.diskGiB
         }
-      }),
-      metadata: {
-        volumeEnabled: !!this.opts?.vmConfig
-      }
+      })
     };
     const touched = await touchRunningSandboxInstance(instanceParams);
     let repairMissingProvider = false;
@@ -184,10 +181,7 @@ export class SandboxClient {
         }
         const created = await createSandboxProvisioningInstance({
           ...instanceParams,
-          metadata: {
-            ...instanceParams.metadata,
-            ...(runtimeImage ? { image: runtimeImage } : {})
-          }
+          ...(runtimeImage ? { image: runtimeImage } : {})
         });
         current = created.instance;
         createdHere = created.created;
@@ -205,7 +199,7 @@ export class SandboxClient {
       }
 
       if (current.status === SandboxInstanceStatusEnum.provisioning) {
-        const operation = current.metadata?.operation;
+        const operation = current.operation;
         const stale =
           operation?.heartbeatAt &&
           operation.heartbeatAt.getTime() < Date.now() - SANDBOX_PROVISIONING_STALE_MS;
@@ -234,7 +228,7 @@ export class SandboxClient {
           type: 'complete',
           status: SandboxInstanceStatusEnum.running,
           touchActive: true,
-          set: runtimeImage ? { 'metadata.image': runtimeImage } : undefined
+          set: runtimeImage ? { image: runtimeImage } : undefined
         }
       };
       await runSandboxLifecycleOperation({
@@ -244,7 +238,7 @@ export class SandboxClient {
         previousStatus:
           current.status === SandboxInstanceStatusEnum.stopped
             ? SandboxInstanceStatusEnum.stopped
-            : current.metadata?.operation?.previousStatus,
+            : current.operation?.previousStatus,
         alreadyClaimed: createdHere
       });
     };

--- a/packages/service/core/ai/sandbox/application/runtime/upgrade.ts
+++ b/packages/service/core/ai/sandbox/application/runtime/upgrade.ts
@@ -79,10 +79,9 @@ export function resolveSandboxRuntimeUpgradeTarget({
     instance.status === SandboxInstanceStatusEnum.running ||
     instance.status === SandboxInstanceStatusEnum.stopped;
   const isOutdatedStableInstance = (instance: SandboxResourceDoc) =>
-    isStableInstance(instance) &&
-    !isSandboxRuntimeImageMatched(targetImage, instance.metadata?.image);
+    isStableInstance(instance) && !isSandboxRuntimeImageMatched(targetImage, instance.image);
   const isFailedArchivePrerequisite = (instance: SandboxResourceDoc) =>
-    Boolean(instance.metadata?.operation?.error) &&
+    Boolean(instance.operation?.error) &&
     (instance.status === SandboxInstanceStatusEnum.stopping ||
       instance.status === SandboxInstanceStatusEnum.archiving);
   const canStartRuntimeUpgradeArchive = (instance: SandboxResourceDoc) =>
@@ -90,7 +89,7 @@ export function resolveSandboxRuntimeUpgradeTarget({
   const statusInstance =
     currentInstance ??
     staleInstances.find((instance) => isSandboxRuntimeUpgradeBusyState(instance.status)) ??
-    staleInstances.find((instance) => Boolean(instance.metadata?.operation?.error)) ??
+    staleInstances.find((instance) => Boolean(instance.operation?.error)) ??
     staleInstances.find((instance) => instance.status === SandboxInstanceStatusEnum.archived) ??
     staleInstances.find(isStableInstance);
   const upgradeInstance =
@@ -122,12 +121,11 @@ export function getSandboxRuntimeUpgradeStatus(
 ): SandboxRuntimeStatusResponse {
   const { targetProvider, targetImage, statusInstance } = context;
   const lifecycleStatus = statusInstance?.status;
-  const operationError = statusInstance?.metadata?.operation?.error;
-  const operationHeartbeatAt = statusInstance?.metadata?.operation?.heartbeatAt;
+  const operationError = statusInstance?.operation?.error;
+  const operationHeartbeatAt = statusInstance?.operation?.heartbeatAt;
   const isCurrentProviderInstance = statusInstance?.provider === targetProvider;
   const isRuntimeImageOutdated =
-    !!statusInstance &&
-    !isSandboxRuntimeImageMatched(targetImage, statusInstance.metadata?.image ?? null);
+    !!statusInstance && !isSandboxRuntimeImageMatched(targetImage, statusInstance.image ?? null);
   const canRetryArchiveIsolationOperation =
     Boolean(operationError) ||
     !operationHeartbeatAt ||
@@ -218,7 +216,7 @@ const isRuntimeConfigurationChanged = (context: SandboxRuntimeUpgradeTarget) => 
   return (
     !!instance &&
     (instance.provider !== context.targetProvider ||
-      !isSandboxRuntimeImageMatched(context.targetImage, instance.metadata?.image ?? null))
+      !isSandboxRuntimeImageMatched(context.targetImage, instance.image ?? null))
   );
 };
 

--- a/packages/service/core/ai/sandbox/application/skillEdit/deploy.ts
+++ b/packages/service/core/ai/sandbox/application/skillEdit/deploy.ts
@@ -2,7 +2,7 @@
  * 沙盒业务层：从 Skill Edit sandbox 保存并发布新的技能版本。
  *
  * API 层负责鉴权和请求校验；本文件负责定位运行态 edit-debug sandbox、打包工作区、
- * 上传版本包、创建版本记录，并同步运行实例的版本元数据。
+ * 上传版本包、创建版本记录，并同步运行实例的 versionId 字段。
  */
 import { mongoSessionRun } from '../../../../../common/mongo/sessionRun';
 import { Types } from '../../../../../common/mongo';
@@ -63,7 +63,7 @@ export async function saveDeploySkillFromSandbox({
   if (
     !sandboxInfo ||
     sandboxInfo.status !== SandboxStatusEnum.running ||
-    sandboxInfo.metadata?.teamId !== teamId
+    sandboxInfo.teamId !== teamId
   ) {
     return Promise.reject(new UserError('Edit sandbox not found or not running'));
   }
@@ -150,10 +150,7 @@ export async function saveDeploySkillFromSandbox({
     sourceType: ChatSourceTypeEnum.skillEdit,
     sourceId: skillId,
     userId: ChatSourceTypeEnum.skillEdit,
-    metadata: {
-      ...(sandboxInfo.metadata || {}),
-      versionId
-    },
+    versionId,
     touchActive: true
   }).catch((err) => {
     logger.error('[Sandbox] Failed to update sandbox versionId after deploy', {

--- a/packages/service/core/ai/sandbox/application/skillEdit/runtime.ts
+++ b/packages/service/core/ai/sandbox/application/skillEdit/runtime.ts
@@ -25,7 +25,6 @@ import {
 } from '../../infrastructure/provider/config';
 import { getSandboxRuntimeProfile } from '../../infrastructure/provider/runtimeProfile';
 import type {
-  AgentSkillSchemaType,
   AgentSkillsVersionSchemaType,
   SandboxImageConfigType
 } from '@fastgpt/global/core/ai/skill/type';
@@ -81,12 +80,10 @@ const EDIT_DEBUG_SANDBOX_SCENARIO = 'edit-debug';
 export type SkillEditRuntimeContext = {
   skillId: string;
   teamId: string;
-  tmbId: string;
   providerConfig: ReturnType<typeof getSandboxProviderConfig>;
   runtimeProfile: ReturnType<typeof getSandboxRuntimeProfile>;
   createConfig: SandboxCreateSpec;
   runtimeImage?: SandboxImageConfigType;
-  skill: AgentSkillSchemaType;
   currentVersion: AgentSkillsVersionSchemaType;
   sessionId: string;
   targetVersionId: string;
@@ -107,10 +104,9 @@ export type InitSkillEditRuntimeSandboxParams = {
 export async function getSkillEditRuntimeContext(params: {
   skillId: string;
   teamId: string;
-  tmbId: string;
   entrypoint?: SandboxCreateSpec['entrypoint'];
 }): Promise<SkillEditRuntimeContext> {
-  const { skillId, teamId, tmbId, entrypoint } = params;
+  const { skillId, teamId, entrypoint } = params;
 
   await assertSandboxAvailable(teamId);
 
@@ -172,12 +168,10 @@ export async function getSkillEditRuntimeContext(params: {
   return {
     skillId,
     teamId,
-    tmbId,
     providerConfig,
     runtimeProfile,
     createConfig,
     runtimeImage,
-    skill: skill as AgentSkillSchemaType,
     currentVersion: currentVersion as AgentSkillsVersionSchemaType,
     sessionId,
     targetVersionId: currentVersion._id.toString(),
@@ -199,7 +193,6 @@ export async function getSkillEditRuntimeStatus(
     | {
         skillId: string;
         teamId: string;
-        tmbId: string;
         entrypoint?: SandboxCreateSpec['entrypoint'];
       }
 ): Promise<SandboxRuntimeStatusResponse> {
@@ -218,7 +211,6 @@ export async function triggerSkillEditRuntimeUpgrade(
     | {
         skillId: string;
         teamId: string;
-        tmbId: string;
         entrypoint?: SandboxCreateSpec['entrypoint'];
       }
 ): Promise<SandboxRuntimeStatusResponse> {
@@ -239,12 +231,10 @@ export async function initSkillEditRuntimeSandbox({
   const {
     skillId,
     teamId,
-    tmbId,
     providerConfig,
     runtimeProfile,
     createConfig,
     runtimeImage,
-    skill,
     currentVersion,
     sessionId,
     targetVersionId,
@@ -259,7 +249,7 @@ export async function initSkillEditRuntimeSandbox({
   const runtimeStatusInstance = runtimeUpgradeTarget.statusInstance;
   const existingLifecycleStatus = runtimeStatusInstance?.status;
   const shouldUnzipFromS3 =
-    !runtimeStatusInstance || runtimeStatusInstance.metadata?.versionId !== targetVersionId;
+    !runtimeStatusInstance || runtimeStatusInstance.versionId !== targetVersionId;
   const shouldCleanWorkspaceBeforeDeploy = !!runtimeStatusInstance;
 
   const prepareContext = (sandbox: ISandbox): SkillPackagePrepareContext => ({
@@ -371,14 +361,9 @@ export async function initSkillEditRuntimeSandbox({
       sourceId: skillId,
       userId: ChatSourceTypeEnum.skillEdit,
       touchActive: true,
-      metadata: {
-        teamId,
-        tmbId,
-        sessionId,
-        ...(runtimeImage ? { image: runtimeImage } : {}),
-        skillName: skill.name,
-        versionId: currentVersion._id.toString()
-      }
+      teamId,
+      ...(runtimeImage ? { image: runtimeImage } : {}),
+      versionId: currentVersion._id.toString()
     });
 
     if (!newSandboxDoc) throw new Error('Failed to find sandbox document after creation');
@@ -594,7 +579,7 @@ export async function getRunningSkillEditSandbox(params: { skillId: string; team
   if (
     !sandboxInfo ||
     sandboxInfo.status !== SandboxStatusEnum.running ||
-    sandboxInfo.metadata?.teamId !== params.teamId
+    sandboxInfo.teamId !== params.teamId
   ) {
     return;
   }

--- a/packages/service/core/ai/sandbox/infrastructure/instance/legacyRepository.ts
+++ b/packages/service/core/ai/sandbox/infrastructure/instance/legacyRepository.ts
@@ -18,7 +18,7 @@ export type LegacySandboxNormalizationDoc = SandboxResourceRef & {
   type?: string | null;
   sourceType?: string | null;
   sourceId?: string | null;
-  metadata?: SandboxResourceRef['metadata'] & {
+  metadata?: {
     skillId?: string | null;
   };
 };
@@ -117,9 +117,7 @@ export const countLegacySandboxFieldCleanups = () =>
 
 /** beta6 阶段归零后，按稳定顺序读取完整 Legacy 集合。 */
 export const findAllLegacySandboxInstanceRecords = () =>
-  MongoLegacySandboxInstance.find({})
-    .sort({ lastActiveAt: -1, _id: 1 })
-    .lean<LegacySandboxInstanceSchemaType[]>();
+  MongoLegacySandboxInstance.collection.find({}).sort({ lastActiveAt: -1, _id: 1 }).toArray();
 
 /** 按 source 查询 Source 删除流程需要清理的 Legacy 实例。 */
 export const findLegacySandboxInstancesBySource = (params: {

--- a/packages/service/core/ai/sandbox/infrastructure/instance/legacySchema.ts
+++ b/packages/service/core/ai/sandbox/infrastructure/instance/legacySchema.ts
@@ -48,7 +48,10 @@ const LegacySandboxMetadataSchema = z
     skillIds: z.array(z.string()).optional(),
     image: SandboxImageSchema.optional(),
     skillName: z.string().optional(),
-    versionId: z.string().optional()
+    versionId: z.string().optional(),
+    // 旧 Skill 编辑 Sandbox 写入的字段；迁移时保留在 Legacy 记录中，但不映射到 v2。
+    providerCreatedAt: z.unknown().optional(),
+    storage: z.unknown().optional()
   })
   .strip();
 

--- a/packages/service/core/ai/sandbox/infrastructure/instance/repository.ts
+++ b/packages/service/core/ai/sandbox/infrastructure/instance/repository.ts
@@ -1,14 +1,13 @@
 /**
  * Sandbox 实例原子层。
  *
- * Repository 只负责 v2 记录查询和 `status + metadata.operation.id` CAS，不执行任何远端副作用。
+ * Repository 只负责 v2 记录查询和 `status + operation.id` CAS，不执行任何远端副作用。
  */
 import { randomUUID } from 'node:crypto';
 import { ChatSourceTypeEnum } from '@fastgpt/global/core/chat/constants';
 import { MongoSandboxInstance } from './schema';
 import {
   SandboxInstanceStatusEnum,
-  SandboxMetadataSchema,
   SandboxOperationTypeEnum,
   type SandboxInstanceSchemaType,
   type SandboxInstanceStatusType,
@@ -36,7 +35,10 @@ export type SandboxResourceDoc = Pick<
   | 'lastActiveAt'
   | 'limit'
   | 'storage'
-  | 'metadata'
+  | 'teamId'
+  | 'image'
+  | 'versionId'
+  | 'operation'
 > & {
   _id: unknown;
 };
@@ -44,7 +46,15 @@ export type SandboxResourceDoc = Pick<
 export type SandboxResourceRef = Partial<
   Pick<
     SandboxResourceDoc,
-    'status' | 'lastActiveAt' | 'sourceType' | 'sourceId' | 'userId' | 'metadata'
+    | 'status'
+    | 'lastActiveAt'
+    | 'sourceType'
+    | 'sourceId'
+    | 'userId'
+    | 'teamId'
+    | 'image'
+    | 'versionId'
+    | 'operation'
   >
 > & {
   provider: SandboxProviderType;
@@ -79,10 +89,8 @@ const buildSandboxResourceRecordFilter = (resource: SandboxResourceRef) =>
     : { provider: resource.provider, sandboxId: resource.sandboxId };
 
 const buildCurrentOperationFilter = (resource: SandboxResourceRef) => {
-  const operationId = resource.metadata?.operation?.id;
-  return operationId
-    ? { 'metadata.operation.id': operationId }
-    : { 'metadata.operation': { $exists: false } };
+  const operationId = resource.operation?.id;
+  return operationId ? { 'operation.id': operationId } : { operation: { $exists: false } };
 };
 
 const buildSandboxResourceSourceQuery = ({ sourceType, sourceId, userId }: SandboxSourceParams) => {
@@ -97,14 +105,13 @@ const buildSandboxResourceSourceQuery = ({ sourceType, sourceId, userId }: Sandb
   throw new Error(`Unsupported sandbox source type: ${exhaustiveCheck}`);
 };
 
-const buildMetadataSet = (metadata?: Record<string, unknown>) => {
-  if (!metadata) return {};
-  const parsed = SandboxMetadataSchema.parse(metadata);
-  const { operation: _operation, ...stableMetadata } = parsed;
-  return Object.fromEntries(
-    Object.entries(stableMetadata).map(([key, value]) => [`metadata.${key}`, value])
-  );
-};
+type SandboxStableFields = Pick<SandboxInstanceSchemaType, 'teamId' | 'image' | 'versionId'>;
+
+const buildSandboxStableFieldsSet = (fields: SandboxStableFields) => ({
+  ...(fields.teamId !== undefined ? { teamId: fields.teamId } : {}),
+  ...(fields.image !== undefined ? { image: fields.image } : {}),
+  ...(fields.versionId !== undefined ? { versionId: fields.versionId } : {})
+});
 
 const expectedOperationByStatus: Record<
   Exclude<SandboxInstanceStatusType, SandboxStableStatusType>,
@@ -137,11 +144,11 @@ export async function claimSandboxOperation(params: ClaimSandboxOperationParams)
     previousStatus ??
     (resource.status && stableStatuses.has(resource.status)
       ? (resource.status as SandboxStableStatusType)
-      : resource.metadata?.operation?.previousStatus);
+      : resource.operation?.previousStatus);
   const nextPhase =
     phase ??
-    (resource.status === status && resource.metadata?.operation?.type === type
-      ? resource.metadata.operation.phase
+    (resource.status === status && resource.operation?.type === type
+      ? resource.operation.phase
       : 'claimed');
 
   return MongoSandboxInstance.findOneAndUpdate(
@@ -154,7 +161,7 @@ export async function claimSandboxOperation(params: ClaimSandboxOperationParams)
     {
       $set: {
         status,
-        'metadata.operation': {
+        operation: {
           id: operationId,
           type,
           phase: nextPhase,
@@ -179,16 +186,16 @@ export async function advanceSandboxOperation(params: {
     {
       ...buildSandboxResourceRecordFilter(params.resource),
       status: params.status,
-      'metadata.operation.id': params.operationId
+      'operation.id': params.operationId
     },
     {
       $set: {
-        'metadata.operation.phase': params.phase,
-        'metadata.operation.heartbeatAt': new Date()
+        'operation.phase': params.phase,
+        'operation.heartbeatAt': new Date()
       },
       $unset: {
-        'metadata.operation.failedAt': '',
-        'metadata.operation.error': ''
+        'operation.failedAt': '',
+        'operation.error': ''
       }
     },
     { new: true }
@@ -206,13 +213,13 @@ export async function markSandboxOperationFailed(params: {
     {
       ...buildSandboxResourceRecordFilter(params.resource),
       status: params.status,
-      'metadata.operation.id': params.operationId
+      'operation.id': params.operationId
     },
     {
       $set: {
-        'metadata.operation.failedAt': new Date(),
-        'metadata.operation.error': params.error,
-        'metadata.operation.heartbeatAt': new Date()
+        'operation.failedAt': new Date(),
+        'operation.error': params.error,
+        'operation.heartbeatAt': new Date()
       }
     }
   );
@@ -235,7 +242,7 @@ export async function completeSandboxOperation(params: {
     {
       ...buildSandboxResourceRecordFilter(params.resource),
       status: params.fromStatus,
-      'metadata.operation.id': params.operationId
+      'operation.id': params.operationId
     },
     {
       $set: {
@@ -243,7 +250,7 @@ export async function completeSandboxOperation(params: {
         ...(params.touchActive ? { lastActiveAt: new Date() } : {}),
         ...(params.set ?? {})
       },
-      $unset: { 'metadata.operation': '' }
+      $unset: { operation: '' }
     },
     { new: true }
   ).lean<SandboxResourceDoc | null>();
@@ -257,33 +264,24 @@ export async function deleteClaimedSandboxRecord(params: {
   return MongoSandboxInstance.deleteOne({
     ...buildSandboxResourceRecordFilter(params.resource),
     status: SandboxInstanceStatusEnum.deleting,
-    'metadata.operation.id': params.operationId
+    'operation.id': params.operationId
   });
 }
 
 /** 创建首次 provisioning 占位；唯一键冲突时返回已经存在的逻辑记录。 */
-export async function createSandboxProvisioningInstance(params: {
-  provider: SandboxProviderType;
-  sandboxId: string;
-  sourceType: ChatSourceTypeEnum;
-  sourceId: string;
-  userId: string;
-  storage?: SandboxInstanceSchemaType['storage'];
-  limit?: Partial<NonNullable<SandboxInstanceSchemaType['limit']>>;
-  metadata?: Record<string, unknown>;
-}) {
+export async function createSandboxProvisioningInstance(
+  params: {
+    provider: SandboxProviderType;
+    sandboxId: string;
+    sourceType: ChatSourceTypeEnum;
+    sourceId: string;
+    userId: string;
+    storage?: SandboxInstanceSchemaType['storage'];
+    limit?: Partial<NonNullable<SandboxInstanceSchemaType['limit']>>;
+  } & SandboxStableFields
+) {
   const now = new Date();
   const operationId = randomUUID();
-  const metadata = SandboxMetadataSchema.parse({
-    ...(params.metadata ?? {}),
-    operation: {
-      id: operationId,
-      type: SandboxOperationTypeEnum.provision,
-      phase: 'claimed',
-      startedAt: now,
-      heartbeatAt: now
-    }
-  });
 
   try {
     const created = await MongoSandboxInstance.create({
@@ -297,7 +295,14 @@ export async function createSandboxProvisioningInstance(params: {
       createdAt: now,
       storage: params.storage,
       limit: params.limit,
-      metadata
+      ...buildSandboxStableFieldsSet(params),
+      operation: {
+        id: operationId,
+        type: SandboxOperationTypeEnum.provision,
+        phase: 'claimed',
+        startedAt: now,
+        heartbeatAt: now
+      }
     });
     return { instance: created.toObject() as SandboxResourceDoc, created: true };
   } catch (error) {
@@ -320,7 +325,6 @@ export async function touchRunningSandboxInstance(params: {
   userId: string;
   storage?: SandboxInstanceSchemaType['storage'];
   limit?: Partial<NonNullable<SandboxInstanceSchemaType['limit']>>;
-  metadata?: Record<string, unknown>;
 }) {
   return MongoSandboxInstance.findOneAndUpdate(
     {
@@ -330,14 +334,13 @@ export async function touchRunningSandboxInstance(params: {
       sourceId: params.sourceId,
       userId: params.userId,
       status: SandboxInstanceStatusEnum.running,
-      'metadata.operation': { $exists: false }
+      operation: { $exists: false }
     },
     {
       $set: {
         lastActiveAt: new Date(),
         ...(params.storage !== undefined ? { storage: params.storage } : {}),
-        ...(params.limit ? { limit: params.limit } : {}),
-        ...buildMetadataSet(params.metadata)
+        ...(params.limit ? { limit: params.limit } : {})
       }
     },
     { new: true }
@@ -349,7 +352,7 @@ export async function findInactiveRunningSandboxResources(inactiveBefore: Date) 
   return MongoSandboxInstance.find({
     status: SandboxInstanceStatusEnum.running,
     lastActiveAt: { $lt: inactiveBefore },
-    'metadata.operation': { $exists: false }
+    operation: { $exists: false }
   }).lean<SandboxResourceDoc[]>();
 }
 
@@ -359,7 +362,7 @@ export function createSandboxResourcesToArchiveCursor(inactiveBefore: Date) {
     provider: { $in: ['opensandbox', 'sealosdevbox'] },
     status: SandboxInstanceStatusEnum.stopped,
     lastActiveAt: { $lt: inactiveBefore },
-    'metadata.operation': { $exists: false }
+    operation: { $exists: false }
   })
     .sort({ lastActiveAt: -1 })
     .lean<SandboxResourceDoc>()
@@ -373,7 +376,7 @@ export async function findStaleSandboxOperations(params: {
 }) {
   return MongoSandboxInstance.find({
     status: { $in: params.statuses },
-    'metadata.operation.heartbeatAt': { $lt: params.heartbeatBefore }
+    'operation.heartbeatAt': { $lt: params.heartbeatBefore }
   }).lean<SandboxResourceDoc[]>();
 }
 
@@ -442,7 +445,7 @@ export async function countRunningSandboxInstancesBySourceType(
     ...(provider ? { provider } : {}),
     sourceType,
     status: SandboxInstanceStatusEnum.running,
-    'metadata.operation': { $exists: false }
+    operation: { $exists: false }
   });
 }
 
@@ -452,9 +455,8 @@ type ClaimSandboxMigrationTargetParams = {
   sourceType: SandboxSourceType;
   sourceId: string;
   userId: string;
-  metadata?: Record<string, unknown>;
   reclaimHeartbeatBefore?: Date;
-};
+} & SandboxStableFields;
 
 /** 创建或接管 Legacy migration 目标；调用方必须已经持有 Source 与 Lifecycle lease。 */
 async function claimSandboxMigrationTarget(params: ClaimSandboxMigrationTargetParams) {
@@ -466,16 +468,6 @@ async function claimSandboxMigrationTarget(params: ClaimSandboxMigrationTargetPa
 
   if (!existing) {
     const now = new Date();
-    const metadata = SandboxMetadataSchema.parse({
-      ...(params.metadata ?? {}),
-      operation: {
-        id: randomUUID(),
-        type: SandboxOperationTypeEnum.legacyMigration,
-        phase: 'claimed',
-        startedAt: now,
-        heartbeatAt: now
-      }
-    });
     try {
       const created = await MongoSandboxInstance.create({
         provider: params.provider,
@@ -486,7 +478,14 @@ async function claimSandboxMigrationTarget(params: ClaimSandboxMigrationTargetPa
         status: SandboxInstanceStatusEnum.legacyMigrating,
         lastActiveAt: now,
         createdAt: now,
-        metadata
+        ...buildSandboxStableFieldsSet(params),
+        operation: {
+          id: randomUUID(),
+          type: SandboxOperationTypeEnum.legacyMigration,
+          phase: 'claimed',
+          startedAt: now,
+          heartbeatAt: now
+        }
       });
       return created.toObject() as SandboxResourceDoc;
     } catch (error) {
@@ -507,7 +506,7 @@ async function claimSandboxMigrationTarget(params: ClaimSandboxMigrationTargetPa
     existing.status === SandboxInstanceStatusEnum.legacyMigrating &&
     params.reclaimHeartbeatBefore
   ) {
-    const operation = existing.metadata?.operation;
+    const operation = existing.operation;
     if (
       !operation?.error &&
       (!operation?.heartbeatAt || operation.heartbeatAt >= params.reclaimHeartbeatBefore)
@@ -522,17 +521,17 @@ async function claimSandboxMigrationTarget(params: ClaimSandboxMigrationTargetPa
     type: SandboxOperationTypeEnum.legacyMigration,
     previousStatus: stableStatuses.has(existing.status)
       ? (existing.status as SandboxStableStatusType)
-      : existing.metadata?.operation?.previousStatus
+      : existing.operation?.previousStatus
   });
-  if (!claimed || !params.metadata) return claimed;
+  if (!claimed) return claimed;
 
   return MongoSandboxInstance.findOneAndUpdate(
     {
       _id: claimed._id,
       status: SandboxInstanceStatusEnum.legacyMigrating,
-      'metadata.operation.id': claimed.metadata?.operation?.id
+      'operation.id': claimed.operation?.id
     },
-    { $set: buildMetadataSet(params.metadata) },
+    { $set: buildSandboxStableFieldsSet(params) },
     { new: true }
   ).lean<SandboxResourceDoc | null>();
 }
@@ -560,7 +559,7 @@ export const claimSkillSandboxMigrationTarget = (
 export async function switchArchivedSandboxProvider(params: {
   resource: SandboxResourceRef;
   provider: SandboxProviderType;
-  image?: NonNullable<SandboxInstanceSchemaType['metadata']>['image'];
+  image?: SandboxInstanceSchemaType['image'];
 }) {
   return MongoSandboxInstance.findOneAndUpdate(
     {
@@ -568,29 +567,30 @@ export async function switchArchivedSandboxProvider(params: {
       provider: params.resource.provider,
       sandboxId: params.resource.sandboxId,
       status: SandboxInstanceStatusEnum.archived,
-      'metadata.operation': { $exists: false }
+      operation: { $exists: false }
     },
     {
       $set: {
         provider: params.provider,
         lastActiveAt: new Date(),
-        ...(params.image ? { 'metadata.image': params.image } : {})
+        ...(params.image ? { image: params.image } : {})
       }
     },
     { new: true }
   ).lean<SandboxResourceDoc | null>();
 }
 
-/** 在 running 稳定态更新业务归属或 metadata，不允许唤醒过渡态。 */
-export async function updateSandboxInstanceRecordBySandboxId(params: {
-  provider?: SandboxProviderType;
-  sandboxId: string;
-  sourceType: ChatSourceTypeEnum;
-  sourceId: string;
-  userId: string;
-  metadata?: Record<string, unknown>;
-  touchActive?: boolean;
-}): Promise<SandboxInstanceSchemaType | null> {
+/** 在 running 稳定态更新业务归属或稳定字段，不允许唤醒过渡态。 */
+export async function updateSandboxInstanceRecordBySandboxId(
+  params: {
+    provider?: SandboxProviderType;
+    sandboxId: string;
+    sourceType: ChatSourceTypeEnum;
+    sourceId: string;
+    userId: string;
+    touchActive?: boolean;
+  } & SandboxStableFields
+): Promise<SandboxInstanceSchemaType | null> {
   return MongoSandboxInstance.findOneAndUpdate(
     {
       sandboxId: params.sandboxId,
@@ -598,7 +598,7 @@ export async function updateSandboxInstanceRecordBySandboxId(params: {
       ...(params.touchActive
         ? {
             status: SandboxInstanceStatusEnum.running,
-            'metadata.operation': { $exists: false }
+            operation: { $exists: false }
           }
         : {})
     },
@@ -607,7 +607,7 @@ export async function updateSandboxInstanceRecordBySandboxId(params: {
         sourceType: params.sourceType,
         sourceId: params.sourceId,
         userId: params.userId,
-        ...buildMetadataSet(params.metadata),
+        ...buildSandboxStableFieldsSet(params),
         ...(params.touchActive ? { lastActiveAt: new Date() } : {})
       }
     },
@@ -623,7 +623,7 @@ export async function findSandboxInstanceBySandboxIdAndTeam(params: {
   return MongoSandboxInstance.findOne({
     sandboxId: params.sandboxId,
     ...(params.provider ? { provider: params.provider } : {}),
-    'metadata.teamId': params.teamId
+    teamId: params.teamId
   });
 }
 
@@ -635,7 +635,7 @@ export async function findSandboxResourceBySandboxIdAndTeam(params: {
   return MongoSandboxInstance.findOne({
     sandboxId: params.sandboxId,
     ...(params.provider ? { provider: params.provider } : {}),
-    'metadata.teamId': params.teamId
+    teamId: params.teamId
   }).lean<SandboxResourceDoc | null>();
 }
 

--- a/packages/service/core/ai/sandbox/infrastructure/instance/schema.ts
+++ b/packages/service/core/ai/sandbox/infrastructure/instance/schema.ts
@@ -8,8 +8,8 @@ const { Schema } = connectionMongo;
 import type { SandboxInstanceSchemaType } from '../../type';
 import {
   SandboxInstanceStatusSchema,
+  SandboxImageSchema,
   SandboxLimitSchema,
-  SandboxMetadataSchema,
   SandboxOperationTypeSchema,
   SandboxProviderSchema,
   SandboxSourceTypeSchema
@@ -36,25 +36,10 @@ const SandboxOperationMongoSchema = new Schema(
   { _id: false, strict: 'throw' }
 );
 
-const SandboxMetadataMongoSchema = new Schema(
+const SandboxImageMongoSchema = new Schema(
   {
-    teamId: String,
-    tmbId: String,
-    volumeEnabled: Boolean,
-    sessionId: String,
-    skillIds: [String],
-    image: {
-      type: new Schema(
-        {
-          repository: { type: String, required: true },
-          tag: String
-        },
-        { _id: false, strict: 'throw' }
-      )
-    },
-    skillName: String,
-    versionId: String,
-    operation: SandboxOperationMongoSchema
+    repository: { type: String, required: true },
+    tag: String
   },
   { _id: false, strict: 'throw' }
 );
@@ -106,10 +91,13 @@ const SandboxInstanceSchema = new Schema(
     storage: {
       type: Schema.Types.Mixed
     },
-    metadata: {
-      type: SandboxMetadataMongoSchema,
-      set: (value: unknown) => SandboxMetadataSchema.parse(value)
-    }
+    teamId: String,
+    image: {
+      type: SandboxImageMongoSchema,
+      set: (value: unknown) => SandboxImageSchema.parse(value)
+    },
+    versionId: String,
+    operation: SandboxOperationMongoSchema
   },
   {
     strict: 'throw'
@@ -130,7 +118,7 @@ const expectedOperationByStatus: Record<string, string | undefined> = {
 
 SandboxInstanceSchema.pre('validate', function validateLifecycleState() {
   const status = this.get('status') as string;
-  const operationType = this.get('metadata.operation.type') as string | undefined;
+  const operationType = this.get('operation.type') as string | undefined;
   const expectedOperation = expectedOperationByStatus[status];
 
   if (!expectedOperation && operationType) {
@@ -156,7 +144,11 @@ defineIndex(SandboxInstanceSchema, {
   key: { status: 1, lastActiveAt: 1 }
 });
 defineIndex(SandboxInstanceSchema, {
-  key: { status: 1, 'metadata.operation.heartbeatAt': 1 }
+  key: { status: 1, 'operation.heartbeatAt': 1 }
+});
+defineIndex(SandboxInstanceSchema, {
+  key: { status: 1, 'metadata.operation.heartbeatAt': 1 },
+  deprecated: true
 });
 
 /**

--- a/packages/service/core/ai/sandbox/infrastructure/provider/adapter.ts
+++ b/packages/service/core/ai/sandbox/infrastructure/provider/adapter.ts
@@ -77,7 +77,8 @@ export function buildSandboxAdapter(
             lifecycle: props.createConfig.lifecycle,
             kubeAccess: props.createConfig.kubeAccess,
             workingDir: props.createConfig.workingDir,
-            upstreamID: props.createConfig.upstreamID
+            upstreamID: props.createConfig.upstreamID,
+            resourceLimits: props.createConfig.resourceLimits
           }
         : undefined;
 

--- a/packages/service/core/ai/sandbox/infrastructure/provider/config.ts
+++ b/packages/service/core/ai/sandbox/infrastructure/provider/config.ts
@@ -158,6 +158,7 @@ export function getSandboxAdapterConfig({
           ? profile.buildConfig({
               createConfig,
               sessionId,
+              resourceLimits,
               env: {
                 ...createConfig?.env,
                 ...baseEnv

--- a/packages/service/core/ai/sandbox/infrastructure/provider/runtimeProfile/sealosdevbox.ts
+++ b/packages/service/core/ai/sandbox/infrastructure/provider/runtimeProfile/sealosdevbox.ts
@@ -33,6 +33,7 @@ export function buildSealosRuntimeProfile(): SandboxRuntimeProfile {
 
       const env = mergeStringRecord(createConfig.env, input.env);
       const metadata = mergeStringRecord(createConfig.metadata, input.metadata);
+      const resourceLimits = input.resourceLimits ?? createConfig.resourceLimits;
       // Sealos adapter 会把 workingDir 写入 CODEX_GATEWAY_CWD，让 exec/code-server 落在同一工作区。
       const workingDir = createConfig.workingDir ?? workDirectory;
       // upstreamID 绑定稳定 sessionId，便于 provider 侧复用/追踪同一业务运行态。
@@ -43,6 +44,7 @@ export function buildSealosRuntimeProfile(): SandboxRuntimeProfile {
         image,
         ...(env ? { env } : {}),
         ...(metadata ? { metadata } : {}),
+        ...(resourceLimits ? { resourceLimits } : {}),
         ...(workingDir ? { workingDir } : {}),
         ...(upstreamID ? { upstreamID } : {})
       };

--- a/packages/service/core/ai/sandbox/type.ts
+++ b/packages/service/core/ai/sandbox/type.ts
@@ -1,7 +1,7 @@
 /**
  * 沙盒模块共享类型。
  *
- * 只定义 sandbox 实例、provider、生命周期 operation 和 metadata schema，不访问服务端资源。
+ * 只定义 sandbox 实例、provider 和生命周期 operation，不访问服务端资源。
  */
 import z from 'zod';
 import {
@@ -107,21 +107,6 @@ export const SandboxOperationSchema = z
   .strict();
 export type SandboxOperationTypeSchemaType = z.infer<typeof SandboxOperationSchema>;
 
-export const SandboxMetadataSchema = z
-  .object({
-    teamId: z.string().optional(),
-    tmbId: z.string().optional(),
-    volumeEnabled: z.boolean().optional(),
-    sessionId: z.string().optional(),
-    skillIds: z.array(z.string()).optional(),
-    image: SandboxImageSchema.optional(),
-    skillName: z.string().optional(),
-    versionId: z.string().optional(),
-    operation: SandboxOperationSchema.optional()
-  })
-  .strict();
-export type SandboxMetadataType = z.infer<typeof SandboxMetadataSchema>;
-
 const expectedOperationByStatus: Partial<Record<SandboxInstanceStatusType, SandboxOperationType>> =
   {
     provisioning: 'provision',
@@ -145,16 +130,19 @@ export const SandboxInstanceZodSchema = z
     limit: SandboxLimitSchema.nullish(),
     provider: SandboxProviderSchema,
     storage: SandboxStorageSchema.nullish(),
-    metadata: SandboxMetadataSchema.nullish()
+    teamId: z.string().optional(),
+    image: SandboxImageSchema.optional(),
+    versionId: z.string().optional(),
+    operation: SandboxOperationSchema.optional()
   })
   .superRefine((instance, ctx) => {
     const expectedOperation = expectedOperationByStatus[instance.status];
-    const operation = instance.metadata?.operation;
+    const operation = instance.operation;
 
     if (!expectedOperation && operation) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: ['metadata', 'operation'],
+        path: ['operation'],
         message: `Stable status ${instance.status} must not keep an operation`
       });
       return;
@@ -162,7 +150,7 @@ export const SandboxInstanceZodSchema = z
     if (expectedOperation && operation?.type !== expectedOperation) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: ['metadata', 'operation'],
+        path: ['operation'],
         message: `Status ${instance.status} requires ${expectedOperation} operation`
       });
     }

--- a/packages/service/test/core/ai/sandbox/application/archive.test.ts
+++ b/packages/service/test/core/ai/sandbox/application/archive.test.ts
@@ -103,20 +103,17 @@ const createResource = (status = 'stopped', overrides: Record<string, unknown> =
     userId: 'user-1',
     status,
     lastActiveAt: new Date('2026-07-01T00:00:00.000Z'),
-    metadata: {},
     ...overrides
   }) as any;
 
 const createClaimed = (status: 'archiving' | 'restoring') =>
   createResource(status, {
-    metadata: {
-      operation: {
-        id: `${status}-operation`,
-        type: status === 'archiving' ? 'archive' : 'restore',
-        phase: 'claimed',
-        startedAt: new Date(),
-        heartbeatAt: new Date()
-      }
+    operation: {
+      id: `${status}-operation`,
+      type: status === 'archiving' ? 'archive' : 'restore',
+      phase: 'claimed',
+      startedAt: new Date(),
+      heartbeatAt: new Date()
     }
   });
 
@@ -196,7 +193,7 @@ describe('sandbox archive lifecycle', () => {
         operationId: 'archiving-operation',
         fromStatus: 'archiving',
         status: 'archived',
-        set: { 'metadata.image': 'sandbox-image' }
+        set: { image: 'sandbox-image' }
       })
     );
   });
@@ -255,21 +252,17 @@ describe('sandbox archive lifecycle', () => {
 
   it('commits providerDeleted archive phase without recreating an empty sandbox', async () => {
     const providerDeleted = createResource('archiving', {
-      metadata: {
-        operation: {
-          id: 'old-archive',
-          type: 'archive',
-          phase: 'providerDeleted',
-          startedAt: new Date(0),
-          heartbeatAt: new Date(0)
-        }
+      operation: {
+        id: 'old-archive',
+        type: 'archive',
+        phase: 'providerDeleted',
+        startedAt: new Date(0),
+        heartbeatAt: new Date(0)
       }
     });
     const reclaimed = {
       ...providerDeleted,
-      metadata: {
-        operation: { ...providerDeleted.metadata.operation, id: 'resumed-archive' }
-      }
+      operation: { ...providerDeleted.operation, id: 'resumed-archive' }
     };
     mocks.findSandboxInstanceBySandboxId.mockResolvedValueOnce(providerDeleted);
     mocks.claimSandboxOperation.mockResolvedValueOnce(reclaimed);
@@ -372,7 +365,7 @@ describe('sandbox archive lifecycle', () => {
         status: 'running',
         touchActive: true,
         set: expect.objectContaining({
-          'metadata.image': { repository: 'fastgpt/sandbox', tag: 'v2' }
+          image: { repository: 'fastgpt/sandbox', tag: 'v2' }
         })
       })
     );
@@ -380,21 +373,19 @@ describe('sandbox archive lifecycle', () => {
 
   it('publishes an already installed restore phase without downloading again', async () => {
     const installed = createResource('restoring', {
-      metadata: {
-        operation: {
-          id: 'old-restore',
-          type: 'restore',
-          phase: 'archiveInstalled',
-          previousStatus: 'archived',
-          startedAt: new Date(0),
-          heartbeatAt: new Date(0),
-          error: 'commit interrupted'
-        }
+      operation: {
+        id: 'old-restore',
+        type: 'restore',
+        phase: 'archiveInstalled',
+        previousStatus: 'archived',
+        startedAt: new Date(0),
+        heartbeatAt: new Date(0),
+        error: 'commit interrupted'
       }
     });
     const reclaimed = {
       ...installed,
-      metadata: { operation: { ...installed.metadata.operation, id: 'resumed-restore' } }
+      operation: { ...installed.operation, id: 'resumed-restore' }
     };
     mocks.findSandboxInstanceBySandboxId.mockResolvedValue(installed);
     mocks.claimSandboxOperation.mockResolvedValueOnce(reclaimed);
@@ -436,14 +427,12 @@ describe('sandbox archive lifecycle', () => {
   it('retries only stale archiving records through lifecycle leases', async () => {
     mocks.findStaleSandboxOperations.mockResolvedValueOnce([
       createResource('archiving', {
-        metadata: {
-          operation: {
-            id: 'stale-archive',
-            type: 'archive',
-            phase: 'archiveUploaded',
-            startedAt: new Date('2026-07-01T00:00:00.000Z'),
-            heartbeatAt: new Date('2026-07-01T00:00:00.000Z')
-          }
+        operation: {
+          id: 'stale-archive',
+          type: 'archive',
+          phase: 'archiveUploaded',
+          startedAt: new Date('2026-07-01T00:00:00.000Z'),
+          heartbeatAt: new Date('2026-07-01T00:00:00.000Z')
         }
       })
     ]);

--- a/packages/service/test/core/ai/sandbox/application/legacyMigration/debugChatCleanup.test.ts
+++ b/packages/service/test/core/ai/sandbox/application/legacyMigration/debugChatCleanup.test.ts
@@ -71,7 +71,7 @@ describe('cleanupLegacySkillDebugChats', () => {
       lean: vi.fn().mockResolvedValue([{ _id: conflictSkillId }])
     });
     mocks.findChats.mockReturnValue({
-      lean: vi.fn().mockResolvedValue([{ chatId: 'legacy-debug-chat' }])
+      lean: vi.fn().mockResolvedValue([{ appId: cleanSkillId, chatId: 'legacy-debug-chat' }])
     });
     mocks.countChats.mockResolvedValue(0);
     mocks.countChatItems.mockResolvedValue(1);
@@ -87,16 +87,15 @@ describe('cleanupLegacySkillDebugChats', () => {
     const result = await cleanupLegacySkillDebugChats({ dryRun: false });
 
     expect(result).toMatchObject({
-      scannedSkillCount: 2,
       cleanup: {
         conflictAppSkillCount: 1,
-        cleanupSkillCount: 1,
+        matchedSkillCount: 1,
         totalLegacyChats: 1,
         totalChatItems: 1,
         totalChatItemResponses: 1,
-        deletedSkillCount: 1,
+        cleanedSkillCount: 1,
         pendingChatCount: 0,
-        list: [{ skillId: cleanSkillId, deleted: true }]
+        list: [{ skillId: cleanSkillId, status: 'deleted' }]
       }
     });
     expect(mocks.deleteChatItemResponses).toHaveBeenCalledOnce();
@@ -107,6 +106,70 @@ describe('cleanupLegacySkillDebugChats', () => {
     });
     expect(mocks.addPublicDeleteJob).toHaveBeenCalledWith({
       prefix: `chat/${cleanSkillId}`
+    });
+  });
+
+  it('reports matched legacy chats without deleting them during dry-run', async () => {
+    mocks.countChats.mockResolvedValue(1);
+
+    const result = await cleanupLegacySkillDebugChats({ dryRun: true });
+
+    expect(result).toMatchObject({
+      cleanup: {
+        conflictAppSkillCount: 1,
+        matchedSkillCount: 1,
+        totalLegacyChats: 1,
+        cleanedSkillCount: 0,
+        pendingChatCount: 1,
+        list: [{ skillId: cleanSkillId, status: 'pending' }]
+      }
+    });
+    expect(mocks.deleteChats).not.toHaveBeenCalled();
+    expect(mocks.addPrivateDeleteJob).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty cleanup list when no legacy debug chat exists', async () => {
+    mocks.findSkills.mockReturnValue({ lean: vi.fn().mockResolvedValue([]) });
+
+    const result = await cleanupLegacySkillDebugChats({ dryRun: false });
+
+    expect(result).toEqual({
+      cleanup: {
+        conflictAppSkillCount: 0,
+        matchedSkillCount: 0,
+        totalLegacyChats: 0,
+        totalChatItems: 0,
+        totalChatItemResponses: 0,
+        cleanedSkillCount: 0,
+        pendingChatCount: 0,
+        list: []
+      }
+    });
+    expect(mocks.findApps).not.toHaveBeenCalled();
+  });
+
+  it('reports empty Skills while keeping the upstream scan semantics', async () => {
+    const emptySkillId = '65f000000000000000000033';
+    mocks.findSkills.mockReturnValue({
+      lean: vi.fn().mockResolvedValue([{ _id: cleanSkillId }, { _id: emptySkillId }])
+    });
+    mocks.findChats.mockImplementation((query: { appId: string }) => ({
+      lean: vi
+        .fn()
+        .mockResolvedValue(query.appId === cleanSkillId ? [{ chatId: 'legacy-debug-chat' }] : [])
+    }));
+
+    const result = await cleanupLegacySkillDebugChats({ dryRun: true });
+
+    expect(result.cleanup).toMatchObject({
+      conflictAppSkillCount: 1,
+      matchedSkillCount: 2,
+      totalLegacyChats: 1,
+      pendingChatCount: 0,
+      list: [
+        { skillId: cleanSkillId, chatCount: 1, status: 'pending' },
+        { skillId: emptySkillId, chatCount: 0, status: 'pending' }
+      ]
     });
   });
 });

--- a/packages/service/test/core/ai/sandbox/application/legacyMigration/service.test.ts
+++ b/packages/service/test/core/ai/sandbox/application/legacyMigration/service.test.ts
@@ -157,14 +157,12 @@ const createMigrationTargetDoc = (sandboxId = 'target-sandbox') =>
     userId: 'user-1',
     status: 'legacyMigrating',
     lastActiveAt: new Date(),
-    metadata: {
-      operation: {
-        id: `operation-${sandboxId}`,
-        type: 'legacyMigration',
-        phase: 'claimed',
-        startedAt: new Date(),
-        heartbeatAt: new Date()
-      }
+    operation: {
+      id: `operation-${sandboxId}`,
+      type: 'legacyMigration',
+      phase: 'claimed',
+      startedAt: new Date(),
+      heartbeatAt: new Date()
     }
   }) as any;
 
@@ -204,7 +202,11 @@ const insertLegacyApp = async (params: {
   });
 };
 
-const insertLegacySkill = async (params: { sandboxId: string; sourceId?: string }) => {
+const insertLegacySkill = async (params: {
+  sandboxId: string;
+  sourceId?: string;
+  metadata?: Record<string, unknown>;
+}) => {
   const sourceId = params.sourceId ?? 'skill-1';
   await MongoLegacySandboxInstance.collection.insertOne({
     provider: 'opensandbox',
@@ -213,7 +215,7 @@ const insertLegacySkill = async (params: { sandboxId: string; sourceId?: string 
     sourceId,
     status: SandboxStatusEnum.stopped,
     lastActiveAt: new Date(),
-    metadata: {}
+    metadata: params.metadata ?? {}
   });
 };
 
@@ -237,15 +239,13 @@ const insertPreBeta6Sandbox = async (params: {
   });
 
 const createDebugChatCleanupResult = (pendingChatCount = 0) => ({
-  scannedSkillCount: 0,
   cleanup: {
     conflictAppSkillCount: 0,
-    cleanupSkillCount: 0,
+    matchedSkillCount: 0,
     totalLegacyChats: pendingChatCount,
     totalChatItems: 0,
     totalChatItemResponses: 0,
-    deletedSkillCount: 0,
-    skippedEmptyCount: 0,
+    cleanedSkillCount: 0,
     pendingChatCount,
     list: []
   }
@@ -523,11 +523,11 @@ describe('legacy sandbox migration', () => {
         .mockResolvedValueOnce(migratingTarget);
       mocks.claimAppSandboxMigrationTarget.mockResolvedValue(migratingTarget);
       mocks.advanceSandboxOperation.mockImplementation(async ({ phase }: any) => {
-        migratingTarget.metadata.operation.phase = phase;
+        migratingTarget.operation.phase = phase;
         return migratingTarget;
       });
       mocks.markSandboxOperationFailed.mockImplementation(async ({ error }: any) => {
-        migratingTarget.metadata.operation.error = error;
+        migratingTarget.operation.error = error;
       });
       mocks.completeSandboxOperation
         .mockRejectedValueOnce(new Error('publish interrupted'))
@@ -542,7 +542,7 @@ describe('legacy sandbox migration', () => {
       });
       expect(mocks.markSandboxOperationFailed).toHaveBeenCalledWith(
         expect.objectContaining({
-          operationId: migratingTarget.metadata.operation.id,
+          operationId: migratingTarget.operation.id,
           status: 'legacyMigrating',
           error: 'publish interrupted'
         })
@@ -577,7 +577,7 @@ describe('legacy sandbox migration', () => {
       expect(mocks.completeSandboxOperation).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({
-          operationId: migratingTarget.metadata.operation.id,
+          operationId: migratingTarget.operation.id,
           fromStatus: 'legacyMigrating',
           status: 'stopped',
           touchActive: true
@@ -729,9 +729,7 @@ describe('legacy sandbox migration', () => {
         expect.objectContaining({
           sandboxId: targetSandboxId,
           sourceId,
-          metadata: expect.objectContaining({
-            image: { repository: 'migration-image', tag: 'latest' }
-          })
+          image: { repository: 'migration-image', tag: 'latest' }
         })
       );
       expect(mocks.getSandboxWorkspaceArchiveForMigration).toHaveBeenCalledWith(
@@ -766,6 +764,49 @@ describe('legacy sandbox migration', () => {
           .lean()
           .then((doc) => doc?.metadata?.userLevelMigration?.phase)
       ).resolves.toBe('completed');
+    });
+
+    it('accepts Legacy Skill metadata fields that are not persisted in v2', async () => {
+      const sourceId = 'skill-with-legacy-metadata';
+      await insertLegacySkill({
+        sandboxId: 'migration-test-skill-legacy-metadata',
+        sourceId,
+        metadata: {
+          providerCreatedAt: new Date(),
+          storage: { key: 'skill-package.zip', uploadedAt: new Date() },
+          skillIds: ['legacy-skill-version'],
+          skillName: 'Legacy Skill',
+          versionId: 'legacy-version'
+        }
+      });
+
+      const result = await migrateLegacySandboxesToUserLevel({ dryRun: false });
+
+      expect(result).toMatchObject({ migratedSkillCount: 1, failedCount: 0 });
+      expect(mocks.claimSkillSandboxMigrationTarget).toHaveBeenCalledWith(
+        expect.objectContaining({
+          image: { repository: 'migration-image', tag: 'latest' },
+          versionId: 'legacy-version'
+        })
+      );
+    });
+
+    it('preflights Legacy records before creating migration targets', async () => {
+      await MongoLegacySandboxInstance.collection.insertOne({
+        provider: 'opensandbox',
+        sandboxId: 'migration-test-invalid-legacy',
+        sourceType: ChatSourceTypeEnum.skillEdit,
+        sourceId: 'invalid-legacy-skill',
+        status: 'not-a-sandbox-status',
+        lastActiveAt: new Date(),
+        metadata: {}
+      } as any);
+
+      await expect(migrateLegacySandboxesToUserLevel({ dryRun: false })).rejects.toThrow(
+        'Legacy Sandbox preflight validation failed'
+      );
+      expect(mocks.getSandboxWorkspaceArchiveForMigration).not.toHaveBeenCalled();
+      expect(mocks.claimSkillSandboxMigrationTarget).not.toHaveBeenCalled();
     });
 
     it('merges a Legacy Skill Workspace into an existing target without overwriting new files', async () => {

--- a/packages/service/test/core/ai/sandbox/application/lifecycle/runner.test.ts
+++ b/packages/service/test/core/ai/sandbox/application/lifecycle/runner.test.ts
@@ -29,14 +29,12 @@ const createResource = (overrides: Record<string, unknown> = {}) =>
     userId: 'user-1',
     status: 'stopping',
     lastActiveAt: new Date('2026-07-01T00:00:00.000Z'),
-    metadata: {
-      operation: {
-        id: 'operation-1',
-        type: 'stop',
-        phase: 'claimed',
-        startedAt: new Date(),
-        heartbeatAt: new Date()
-      }
+    operation: {
+      id: 'operation-1',
+      type: 'stop',
+      phase: 'claimed',
+      startedAt: new Date(),
+      heartbeatAt: new Date()
     },
     ...overrides
   }) as any;
@@ -52,14 +50,12 @@ describe('sandbox lifecycle runner', () => {
     mocks.claimSandboxOperation.mockResolvedValue(createResource());
     mocks.advanceSandboxOperation.mockImplementation(async ({ phase }: { phase: string }) =>
       createResource({
-        metadata: {
-          operation: {
-            id: 'operation-1',
-            type: 'stop',
-            phase,
-            startedAt: new Date(),
-            heartbeatAt: new Date()
-          }
+        operation: {
+          id: 'operation-1',
+          type: 'stop',
+          phase,
+          startedAt: new Date(),
+          heartbeatAt: new Date()
         }
       })
     );
@@ -102,14 +98,12 @@ describe('sandbox lifecycle runner', () => {
     const secondStep = vi.fn(async () => undefined);
     mocks.claimSandboxOperation.mockResolvedValue(
       createResource({
-        metadata: {
-          operation: {
-            id: 'operation-2',
-            type: 'stop',
-            phase: 'providerStopped',
-            startedAt: new Date(),
-            heartbeatAt: new Date()
-          }
+        operation: {
+          id: 'operation-2',
+          type: 'stop',
+          phase: 'providerStopped',
+          startedAt: new Date(),
+          heartbeatAt: new Date()
         }
       })
     );

--- a/packages/service/test/core/ai/sandbox/application/providerMigration.test.ts
+++ b/packages/service/test/core/ai/sandbox/application/providerMigration.test.ts
@@ -86,7 +86,6 @@ const createInstance = (overrides: Record<string, unknown> = {}) =>
     userId: params.userId,
     status: 'running',
     lastActiveAt: new Date('2026-07-01T00:00:00.000Z'),
-    metadata: {},
     ...overrides
   }) as any;
 
@@ -178,26 +177,22 @@ describe('sandbox provider migration lifecycle', () => {
   it('rolls an archiveInstalled old-provider restore back to archived without deleting S3', async () => {
     const restoring = createInstance({
       status: 'restoring',
-      metadata: {
-        operation: {
-          id: 'old-restore',
-          type: 'restore',
-          phase: 'archiveInstalled',
-          previousStatus: 'archived',
-          startedAt: new Date(0),
-          heartbeatAt: new Date(0),
-          error: 'worker stopped'
-        }
+      operation: {
+        id: 'old-restore',
+        type: 'restore',
+        phase: 'archiveInstalled',
+        previousStatus: 'archived',
+        startedAt: new Date(0),
+        heartbeatAt: new Date(0),
+        error: 'worker stopped'
       }
     });
     const archived = createInstance({ status: 'archived' });
     const restoreClaim = {
       ...restoring,
-      metadata: {
-        operation: {
-          ...restoring.metadata.operation,
-          id: 'rollback-restore'
-        }
+      operation: {
+        ...restoring.operation,
+        id: 'rollback-restore'
       }
     };
     mocks.findSandboxInstanceBySource

--- a/packages/service/test/core/ai/sandbox/application/resource.test.ts
+++ b/packages/service/test/core/ai/sandbox/application/resource.test.ts
@@ -70,21 +70,18 @@ const createResource = (overrides: Record<string, unknown> = {}) =>
     userId: 'user-1',
     status: 'running',
     lastActiveAt: new Date('2026-07-01T00:00:00.000Z'),
-    metadata: {},
     ...overrides
   }) as any;
 
 const createClaimed = (status: string, type: string) =>
   createResource({
     status,
-    metadata: {
-      operation: {
-        id: 'operation-1',
-        type,
-        phase: 'claimed',
-        startedAt: new Date(),
-        heartbeatAt: new Date()
-      }
+    operation: {
+      id: 'operation-1',
+      type,
+      phase: 'claimed',
+      startedAt: new Date(),
+      heartbeatAt: new Date()
     }
   });
 
@@ -224,10 +221,10 @@ describe('sandbox resource lifecycle', () => {
 
   it('finishes archiveDeleted delete phase without replaying remote side effects', async () => {
     const deleting = createClaimed('deleting', 'delete');
-    deleting.metadata.operation.phase = 'archiveDeleted';
+    deleting.operation.phase = 'archiveDeleted';
     const reclaimed = createClaimed('deleting', 'delete');
-    reclaimed.metadata.operation.id = 'resumed-delete';
-    reclaimed.metadata.operation.phase = 'archiveDeleted';
+    reclaimed.operation.id = 'resumed-delete';
+    reclaimed.operation.phase = 'archiveDeleted';
     mocks.findSandboxInstanceBySandboxId.mockResolvedValueOnce(deleting);
     mocks.claimSandboxOperation.mockResolvedValueOnce(reclaimed);
 

--- a/packages/service/test/core/ai/sandbox/application/runtime/client.test.ts
+++ b/packages/service/test/core/ai/sandbox/application/runtime/client.test.ts
@@ -131,17 +131,15 @@ const createInstance = (status: string, operationId?: string) =>
     userId: query.userId,
     status,
     lastActiveAt: new Date('2026-07-01T00:00:00.000Z'),
-    metadata: operationId
+    operation: operationId
       ? {
-          operation: {
-            id: operationId,
-            type: 'provision',
-            phase: 'claimed',
-            startedAt: new Date(),
-            heartbeatAt: new Date()
-          }
+          id: operationId,
+          type: 'provision',
+          phase: 'claimed',
+          startedAt: new Date(),
+          heartbeatAt: new Date()
         }
-      : {}
+      : undefined
   }) as any;
 
 describe('sandbox runtime client lifecycle', () => {
@@ -181,7 +179,7 @@ describe('sandbox runtime client lifecycle', () => {
 
     expect(client.getSandboxId()).toBe(query.sandboxId);
     expect(mocks.touchRunningSandboxInstance).toHaveBeenCalledWith(
-      expect.objectContaining({ sandboxId: query.sandboxId, metadata: { volumeEnabled: false } })
+      expect.objectContaining({ sandboxId: query.sandboxId })
     );
     expect(mocks.ensureConnectedSandboxRunning).toHaveBeenCalledWith(expect.anything(), {
       allowCreate: false
@@ -245,10 +243,7 @@ describe('sandbox runtime client lifecycle', () => {
     );
     expect(mocks.createSandboxProvisioningInstance).toHaveBeenCalledWith(
       expect.objectContaining({
-        metadata: {
-          volumeEnabled: false,
-          image: { repository: 'fastgpt/sandbox', tag: 'v2' }
-        }
+        image: { repository: 'fastgpt/sandbox', tag: 'v2' }
       })
     );
     expect(mocks.completeSandboxOperation).toHaveBeenCalledWith(
@@ -299,11 +294,11 @@ describe('sandbox runtime client lifecycle', () => {
 
   it('publishes a stale providerEnsured phase without reconnecting the provider', async () => {
     const provisioning = createInstance('provisioning', 'old-provision');
-    provisioning.metadata.operation.phase = 'providerEnsured';
-    provisioning.metadata.operation.heartbeatAt = new Date(0);
+    provisioning.operation.phase = 'providerEnsured';
+    provisioning.operation.heartbeatAt = new Date(0);
     const reclaimed = createInstance('provisioning', 'resumed-provision');
-    reclaimed.metadata.operation.phase = 'providerEnsured';
-    reclaimed.metadata.operation.heartbeatAt = new Date(0);
+    reclaimed.operation.phase = 'providerEnsured';
+    reclaimed.operation.heartbeatAt = new Date(0);
     mocks.touchRunningSandboxInstance.mockResolvedValue(null);
     mocks.findSandboxInstanceBySource.mockResolvedValue(provisioning);
     mocks.claimSandboxOperation.mockResolvedValueOnce(reclaimed);
@@ -327,7 +322,7 @@ describe('sandbox runtime client lifecycle', () => {
       .mockResolvedValueOnce(failedProvisioning)
       .mockResolvedValueOnce(retriedProvisioning);
     mocks.markSandboxOperationFailed.mockImplementationOnce(async ({ error }: any) => {
-      failedProvisioning.metadata.operation.error = error;
+      failedProvisioning.operation.error = error;
     });
     mocks.ensureConnectedSandboxRunning.mockRejectedValueOnce(new Error('provider failed'));
 
@@ -353,7 +348,7 @@ describe('sandbox runtime client lifecycle', () => {
       expect.objectContaining({
         operationId: 'retried-provision',
         status: 'running',
-        set: { 'metadata.image': { repository: 'fastgpt/sandbox', tag: 'v2' } }
+        set: { image: { repository: 'fastgpt/sandbox', tag: 'v2' } }
       })
     );
   });

--- a/packages/service/test/core/ai/sandbox/application/runtime/upgrade.test.ts
+++ b/packages/service/test/core/ai/sandbox/application/runtime/upgrade.test.ts
@@ -57,10 +57,8 @@ const createResource = (
     userId: 'user-1',
     status,
     lastActiveAt: new Date(),
-    metadata: {
-      image: params.image ?? targetImage,
-      ...(params.operation ? { operation: params.operation } : {})
-    }
+    image: params.image ?? targetImage,
+    ...(params.operation ? { operation: params.operation } : {})
   }) as any;
 
 const getStatus = (statusInstance?: any) =>
@@ -140,7 +138,7 @@ describe('getSandboxRuntimeUpgradeStatus', () => {
 
   it('requires an upgrade when repository/tag is missing or changed', () => {
     const missingImage = createResource('running');
-    missingImage.metadata = {};
+    delete missingImage.image;
     expect(getStatus(missingImage)).toEqual({ status: 'upgradeRequired' });
     expect(
       getStatus(createResource('stopped', { image: { repository: 'runtime-image', tag: 'v1' } }))
@@ -242,7 +240,7 @@ describe('App sandbox runtime upgrade service', () => {
     });
     mocks.findSandboxResourcesBySource
       .mockResolvedValueOnce([instance])
-      .mockResolvedValueOnce([createResource('archived', { image: instance.metadata.image })]);
+      .mockResolvedValueOnce([createResource('archived', { image: instance.image })]);
     const onUpgrade = vi.fn();
 
     await expect(ensureAppSandboxRuntimeReady({ query, onUpgrade })).resolves.toBe(true);
@@ -275,11 +273,11 @@ describe('App sandbox runtime upgrade service', () => {
       image: { repository: 'runtime-image', tag: 'v1' },
       operation: { error: 'stop failed' }
     });
-    const stoppedInstance = createResource('stopped', { image: instance.metadata.image });
+    const stoppedInstance = createResource('stopped', { image: instance.image });
     mocks.findSandboxResourcesBySource
       .mockResolvedValueOnce([instance])
       .mockResolvedValueOnce([stoppedInstance])
-      .mockResolvedValueOnce([createResource('archived', { image: instance.metadata.image })]);
+      .mockResolvedValueOnce([createResource('archived', { image: instance.image })]);
 
     await expect(ensureAppSandboxRuntimeReady({ query })).resolves.toBe(true);
     expect(mocks.stopSandboxResource).toHaveBeenCalledWith(instance);

--- a/packages/service/test/core/ai/sandbox/application/skillEdit/deploy.test.ts
+++ b/packages/service/test/core/ai/sandbox/application/skillEdit/deploy.test.ts
@@ -91,9 +91,7 @@ describe('saveDeploySkillFromSandbox', () => {
     mocks.findSandboxInstanceBySandboxIdAndSource.mockResolvedValue({
       sandboxId: 'sandbox-1',
       status: SandboxStatusEnum.running,
-      metadata: {
-        teamId: 'team-1'
-      }
+      teamId: 'team-1'
     });
     mocks.packageSkillInSandbox.mockResolvedValue(Buffer.from('mock zip'));
     mocks.validateZipStructure.mockResolvedValue({ valid: true });
@@ -140,7 +138,7 @@ describe('saveDeploySkillFromSandbox', () => {
     expect(mocks.removeSkillPackageTTL).not.toHaveBeenCalled();
   });
 
-  it('touches the sandbox version metadata after deploy only when archive state has not changed', async () => {
+  it('touches the sandbox versionId after deploy only when archive state has not changed', async () => {
     await expect(
       saveDeploySkillFromSandbox({
         skillId: 'skill-1',
@@ -160,9 +158,7 @@ describe('saveDeploySkillFromSandbox', () => {
         sourceId: 'skill-1',
         userId: 'skillEdit',
         touchActive: true,
-        metadata: expect.objectContaining({
-          teamId: 'team-1'
-        })
+        versionId: expect.any(String)
       })
     );
     expect(mocks.updateCurrentVersion).toHaveBeenCalledWith({
@@ -195,9 +191,7 @@ describe('saveDeploySkillFromSandbox', () => {
     mocks.findSandboxInstanceBySandboxIdAndSource.mockResolvedValueOnce({
       sandboxId: 'sandbox-1',
       status: SandboxStatusEnum.running,
-      metadata: {
-        teamId: 'team-other'
-      }
+      teamId: 'team-other'
     });
 
     await expect(

--- a/packages/service/test/core/ai/sandbox/application/skillEdit/runtime.test.ts
+++ b/packages/service/test/core/ai/sandbox/application/skillEdit/runtime.test.ts
@@ -142,10 +142,8 @@ const createResource = (status = 'running', overrides: Record<string, unknown> =
     sourceId: 'skill-1',
     status,
     lastActiveAt: new Date(),
-    metadata: {
-      image: { repository: 'runtime-image', tag: 'v2' },
-      versionId: 'version-1'
-    },
+    image: { repository: 'runtime-image', tag: 'v2' },
+    versionId: 'version-1',
     ...overrides
   }) as any;
 
@@ -158,7 +156,6 @@ const createContext = (
   return {
     skillId: 'skill-1',
     teamId: 'team-1',
-    tmbId: 'tmb-1',
     providerConfig: { provider: 'opensandbox' },
     runtimeProfile: {
       provider: 'opensandbox',
@@ -167,7 +164,6 @@ const createContext = (
     },
     createConfig: { image: { repository: 'runtime-image', tag: 'v2' } },
     runtimeImage: { repository: 'runtime-image', tag: 'v2' },
-    skill: { _id: 'skill-1', name: 'Test skill', currentVersionId: 'version-1' },
     currentVersion: { _id: 'version-1', skillId: 'skill-1', storageKey: 'storage-key' },
     sessionId: 'edit-debug-skill-1',
     targetVersionId: 'version-1',
@@ -268,10 +264,8 @@ describe('skill edit runtime status', () => {
     ).resolves.toEqual({ status: 'readyToInit' });
 
     const outdated = createResource('running', {
-      metadata: {
-        image: { repository: 'old-image', tag: 'v1' },
-        versionId: 'version-1'
-      }
+      image: { repository: 'old-image', tag: 'v1' },
+      versionId: 'version-1'
     });
     await expect(
       getSkillEditRuntimeStatus({
@@ -343,7 +337,8 @@ describe('skill edit runtime initialization', () => {
 
   it('deploys the target package after runtime client restores an outdated record', async () => {
     const archived = createResource('archived', {
-      metadata: { image: { repository: 'old-image', tag: 'v1' }, versionId: 'old-version' }
+      image: { repository: 'old-image', tag: 'v1' },
+      versionId: 'old-version'
     });
 
     await initSkillEditRuntimeSandbox({
@@ -352,7 +347,8 @@ describe('skill edit runtime initialization', () => {
 
     expect(mocks.updateSandboxInstanceRecordBySandboxId).toHaveBeenCalledWith(
       expect.objectContaining({
-        metadata: expect.objectContaining({ versionId: 'version-1', teamId: 'team-1' })
+        versionId: 'version-1',
+        teamId: 'team-1'
       })
     );
   });
@@ -408,14 +404,14 @@ describe('skill edit runtime context and read-only query', () => {
     mocks.checkTeamSandboxPermission.mockRejectedValueOnce(new Error('denied'));
 
     await expect(
-      getSkillEditRuntimeContext({ skillId: 'skill-1', teamId: 'team-1', tmbId: 'tmb-1' })
+      getSkillEditRuntimeContext({ skillId: 'skill-1', teamId: 'team-1' })
     ).rejects.toThrow();
     expect(mocks.mongoSkillFindOne).not.toHaveBeenCalled();
   });
 
   it('returns only a running sandbox owned by the requested team', async () => {
     mocks.findSandboxInstanceBySandboxIdAndSource.mockResolvedValueOnce(
-      createResource('running', { metadata: { teamId: 'team-1' } })
+      createResource('running', { teamId: 'team-1' })
     );
 
     await expect(
@@ -423,7 +419,7 @@ describe('skill edit runtime context and read-only query', () => {
     ).resolves.toMatchObject({ sandboxId: 'edit-debug-skill-1' });
 
     mocks.findSandboxInstanceBySandboxIdAndSource.mockResolvedValueOnce(
-      createResource('running', { metadata: { teamId: 'other-team' } })
+      createResource('running', { teamId: 'other-team' })
     );
     await expect(
       getRunningSkillEditSandbox({ skillId: 'skill-1', teamId: 'team-1' })

--- a/packages/service/test/core/ai/sandbox/infrastructure/instance/repository.test.ts
+++ b/packages/service/test/core/ai/sandbox/infrastructure/instance/repository.test.ts
@@ -58,7 +58,7 @@ describe('sandbox instance lifecycle repository', () => {
       provider: 'opensandbox',
       sourceType: ChatSourceTypeEnum.app,
       ...identity,
-      metadata: { teamId: 'team-1' }
+      teamId: 'team-1'
     });
     const duplicate = await createSandboxProvisioningInstance({
       provider: 'opensandbox',
@@ -69,7 +69,7 @@ describe('sandbox instance lifecycle repository', () => {
     expect(first.created).toBe(true);
     expect(first.instance).toMatchObject({
       status: SandboxInstanceStatusEnum.provisioning,
-      metadata: { operation: { type: SandboxOperationTypeEnum.provision, phase: 'claimed' } }
+      operation: { type: SandboxOperationTypeEnum.provision, phase: 'claimed' }
     });
     expect(duplicate.created).toBe(false);
     expect(duplicate.instance?._id.toString()).toBe(first.instance?._id.toString());
@@ -90,7 +90,7 @@ describe('sandbox instance lifecycle repository', () => {
       sourceType: ChatSourceTypeEnum.app,
       ...identity
     });
-    const operationId = instance!.metadata!.operation!.id;
+    const operationId = instance!.operation!.id;
 
     await expect(
       completeSandboxOperation({
@@ -114,20 +114,20 @@ describe('sandbox instance lifecycle repository', () => {
 
     await expect(
       MongoSandboxInstance.findOne({ sandboxId: identity.sandboxId }).lean()
-    ).resolves.not.toHaveProperty('metadata.operation');
+    ).resolves.not.toHaveProperty('operation');
   });
 
-  it('touches only the matching published identity and preserves metadata', async () => {
+  it('touches only the matching published identity and preserves stable fields', async () => {
     const identity = createAppIdentity();
     const { instance } = await createSandboxProvisioningInstance({
       provider: 'opensandbox',
       sourceType: ChatSourceTypeEnum.app,
       ...identity,
-      metadata: { teamId: 'team-1' }
+      teamId: 'team-1'
     });
     await completeSandboxOperation({
       resource: instance!,
-      operationId: instance!.metadata!.operation!.id,
+      operationId: instance!.operation!.id,
       fromStatus: SandboxInstanceStatusEnum.provisioning,
       status: SandboxInstanceStatusEnum.running
     });
@@ -136,12 +136,11 @@ describe('sandbox instance lifecycle repository', () => {
       touchRunningSandboxInstance({
         provider: 'opensandbox',
         sourceType: ChatSourceTypeEnum.app,
-        ...identity,
-        metadata: { volumeEnabled: true }
+        ...identity
       })
     ).resolves.toMatchObject({
       status: SandboxInstanceStatusEnum.running,
-      metadata: { teamId: 'team-1', volumeEnabled: true }
+      teamId: 'team-1'
     });
 
     await expect(
@@ -170,7 +169,7 @@ describe('sandbox instance lifecycle repository', () => {
       type: SandboxOperationTypeEnum.stop,
       matchLastActiveAt: true
     });
-    const operationId = claimed!.metadata!.operation!.id;
+    const operationId = claimed!.operation!.id;
 
     await expect(
       advanceSandboxOperation({
@@ -179,7 +178,7 @@ describe('sandbox instance lifecycle repository', () => {
         status: SandboxInstanceStatusEnum.stopping,
         phase: 'providerStopped'
       })
-    ).resolves.toMatchObject({ metadata: { operation: { phase: 'providerStopped' } } });
+    ).resolves.toMatchObject({ operation: { phase: 'providerStopped' } });
     await markSandboxOperationFailed({
       resource: claimed!,
       operationId,
@@ -188,7 +187,7 @@ describe('sandbox instance lifecycle repository', () => {
     });
     await expect(MongoSandboxInstance.findById(claimed!._id).lean()).resolves.toMatchObject({
       status: SandboxInstanceStatusEnum.stopping,
-      metadata: { operation: { error: 'provider timeout' } }
+      operation: { error: 'provider timeout' }
     });
     const failed = await MongoSandboxInstance.findById(claimed!._id).lean<SandboxResourceDoc>();
     const retried = await claimSandboxOperation({
@@ -196,12 +195,12 @@ describe('sandbox instance lifecycle repository', () => {
       status: SandboxInstanceStatusEnum.stopping,
       type: SandboxOperationTypeEnum.stop
     });
-    expect(retried?.metadata?.operation).toMatchObject({
+    expect(retried?.operation).toMatchObject({
       phase: 'providerStopped',
       type: SandboxOperationTypeEnum.stop,
       previousStatus: SandboxInstanceStatusEnum.running
     });
-    expect(retried?.metadata?.operation?.id).not.toBe(operationId);
+    expect(retried?.operation?.id).not.toBe(operationId);
     await expect(
       completeSandboxOperation({
         resource: claimed!,
@@ -213,7 +212,7 @@ describe('sandbox instance lifecycle repository', () => {
     await expect(
       completeSandboxOperation({
         resource: retried!,
-        operationId: retried!.metadata!.operation!.id,
+        operationId: retried!.operation!.id,
         fromStatus: SandboxInstanceStatusEnum.stopping,
         status: SandboxInstanceStatusEnum.stopped
       })
@@ -225,7 +224,7 @@ describe('sandbox instance lifecycle repository', () => {
     const first = await claimAppSandboxMigrationTarget({
       provider: 'opensandbox',
       ...identity,
-      metadata: { teamId: 'team-1' }
+      teamId: 'team-1'
     });
     const second = await claimAppSandboxMigrationTarget({
       provider: 'opensandbox',
@@ -233,12 +232,12 @@ describe('sandbox instance lifecycle repository', () => {
     });
 
     expect(first).toMatchObject({ status: SandboxInstanceStatusEnum.legacyMigrating });
-    expect(second?.metadata?.operation?.id).not.toBe(first?.metadata?.operation?.id);
+    expect(second?.operation?.id).not.toBe(first?.operation?.id);
 
     await expect(
       completeSandboxOperation({
         resource: second!,
-        operationId: first!.metadata!.operation!.id,
+        operationId: first!.operation!.id,
         fromStatus: SandboxInstanceStatusEnum.legacyMigrating,
         status: SandboxInstanceStatusEnum.running
       })
@@ -246,7 +245,7 @@ describe('sandbox instance lifecycle repository', () => {
     await expect(
       completeSandboxOperation({
         resource: second!,
-        operationId: second!.metadata!.operation!.id,
+        operationId: second!.operation!.id,
         fromStatus: SandboxInstanceStatusEnum.legacyMigrating,
         status: SandboxInstanceStatusEnum.running
       })
@@ -274,9 +273,7 @@ describe('sandbox instance lifecycle repository', () => {
     ).resolves.toMatchObject({
       provider: 'sealosdevbox',
       status: SandboxInstanceStatusEnum.archived,
-      metadata: {
-        image: { repository: 'registry.example.com/sandbox', tag: 'v2' }
-      }
+      image: { repository: 'registry.example.com/sandbox', tag: 'v2' }
     });
     await expect(
       switchArchivedSandboxProvider({
@@ -318,13 +315,13 @@ describe('sandbox instance lifecycle repository', () => {
     await expect(
       deleteClaimedSandboxRecord({
         resource: deleting!,
-        operationId: migrating!.metadata!.operation!.id
+        operationId: migrating!.operation!.id
       })
     ).resolves.toMatchObject({ deletedCount: 0 });
     await expect(
       deleteClaimedSandboxRecord({
         resource: deleting!,
-        operationId: deleting!.metadata!.operation!.id
+        operationId: deleting!.operation!.id
       })
     ).resolves.toMatchObject({ deletedCount: 1 });
   });
@@ -371,7 +368,7 @@ describe('sandbox instance lifecycle repository', () => {
       provider: 'opensandbox',
       sandboxId,
       sourceId,
-      metadata: { teamId: 'team-1' }
+      teamId: 'team-1'
     });
 
     expect(claimed).toMatchObject({
@@ -383,7 +380,7 @@ describe('sandbox instance lifecycle repository', () => {
     });
     await completeSandboxOperation({
       resource: claimed!,
-      operationId: claimed!.metadata!.operation!.id,
+      operationId: claimed!.operation!.id,
       fromStatus: SandboxInstanceStatusEnum.legacyMigrating,
       status: SandboxInstanceStatusEnum.running
     });

--- a/packages/service/test/core/ai/sandbox/infrastructure/instance/schema.test.ts
+++ b/packages/service/test/core/ai/sandbox/infrastructure/instance/schema.test.ts
@@ -30,13 +30,19 @@ describe('MongoSandboxInstance schema indexes', () => {
     expect(logicalIndex?.[0]).toEqual({ sourceType: 1, sourceId: 1, userId: 1 });
 
     expect(indexes.some(([keys]) => keys.status === 1 && keys.lastActiveAt === 1)).toBe(true);
-    expect(
-      indexes.some(([keys]) => keys.status === 1 && keys['metadata.operation.heartbeatAt'] === 1)
-    ).toBe(true);
+    expect(indexes.some(([keys]) => keys.status === 1 && keys['operation.heartbeatAt'] === 1)).toBe(
+      true
+    );
   });
 
-  it('does not register historical sandbox indexes for automatic cleanup', () => {
-    expect(getSchemaDeprecatedMongoIndexes(MongoSandboxInstance.schema)).toEqual([]);
+  it('registers the nested operation index for automatic cleanup', () => {
+    expect(getSchemaDeprecatedMongoIndexes(MongoSandboxInstance.schema)).toEqual([
+      {
+        indexName: 'status_1_metadata.operation.heartbeatAt_1',
+        key: { status: 1, 'metadata.operation.heartbeatAt': 1 },
+        options: undefined
+      }
+    ]);
   });
 
   it('accepts stable states without operation and matching transition operations', async () => {
@@ -48,14 +54,12 @@ describe('MongoSandboxInstance schema indexes', () => {
       new MongoSandboxInstance({
         ...baseInstance,
         status: 'archiving',
-        metadata: {
-          operation: {
-            id: 'archive-operation',
-            type: 'archive',
-            phase: 'claimed',
-            startedAt: new Date(),
-            heartbeatAt: new Date()
-          }
+        operation: {
+          id: 'archive-operation',
+          type: 'archive',
+          phase: 'claimed',
+          startedAt: new Date(),
+          heartbeatAt: new Date()
         }
       }).validate()
     ).resolves.toBeUndefined();
@@ -70,14 +74,12 @@ describe('MongoSandboxInstance schema indexes', () => {
       new MongoSandboxInstance({
         ...baseInstance,
         status: 'archiving',
-        metadata: {
-          operation: {
-            id: 'wrong-operation',
-            type: 'stop',
-            phase: 'claimed',
-            startedAt: new Date(),
-            heartbeatAt: new Date()
-          }
+        operation: {
+          id: 'wrong-operation',
+          type: 'stop',
+          phase: 'claimed',
+          startedAt: new Date(),
+          heartbeatAt: new Date()
         }
       }).validate()
     ).rejects.toThrow('Status archiving requires archive operation');
@@ -86,14 +88,12 @@ describe('MongoSandboxInstance schema indexes', () => {
       new MongoSandboxInstance({
         ...baseInstance,
         status: 'running',
-        metadata: {
-          operation: {
-            id: 'stale-operation',
-            type: 'stop',
-            phase: 'claimed',
-            startedAt: new Date(),
-            heartbeatAt: new Date()
-          }
+        operation: {
+          id: 'stale-operation',
+          type: 'stop',
+          phase: 'claimed',
+          startedAt: new Date(),
+          heartbeatAt: new Date()
         }
       }).validate()
     ).rejects.toThrow('Stable status running must not keep an operation');
@@ -108,34 +108,18 @@ describe('MongoSandboxInstance schema indexes', () => {
       new MongoSandboxInstance({
         ...baseInstance,
         status: 'archiving',
-        metadata: {
-          operation: {
-            id: 'provider-migration-operation',
-            type: 'providerMigration',
-            phase: 'claimed',
-            startedAt: new Date(),
-            heartbeatAt: new Date()
-          }
+        operation: {
+          id: 'provider-migration-operation',
+          type: 'providerMigration',
+          phase: 'claimed',
+          startedAt: new Date(),
+          heartbeatAt: new Date()
         }
       }).validate()
     ).rejects.toThrow();
   });
 
-  it('rejects legacy archive and migration metadata in the v2 model', async () => {
-    await expect(
-      new MongoSandboxInstance({
-        ...baseInstance,
-        status: 'running',
-        metadata: { archive: { state: 'archived' } }
-      }).validate()
-    ).rejects.toThrow();
-
-    await expect(
-      new MongoSandboxInstance({
-        ...baseInstance,
-        status: 'running',
-        metadata: { migration: 'migrating' }
-      }).validate()
-    ).rejects.toThrow();
+  it('does not define a metadata container in the v2 model', () => {
+    expect(MongoSandboxInstance.schema.path('metadata')).toBeUndefined();
   });
 });

--- a/packages/service/test/core/ai/sandbox/infrastructure/provider/adapter.test.ts
+++ b/packages/service/test/core/ai/sandbox/infrastructure/provider/adapter.test.ts
@@ -108,7 +108,10 @@ describe('sandbox provider adapter', () => {
       },
       {
         sandboxId: 'sealos-sandbox-1',
-        createConfig: { env: { A: 'B' } }
+        createConfig: {
+          env: { A: 'B' },
+          resourceLimits: { cpuCount: 2, memoryMiB: 4096, diskGiB: 10 }
+        }
       }
     );
 
@@ -119,7 +122,10 @@ describe('sandbox provider adapter', () => {
         token: 'token',
         sandboxId: 'sealos-sandbox-1'
       },
-      createConfig: expect.objectContaining({ env: { A: 'B' } })
+      createConfig: expect.objectContaining({
+        env: { A: 'B' },
+        resourceLimits: { cpuCount: 2, memoryMiB: 4096, diskGiB: 10 }
+      })
     });
   });
 

--- a/packages/service/test/core/ai/sandbox/infrastructure/provider/config.test.ts
+++ b/packages/service/test/core/ai/sandbox/infrastructure/provider/config.test.ts
@@ -139,7 +139,8 @@ describe('sandbox provider config', () => {
     const result = getSandboxAdapterConfig({
       provider: 'sealosdevbox',
       runtime: true,
-      sessionId: 'session-1'
+      sessionId: 'session-1',
+      resourceLimits: { cpuCount: 2, memoryMiB: 4096, diskGiB: 10 }
     });
 
     expect(result.providerConfig).toEqual({
@@ -153,6 +154,7 @@ describe('sandbox provider config', () => {
         repository: 'default-sealos-image',
         tag: 'latest'
       },
+      resourceLimits: { cpuCount: 2, memoryMiB: 4096, diskGiB: 10 },
       workingDir: '/home/devbox/workspace',
       upstreamID: 'session-1',
       env: {

--- a/packages/service/test/core/ai/sandbox/infrastructure/provider/runtimeProfile.test.ts
+++ b/packages/service/test/core/ai/sandbox/infrastructure/provider/runtimeProfile.test.ts
@@ -106,6 +106,7 @@ describe('sandbox runtime profile', () => {
             maxFrameBytes: 16 * 1024 * 1024
           }
         }),
+        resourceLimits: { cpuCount: 2, memoryMiB: 4096, diskGiB: 10 },
         metadata: { teamId: 'team-1' }
       })
     ).toMatchObject({
@@ -124,6 +125,7 @@ describe('sandbox runtime profile', () => {
       metadata: {
         teamId: 'team-1'
       },
+      resourceLimits: { cpuCount: 2, memoryMiB: 4096, diskGiB: 10 },
       workingDir: '/custom/devbox/workspace',
       upstreamID: 'session-1'
     });

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/hooks/useChatGenerate.ts
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/hooks/useChatGenerate.ts
@@ -167,7 +167,6 @@ export const useChatGenerate = ({
   const chatAuthTarget = useChatAuthApiTarget({ sourceTarget, outLinkAuthData });
 
   const generatingMessageQueueRef = useRef<QueuedGeneratingMessage[]>([]);
-  const sendPromptRef = useRef<SendPromptFnType>();
 
   const applyGeneratingMessage = useMemoizedFn(
     (
@@ -906,10 +905,6 @@ export const useChatGenerate = ({
       )();
     }
   );
-
-  useEffect(() => {
-    sendPromptRef.current = sendPrompt;
-  }, [sendPrompt]);
 
   return {
     abortRequest,

--- a/projects/app/src/pages/api/admin/4160/initUserSandbox.ts
+++ b/projects/app/src/pages/api/admin/4160/initUserSandbox.ts
@@ -23,15 +23,13 @@ const InitUserSandboxResponseSchema = z.object({
     orphanDeletedCount: z.number().int().nonnegative(),
     orphanFailedCount: z.number().int().nonnegative(),
     sandboxPendingCount: z.number().int().nonnegative(),
-    scannedSkillCount: z.number().int().nonnegative(),
     legacyDebugChatCleanup: z.object({
       conflictAppSkillCount: z.number().int().nonnegative(),
-      cleanupSkillCount: z.number().int().nonnegative(),
+      matchedSkillCount: z.number().int().nonnegative(),
       totalLegacyChats: z.number().int().nonnegative(),
       totalChatItems: z.number().int().nonnegative(),
       totalChatItemResponses: z.number().int().nonnegative(),
-      deletedSkillCount: z.number().int().nonnegative(),
-      skippedEmptyCount: z.number().int().nonnegative(),
+      cleanedSkillCount: z.number().int().nonnegative(),
       pendingChatCount: z.number().int().nonnegative(),
       list: z.array(
         z.object({
@@ -39,7 +37,7 @@ const InitUserSandboxResponseSchema = z.object({
           chatCount: z.number().int().nonnegative(),
           chatItemCount: z.number().int().nonnegative(),
           chatItemResponseCount: z.number().int().nonnegative(),
-          deleted: z.boolean()
+          status: z.enum(['pending', 'deleted'])
         })
       )
     }),

--- a/projects/app/src/pages/api/core/ai/skill/runtime/getStatus.ts
+++ b/projects/app/src/pages/api/core/ai/skill/runtime/getStatus.ts
@@ -25,7 +25,7 @@ async function handler(
     return Promise.reject(SkillErrEnum.invalidSkillId);
   }
 
-  const { teamId, tmbId, skill } = await authSkill({
+  const { teamId, skill } = await authSkill({
     req,
     authToken: true,
     authApiKey: true,
@@ -39,8 +39,7 @@ async function handler(
 
   const context = await getSkillEditRuntimeContext({
     skillId,
-    teamId,
-    tmbId
+    teamId
   });
   const status = await getSkillEditRuntimeStatus({ context });
 

--- a/projects/app/src/pages/api/core/ai/skill/runtime/init.ts
+++ b/projects/app/src/pages/api/core/ai/skill/runtime/init.ts
@@ -49,7 +49,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return;
     }
 
-    const { teamId, tmbId, skill } = await authSkill({
+    const { teamId, skill } = await authSkill({
       req,
       authToken: true,
       authApiKey: true,
@@ -73,8 +73,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const context = await getSkillEditRuntimeContext({
       skillId,
-      teamId,
-      tmbId
+      teamId
     });
     const status = await getSkillEditRuntimeStatus({ context });
 

--- a/projects/app/src/pages/api/core/ai/skill/runtime/upgrade.ts
+++ b/projects/app/src/pages/api/core/ai/skill/runtime/upgrade.ts
@@ -25,7 +25,7 @@ async function handler(
     return Promise.reject(SkillErrEnum.invalidSkillId);
   }
 
-  const { teamId, tmbId, skill } = await authSkill({
+  const { teamId, skill } = await authSkill({
     req,
     authToken: true,
     authApiKey: true,
@@ -39,8 +39,7 @@ async function handler(
 
   const context = await getSkillEditRuntimeContext({
     skillId,
-    teamId,
-    tmbId
+    teamId
   });
   const status = await triggerSkillEditRuntimeUpgrade({ context });
 

--- a/projects/app/test/api/core/ai/skill/debugChat.test.ts
+++ b/projects/app/test/api/core/ai/skill/debugChat.test.ts
@@ -424,11 +424,8 @@ describe('debugChat handler — parameter validation', () => {
       sourceId: skillId,
       userId: ChatSourceTypeEnum.skillEdit,
       status: 'running',
-      metadata: {
-        teamId: testUser.teamId,
-        tmbId: testUser.tmbId,
-        image: { repository: 'test-image', tag: 'latest' }
-      }
+      teamId: testUser.teamId,
+      image: { repository: 'test-image', tag: 'latest' }
     });
 
     await Call(debugChatApi.default, {
@@ -470,11 +467,8 @@ describe('debugChat handler — parameter validation', () => {
       sourceId: skillId,
       userId: ChatSourceTypeEnum.skillEdit,
       status: 'running',
-      metadata: {
-        teamId: testUser.teamId,
-        tmbId: testUser.tmbId,
-        image: { repository: 'test-image', tag: 'latest' }
-      }
+      teamId: testUser.teamId,
+      image: { repository: 'test-image', tag: 'latest' }
     });
 
     await Call(debugChatApi.default, {
@@ -508,11 +502,8 @@ describe('debugChat handler — parameter validation', () => {
       sourceId: skillId,
       userId: ChatSourceTypeEnum.skillEdit,
       status: 'running',
-      metadata: {
-        teamId: testUser.teamId,
-        tmbId: testUser.tmbId,
-        image: { repository: 'test-image', tag: 'latest' }
-      }
+      teamId: testUser.teamId,
+      image: { repository: 'test-image', tag: 'latest' }
     });
 
     await Call(debugChatApi.default, {

--- a/projects/app/test/pages/api/admin/4160/initUserSandbox.test.ts
+++ b/projects/app/test/pages/api/admin/4160/initUserSandbox.test.ts
@@ -36,15 +36,13 @@ describe('initUserSandbox API', () => {
         orphanDeletedCount: 0,
         orphanFailedCount: 0,
         sandboxPendingCount: 0,
-        scannedSkillCount: 0,
         legacyDebugChatCleanup: {
           conflictAppSkillCount: 0,
-          cleanupSkillCount: 0,
+          matchedSkillCount: 0,
           totalLegacyChats: 0,
           totalChatItems: 0,
           totalChatItemResponses: 0,
-          deletedSkillCount: 0,
-          skippedEmptyCount: 0,
+          cleanedSkillCount: 0,
           pendingChatCount: 0,
           list: []
         },

--- a/sdk/sandbox-adapter/src/adapters/sealos-devbox/adapter.ts
+++ b/sdk/sandbox-adapter/src/adapters/sealos-devbox/adapter.ts
@@ -52,7 +52,14 @@ export type SealosDevboxConfig = {
 /** Creation fields implemented by the Sealos Devbox API adapter. */
 export type SealosDevboxCreateConfig = Pick<
   SandboxCreateSpec,
-  'image' | 'env' | 'labels' | 'lifecycle' | 'kubeAccess' | 'workingDir' | 'upstreamID'
+  | 'image'
+  | 'env'
+  | 'labels'
+  | 'lifecycle'
+  | 'kubeAccess'
+  | 'workingDir'
+  | 'upstreamID'
+  | 'resourceLimits'
 >;
 
 export class SealosDevboxAdapter extends BaseSandboxAdapter {
@@ -116,9 +123,36 @@ export class SealosDevboxAdapter extends BaseSandboxAdapter {
       env.CODEX_GATEWAY_CWD = spec.workingDir;
     }
 
+    const resourceLimits = spec.resourceLimits;
+    const assertPositiveResource = (value: number, name: string): void => {
+      if (!Number.isFinite(value) || value <= 0) {
+        throw new RangeError(`Devbox ${name} resource limit must be greater than 0`);
+      }
+    };
+
+    if (resourceLimits?.cpuCount !== undefined) {
+      assertPositiveResource(resourceLimits.cpuCount, 'cpu');
+    }
+    if (resourceLimits?.memoryMiB !== undefined) {
+      assertPositiveResource(resourceLimits.memoryMiB, 'memory');
+    }
+    if (resourceLimits?.diskGiB !== undefined) {
+      assertPositiveResource(resourceLimits.diskGiB, 'storage');
+      if (resourceLimits.diskGiB > 20) {
+        throw new RangeError('Devbox storage resource limit must not exceed 20G');
+      }
+    }
+
     return {
       name: this._id,
       image: spec.image?.repository ? formatImageSpec(spec.image) : undefined,
+      ...(resourceLimits?.cpuCount === undefined ? {} : { cpu: String(resourceLimits.cpuCount) }),
+      ...(resourceLimits?.memoryMiB === undefined
+        ? {}
+        : { memory: `${resourceLimits.memoryMiB}Mi` }),
+      ...(resourceLimits?.diskGiB === undefined
+        ? {}
+        : { storageLimit: `${resourceLimits.diskGiB}Gi` }),
       env: Object.keys(env).length > 0 ? env : undefined,
       labels: spec.labels,
       upstreamID: spec.upstreamID,

--- a/sdk/sandbox-adapter/src/adapters/sealos-devbox/types.ts
+++ b/sdk/sandbox-adapter/src/adapters/sealos-devbox/types.ts
@@ -64,6 +64,12 @@ export type DevboxMutationData = {
 export type DevboxCreateRequest = {
   name: string;
   image?: string;
+  /** Kubernetes CPU resource quantity, for example `2000m` or `2`. */
+  cpu?: string;
+  /** Kubernetes memory resource quantity, for example `4096Mi` or `4Gi`. */
+  memory?: string;
+  /** Kubernetes storage resource quantity. Devbox accepts at most `20G`. */
+  storageLimit?: string;
   env?: Record<string, string>;
   labels?: Array<{ key: string; value: string }>;
   upstreamID?: string;

--- a/sdk/sandbox-adapter/tests/unit/adapters/sealos-devbox/adapter.test.ts
+++ b/sdk/sandbox-adapter/tests/unit/adapters/sealos-devbox/adapter.test.ts
@@ -21,6 +21,67 @@ describe('SealosDevboxAdapter', () => {
     expect(adapter.rootPath).toBe('/workspace');
   });
 
+  it('maps resource limits to Kubernetes quantities when creating a devbox', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      if (String(input).endsWith('/api/v1/devbox/sandbox-1')) {
+        return jsonResponse({
+          code: 200,
+          message: 'running',
+          data: {
+            name: 'sandbox-1',
+            image: 'registry.example.com/devbox/runtime:custom-v2',
+            state: { phase: 'Running' },
+            ssh: {}
+          }
+        });
+      }
+      return jsonResponse({ code: 201, message: 'created', data: { name: 'sandbox-1' } });
+    });
+    const adapter = new SealosDevboxAdapter(CONFIG, {
+      image: { repository: 'registry.example.com/devbox/runtime', tag: 'custom-v2' },
+      resourceLimits: { cpuCount: 2, memoryMiB: 4096, diskGiB: 10 },
+      upstreamID: 'session-123'
+    });
+
+    await adapter.create();
+
+    const request = JSON.parse(String((fetchMock.mock.calls[0]?.[1] as RequestInit).body));
+    expect(request).toMatchObject({
+      name: 'sandbox-1',
+      image: 'registry.example.com/devbox/runtime:custom-v2',
+      cpu: '2',
+      memory: '4096Mi',
+      storageLimit: '10Gi',
+      upstreamID: 'session-123'
+    });
+  });
+
+  it('leaves resource quantities unset so Devbox server defaults apply', () => {
+    const adapter = new SealosDevboxAdapter(CONFIG);
+    const request = (
+      adapter as unknown as { buildCreateRequest: () => Record<string, unknown> }
+    ).buildCreateRequest();
+
+    expect(request).not.toHaveProperty('cpu');
+    expect(request).not.toHaveProperty('memory');
+    expect(request).not.toHaveProperty('storageLimit');
+  });
+
+  it.each([
+    ['cpuCount', { cpuCount: 0 }],
+    ['cpuCount', { cpuCount: Number.NaN }],
+    ['memoryMiB', { memoryMiB: -1 }],
+    ['diskGiB', { diskGiB: 21 }]
+  ])('rejects invalid %s resource limits', (_name, resourceLimits) => {
+    const adapter = new SealosDevboxAdapter(CONFIG, { resourceLimits });
+
+    expect(() =>
+      (
+        adapter as unknown as { buildCreateRequest: () => Record<string, unknown> }
+      ).buildCreateRequest()
+    ).toThrow('Devbox');
+  });
+
   it('maps stop to the reversible pause endpoint', async () => {
     const fetchMock = vi
       .spyOn(globalThis, 'fetch')


### PR DESCRIPTION
## What changed

- move v2 Sandbox lifecycle and stable fields from `metadata` to root fields
- validate Legacy records with the permissive Legacy schema and map only supported fields into v2
- align legacy Skill debug-chat cleanup reporting and migration regression coverage
- pass CPU, memory, and disk limits through to Sealos Devbox creation

## Tests

- service Sandbox migration/schema/provider tests: 57 passed
- app migration API and Skill debug-chat tests: 26 passed
- sandbox-adapter Sealos Devbox tests: 11 passed

Only targeted tests were run.