### PR TITLE
feat(sandbox): align E2B provider with OpenSandbox/SealosDevbox patterns

### DIFF
--- a/packages/service/core/ai/sandbox/infrastructure/provider/adapter.ts
+++ b/packages/service/core/ai/sandbox/infrastructure/provider/adapter.ts
@@ -61,7 +61,9 @@ export function buildSandboxAdapter(
       }
       return createSandbox('e2b', {
         apiKey: providerConfig.apiKey,
-        sandboxId: props.sandboxId
+        sandboxId: props.sandboxId,
+        metadata: props.createConfig?.metadata as Record<string, string> | undefined,
+        envs: props.createConfig?.env as Record<string, string> | undefined
       });
 
     default:

--- a/packages/service/core/ai/sandbox/infrastructure/provider/config.ts
+++ b/packages/service/core/ai/sandbox/infrastructure/provider/config.ts
@@ -191,7 +191,9 @@ export function getSandboxAdapterConfig({
         providerConfig,
         createConfig: runtime
           ? profile.buildConfig({
-              createConfig
+              createConfig,
+              sessionId,
+              env: { ...createConfig?.env, ...baseEnv }
             })
           : undefined
       };

--- a/packages/service/core/ai/sandbox/infrastructure/provider/runtimeProfile/e2b.ts
+++ b/packages/service/core/ai/sandbox/infrastructure/provider/runtimeProfile/e2b.ts
@@ -5,8 +5,11 @@
  */
 import type { SandboxRuntimeProfile } from './types';
 import { getSandboxSkillsRootPath, mergeStringRecord, mergeUnknownRecord } from './utils';
+import { E2B_DEFAULT_ROOT_PATH } from '@fastgpt-sdk/sandbox-adapter';
 
-const E2B_DEFAULT_WORK_DIRECTORY = '/home/user';
+// Align with OpenSandbox: /workspace is the persistent working directory,
+// separate from HOME (/home/user) where dotfiles and credentials live.
+const E2B_DEFAULT_WORK_DIRECTORY = E2B_DEFAULT_ROOT_PATH;
 
 /**
  * 构建 E2B 的 FastGPT 运行态 profile。

--- a/sdk/sandbox-adapter/src/adapters/E2BAdapter/index.ts
+++ b/sdk/sandbox-adapter/src/adapters/E2BAdapter/index.ts
@@ -3,6 +3,7 @@ import { BaseSandboxAdapter } from '../BaseSandboxAdapter';
 import { CommandPolyfillService } from '@/polyfill/CommandPolyfillService';
 import { CommandExecutionError, ConnectionError } from '@/errors';
 import { fileDataToUint8Array, uint8ArrayToCleanArrayBuffer } from '@/utils/files';
+import { E2B_DEFAULT_ROOT_PATH } from '@/constants';
 import type {
   ExecuteOptions,
   ExecuteResult,
@@ -13,7 +14,8 @@ import type {
   FileDeleteResult,
   FileReadResult,
   MoveEntry,
-  DirectoryEntry
+  DirectoryEntry,
+  Endpoint
 } from '@/types';
 import type { E2BConfig } from './type';
 
@@ -26,7 +28,10 @@ export class E2BAdapter extends BaseSandboxAdapter {
   readonly provider = 'e2b' as const;
 
   get rootPath(): string {
-    return '/home/user';
+    // Align with OpenSandbox: use /workspace as the working directory so that
+    // command execution and file operations default to the persistent volume
+    // mount point instead of HOME (/home/user).
+    return E2B_DEFAULT_ROOT_PATH;
   }
 
   private sandbox: Sandbox | null = null;
@@ -61,11 +66,23 @@ export class E2BAdapter extends BaseSandboxAdapter {
       const sandboxes = await paginator.nextItems();
       if (sandboxes.length > 0) {
         const sandboxInfo = sandboxes[0];
-        // 连接到找到的沙盒
-        const sandbox = await Sandbox.connect(sandboxInfo.sandboxId, {
-          apiKey: this.config.apiKey
-        });
-        return sandbox;
+        // The sandbox record exists in the control plane, but the actual
+        // instance may have been reclaimed by the platform. If connect fails,
+        // return null so that ensureRunning() falls through to create a new
+        // sandbox instead of throwing and getting stuck.
+        try {
+          const sandbox = await Sandbox.connect(sandboxInfo.sandboxId, {
+            apiKey: this.config.apiKey
+          });
+          return sandbox;
+        } catch (connectError: any) {
+          console.warn(
+            '[E2BAdapter] Found sandbox record but connect failed (may have been reclaimed), will create new:',
+            sandboxInfo.sandboxId,
+            connectError?.message || connectError
+          );
+          return null;
+        }
       }
 
       return null;
@@ -202,6 +219,34 @@ export class E2BAdapter extends BaseSandboxAdapter {
     }
   }
 
+  // ==================== Endpoint ====================
+
+  async getEndpoint(port: number): Promise<Endpoint> {
+    await this.ensureSandbox();
+
+    const domain = process.env.E2B_DOMAIN || '';
+    if (!domain) {
+      throw new Error('Cannot resolve E2B endpoint: E2B_DOMAIN env not set');
+    }
+
+    const sandboxId = this.sandbox?.sandboxId || '';
+    if (!sandboxId) {
+      throw new Error('Cannot resolve E2B endpoint: sandbox not connected');
+    }
+
+    // E2B port forwarding URL pattern: {port}-{sandboxId}.{domain}
+    const host = `${port}-${sandboxId}.${domain}`;
+    const protocol = 'https';
+    const url = `${protocol}://${host}`;
+
+    return {
+      host,
+      port,
+      protocol: protocol as 'http' | 'https',
+      url
+    };
+  }
+
   // ==================== 命令执行 ====================
 
   async execute(command: string, options?: ExecuteOptions): Promise<ExecuteResult> {
@@ -245,7 +290,11 @@ export class E2BAdapter extends BaseSandboxAdapter {
 
       for (const path of paths.map((p) => this.normalizePath(p))) {
         try {
-          const content = await sandbox.files.read(path);
+          // Explicitly read as bytes — E2B SDK defaults to 'text' format,
+          // which corrupts binary files (zip, images, etc.) by transcoding
+          // through UTF-8 text. This causes "Corrupted zip: missing N bytes"
+          // errors when reading skill packages or other binary artifacts.
+          const content = await sandbox.files.read(path, { format: 'bytes' });
           results.push({
             path,
             content: Buffer.from(content),

--- a/sdk/sandbox-adapter/src/constants.ts
+++ b/sdk/sandbox-adapter/src/constants.ts
@@ -1,1 +1,6 @@
 export const OPEN_SANDBOX_DEFAULT_ROOT_PATH = '/workspace';
+
+// Align E2B with OpenSandbox: separate the working directory (/workspace)
+// from HOME (/home/user), so that persistent volumes (OSS mounts, NAS, etc.)
+// can be attached to /workspace while dotfiles and credentials stay local.
+export const E2B_DEFAULT_ROOT_PATH = '/workspace';


### PR DESCRIPTION
## Background
The E2B provider diverges from OpenSandbox and SealosDevbox in several ways. This PR aligns them so that E2B can be used as a drop-in replacement with the same feature set.

## Changes

### 1. Working directory: /home/user → /workspace
Align with OpenSandbox, where the working directory (/workspace, the persistent volume mount point) is separate from HOME (/home/user, where dotfiles and credentials live). The OpenSandboxAdapter defines the same rootPath as /workspace.

### 2. Pass metadata and envs to createSandbox
OpenSandbox and SealosDevbox both forward the full createConfig (including metadata and env) to their adapters. E2B was the only provider that dropped them. This PR passes metadata and envs through, for two purposes:
- **Consistency**: all providers now receive the same data
- **Downstream gateway integration**: a gateway sitting between FastGPT and the E2B API (e.g., for metadata injection) can use the metadata to identify the sandbox and apply platform-specific patches (OSS mounts, VPC config, etc.)

### 3. findSandbox: tolerate connect failures
Align with OpenSandboxAdapter, which also returns null (instead of throwing) when a sandbox record exists in the control plane but the actual instance has been reclaimed. This lets ensureRunning() fall through to create a new sandbox.

### 4. Implement getEndpoint()
Support IDE Agent endpoint resolution via the E2B port forwarding URL pattern ({port}-{sandboxId}.{domain}), using the E2B_DOMAIN env var.

### 5. Read binary files as bytes
E2B SDK's files.read() defaults to text format, which corrupts binary files. Explicitly pass { format: 'bytes' } to prevent transcoding issues.