### PR TITLE
fix(chat): stop repeated collection quote requests

### DIFF
--- a/packages/web/hooks/useLinkedScroll.tsx
+++ b/packages/web/hooks/useLinkedScroll.tsx
@@ -8,6 +8,10 @@ import { useRequest } from './useRequest';
 
 const threshold = 200;
 
+/**
+ * 加载以锚点为中心的关联列表，并按滚动位置补充前后数据。
+ * 关闭分页时仍保留滚动容器和初始锚点请求，适用于只展示单条数据的场景。
+ */
 export function useLinkedScroll<
   TParams extends LinkedPaginationProps,
   TData extends LinkedListResponse
@@ -18,12 +22,14 @@ export function useLinkedScroll<
     params = {},
     currentData,
     defaultScroll = 'top',
+    enablePagination = true,
     showErrorToast = true
   }: {
     pageSize?: number;
     params?: Record<string, any>;
     currentData?: { id: string; anchor?: any };
     defaultScroll?: 'top' | 'bottom';
+    enablePagination?: boolean;
     showErrorToast?: boolean;
   }
 ) {
@@ -246,7 +252,7 @@ export function useLinkedScroll<
 
       useDebounceEffect(
         () => {
-          if (!actualContainerRef?.current || isLoading) return;
+          if (!enablePagination || !actualContainerRef?.current || isLoading) return;
 
           const { scrollTop, scrollHeight, clientHeight } = actualContainerRef.current;
 
@@ -260,7 +266,7 @@ export function useLinkedScroll<
             loadPrevData(actualContainerRef);
           }
         },
-        [scroll],
+        [scroll, enablePagination],
         { wait: 200 }
       );
 
@@ -280,7 +286,7 @@ export function useLinkedScroll<
         </MyBox>
       );
     },
-    [isLoading]
+    [enablePagination, isLoading]
   );
 
   return {

--- a/projects/app/src/pageComponents/chat/ChatQuoteList/CollectionQuoteReader.tsx
+++ b/projects/app/src/pageComponents/chat/ChatQuoteList/CollectionQuoteReader.tsx
@@ -111,7 +111,8 @@ const CollectionReader = ({
     loadInitData
   } = useLinkedScroll(getCollectionQuote, {
     params,
-    currentData: currentQuoteItem
+    currentData: currentQuoteItem,
+    enablePagination: !singleQuote
   });
 
   const isDeleted = useMemo(


### PR DESCRIPTION
修复移动端内联引用进入单条分块详情后，因隐藏相邻分块导致滚动分页监听持续触发 `getCollectionQuote` 请求的问题。

- 单条引用仍保留初始锚点请求
- 单条模式关闭上下分页加载
- 普通引用详情继续支持滚动分页

验证：
- `pnpm --filter @fastgpt/app typecheck`
- `pnpm exec eslint packages/web/hooks/useLinkedScroll.tsx projects/app/src/pageComponents/chat/ChatQuoteList/CollectionQuoteReader.tsx`
- `pnpm --filter @fastgpt/app test`（183 files / 1408 tests）