### PR TITLE
fix(workflow): restore tool parameter label

### DIFF
--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/render/RenderToolInput/index.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/render/RenderToolInput/index.tsx
@@ -52,7 +52,7 @@ const RenderToolInput = ({
   return (
     <>
       <HStack mb={2} justifyContent={'space-between'}>
-        <IOTitle text={t('common:Input')} mb={0} />
+        <IOTitle text={t('workflow:tool_input')} mb={0} />
         <Button
           variant={'whiteBase'}
           leftIcon={<SmallAddIcon />}


### PR DESCRIPTION
## Changes
- restore the dynamic tool-input section title to Tool Parameters
- keep the normal node-input section title unchanged

## Verification
- pnpm exec prettier --check projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/render/RenderToolInput/index.tsx
- git diff --check

Note: pnpm --dir projects/app typecheck is currently blocked by existing ResourceLimits.storageSize errors in sandbox service files outside this change.