### PR TITLE
fix(workflow): preserve tool node input configuration

### DIFF
--- a/packages/service/test/core/app/tool/utils/client.test.ts
+++ b/packages/service/test/core/app/tool/utils/client.test.ts
@@ -240,4 +240,35 @@ describe('getClientToolPreviewNode', () => {
     });
     expect(getToolConfigStatus({ tool: result }).status).not.toBe('waitingForConfig');
   });
+
+  it('defaults an ordinary workflow user question to Agent generation', async () => {
+    const appId = '507f1f77bcf86cd799439021';
+    mocks.findById.mockReturnValueOnce({
+      lean: vi.fn().mockResolvedValue({
+        _id: appId,
+        teamId: '507f1f77bcf86cd799439022',
+        type: AppTypeEnum.workflow,
+        name: 'Workflow',
+        avatar: 'workflow.svg',
+        intro: ''
+      })
+    });
+    mocks.getAppVersionById.mockResolvedValueOnce({
+      nodes: [],
+      edges: [],
+      chatConfig: {},
+      versionId: 'version-id',
+      versionName: 'Version 1'
+    });
+
+    const result = await getClientToolPreviewNode({ appId, versionId: '' });
+
+    expect(result.flowNodeType).toBe('appModule');
+    expect(result.inputs.find((item) => item.key === 'userChatInput')).toMatchObject({
+      selectedType: 'agentGenerated',
+      renderTypeList: ['agentGenerated', 'reference', 'textarea'],
+      isToolParam: true
+    });
+    expect(getToolConfigStatus({ tool: result }).status).not.toBe('waitingForConfig');
+  });
 });

--- a/projects/app/src/pageComponents/app/detail/Edit/component/ConfigToolModal.tsx
+++ b/projects/app/src/pageComponents/app/detail/Edit/component/ConfigToolModal.tsx
@@ -350,7 +350,7 @@ const ToolHeaderCard = ({
             <Avatar src={tool.avatar} w={'24px'} h={'24px'} borderRadius={'sm'} />
             <Flex alignItems={'center'} gap={2} minW={0}>
               <Box
-                color={'myGray.500'}
+                color={'myGray.900'}
                 fontSize={'14px'}
                 lineHeight={'20px'}
                 className="textEllipsis"

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/components/NodeTemplates/list.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/components/NodeTemplates/list.tsx
@@ -292,6 +292,8 @@ const NodeTemplateList = ({
         })();
 
         const currentNode = getNodeById(handleParams?.nodeId);
+        // 工具选择器保留历史可选项；未声明 isTool 的节点按普通节点初始化输入类型。
+        const isToolMode = isToolSelector && templateNode.isTool === true;
 
         // Popover insertion inherits the source node's parent; a dragged
         // loopRunBreak with no inherited parent falls back to hit-testing.
@@ -378,9 +380,9 @@ const NodeTemplateList = ({
             intro: t(templateNode.intro as any),
             inputs: inputsWithAutoFill.map((input) =>
               normalizeFlowNodeInputType(input, {
-                isTool: isToolSelector,
+                isTool: isToolMode,
                 // 插件预览中的 selectedType 是定义侧控件，不代表画布上的最终选择。
-                forceDefaultMode: isToolSelector
+                forceDefaultMode: isToolMode
               })
             ),
             outputs: templateNode.outputs

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeCode/index.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeCode/index.tsx
@@ -200,7 +200,6 @@ const NodeCode = ({ data, selected }: NodeProps<FlowNodeItemType>) => {
           nodeId={nodeId}
           flowInputList={commonInputs}
           CustomComponent={CustomComponent}
-          isTool={isTool}
         />
       </Container>
       <Container>

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeExtract/index.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeExtract/index.tsx
@@ -173,7 +173,6 @@ const NodeExtract = ({ data, selected }: NodeProps<FlowNodeItemType>) => {
           nodeId={nodeId}
           flowInputList={commonInputs}
           CustomComponent={CustomComponent}
-          isTool={isTool}
         />
       </Container>
       <Container>

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeHttp/index.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeHttp/index.tsx
@@ -850,7 +850,6 @@ const NodeHttp = ({ data, selected }: NodeProps<FlowNodeItemType>) => {
           nodeId={nodeId}
           flowInputList={commonInputs}
           CustomComponent={CustomComponents}
-          isTool={isTool}
         />
       </Container>
       <Container>

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeSimple.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeSimple.tsx
@@ -12,6 +12,7 @@ import { useContextSelector } from 'use-context-selector';
 import CatchError from './render/RenderOutput/CatchError';
 import { useMemoEnhance } from '@fastgpt/web/hooks/useMemoEnhance';
 import { WorkflowUtilsContext } from '../../context/workflowUtilsContext';
+import { AppNodeFlowNodeTypeMap } from '@fastgpt/global/core/workflow/node/constant';
 
 const NodeSimple = ({
   data,
@@ -30,6 +31,8 @@ const NodeSimple = ({
     () => splitOutput(outputs),
     [splitOutput, outputs]
   );
+  // 内置节点作为 ToolCall 工具时，保留模型、知识库等节点本地运行配置。
+  const shouldFilterToolParams = isTool && !!AppNodeFlowNodeTypeMap[data.flowNodeType];
 
   const Render = useMemo(() => {
     return (
@@ -45,7 +48,11 @@ const NodeSimple = ({
           <>
             <Container>
               <IOTitle text={t('common:Input')} nodeId={nodeId} inputs={inputs} />
-              <RenderInput nodeId={nodeId} flowInputList={commonInputs} isTool={isTool} />
+              <RenderInput
+                nodeId={nodeId}
+                flowInputList={commonInputs}
+                isTool={shouldFilterToolParams}
+              />
             </Container>
           </>
         )}
@@ -66,6 +73,7 @@ const NodeSimple = ({
     selected,
     data,
     isTool,
+    shouldFilterToolParams,
     nodeId,
     inputs,
     commonInputs,


### PR DESCRIPTION
## Changes
- keep local model, dataset, and node-specific configuration available for built-in nodes attached as ToolCall tools
- initialize non-tool nodes selected from the tool selector with their normal input mode
- align the Agent tool configuration modal tool-name color with myGray.900
- add coverage for tool input default-mode compatibility

## Verification
- pnpm --dir projects/app typecheck
- pnpm --dir projects/app test test/web/core/app/workflow/utils.test.ts
- pnpm exec prettier --check ...
- git diff --check