### PR TITLE
feat: add AGENT_SANDBOX_OPENSANDBOX_DISABLE_NETWORK_POLICY env var

### DIFF
--- a/packages/service/core/ai/sandbox/infrastructure/provider/runtimeProfile/opensandbox.ts
+++ b/packages/service/core/ai/sandbox/infrastructure/provider/runtimeProfile/opensandbox.ts
@@ -65,7 +65,8 @@ export function buildOpenSandboxRuntimeProfile(): SandboxRuntimeProfile {
       // Docker 模式下默认拒绝常见宿主机别名；公网默认保持放行，私网 CIDR 需依赖部署网络边界。
       const networkPolicy =
         createConfig.networkPolicy ??
-        (serviceEnv.AGENT_SANDBOX_OPENSANDBOX_RUNTIME === 'docker'
+        (!serviceEnv.AGENT_SANDBOX_OPENSANDBOX_DISABLE_NETWORK_POLICY &&
+        serviceEnv.AGENT_SANDBOX_OPENSANDBOX_RUNTIME === 'docker'
           ? OPEN_SANDBOX_DOCKER_LOCAL_NETWORK_POLICY
           : undefined);
 

--- a/packages/service/env.ts
+++ b/packages/service/env.ts
@@ -88,6 +88,12 @@ export const serviceEnv = createEnv({
     AGENT_SANDBOX_OPENSANDBOX_USE_SERVER_PROXY: BoolSchema.default(true),
     AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_URL: UrlSchema.optional(),
     AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_TOKEN: z.string().optional(),
+    AGENT_SANDBOX_OPENSANDBOX_DISABLE_NETWORK_POLICY: BoolSchema.default(false).meta({
+      description:
+        'Disable the default outbound network policy for OpenSandbox Docker runtime. ' +
+        'Set to true when the OpenSandbox server uses a user-defined Docker network (not bridge), ' +
+        'as networkPolicy is only supported with network_mode=bridge.'
+    }),
     AGENT_SANDBOX_DISK_MB: NumSchema.min(1).default(1024).meta({
       description:
         'Agent sandbox 磁盘大小基准（MB）。冷归档包上限等于该值，Skill 包和 IDE 单文件上限按该值的一半四舍五入计算。'


### PR DESCRIPTION
Add `AGENT_SANDBOX_OPENSANDBOX_DISABLE_NETWORK_POLICY` env var to optionally disable the default outbound network policy for OpenSandbox Docker runtime.

When the OpenSandbox server uses a user-defined Docker network (not bridge), `networkPolicy` is not supported. See opensandbox-group/OpenSandbox#467 for context.