### PR TITLE
fix(sandbox): read binary files as bytes to prevent corruption

### DIFF
--- a/sdk/sandbox-adapter/src/adapters/E2BAdapter/index.ts
+++ b/sdk/sandbox-adapter/src/adapters/E2BAdapter/index.ts
@@ -245,7 +245,11 @@ export class E2BAdapter extends BaseSandboxAdapter {
 
       for (const path of paths.map((p) => this.normalizePath(p))) {
         try {
-          const content = await sandbox.files.read(path);
+          // Explicitly read as bytes — E2B SDK defaults to 'text' format,
+          // which corrupts binary files (zip, images, etc.) by transcoding
+          // through UTF-8 text. This causes "Corrupted zip: missing N bytes"
+          // errors when reading skill packages or other binary artifacts.
+          const content = await sandbox.files.read(path, { format: 'bytes' });
           results.push({
             path,
             content: Buffer.from(content),


### PR DESCRIPTION
## Problem
E2B SDK's \`files.read()\` defaults to \`format: 'text'\`, which transcodes binary content through UTF-8. This corrupts binary files (zip packages, images, etc.), causing errors like "Corrupted zip: missing N bytes" when reading skill packages.

## Fix
Explicitly pass \`{ format: 'bytes' }\` to \`sandbox.files.read()\` so binary content is returned as raw bytes without transcoding.

## Testing
Verified that skill packages (zip) can be read correctly without corruption after this fix.