### PR TITLE
fix(dataset): export index and metadata columns in exportAll

### DIFF
--- a/projects/app/src/pages/api/core/dataset/exportAll.ts
+++ b/projects/app/src/pages/api/core/dataset/exportAll.ts
@@ -10,6 +10,7 @@ import {
 } from '@fastgpt/service/support/user/utils';
 import { NextAPI } from '@/service/middleware/entry';
 import { WritePermissionVal } from '@fastgpt/global/support/permission/constant';
+import { Types } from '@fastgpt/service/common/mongo';
 import { readFromSecondary } from '@fastgpt/service/common/mongo/utils';
 import type { DatasetDataSchemaType } from '@fastgpt/global/core/dataset/type';
 import { sanitizeCsvField } from '@fastgpt/service/common/file/csv';
@@ -53,8 +54,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse<any>) {
   });
 
   const match = {
-    teamId,
-    datasetId: { $in: datasets.map((d) => d._id) }
+    teamId: new Types.ObjectId(teamId),
+    datasetId: { $in: datasets.map((d) => new Types.ObjectId(d._id)) }
   };
 
   const [exportSchema] = await MongoDatasetData.aggregate<ExportSchemaType>(


### PR DESCRIPTION
### bug
exportall 时不存在index和metadata列

### summary
The schema-detection aggregate in exportAll builds its $match from teamId (returned by authDataset as a string). find() casts the string to ObjectId, but aggregate() does not schema-cast $match values, so the aggregation matched zero documents. exportSchema became undefined, indexCount/hasMetadata fell back to 0/false, and the CSV header collapsed to q,a.

### validate
exportall 时存在index和metadata列