### PR TITLE
refactor: real pagination for app/dataset/skill list APIs

### DIFF
--- a/packages/global/common/error/code/common.ts
+++ b/packages/global/common/error/code/common.ts
@@ -11,7 +11,8 @@ export enum CommonErrEnum {
   missingParams = 'missingParams',
   inheritPermissionError = 'inheritPermissionError',
   folderDepthLimit = 'folderDepthLimit',
-  folderMoveDepthLimit = 'folderMoveDepthLimit'
+  folderMoveDepthLimit = 'folderMoveDepthLimit',
+  tooManyReadableResources = 'tooManyReadableResources'
 }
 const datasetErr = [
   {
@@ -46,6 +47,11 @@ const datasetErr = [
   {
     statusText: CommonErrEnum.folderMoveDepthLimit,
     message: i18nT('common:error.folderMoveDepthLimit')
+  },
+  {
+    statusText: CommonErrEnum.tooManyReadableResources,
+    message: i18nT('common:error.tooManyReadableResources'),
+    httpStatus: 400
   }
 ];
 export default datasetErr.reduce((acc, cur, index) => {

--- a/packages/global/openapi/core/ai/skill/api.ts
+++ b/packages/global/openapi/core/ai/skill/api.ts
@@ -13,6 +13,9 @@ import {
 } from '../../../../core/ai/skill/type';
 import { SkillPermissionSchema } from '../../../../support/permission/skill/controller.schema';
 import { ChatCompletionMessageParamSchema } from '../../../../core/ai/llm/type';
+import { ObjectIdSchema } from '../../../../common/type/mongo';
+import { PaginationResponseSchema } from '../../../api';
+import { ListV2PaginationSchema, v2PaginationMutualExclusion } from '../../../pagination';
 
 const IdSchema = z.string().min(1).meta({ description: '资源 ID' });
 const SandboxInstanceKeySchema = z.string().min(1).describe('FastGPT sandbox instance key');
@@ -56,6 +59,55 @@ export const ListSkillsResponseSchema = z.object({
   total: z.number()
 });
 export type ListSkillsResponse = z.infer<typeof ListSkillsResponseSchema>;
+
+/* ============================================================================
+ * API: 获取技能列表（分页版）
+ * Route: POST /api/core/ai/skill/listV2
+ * ============================================================================ */
+export const ListSkillsV2QuerySchema = ListV2PaginationSchema.extend({
+  source: z.enum(['store', 'mine']).optional().describe('技能来源: store=系统技能, mine=我的技能'),
+  searchKey: z.string().optional().describe('搜索关键词'),
+  category: AgentSkillCategorySchema.optional().describe('技能分类'),
+  type: AgentSkillTypeSchema.optional().describe('技能类型过滤'),
+  skillIds: z.array(IdSchema).optional().describe('按技能 ID 列表过滤，用于校验已关联技能状态'),
+  parentId: NullableParentIdSchema,
+  withAppCount: z.boolean().optional().describe('是否返回引用应用数量')
+}).superRefine(v2PaginationMutualExclusion);
+export type ListSkillsV2Query = z.infer<typeof ListSkillsV2QuerySchema>;
+
+/**
+ * v2 技能列表项。基为具体 ZodObject 的 AgentSkillListItemSchema 派生，
+ * 字段契约按运行时实际输出修正：
+ * - _id/parentId/tmbId 用 ObjectIdSchema 预处理（运行时为 Mongo ObjectId）并支持 nullish（system skill tmbId 可为 null）
+ * - createTime/updateTime 与运行时 Date 对齐（z.coerce.date()）
+ * - 补 tmbId/private（运行时实际返回）
+ * - sourceMember.status 可为 null（成员缺失时以占位返回）
+ */
+export const ListSkillsV2ItemSchema = AgentSkillListItemSchema.omit({
+  createTime: true,
+  updateTime: true
+}).extend({
+  source: AgentSkillSourceSchema,
+  type: AgentSkillTypeSchema,
+  createTime: z.coerce.date(),
+  updateTime: z.coerce.date(),
+  _id: ObjectIdSchema,
+  parentId: ObjectIdSchema.nullable().optional(),
+  tmbId: ObjectIdSchema.nullable().optional(),
+  private: z.boolean().optional().describe('是否仅自己可见'),
+  permission: SkillPermissionSchema,
+  sourceMember: z
+    .object({
+      name: z.string(),
+      avatar: z.string().nullable().optional(),
+      status: z.enum(TeamMemberStatusEnum).nullable()
+    })
+    .optional()
+});
+export type ListSkillsV2Item = z.infer<typeof ListSkillsV2ItemSchema>;
+
+export const ListSkillsV2ResponseSchema = PaginationResponseSchema(ListSkillsV2ItemSchema);
+export type ListSkillsV2Response = z.infer<typeof ListSkillsV2ResponseSchema>;
 
 export const CreateSkillBodySchema = z.object({
   parentId: NullableParentIdSchema,

--- a/packages/global/openapi/core/ai/skill/index.ts
+++ b/packages/global/openapi/core/ai/skill/index.ts
@@ -19,6 +19,8 @@ import {
   ListSkillVersionsResponseSchema,
   ListSkillsQuerySchema,
   ListSkillsResponseSchema,
+  ListSkillsV2QuerySchema,
+  ListSkillsV2ResponseSchema,
   SaveDeploySkillBodySchema,
   SaveDeploySkillResponseSchema,
   SkillDebugChatBodySchema,
@@ -51,6 +53,34 @@ export const SkillPath: OpenAPIPath = {
               schema: ListSkillsResponseSchema
             }
           }
+        }
+      }
+    }
+  },
+  '/core/ai/skill/listV2': {
+    post: {
+      summary: '获取技能列表（分页）',
+      description: '分页获取当前用户可读的系统技能或个人技能，返回 {list, total}',
+      tags: [DevApiTagsMap.aiSkill],
+      requestBody: {
+        content: {
+          'application/json': {
+            schema: ListSkillsV2QuerySchema
+          }
+        }
+      },
+      responses: {
+        200: {
+          description: '成功返回技能列表和总数',
+          content: {
+            'application/json': {
+              schema: ListSkillsV2ResponseSchema
+            }
+          }
+        },
+        403: {
+          description:
+            'Phase 1（owner-only gate）期间，非团队 owner 请求返回 403；Phase 2 全量开放后移除'
         }
       }
     }

--- a/packages/global/openapi/core/app/common/api.ts
+++ b/packages/global/openapi/core/app/common/api.ts
@@ -15,6 +15,9 @@ import { AppPermissionSchema } from '../../../../support/permission/app/controll
 import { SourceMemberSchema } from '../../../../support/user/type';
 import { OpenAPIStoreNodeItemTypeSchema } from '../../workflow/node';
 import { BoolSchema, NumSchema } from '../../../../common/zod';
+import { PaginationResponseSchema } from '../../../api';
+import { ListV2PaginationSchema, v2PaginationMutualExclusion } from '../../../pagination';
+import { TeamMemberStatusEnum } from '../../../../support/user/team/constant';
 import z from 'zod';
 
 const AppIdSchema = ObjectIdSchema.meta({
@@ -255,6 +258,64 @@ export const ListAppResponseSchema = z.array(AppListItemSchema).meta({
   description: '应用列表'
 });
 export type ListAppResponseType = z.infer<typeof ListAppResponseSchema>;
+
+/* ============================================================================
+ * API: 获取应用列表（分页版）
+ * Route: POST /api/core/app/listV2
+ * Method: POST
+ * Description: 分页获取当前团队下当前用户可读的应用或文件夹列表。
+ * Tags: ['基础管理']
+ * ============================================================================ */
+
+export const ListAppV2BodySchema = ListV2PaginationSchema.extend({
+  parentId: ParentIdSchema.optional().meta({
+    example: '68ad85a7463006c963799a05',
+    description: '父级应用/文件夹 ID，为空时查询根目录'
+  }),
+  type: z
+    .preprocess(
+      preprocessListAppType,
+      z.union([z.enum(AppTypeEnum), z.array(z.enum(AppTypeEnum))]).optional()
+    )
+    .optional()
+    .meta({
+      example: AppTypeEnum.workflow,
+      description: '应用类型筛选，支持单个类型或类型数组；空字符串按全部类型处理'
+    }),
+  searchKey: z.string().optional().meta({
+    example: '客服',
+    description: '应用名称或介绍搜索关键词'
+  })
+}).superRefine(v2PaginationMutualExclusion);
+export type ListAppV2BodyType = z.infer<typeof ListAppV2BodySchema>;
+
+/**
+ * v2 应用列表项。独立完整 object（不对被断言为通用 ZodType 的 AppListItemSchema 调 .extend()），
+ * 字段与旧 AppListItemSchema 逐一对应；仅 sourceMember.status 可为 null ——
+ * 成员缺失（已删除/离职）时以占位返回，不丢弃资源。
+ */
+export const ListAppV2ItemSchema = z.object({
+  _id: ObjectIdSchema.meta({ description: '应用 ID' }),
+  parentId: ParentIdSchema.meta({ description: '父级应用/文件夹 ID' }),
+  tmbId: ObjectIdSchema.meta({ description: '创建者团队成员 ID' }),
+  name: z.string().meta({ example: '客服应用', description: '应用名称' }),
+  avatar: z.string().meta({ description: '应用头像' }),
+  intro: z.string().meta({ description: '应用介绍' }),
+  type: z.enum(AppTypeEnum).meta({ example: AppTypeEnum.workflow, description: '应用类型' }),
+  updateTime: z.coerce.date().meta({ description: '更新时间' }),
+  pluginData: AppSchemaTypeSchema.shape.pluginData,
+  permission: AppPermissionSchema,
+  inheritPermission: BoolSchema.optional().meta({ description: '是否继承父级权限' }),
+  private: BoolSchema.optional().meta({ description: '是否仅自己可见' }),
+  hasInteractiveNode: BoolSchema.optional().meta({ description: '是否包含交互节点' }),
+  sourceMember: SourceMemberSchema.extend({
+    status: z.enum(TeamMemberStatusEnum).nullable()
+  }).meta({ description: '创建者信息，成员缺失时为占位（status 为 null）' })
+});
+export type ListAppV2ItemType = z.infer<typeof ListAppV2ItemSchema>;
+
+export const ListAppV2ResponseSchema = PaginationResponseSchema(ListAppV2ItemSchema);
+export type ListAppV2ResponseType = z.infer<typeof ListAppV2ResponseSchema>;
 
 /* ============================================================================
  * API: 获取应用详情

--- a/packages/global/openapi/core/app/common/index.ts
+++ b/packages/global/openapi/core/app/common/index.ts
@@ -13,6 +13,8 @@ import {
   GetAppDetailResponseSchema,
   ListAppBodySchema,
   ListAppResponseSchema,
+  ListAppV2BodySchema,
+  ListAppV2ResponseSchema,
   TransitionWorkflowBodySchema,
   TransitionWorkflowResponseSchema,
   UpdateAppBodySchema,
@@ -41,6 +43,34 @@ export const AppCommonPath: OpenAPIPath = {
               schema: ListAppResponseSchema
             }
           }
+        }
+      }
+    }
+  },
+  '/core/app/listV2': {
+    post: {
+      summary: '获取应用列表（分页）',
+      description: '分页获取当前团队下当前用户可读的应用或文件夹列表，返回 {list, total}',
+      tags: [DevApiTagsMap.appCommon],
+      requestBody: {
+        content: {
+          'application/json': {
+            schema: ListAppV2BodySchema
+          }
+        }
+      },
+      responses: {
+        200: {
+          description: '成功获取应用列表和总数',
+          content: {
+            'application/json': {
+              schema: ListAppV2ResponseSchema
+            }
+          }
+        },
+        403: {
+          description:
+            'Phase 1（owner-only gate）期间，非团队 owner 请求返回 403；Phase 2 全量开放后移除'
         }
       }
     }

--- a/packages/global/openapi/core/dataset/api.ts
+++ b/packages/global/openapi/core/dataset/api.ts
@@ -9,6 +9,10 @@ import {
   DatasetListItemSchema,
   SearchDataResponseItemSchema
 } from '../../../core/dataset/type';
+import { PaginationResponseSchema } from '../../api';
+import { ListV2PaginationSchema, v2PaginationMutualExclusion } from '../../pagination';
+import { SourceMemberSchema } from '../../../support/user/type';
+import { TeamMemberStatusEnum } from '../../../support/user/team/constant';
 
 /* ============================================================================
  * API: 创建知识库
@@ -196,6 +200,41 @@ export type GetDatasetListBody = z.infer<typeof GetDatasetListBodySchema>;
 // 出参复用 DatasetListItemSchema
 export const GetDatasetListResponseSchema = z.array(DatasetListItemSchema);
 export type GetDatasetListResponse = z.infer<typeof GetDatasetListResponseSchema>;
+
+/* ============================================================================
+ * API: 获取知识库列表（分页版）
+ * Route: POST /api/core/dataset/listV2
+ * ============================================================================ */
+export const ListDatasetV2BodySchema = ListV2PaginationSchema.extend({
+  parentId: ParentIdSchema.optional().meta({
+    example: '68ad85a7463006c963799a05',
+    description: '父级文件夹 ID,null 或不传表示根目录'
+  }),
+  type: z.enum(DatasetTypeEnum).optional().meta({
+    example: DatasetTypeEnum.dataset,
+    description: '知识库类型筛选（仅单值，与旧 schema 一致）'
+  }),
+  searchKey: z.string().optional().meta({
+    example: '产品文档',
+    description: '搜索关键词,按名称和简介模糊匹配'
+  })
+}).superRefine(v2PaginationMutualExclusion);
+export type ListDatasetV2Body = z.infer<typeof ListDatasetV2BodySchema>;
+
+/**
+ * v2 知识库列表项。基为具体 ZodObject 的 DatasetListItemSchema 派生，
+ * 仅 sourceMember.status 可为 null —— 成员缺失（已删除/离职）时以占位返回，不丢弃资源。
+ * 注意：DatasetListItemSchema 不含 parentId（旧 route 也不返回），v2 不得新增该响应字段。
+ */
+export const ListDatasetV2ItemSchema = DatasetListItemSchema.extend({
+  sourceMember: SourceMemberSchema.extend({
+    status: z.enum(TeamMemberStatusEnum).nullable()
+  })
+});
+export type ListDatasetV2Item = z.infer<typeof ListDatasetV2ItemSchema>;
+
+export const ListDatasetV2ResponseSchema = PaginationResponseSchema(ListDatasetV2ItemSchema);
+export type ListDatasetV2Response = z.infer<typeof ListDatasetV2ResponseSchema>;
 
 /* ============================================================================
  * API: 获取知识库路径

--- a/packages/global/openapi/core/dataset/index.ts
+++ b/packages/global/openapi/core/dataset/index.ts
@@ -18,7 +18,9 @@ import {
   CreateDatasetFolderBodySchema,
   SearchDatasetTestBodySchema,
   ExportDatasetQuerySchema,
-  GetDatasetPermissionQuerySchema
+  GetDatasetPermissionQuerySchema,
+  ListDatasetV2BodySchema,
+  ListDatasetV2ResponseSchema
 } from './api';
 
 export const DatasetPath: OpenAPIPath = {
@@ -94,6 +96,34 @@ export const DatasetPath: OpenAPIPath = {
       responses: {
         200: {
           description: '成功返回知识库列表'
+        }
+      }
+    }
+  },
+  '/core/dataset/listV2': {
+    post: {
+      summary: '获取知识库列表（分页）',
+      description: '分页获取当前用户可读的知识库列表，返回 {list, total}',
+      tags: [DevApiTagsMap.datasetCommon, SystemOpenApiTagMap.dataset],
+      requestBody: {
+        content: {
+          'application/json': {
+            schema: ListDatasetV2BodySchema
+          }
+        }
+      },
+      responses: {
+        200: {
+          description: '成功返回知识库列表和总数',
+          content: {
+            'application/json': {
+              schema: ListDatasetV2ResponseSchema
+            }
+          }
+        },
+        403: {
+          description:
+            'Phase 1（owner-only gate）期间，非团队 owner 请求返回 403；Phase 2 全量开放后移除'
         }
       }
     }

--- a/packages/global/openapi/pagination.ts
+++ b/packages/global/openapi/pagination.ts
@@ -1,0 +1,30 @@
+import z from 'zod';
+
+/**
+ * v2 list 接口共享分页参数（形制对齐 PaginationSchema，契约收紧）。
+ *
+ * 注意：ListV2PaginationSchema 是 raw object（不含任何 refinement）——
+ * Zod 4.1.12 下对含 refinement 的 object 调 .extend() 会在模块初始化时抛错
+ * （"Object schemas containing refinements cannot be extended. Use .safeExtend() instead."），
+ * 因此各资源 body schema 先 extend 此 raw object，再对最终 object 应用 v2PaginationMutualExclusion。
+ */
+export const V2PageSizeSchema = z.number().int().min(1).max(100).optional();
+export const V2OffsetSchema = z.number().int().min(0).optional();
+export const V2PageNumSchema = z.number().int().min(1).optional();
+
+export const ListV2PaginationSchema = z.object({
+  pageSize: V2PageSizeSchema,
+  offset: V2OffsetSchema,
+  pageNum: V2PageNumSchema
+});
+export type ListV2PaginationShape = z.infer<typeof ListV2PaginationSchema>;
+
+/** offset 与 pageNum 互斥（二选一）；各资源 body schema 在最终 object 上应用 */
+export const v2PaginationMutualExclusion = (v: ListV2PaginationShape, ctx: z.RefinementCtx) => {
+  if (v.offset !== undefined && v.pageNum !== undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'offset 与 pageNum 互斥，二选一'
+    });
+  }
+};

--- a/packages/service/common/api/paginationV2.ts
+++ b/packages/service/common/api/paginationV2.ts
@@ -1,0 +1,18 @@
+/**
+ * v2 list 接口的私有分页解析。
+ *
+ * 不复用 legacy `parsePaginationRequest`（packages/service/common/api/pagination.ts）：
+ * 它基于"键存在/truthy"分支（仅当 body 含 pageSize 键才读取、offset 用 truthy 判断导致
+ * offset:0 失效、接受数字字符串），与 v2 严格契约冲突；公共实现保持零改动。
+ *
+ * 输入为已通过 ListV2PaginationSchema 校验的 body（number 类型保证、offset/pageNum 互斥已校验）。
+ */
+export const parseV2Pagination = (body: {
+  pageSize?: number;
+  offset?: number;
+  pageNum?: number;
+}): { pageSize: number; offset: number } => {
+  const pageSize = body.pageSize ?? 10; // 缺省 10（与 PaginationSchema 默认一致）
+  const offset = body.offset ?? ((body.pageNum ?? 1) - 1) * pageSize; // ?? 语义：offset=0 正确生效
+  return { pageSize, offset };
+};

--- a/packages/service/core/ai/skill/manage/listV2.ts
+++ b/packages/service/core/ai/skill/manage/listV2.ts
@@ -1,0 +1,258 @@
+import { Types } from '../../../../common/mongo';
+import { MongoApp } from '../../../app/schema';
+import { AppResourceRefsSkillIdsPath, buildAppSkillRefMongoQuery } from '../../../app/resourceRefs';
+import { MongoAgentSkills } from '../model/schema';
+import { SkillPermission } from '@fastgpt/global/support/permission/skill/controller';
+import { PerResourceTypeEnum } from '@fastgpt/global/support/permission/constant';
+import { parseParentIdInMongo } from '@fastgpt/global/common/parentFolder/utils';
+import { replaceRegChars } from '@fastgpt/global/common/string/tools';
+import { AgentSkillSourceEnum, AgentSkillTypeEnum } from '@fastgpt/global/core/ai/skill/constants';
+import type { AgentSkillCreationStatusEnum } from '@fastgpt/global/core/ai/skill/constants';
+import { isPrivateResourceByCollaborators, sumPer } from '@fastgpt/global/support/permission/utils';
+import { readFromSecondary } from '../../../../common/mongo/utils';
+import {
+  getMyResourcePermission,
+  buildReadableMatch,
+  mergeMongoAndQuery,
+  addSourceMemberV2,
+  READABLE_IDS_LIMIT
+} from '../../../../support/permission/resource/readable';
+import { CommonErrEnum } from '@fastgpt/global/common/error/code/common';
+import type { ListSkillsV2Query } from '@fastgpt/global/openapi/core/ai/skill/api';
+
+type TeamPermission = {
+  isOwner: boolean;
+};
+
+type ListReadableAgentSkillsV2Params = ListSkillsV2Query & {
+  teamId: string;
+  tmbId: string;
+  teamPer: TeamPermission;
+  pageSize: number;
+  offset: number;
+  creationStatus?: AgentSkillCreationStatusEnum;
+};
+
+/**
+ * v2 技能列表页内实现。
+ *
+ * 权威语义 = 现有列表实现的最终可见集合（getPer + hasReadPer 过滤后）：
+ * - source === 'store' 只去掉 teamId 条件，非 owner 仍应用权限谓词（perMatch = {} 仅限团队 owner）
+ * - skillIds 分支同样应用权限谓词（以最终内存过滤为准，不复制旧超集写法）
+ * - find 与 countDocuments 同一 match 常量 + 同一 readFromSecondary
+ * 不动 manage/list.ts（被 ChatAgentHelper 复用的旧实现）。
+ */
+export const listReadableAgentSkillsV2 = async ({
+  teamId,
+  tmbId,
+  teamPer,
+  parentId,
+  source,
+  searchKey,
+  category,
+  type,
+  skillIds,
+  withAppCount,
+  pageSize,
+  offset,
+  creationStatus
+}: ListReadableAgentSkillsV2Params) => {
+  const selectedSkillIds = skillIds?.filter(Boolean) ?? [];
+  const isSkillIdsQuery = selectedSkillIds.length > 0;
+
+  const { myPerList, roleListMap, readableDirectIds } = await getMyResourcePermission({
+    teamId,
+    tmbId,
+    resourceType: PerResourceTypeEnum.agentSkill,
+    createPermission: (role) => new SkillPermission({ role })
+  });
+
+  // 可读集合过大时拒绝请求（$in 数组过大会让查询与计数失控）；检查放 service 层是因为可读集合在此计算
+  if (!teamPer.isOwner && readableDirectIds.length > READABLE_IDS_LIMIT) {
+    return Promise.reject(CommonErrEnum.tooManyReadableResources);
+  }
+
+  // 页内 Per 计算用的角色 Map（与 manage/list.ts:99-126 同款构建）
+  const myTmbRoleByResourceId = new Map<string, number>();
+  const myGroupOrgRoleByResourceId = new Map<string, number>();
+  myPerList.forEach((item) => {
+    const resourceId = String(item.resourceId);
+    if (item.tmbId) {
+      myTmbRoleByResourceId.set(resourceId, item.permission);
+    } else if (item.groupId || item.orgId) {
+      const permissionList = myGroupOrgRoleByResourceId.get(resourceId);
+      myGroupOrgRoleByResourceId.set(
+        resourceId,
+        permissionList === undefined ? item.permission : sumPer(permissionList, item.permission)!
+      );
+    }
+  });
+
+  const perMatch = teamPer.isOwner
+    ? {}
+    : buildReadableMatch({
+        readableDirectIds,
+        tmbId,
+        folderTypeList: [AgentSkillTypeEnum.folder]
+      });
+
+  const findSkillQuery = (() => {
+    const sourceQuery = (() => {
+      if (source === 'store') return { source: AgentSkillSourceEnum.system };
+      if (source === 'mine') return { source: AgentSkillSourceEnum.personal };
+      return {};
+    })();
+    const typeQuery = {
+      ...(category ? { category: { $in: [category] } } : {}),
+      ...(type ? { type } : {})
+    };
+    const baseQuery = {
+      deleteTime: null,
+      ...sourceQuery,
+      ...typeQuery,
+      ...(creationStatus ? { creationStatus } : {})
+    };
+    const searchMatch = searchKey
+      ? {
+          $or: [
+            { name: { $regex: new RegExp(`${replaceRegChars(searchKey)}`, 'i') } },
+            { description: { $regex: new RegExp(`${replaceRegChars(searchKey)}`, 'i') } }
+          ]
+        }
+      : {};
+
+    if (isSkillIdsQuery) {
+      const scopeQuery = source
+        ? source === 'store'
+          ? {}
+          : { teamId }
+        : {
+            $or: [{ teamId }, { source: AgentSkillSourceEnum.system }]
+          };
+
+      return mergeMongoAndQuery(
+        baseQuery,
+        scopeQuery,
+        perMatch,
+        {
+          _id: { $in: selectedSkillIds }
+        },
+        searchMatch
+      );
+    }
+
+    const teamIdQuery = source === 'store' ? {} : { teamId };
+
+    if (searchKey) {
+      return mergeMongoAndQuery(perMatch, teamIdQuery, baseQuery, searchMatch);
+    }
+
+    return mergeMongoAndQuery(perMatch, teamIdQuery, baseQuery, parseParentIdInMongo(parentId));
+  })();
+
+  const [mySkills, total] = await Promise.all([
+    MongoAgentSkills.find(findSkillQuery, undefined, { ...readFromSecondary })
+      .sort({ updateTime: -1, _id: -1 })
+      .skip(offset)
+      .limit(pageSize)
+      .lean(),
+    MongoAgentSkills.countDocuments(findSkillQuery, { ...readFromSecondary })
+  ]);
+
+  const formatSkills = mySkills.map((skill) => {
+    const { Per, privateSkill } = (() => {
+      const getPer = (skillId: string) => {
+        const tmbRole = myTmbRoleByResourceId.get(skillId);
+        const groupAndOrgRole = myGroupOrgRoleByResourceId.get(skillId);
+        return new SkillPermission({
+          role: tmbRole ?? groupAndOrgRole,
+          isOwner: String(skill.tmbId) === String(tmbId) || teamPer.isOwner
+        });
+      };
+
+      if (skill.inheritPermission && skill.parentId && skill.type !== AgentSkillTypeEnum.folder) {
+        const resourceClbs = roleListMap.get(String(skill._id)) ?? [];
+        const parentClbs = roleListMap.get(String(skill.parentId)) ?? [];
+
+        return {
+          Per: getPer(String(skill.parentId)).addRole(getPer(String(skill._id)).role),
+          privateSkill: isPrivateResourceByCollaborators({
+            resourceClbs,
+            parentClbs,
+            inheritPermission: true
+          })
+        };
+      }
+
+      const resourceClbs = roleListMap.get(String(skill._id)) ?? [];
+
+      return {
+        Per: getPer(String(skill._id)),
+        privateSkill: isPrivateResourceByCollaborators({
+          resourceClbs
+        })
+      };
+    })();
+
+    return {
+      _id: String(skill._id),
+      avatar: skill.avatar,
+      name: skill.name,
+      description: skill.description,
+      type: skill.type,
+      source: skill.source,
+      category: skill.category,
+      inheritPermission: skill.inheritPermission,
+      currentVersionId: skill.currentVersionId ? String(skill.currentVersionId) : undefined,
+      creationStatus: skill.creationStatus,
+      tmbId: skill.tmbId ? String(skill.tmbId) : null,
+      parentId: skill.parentId ? String(skill.parentId) : null,
+      createTime: skill.createTime,
+      updateTime: skill.updateTime,
+      permission: Per,
+      private: privateSkill
+    };
+  });
+
+  // 谓词等价性防御：命中谓词外资源说明权限谓词回归，仅告警不改结果
+  const invalidSkill = formatSkills.find((skill) => !skill.permission.hasReadPer);
+  if (invalidSkill) {
+    console.warn('[listV2] skill 命中权限谓词外资源（谓词回归？）', invalidSkill._id);
+  }
+
+  const nonFolderSkills =
+    withAppCount !== false ? formatSkills.filter((s) => s.type !== AgentSkillTypeEnum.folder) : [];
+  const appCountMap = new Map<string, number>();
+  if (nonFolderSkills.length > 0) {
+    const skillIdStrings = nonFolderSkills.map((skill) => String(skill._id));
+    const counts = await MongoApp.aggregate<{ _id: string; count: number }>([
+      {
+        $match: {
+          teamId: new Types.ObjectId(String(teamId)),
+          deleteTime: null,
+          ...buildAppSkillRefMongoQuery(skillIdStrings)
+        }
+      },
+      { $unwind: `$${AppResourceRefsSkillIdsPath}` },
+      { $match: buildAppSkillRefMongoQuery(skillIdStrings) },
+      {
+        $group: {
+          _id: `$${AppResourceRefsSkillIdsPath}`,
+          count: { $sum: 1 }
+        }
+      }
+    ]);
+    counts.forEach((item) => {
+      appCountMap.set(String(item._id), item.count);
+    });
+  }
+
+  const listWithAppCount = formatSkills.map((skill) => ({
+    ...skill,
+    appCount: appCountMap.get(skill._id) ?? 0
+  }));
+
+  const list = await addSourceMemberV2({ list: listWithAppCount });
+
+  return { list, total };
+};

--- a/packages/service/core/ai/skill/model/schema.ts
+++ b/packages/service/core/ai/skill/model/schema.ts
@@ -133,6 +133,19 @@ defineIndex(AgentSkillsSchema, { key: { category: 1 } });
 // 文件夹树查询：findSkillAndAllChildren 按 teamId + parentId + deleteTime 逐层查子节点。
 defineIndex(AgentSkillsSchema, { key: { teamId: 1, parentId: 1, deleteTime: 1 } });
 
+// v2 list 接口（listV2）：mine 分支（source+teamId 等值）过滤+排序，非 owner 继承分支前缀
+defineIndex(AgentSkillsSchema, {
+  key: { source: 1, teamId: 1, parentId: 1, deleteTime: 1, type: 1, updateTime: -1, _id: -1 }
+});
+// v2 list 接口：store 分支（无 teamId 前缀）
+defineIndex(AgentSkillsSchema, {
+  key: { source: 1, deleteTime: 1, type: 1, updateTime: -1, _id: -1 }
+});
+// v2 list 接口：mine 场景创建者分支（{tmbId}，依赖外层 teamId）
+defineIndex(AgentSkillsSchema, { key: { teamId: 1, tmbId: 1 } });
+// v2 list 接口：store 场景创建者分支（无 teamId 约束，单键索引）
+defineIndex(AgentSkillsSchema, { key: { tmbId: 1 } });
+
 export const MongoAgentSkills = getMongoModel<MongoAgentSkillSchemaType>(
   agentSkillsCollectionName,
   AgentSkillsSchema

--- a/packages/service/core/app/schema.ts
+++ b/packages/service/core/app/schema.ts
@@ -140,6 +140,13 @@ defineIndex(AppSchema, {
   key: { teamId: 1, deleteTime: 1, 'resourceRefs.skillIds': 1 }
 });
 
+// v2 list 接口（listV2）：owner 目录路径的过滤+排序，非 owner 继承分支前缀
+defineIndex(AppSchema, {
+  key: { teamId: 1, parentId: 1, deleteTime: 1, type: 1, updateTime: -1, _id: -1 }
+});
+// v2 list 接口：非 owner 创建者分支（{tmbId}）
+defineIndex(AppSchema, { key: { teamId: 1, tmbId: 1 } });
+
 // Schedule
 defineIndex(AppSchema, {
   key: { scheduledTriggerConfig: 1, scheduledTriggerNextTime: -1 },

--- a/packages/service/core/dataset/schema.ts
+++ b/packages/service/core/dataset/schema.ts
@@ -155,4 +155,11 @@ defineIndex(DatasetSchema, { key: { teamId: 1 } });
 defineIndex(DatasetSchema, { key: { type: 1 } }); // Admin count
 defineIndex(DatasetSchema, { key: { deleteTime: 1 } }); // 添加软删除字段索引
 
+// v2 list 接口（listV2）：owner 目录路径的过滤+排序，非 owner 继承分支前缀
+defineIndex(DatasetSchema, {
+  key: { teamId: 1, parentId: 1, deleteTime: 1, type: 1, updateTime: -1, _id: -1 }
+});
+// v2 list 接口：非 owner 创建者分支（{tmbId}）
+defineIndex(DatasetSchema, { key: { teamId: 1, tmbId: 1 } });
+
 export const MongoDataset = getMongoModel<DatasetSchemaType>(DatasetCollectionName, DatasetSchema);

--- a/packages/service/support/permission/resource/readable.ts
+++ b/packages/service/support/permission/resource/readable.ts
@@ -1,0 +1,212 @@
+import { MongoResourcePermission } from '../schema';
+import { getGroupsByTmbId } from '../memberGroup/controllers';
+import { getOrgIdSetWithParentByTmbId } from '../org/controllers';
+import { MongoTeamMember } from '../../user/team/teamMemberSchema';
+import { TeamMemberStatusEnum } from '@fastgpt/global/support/user/team/constant';
+import type { PerResourceTypeEnum } from '@fastgpt/global/support/permission/constant';
+import type {
+  PermissionValueType,
+  ResourcePermissionType
+} from '@fastgpt/global/support/permission/type';
+import type { Permission } from '@fastgpt/global/support/permission/controller';
+import { sumPer } from '@fastgpt/global/support/permission/utils';
+
+/**
+ * v2 list 接口共享权限 helper。
+ *
+ * 只被 v2 路由引用；旧路由与旧 service 文件保持零改动。
+ */
+
+/** 可读资源 id 超过该数量时拒绝列表请求（$in 数组过大时查询与计数会失控）；阈值需预生产实测校准 */
+export const READABLE_IDS_LIMIT = 10000;
+
+export type MyResourcePermissionResult = {
+  /** 我相关的权限记录（tmbId 是我 / groupId ∈ 我的组 / orgId ∈ 我的组织），语义与旧列表实现相同 */
+  myPerList: ResourcePermissionType[];
+  /** 按 resourceId 分组的团队全量权限记录（供页内 Per/private 计算） */
+  roleListMap: Map<string, ResourcePermissionType[]>;
+  /** 出现过任意权限记录的 resourceId（含 permission=0 记录）。注意：有记录不等于可读，见 readableDirectIds */
+  anyRecordedIds: string[];
+  /** 当前成员直接可读（角色位含 read）的资源 id 集合 */
+  readableDirectIds: string[];
+};
+
+/**
+ * 拉取团队级权限记录 + 成员组/组织展开，并计算直接可读集合。
+ *
+ * readableDirectIds 判定必须复用资源类型对应的 Permission 类（createPermission 分派）：
+ * app 有 readChatLog 等额外角色映射，不能假定通用映射；且需保留 `tmbRole ?? groupAndOrgRole`
+ * 的 `??` 语义与 undefined 中间值（个人直授 permission=0 时压过组/组织角色，不回落）。
+ */
+export const getMyResourcePermission = async ({
+  teamId,
+  tmbId,
+  resourceType,
+  createPermission
+}: {
+  teamId: string;
+  tmbId: string;
+  resourceType: PerResourceTypeEnum;
+  createPermission: (role?: PermissionValueType) => Permission;
+}): Promise<MyResourcePermissionResult> => {
+  const [roleList, myGroupMap, myOrgSet] = await Promise.all([
+    MongoResourcePermission.find({
+      resourceType,
+      teamId,
+      resourceId: {
+        $exists: true
+      }
+    }).lean(),
+    getGroupsByTmbId({
+      tmbId,
+      teamId
+    }).then((item) => {
+      const map = new Map<string, 1>();
+      item.forEach((item) => {
+        map.set(String(item._id), 1);
+      });
+      return map;
+    }),
+    getOrgIdSetWithParentByTmbId({
+      teamId,
+      tmbId
+    })
+  ]);
+
+  const roleListMap = new Map<string, ResourcePermissionType[]>();
+  roleList.forEach((item) => {
+    const resourceId = String(item.resourceId);
+    const list = roleListMap.get(resourceId) ?? [];
+    list.push(item);
+    roleListMap.set(resourceId, list);
+  });
+
+  const myPerList = roleList.filter(
+    (item) =>
+      String(item.tmbId) === String(tmbId) ||
+      myGroupMap.has(String(item.groupId)) ||
+      myOrgSet.has(String(item.orgId))
+  );
+
+  const anyRecordedIds = Array.from(new Set(myPerList.map((item) => String(item.resourceId))));
+
+  // 按 resourceId 聚合角色位：tmb 直授优先（?? 语义，permission=0 保留不回落），组/组织按位或
+  const perAggByResourceId = new Map<
+    string,
+    { tmbRole?: PermissionValueType; groupOrgRoles: PermissionValueType[] }
+  >();
+  myPerList.forEach((item) => {
+    const resourceId = String(item.resourceId);
+    const agg = perAggByResourceId.get(resourceId) ?? {
+      groupOrgRoles: [] as PermissionValueType[]
+    };
+    if (item.tmbId) {
+      agg.tmbRole = item.permission;
+    }
+    if (item.groupId || item.orgId) {
+      agg.groupOrgRoles.push(item.permission);
+    }
+    perAggByResourceId.set(resourceId, agg);
+  });
+
+  const readableDirectIds: string[] = [];
+  perAggByResourceId.forEach((agg, resourceId) => {
+    const groupAndOrgRole = agg.groupOrgRoles.length > 0 ? sumPer(...agg.groupOrgRoles) : undefined;
+    const per = createPermission(agg.tmbRole ?? groupAndOrgRole);
+    if (per.hasReadPer) {
+      readableDirectIds.push(resourceId);
+    }
+  });
+
+  return {
+    myPerList,
+    roleListMap,
+    anyRecordedIds,
+    readableDirectIds
+  };
+};
+
+/**
+ * 构造非 owner 的权限谓词（$or 三分支）：
+ * 1. 直接可读资源；2. 创建者（getPer isOwner 语义）；3. 一层继承（直接父可读 + inheritPermission + 非文件夹）。
+ */
+export const buildReadableMatch = ({
+  readableDirectIds,
+  tmbId,
+  folderTypeList
+}: {
+  readableDirectIds: string[];
+  tmbId: string;
+  folderTypeList: string[];
+}) => ({
+  $or: [
+    { _id: { $in: readableDirectIds } },
+    { tmbId },
+    {
+      type: { $nin: folderTypeList },
+      inheritPermission: true,
+      parentId: { $in: readableDirectIds }
+    }
+  ]
+});
+
+/**
+ * 多个过滤条件可能都包含 $or，用 $and 合并避免对象展开时覆盖同名键。
+ * 与 packages/service/core/ai/skill/manage/list.ts 的本地函数同逻辑；
+ * 本文件为 v2 专用新实现，旧文件 import 零改动。
+ */
+export const mergeMongoAndQuery = (...queries: Record<string, unknown>[]) => {
+  const validQueries = queries.filter((query) => Object.keys(query).length > 0);
+
+  if (validQueries.length === 0) return {};
+  if (validQueries.length === 1) return validQueries[0];
+
+  return {
+    $and: validQueries
+  };
+};
+
+export type SourceMemberV2Type = {
+  name: string;
+  avatar: string | null;
+  status: TeamMemberStatusEnum | null;
+};
+
+/**
+ * v2 页内 sourceMember 变体：
+ * 不调用公共 addSourceMember（其对缺成员直接丢项），缺成员或 tmbId 为 null 时保留资源并输出占位
+ * `{ name: '未知成员', avatar: null, status: null }`（不作虚假状态陈述）。
+ */
+export const addSourceMemberV2 = async <T extends { tmbId: string | null }>({
+  list
+}: {
+  list: T[];
+}): Promise<Array<T & { sourceMember: SourceMemberV2Type }>> => {
+  if (!Array.isArray(list)) return [];
+
+  const tmbIdList = list
+    .map((item) => (item.tmbId ? String(item.tmbId) : undefined))
+    .filter(Boolean);
+  const tmbList = await MongoTeamMember.find(
+    {
+      _id: { $in: tmbIdList }
+    },
+    'tmbId name avatar status'
+  ).lean();
+  const tmbMap = new Map(tmbList.map((tmb) => [String(tmb._id), tmb]));
+
+  return list.map((item) => {
+    const tmb = item.tmbId ? tmbMap.get(String(item.tmbId)) : undefined;
+
+    return {
+      ...item,
+      sourceMember: tmb
+        ? {
+            name: tmb.name,
+            avatar: tmb.avatar ?? null,
+            status: tmb.status ?? TeamMemberStatusEnum.active
+          }
+        : { name: '未知成员', avatar: null, status: null }
+    };
+  });
+};

--- a/projects/app/src/pages/api/core/ai/skill/listV2.ts
+++ b/projects/app/src/pages/api/core/ai/skill/listV2.ts
@@ -1,0 +1,85 @@
+import { NextAPI } from '@/service/middleware/entry';
+import { authUserPer } from '@fastgpt/service/support/permission/user/auth';
+import { ReadPermissionVal } from '@fastgpt/global/support/permission/constant';
+import type { ApiRequestProps } from '@fastgpt/next/type';
+import { authSkill } from '@fastgpt/service/support/permission/skill/auth';
+import { parseApiInput } from '@fastgpt/service/common/zod/requestParseError';
+import { parseV2Pagination } from '@fastgpt/service/common/api/paginationV2';
+import { listReadableAgentSkillsV2 } from '@fastgpt/service/core/ai/skill/manage/listV2';
+import {
+  ListSkillsV2QuerySchema,
+  type ListSkillsV2Query,
+  type ListSkillsV2Response
+} from '@fastgpt/global/openapi/core/ai/skill/api';
+
+/*
+  获取 Skill 列表（分页版）
+  - 入参从 body 读取（与旧路由一致）；分页参数 pageSize/offset/pageNum
+  - 权限谓词与页内实现见 listReadableAgentSkillsV2
+*/
+
+async function handler(req: ApiRequestProps<ListSkillsV2Query>): Promise<ListSkillsV2Response> {
+  const {
+    parentId,
+    source,
+    searchKey,
+    category,
+    type,
+    skillIds,
+    withAppCount,
+    pageSize: rawPageSize,
+    offset: rawOffset,
+    pageNum: rawPageNum
+  } = parseApiInput({
+    req,
+    bodySchema: ListSkillsV2QuerySchema
+  }).body;
+  const { pageSize, offset } = parseV2Pagination({
+    pageSize: rawPageSize,
+    offset: rawOffset,
+    pageNum: rawPageNum
+  });
+  const selectedSkillIds = skillIds?.filter(Boolean) ?? [];
+  const isSkillIdsQuery = selectedSkillIds.length > 0;
+
+  // Auth user permission
+  const [{ tmbId, teamId, permission: teamPer }] = await Promise.all([
+    authUserPer({
+      req,
+      authToken: true,
+      authApiKey: true,
+      per: ReadPermissionVal
+    }),
+    ...(parentId && !isSkillIdsQuery
+      ? [
+          authSkill({
+            req,
+            authToken: true,
+            authApiKey: true,
+            per: ReadPermissionVal,
+            skillId: parentId
+          })
+        ]
+      : [])
+  ]);
+
+  const result = await listReadableAgentSkillsV2({
+    teamId,
+    tmbId,
+    teamPer,
+    parentId,
+    source,
+    searchKey,
+    category,
+    type,
+    skillIds: selectedSkillIds,
+    pageSize,
+    offset,
+    withAppCount
+  });
+
+  // 与旧接口一致：不 parse 响应（旧 skill/list 直接返回 result）
+  return result;
+}
+
+export default NextAPI(handler);

--- a/projects/app/src/pages/api/core/app/listV2.ts
+++ b/projects/app/src/pages/api/core/app/listV2.ts
@@ -1,0 +1,212 @@
+import { MongoApp } from '@fastgpt/service/core/app/schema';
+import { NextAPI } from '@/service/middleware/entry';
+import {
+  PerResourceTypeEnum,
+  ReadPermissionVal
+} from '@fastgpt/global/support/permission/constant';
+import { AppPermission } from '@fastgpt/global/support/permission/app/controller';
+import { type ApiRequestProps } from '@fastgpt/next/type';
+import { parseParentIdInMongo } from '@fastgpt/global/common/parentFolder/utils';
+import { AppFolderTypeList, AppTypeEnum } from '@fastgpt/global/core/app/constants';
+import { authApp } from '@fastgpt/service/support/permission/app/auth';
+import { authUserPer } from '@fastgpt/service/support/permission/user/auth';
+import { replaceRegChars } from '@fastgpt/global/common/string/tools';
+import { FlowNodeTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
+import { isPrivateResourceByCollaborators, sumPer } from '@fastgpt/global/support/permission/utils';
+import { parseApiInput } from '@fastgpt/service/common/zod/requestParseError';
+import { parseV2Pagination } from '@fastgpt/service/common/api/paginationV2';
+import { readFromSecondary } from '@fastgpt/service/common/mongo/utils';
+import { CommonErrEnum } from '@fastgpt/global/common/error/code/common';
+import {
+  getMyResourcePermission,
+  buildReadableMatch,
+  mergeMongoAndQuery,
+  addSourceMemberV2,
+  READABLE_IDS_LIMIT
+} from '@fastgpt/service/support/permission/resource/readable';
+import {
+  ListAppV2BodySchema,
+  ListAppV2ResponseSchema,
+  type ListAppV2BodyType,
+  type ListAppV2ResponseType
+} from '@fastgpt/global/openapi/core/app/common/api';
+
+/*
+  获取 APP 列表（分页版）
+  1. 校验 folder 权限和获取 team 权限（owner 单独处理）
+  2. getMyResourcePermission 计算直接可读集合（readableDirectIds）
+  3. owner → perMatch={}；非 owner → buildReadableMatch 三分支精确谓词
+  4. match 逐模式：searchKey 无顶层 parentId（全局搜索）；显式 parentId 时 AND 目录条件
+  5. find 与 countDocuments 同一 match 常量 + 同一 readFromSecondary，skip/limit 下推
+  6. 页内 Per/private/hasInteractiveNode 计算 + sourceMember 页内占位
+*/
+
+async function handler(req: ApiRequestProps<ListAppV2BodyType>): Promise<ListAppV2ResponseType> {
+  const {
+    parentId,
+    type,
+    searchKey,
+    pageSize: rawPageSize,
+    offset: rawOffset,
+    pageNum: rawPageNum
+  } = parseApiInput({
+    req,
+    bodySchema: ListAppV2BodySchema
+  }).body;
+  const { pageSize, offset } = parseV2Pagination({
+    pageSize: rawPageSize,
+    offset: rawOffset,
+    pageNum: rawPageNum
+  });
+
+  // Auth user permission
+  const [{ tmbId, teamId, permission: teamPer }] = await Promise.all([
+    authUserPer({
+      req,
+      authToken: true,
+      authApiKey: true,
+      per: ReadPermissionVal
+    }),
+    ...(parentId
+      ? [
+          authApp({
+            req,
+            authToken: true,
+            authApiKey: true,
+            appId: parentId,
+            per: ReadPermissionVal
+          })
+        ]
+      : [])
+  ]);
+
+  const { myPerList, roleListMap, readableDirectIds } = await getMyResourcePermission({
+    teamId,
+    tmbId,
+    resourceType: PerResourceTypeEnum.app,
+    createPermission: (role) => new AppPermission({ role })
+  });
+
+  // 可读集合过大时拒绝请求（$in 数组过大会让查询与计数失控）
+  if (!teamPer.isOwner && readableDirectIds.length > READABLE_IDS_LIMIT) {
+    return Promise.reject(CommonErrEnum.tooManyReadableResources);
+  }
+
+  const perMatch = teamPer.isOwner
+    ? {}
+    : buildReadableMatch({
+        readableDirectIds,
+        tmbId,
+        folderTypeList: AppFolderTypeList
+      });
+
+  const typeCond = (() => {
+    if (type) {
+      // 显式指定类型时按指定类型查询（包括 hidden）
+      return Array.isArray(type) ? { type: { $in: type } } : { type };
+    }
+    // 未指定时排除 hidden 类型
+    return { type: { $ne: AppTypeEnum.hidden } } as const;
+  })();
+
+  const searchMatch = searchKey
+    ? {
+        $or: [
+          { name: { $regex: new RegExp(`${replaceRegChars(searchKey)}`, 'i') } },
+          { intro: { $regex: new RegExp(`${replaceRegChars(searchKey)}`, 'i') } }
+        ]
+      }
+    : {};
+
+  // 逐模式 match：searchKey 全局搜索（无顶层 parentId）；否则显式 parentId（undefined 时为空对象被合并忽略）
+  const match = mergeMongoAndQuery(
+    { teamId, deleteTime: null },
+    typeCond,
+    perMatch,
+    searchKey ? searchMatch : parseParentIdInMongo(parentId)
+  );
+
+  const [myApps, total] = await Promise.all([
+    MongoApp.find(
+      match,
+      '_id parentId avatar type name intro tmbId updateTime pluginData inheritPermission modules',
+      { ...readFromSecondary }
+    )
+      .sort({ updateTime: -1, _id: -1 })
+      .skip(offset)
+      .limit(pageSize)
+      .lean(),
+    MongoApp.countDocuments(match, { ...readFromSecondary })
+  ]);
+
+  // 页内后处理：Per/private（myPerList 计算角色 + roleListMap 计算协作方）+ hasInteractiveNode（modules）
+  const formatApps = myApps.map((app) => {
+    const { Per, privateApp } = (() => {
+      const getPer = (appId: string) => {
+        const myRecords = myPerList.filter((item) => String(item.resourceId) === appId);
+        const tmbRole = myRecords.find((item) => !!item.tmbId)?.permission;
+        const groupAndOrgRole = sumPer(
+          ...myRecords
+            .filter((item) => !!item.groupId || !!item.orgId)
+            .map((item) => item.permission)
+        );
+
+        return new AppPermission({
+          role: tmbRole ?? groupAndOrgRole,
+          isOwner: String(app.tmbId) === String(tmbId) || teamPer.isOwner
+        });
+      };
+
+      // Inherit app, check parent folder clb and it's own clb
+      if (!AppFolderTypeList.includes(app.type) && app.parentId && app.inheritPermission) {
+        const resourceClbs = roleListMap.get(String(app._id)) ?? [];
+        const parentClbs = roleListMap.get(String(app.parentId)) ?? [];
+
+        return {
+          Per: getPer(String(app.parentId)).addRole(getPer(String(app._id)).role),
+          privateApp: isPrivateResourceByCollaborators({
+            resourceClbs,
+            parentClbs,
+            inheritPermission: true
+          })
+        };
+      }
+
+      const resourceClbs = roleListMap.get(String(app._id)) ?? [];
+
+      return {
+        Per: getPer(String(app._id)),
+        privateApp: isPrivateResourceByCollaborators({
+          resourceClbs
+        })
+      };
+    })();
+
+    const { modules, ...rest } = app;
+    const hasInteractiveNode = modules?.some((item) =>
+      [FlowNodeTypeEnum.formInput, FlowNodeTypeEnum.userSelect].includes(item.flowNodeType)
+    );
+
+    return {
+      ...rest,
+      parentId: app.parentId,
+      permission: Per,
+      private: privateApp,
+      hasInteractiveNode
+    };
+  });
+
+  // 谓词等价性防御：命中谓词外资源说明权限谓词回归，仅告警不改结果
+  const invalidApp = formatApps.find((app) => !app.permission.hasReadPer);
+  if (invalidApp) {
+    console.warn('[listV2] app 命中权限谓词外资源（谓词回归？）', invalidApp._id);
+  }
+
+  const list = await addSourceMemberV2({
+    list: formatApps
+  });
+
+  return ListAppV2ResponseSchema.parse({ list, total });
+}
+
+export default NextAPI(handler);

--- a/projects/app/src/pages/api/core/dataset/listV2.ts
+++ b/projects/app/src/pages/api/core/dataset/listV2.ts
@@ -1,0 +1,209 @@
+import { DatasetTypeEnum } from '@fastgpt/global/core/dataset/constants';
+import { MongoDataset } from '@fastgpt/service/core/dataset/schema';
+import { authUserPer } from '@fastgpt/service/support/permission/user/auth';
+import { NextAPI } from '@/service/middleware/entry';
+import { DatasetPermission } from '@fastgpt/global/support/permission/dataset/controller';
+import {
+  PerResourceTypeEnum,
+  ReadPermissionVal
+} from '@fastgpt/global/support/permission/constant';
+import { parseParentIdInMongo } from '@fastgpt/global/common/parentFolder/utils';
+import type { ApiRequestProps } from '@fastgpt/next/type';
+import { authDataset } from '@fastgpt/service/support/permission/dataset/auth';
+import { replaceRegChars } from '@fastgpt/global/common/string/tools';
+import { getEmbeddingModel } from '@fastgpt/service/core/ai/model';
+import { isPrivateResourceByCollaborators, sumPer } from '@fastgpt/global/support/permission/utils';
+import { parseApiInput } from '@fastgpt/service/common/zod/requestParseError';
+import { parseV2Pagination } from '@fastgpt/service/common/api/paginationV2';
+import { readFromSecondary } from '@fastgpt/service/common/mongo/utils';
+import { CommonErrEnum } from '@fastgpt/global/common/error/code/common';
+import {
+  getMyResourcePermission,
+  buildReadableMatch,
+  mergeMongoAndQuery,
+  addSourceMemberV2,
+  READABLE_IDS_LIMIT
+} from '@fastgpt/service/support/permission/resource/readable';
+import {
+  ListDatasetV2BodySchema,
+  type ListDatasetV2Body,
+  type ListDatasetV2Response
+} from '@fastgpt/global/openapi/core/dataset/api';
+
+/*
+  获取知识库列表（分页版）
+  - 搜索分支不带 type 过滤（与旧接口行为一致，旧实现搜索时不按 type 过滤）
+  - projection 收窄为页所需字段（parentId 供页内权限计算，不作为响应字段）
+  - find 与 countDocuments 同一 match 常量 + 同一 readFromSecondary
+*/
+
+async function handler(req: ApiRequestProps<ListDatasetV2Body>): Promise<ListDatasetV2Response> {
+  const {
+    parentId,
+    type,
+    searchKey,
+    pageSize: rawPageSize,
+    offset: rawOffset,
+    pageNum: rawPageNum
+  } = parseApiInput({
+    req,
+    bodySchema: ListDatasetV2BodySchema
+  }).body;
+  const { pageSize, offset } = parseV2Pagination({
+    pageSize: rawPageSize,
+    offset: rawOffset,
+    pageNum: rawPageNum
+  });
+
+  // Auth user permission
+  const [{ tmbId, teamId, permission: teamPer }] = await Promise.all([
+    authUserPer({
+      req,
+      authToken: true,
+      authApiKey: true,
+      per: ReadPermissionVal
+    }),
+    ...(parentId
+      ? [
+          authDataset({
+            req,
+            authToken: true,
+            authApiKey: true,
+            per: ReadPermissionVal,
+            datasetId: parentId
+          })
+        ]
+      : [])
+  ]);
+
+  const { myPerList, roleListMap, readableDirectIds } = await getMyResourcePermission({
+    teamId,
+    tmbId,
+    resourceType: PerResourceTypeEnum.dataset,
+    createPermission: (role) => new DatasetPermission({ role })
+  });
+
+  // 可读集合过大时拒绝请求（$in 数组过大会让查询与计数失控）
+  if (!teamPer.isOwner && readableDirectIds.length > READABLE_IDS_LIMIT) {
+    return Promise.reject(CommonErrEnum.tooManyReadableResources);
+  }
+
+  const perMatch = teamPer.isOwner
+    ? {}
+    : buildReadableMatch({
+        readableDirectIds,
+        tmbId,
+        folderTypeList: [DatasetTypeEnum.folder]
+      });
+
+  const typeCond = type ? { type } : {};
+
+  const searchMatch = searchKey
+    ? {
+        $or: [
+          { name: { $regex: new RegExp(`${replaceRegChars(searchKey)}`, 'i') } },
+          { intro: { $regex: new RegExp(`${replaceRegChars(searchKey)}`, 'i') } }
+        ]
+      }
+    : {};
+
+  // 逐模式 match：搜索分支不带 type（复刻旧语义）；searchKey 无顶层 parentId
+  const match = mergeMongoAndQuery(
+    { teamId, deleteTime: null }, // 关键：只返回未删除的数据
+    perMatch,
+    searchKey ? searchMatch : typeCond,
+    searchKey ? {} : parseParentIdInMongo(parentId)
+  );
+
+  const [myDatasets, total] = await Promise.all([
+    MongoDataset.find(
+      match,
+      '_id avatar name intro type vectorModel inheritPermission tmbId updateTime parentId',
+      {
+        ...readFromSecondary
+      }
+    )
+      .sort({ updateTime: -1, _id: -1 })
+      .skip(offset)
+      .limit(pageSize)
+      .lean(),
+    MongoDataset.countDocuments(match, { ...readFromSecondary })
+  ]);
+
+  // 页内后处理：Per/private + getEmbeddingModel
+  const formatDatasets = myDatasets.map((dataset) => {
+    const { Per, privateDataset } = (() => {
+      const getPer = (datasetId: string) => {
+        const myRecords = myPerList.filter((item) => String(item.resourceId) === datasetId);
+        const tmbRole = myRecords.find((item) => !!item.tmbId)?.permission;
+        const groupAndOrgRole = sumPer(
+          ...myRecords
+            .filter((item) => !!item.groupId || !!item.orgId)
+            .map((item) => item.permission)
+        );
+
+        return new DatasetPermission({
+          role: tmbRole ?? groupAndOrgRole,
+          isOwner: String(dataset.tmbId) === String(tmbId) || teamPer.isOwner
+        });
+      };
+
+      // inherit
+      if (
+        dataset.inheritPermission &&
+        dataset.parentId &&
+        dataset.type !== DatasetTypeEnum.folder
+      ) {
+        const resourceClbs = roleListMap.get(String(dataset._id)) ?? [];
+        const parentClbs = roleListMap.get(String(dataset.parentId)) ?? [];
+
+        return {
+          Per: getPer(String(dataset.parentId)).addRole(getPer(String(dataset._id)).role),
+          privateDataset: isPrivateResourceByCollaborators({
+            resourceClbs,
+            parentClbs,
+            inheritPermission: true
+          })
+        };
+      }
+
+      const resourceClbs = roleListMap.get(String(dataset._id)) ?? [];
+
+      return {
+        Per: getPer(String(dataset._id)),
+        privateDataset: isPrivateResourceByCollaborators({
+          resourceClbs
+        })
+      };
+    })();
+
+    return {
+      _id: dataset._id,
+      avatar: dataset.avatar,
+      name: dataset.name,
+      intro: dataset.intro,
+      type: dataset.type,
+      vectorModel: getEmbeddingModel(dataset.vectorModel),
+      inheritPermission: dataset.inheritPermission,
+      tmbId: dataset.tmbId,
+      updateTime: dataset.updateTime,
+      permission: Per,
+      private: privateDataset
+    };
+  });
+
+  // 谓词等价性防御：命中谓词外资源说明权限谓词回归，仅告警不改结果
+  const invalidDataset = formatDatasets.find((dataset) => !dataset.permission.hasReadPer);
+  if (invalidDataset) {
+    console.warn('[listV2] dataset 命中权限谓词外资源（谓词回归？）', invalidDataset._id);
+  }
+
+  const list = await addSourceMemberV2({
+    list: formatDatasets
+  });
+
+  // 与旧接口一致：不 parse 响应（旧 dataset/list 直接返回；vectorModel 依赖运行时模型配置）
+  return { list, total };
+}
+
+export default NextAPI(handler);

--- a/projects/app/test/api/core/ai/skill/listV2.test.ts
+++ b/projects/app/test/api/core/ai/skill/listV2.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest';
+import { Types } from 'mongoose';
+import handler from '@/pages/api/core/ai/skill/listV2';
+import oldHandler from '@/pages/api/core/ai/skill/list';
+import { MongoAgentSkills } from '@fastgpt/service/core/ai/skill/model/schema';
+import { MongoResourcePermission } from '@fastgpt/service/support/permission/schema';
+import { AgentSkillSourceEnum, AgentSkillTypeEnum } from '@fastgpt/global/core/ai/skill/constants';
+import { PerResourceTypeEnum } from '@fastgpt/global/support/permission/constant';
+import { ReadRoleVal } from '@fastgpt/global/support/permission/constant';
+import { getNanoid } from '@fastgpt/global/common/string/tools';
+import { getUser } from '@test/datas/users';
+import { Call } from '@test/utils/request';
+import type {
+  ListSkillsV2Query,
+  ListSkillsV2Response
+} from '@fastgpt/global/openapi/core/ai/skill/api';
+
+const createSkill = (data: {
+  name: string;
+  teamId?: string | null;
+  tmbId?: string | null;
+  type?: AgentSkillTypeEnum;
+  source?: AgentSkillSourceEnum;
+  parentId?: string | null;
+  inheritPermission?: boolean;
+}) =>
+  MongoAgentSkills.create({
+    name: data.name,
+    type: data.type ?? AgentSkillTypeEnum.skill,
+    source: data.source ?? AgentSkillSourceEnum.personal,
+    ...(data.teamId !== undefined ? { teamId: data.teamId } : {}),
+    ...(data.tmbId !== undefined ? { tmbId: data.tmbId } : {}),
+    ...(data.parentId !== undefined
+      ? { parentId: data.parentId ? new Types.ObjectId(data.parentId) : null }
+      : {}),
+    ...(data.inheritPermission !== undefined ? { inheritPermission: data.inheritPermission } : {})
+  });
+
+describe('POST /api/core/ai/skill/listV2', () => {
+  it('owner + mine：与旧接口可见集合一致（相等）', async () => {
+    const owner = await getUser(`listv2-sk-owner-${getNanoid(6)}`);
+    await createSkill({ name: 'S1', teamId: owner.teamId, tmbId: owner.tmbId });
+
+    const res = await Call<ListSkillsV2Query, Record<string, never>, ListSkillsV2Response>(
+      handler,
+      { auth: owner, body: { source: 'mine', pageSize: 100 } }
+    );
+    const oldRes = await Call(oldHandler, { auth: owner, body: { source: 'mine' } });
+
+    expect(res.code).toBe(200);
+    expect(res.data.list.map((item) => String(item._id))).toEqual(
+      oldRes.data.list.map((item: { _id: string }) => String(item._id))
+    );
+  });
+
+  it('非 owner + tmb 直授：与旧一致（相等）', async () => {
+    const owner = await getUser(`listv2-sk-nonowner-${getNanoid(6)}`);
+    const member = await getUser(`listv2-sk-nonowner-m-${getNanoid(6)}`, owner.teamId);
+
+    const granted = await createSkill({
+      name: 'Granted',
+      teamId: owner.teamId,
+      tmbId: owner.tmbId
+    });
+    await createSkill({ name: 'Not Granted', teamId: owner.teamId, tmbId: owner.tmbId });
+    await MongoResourcePermission.create({
+      resourceType: PerResourceTypeEnum.agentSkill,
+      teamId: owner.teamId,
+      resourceId: granted._id,
+      tmbId: member.tmbId,
+      permission: ReadRoleVal
+    });
+
+    const res = await Call<ListSkillsV2Query, Record<string, never>, ListSkillsV2Response>(
+      handler,
+      { auth: member, body: { source: 'mine', pageSize: 100 } }
+    );
+    const oldRes = await Call(oldHandler, { auth: member, body: { source: 'mine' } });
+
+    expect(res.code).toBe(200);
+    const v2Ids = res.data.list.map((item) => String(item._id));
+    const oldIds = oldRes.data.list.map((item: { _id: string }) => String(item._id));
+    expect(v2Ids).toEqual(oldIds);
+    expect(v2Ids).toContain(String(granted._id));
+  });
+
+  it('store + 非 owner：仅权限记录内的 system skill 可见（权威语义，与旧列表一致）', async () => {
+    const owner = await getUser(`listv2-sk-store-${getNanoid(6)}`);
+    const member = await getUser(`listv2-sk-store-m-${getNanoid(6)}`, owner.teamId);
+
+    const grantedSystem = await createSkill({
+      name: 'System Granted',
+      source: AgentSkillSourceEnum.system,
+      teamId: owner.teamId,
+      tmbId: owner.tmbId
+    });
+    await createSkill({
+      name: 'System Not Granted',
+      source: AgentSkillSourceEnum.system,
+      teamId: owner.teamId,
+      tmbId: owner.tmbId
+    });
+    await MongoResourcePermission.create({
+      resourceType: PerResourceTypeEnum.agentSkill,
+      teamId: owner.teamId,
+      resourceId: grantedSystem._id,
+      tmbId: member.tmbId,
+      permission: ReadRoleVal
+    });
+
+    const res = await Call<ListSkillsV2Query, Record<string, never>, ListSkillsV2Response>(
+      handler,
+      { auth: member, body: { source: 'store', pageSize: 100 } }
+    );
+    const oldRes = await Call(oldHandler, { auth: member, body: { source: 'store' } });
+
+    expect(res.code).toBe(200);
+    const v2Ids = res.data.list.map((item) => String(item._id));
+    const oldIds = oldRes.data.list.map((item: { _id: string }) => String(item._id));
+    // 无权限记录的 system skill 不展示（与旧列表语义一致，perMatch 未因 store 取消）
+    expect(v2Ids).toEqual(oldIds);
+    expect(v2Ids).toEqual([String(grantedSystem._id)]);
+  });
+
+  it('skillIds 分支：非 owner 无权 skill 被过滤（与旧一致）', async () => {
+    const owner = await getUser(`listv2-sk-ids-${getNanoid(6)}`);
+    const member = await getUser(`listv2-sk-ids-m-${getNanoid(6)}`, owner.teamId);
+
+    const owned = await createSkill({ name: 'Owned', teamId: owner.teamId, tmbId: member.tmbId });
+    const protectedSkill = await createSkill({
+      name: 'Protected',
+      teamId: owner.teamId,
+      tmbId: owner.tmbId
+    });
+    await MongoResourcePermission.create({
+      resourceType: PerResourceTypeEnum.agentSkill,
+      teamId: owner.teamId,
+      resourceId: owned._id,
+      tmbId: member.tmbId,
+      permission: ReadRoleVal
+    });
+
+    const body: ListSkillsV2Query = {
+      source: 'mine',
+      skillIds: [String(owned._id), String(protectedSkill._id)],
+      pageSize: 100
+    };
+    const res = await Call<ListSkillsV2Query, Record<string, never>, ListSkillsV2Response>(
+      handler,
+      { auth: member, body }
+    );
+    const oldRes = await Call(oldHandler, { auth: member, body });
+
+    expect(res.code).toBe(200);
+    expect(res.data.list.map((item) => String(item._id))).toEqual(
+      oldRes.data.list.map((item: { _id: string }) => String(item._id))
+    );
+    expect(res.data.list.map((item) => String(item._id))).toEqual([String(owned._id)]);
+  });
+
+  it('目录继承：父文件夹 read → 子 skill 可见（与旧一致）', async () => {
+    const owner = await getUser(`listv2-sk-inherit-${getNanoid(6)}`);
+    const member = await getUser(`listv2-sk-inherit-m-${getNanoid(6)}`, owner.teamId);
+
+    const folder = await createSkill({
+      name: 'Folder',
+      type: AgentSkillTypeEnum.folder,
+      teamId: owner.teamId,
+      tmbId: owner.tmbId
+    });
+    const child = await createSkill({
+      name: 'Child',
+      teamId: owner.teamId,
+      tmbId: owner.tmbId,
+      parentId: String(folder._id),
+      inheritPermission: true
+    });
+    await MongoResourcePermission.create({
+      resourceType: PerResourceTypeEnum.agentSkill,
+      teamId: owner.teamId,
+      resourceId: folder._id,
+      tmbId: member.tmbId,
+      permission: ReadRoleVal
+    });
+
+    const body: ListSkillsV2Query = {
+      source: 'mine',
+      parentId: String(folder._id),
+      pageSize: 100
+    };
+    const res = await Call<ListSkillsV2Query, Record<string, never>, ListSkillsV2Response>(
+      handler,
+      { auth: member, body }
+    );
+    const oldRes = await Call(oldHandler, { auth: member, body });
+
+    expect(res.code).toBe(200);
+    const v2Ids = res.data.list.map((item) => String(item._id));
+    expect(v2Ids).toContain(String(child._id));
+    expect(v2Ids).toEqual(oldRes.data.list.map((item: { _id: string }) => String(item._id)));
+  });
+
+  it('分页：total 为全量计数（25 条 / pageSize 10 → total 25、list 10）', async () => {
+    const owner = await getUser(`listv2-sk-paging-${getNanoid(6)}`);
+    await Promise.all(
+      Array.from({ length: 25 }, (_, i) =>
+        createSkill({ name: `S ${i}`, teamId: owner.teamId, tmbId: owner.tmbId })
+      )
+    );
+
+    const res = await Call<ListSkillsV2Query, Record<string, never>, ListSkillsV2Response>(
+      handler,
+      { auth: owner, body: { source: 'mine', pageSize: 10, pageNum: 1 } }
+    );
+
+    expect(res.code).toBe(200);
+    expect(res.data.total).toBe(25);
+    expect(res.data.list).toHaveLength(10);
+    expect(res.data.total).toBeGreaterThan(res.data.list.length);
+  });
+
+  it('owner + store + tmbId=null 的 system skill：v2 保留 + 占位，旧接口丢项', async () => {
+    const owner = await getUser(`listv2-sk-system-${getNanoid(6)}`);
+    // 与 controller.test.ts:262-276 相同的 system skill 夹具（teamId/tmbId 为 null）
+    await createSkill({
+      name: 'Null Tmb System Skill',
+      source: AgentSkillSourceEnum.system,
+      teamId: null,
+      tmbId: null
+    });
+
+    const res = await Call<ListSkillsV2Query, Record<string, never>, ListSkillsV2Response>(
+      handler,
+      { auth: owner, body: { source: 'store', pageSize: 100 } }
+    );
+    const oldRes = await Call(oldHandler, { auth: owner, body: { source: 'store' } });
+
+    expect(res.code).toBe(200);
+    const v2System = res.data.list.find((item) => item.name === 'Null Tmb System Skill');
+    // v2：保留 + 占位（status null）
+    expect(v2System).toBeDefined();
+    expect(v2System!.tmbId).toBeNull();
+    expect(v2System!.sourceMember).toEqual({ name: '未知成员', avatar: null, status: null });
+    // 旧接口：addSourceMember 丢项（tmbId null）
+    const oldIds = oldRes.data.list.map((item: { _id: string }) => String(item._id));
+    expect(oldIds).not.toContain(String(v2System!._id));
+  });
+});

--- a/projects/app/test/api/core/app/listV2.test.ts
+++ b/projects/app/test/api/core/app/listV2.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from 'vitest';
+import { Types } from 'mongoose';
+import handler from '@/pages/api/core/app/listV2';
+import oldHandler from '@/pages/api/core/app/list';
+import { MongoApp } from '@fastgpt/service/core/app/schema';
+import { MongoResourcePermission } from '@fastgpt/service/support/permission/schema';
+import { AppTypeEnum } from '@fastgpt/global/core/app/constants';
+import { PerResourceTypeEnum } from '@fastgpt/global/support/permission/constant';
+import { ReadRoleVal, ReadPermissionVal } from '@fastgpt/global/support/permission/constant';
+import { CommonErrEnum } from '@fastgpt/global/common/error/code/common';
+import { getNanoid } from '@fastgpt/global/common/string/tools';
+import { getUser } from '@test/datas/users';
+import { Call } from '@test/utils/request';
+import type {
+  ListAppV2BodyType,
+  ListAppV2ResponseType
+} from '@fastgpt/global/openapi/core/app/common/api';
+
+const createApp = (data: {
+  name: string;
+  teamId: string;
+  tmbId: string;
+  type?: AppTypeEnum;
+  parentId?: string | null;
+  inheritPermission?: boolean;
+  deleteTime?: Date | null;
+  updateTime?: Date;
+}) =>
+  MongoApp.create({
+    name: data.name,
+    type: data.type ?? AppTypeEnum.workflow,
+    teamId: data.teamId,
+    tmbId: data.tmbId,
+    ...(data.parentId !== undefined ? { parentId: data.parentId } : {}),
+    ...(data.inheritPermission !== undefined ? { inheritPermission: data.inheritPermission } : {}),
+    ...(data.deleteTime !== undefined ? { deleteTime: data.deleteTime } : {}),
+    ...(data.updateTime !== undefined ? { updateTime: data.updateTime } : {})
+  });
+
+const grantRead = ({
+  teamId,
+  resourceId,
+  tmbId,
+  permission = ReadRoleVal
+}: {
+  teamId: string;
+  resourceId: Types.ObjectId;
+  tmbId: string;
+  permission?: number;
+}) =>
+  MongoResourcePermission.create({
+    resourceType: PerResourceTypeEnum.app,
+    teamId,
+    resourceId,
+    tmbId,
+    permission
+  });
+
+describe('POST /api/core/app/listV2', () => {
+  it('owner + 无 parentId：v2 返回全团队（含子目录），旧接口仅根目录（预期不相等）', async () => {
+    const owner = await getUser(`listv2-app-owner-all-${getNanoid(6)}`);
+
+    const rootApp = await createApp({ name: 'Root App', teamId: owner.teamId, tmbId: owner.tmbId });
+    const folder = await createApp({
+      name: 'Folder',
+      type: AppTypeEnum.folder,
+      teamId: owner.teamId,
+      tmbId: owner.tmbId
+    });
+    const childApp = await createApp({
+      name: 'Child App',
+      teamId: owner.teamId,
+      tmbId: owner.tmbId,
+      parentId: String(folder._id)
+    });
+
+    const oldRes = await Call(handler, {
+      auth: owner,
+      body: {}
+    });
+    const oldList = await Call(oldHandler, { auth: owner, body: {} });
+
+    expect(oldRes.code).toBe(200);
+    expect(oldList.code).toBe(200);
+    const v2Ids = oldRes.data.list.map((item: { _id: string }) => String(item._id));
+    const oldIds = oldList.data.map((item: { _id: string }) => String(item._id));
+
+    // v2 = 全团队；旧 owner 无 parentId 仅根目录（Root App + Folder）
+    expect(v2Ids).toContain(String(childApp._id));
+    expect(v2Ids).toContain(String(rootApp._id));
+    expect(oldIds).not.toContain(String(childApp._id));
+    expect(oldIds).toContain(String(rootApp._id));
+    // 预期不相等断言（差异 4）
+    expect(v2Ids).not.toEqual(oldIds);
+  });
+
+  it('owner + parentId：目录内列表与旧接口一致（预期相等）', async () => {
+    const owner = await getUser(`listv2-app-owner-dir-${getNanoid(6)}`);
+
+    const folder = await createApp({
+      name: 'Folder',
+      type: AppTypeEnum.folder,
+      teamId: owner.teamId,
+      tmbId: owner.tmbId
+    });
+    await createApp({
+      name: 'In Folder',
+      teamId: owner.teamId,
+      tmbId: owner.tmbId,
+      parentId: String(folder._id)
+    });
+    await createApp({ name: 'Root Only', teamId: owner.teamId, tmbId: owner.tmbId });
+
+    const res = await Call<ListAppV2BodyType, Record<string, never>, ListAppV2ResponseType>(
+      handler,
+      { auth: owner, body: { parentId: String(folder._id), pageSize: 100 } }
+    );
+    const oldRes = await Call(oldHandler, { auth: owner, body: { parentId: String(folder._id) } });
+
+    expect(res.code).toBe(200);
+    const v2Ids = res.data.list.map((item) => String(item._id));
+    const oldIds = oldRes.data.map((item: { _id: string }) => String(item._id));
+    expect(v2Ids).toEqual(oldIds);
+  });
+
+  it('owner + searchKey：全局搜索（相等）', async () => {
+    const owner = await getUser(`listv2-app-owner-search-${getNanoid(6)}`);
+    await createApp({ name: 'Searchable App X', teamId: owner.teamId, tmbId: owner.tmbId });
+
+    const res = await Call<ListAppV2BodyType, Record<string, never>, ListAppV2ResponseType>(
+      handler,
+      { auth: owner, body: { searchKey: 'Searchable' } }
+    );
+    const oldRes = await Call(oldHandler, { auth: owner, body: { searchKey: 'Searchable' } });
+
+    expect(res.code).toBe(200);
+    expect(res.data.total).toBe(1);
+    expect(res.data.list.map((item) => String(item._id))).toEqual(
+      oldRes.data.map((item: { _id: string }) => String(item._id))
+    );
+  });
+
+  it('非 owner tmb 直授：v2 与旧接口可见集合一致（预期相等）', async () => {
+    const owner = await getUser(`listv2-app-nonowner-${getNanoid(6)}`);
+    const member = await getUser(`listv2-app-nonowner-m-${getNanoid(6)}`, owner.teamId);
+
+    const granted = await createApp({ name: 'Granted', teamId: owner.teamId, tmbId: owner.tmbId });
+    await createApp({ name: 'Not Granted', teamId: owner.teamId, tmbId: owner.tmbId });
+    await grantRead({ teamId: owner.teamId, resourceId: granted._id, tmbId: member.tmbId });
+
+    const res = await Call<ListAppV2BodyType, Record<string, never>, ListAppV2ResponseType>(
+      handler,
+      { auth: member, body: { pageSize: 100 } }
+    );
+    const oldRes = await Call(oldHandler, { auth: member, body: {} });
+
+    expect(res.code).toBe(200);
+    const v2Ids = res.data.list.map((item) => String(item._id));
+    const oldIds = oldRes.data.map((item: { _id: string }) => String(item._id));
+    expect(v2Ids).toEqual(oldIds);
+    expect(v2Ids).toContain(String(granted._id));
+  });
+
+  it('permission=0 + parent read 反例：v2 与旧接口均可见（预期相等，AnyRecorded 覆盖）', async () => {
+    const owner = await getUser(`listv2-app-zero-owner-${getNanoid(6)}`);
+    const member = await getUser(`listv2-app-zero-m-${getNanoid(6)}`, owner.teamId);
+
+    const folder = await createApp({
+      name: 'Folder',
+      type: AppTypeEnum.folder,
+      teamId: owner.teamId,
+      tmbId: owner.tmbId
+    });
+    const child = await createApp({
+      name: 'Child',
+      teamId: owner.teamId,
+      tmbId: owner.tmbId,
+      parentId: String(folder._id),
+      inheritPermission: true
+    });
+
+    await grantRead({ teamId: owner.teamId, resourceId: folder._id, tmbId: member.tmbId });
+    // 成员对 child 有一条 permission=0 的个人记录（AnyRecorded 含、ReadableDirect 不含）
+    await grantRead({
+      teamId: owner.teamId,
+      resourceId: child._id,
+      tmbId: member.tmbId,
+      permission: 0
+    });
+
+    const res = await Call<ListAppV2BodyType, Record<string, never>, ListAppV2ResponseType>(
+      handler,
+      { auth: member, body: { pageSize: 100 } }
+    );
+    const oldRes = await Call(oldHandler, { auth: member, body: {} });
+
+    expect(res.code).toBe(200);
+    expect(oldRes.code).toBe(200);
+    const v2Ids = res.data.list.map((item) => String(item._id));
+    const oldIds = oldRes.data.map((item: { _id: string }) => String(item._id));
+    // 经父目录继承，child 两侧均可见 → 预期相等
+    expect(v2Ids).toContain(String(child._id));
+    expect(v2Ids).toEqual(oldIds);
+  });
+
+  it('跨目录创建者（无权限记录）：v2 可见、旧不可见（预期不相等）', async () => {
+    const owner = await getUser(`listv2-app-creator-owner-${getNanoid(6)}`);
+    const member = await getUser(`listv2-app-creator-m-${getNanoid(6)}`, owner.teamId);
+
+    const folderB = await createApp({
+      name: 'Folder B',
+      type: AppTypeEnum.folder,
+      teamId: owner.teamId,
+      tmbId: owner.tmbId
+    });
+    // 成员在目录 B 内创建 app（直接建表，不写权限记录 → 无记录创建者）
+    await createApp({
+      name: 'Member Created',
+      teamId: owner.teamId,
+      tmbId: member.tmbId,
+      parentId: String(folderB._id)
+    });
+
+    const res = await Call<ListAppV2BodyType, Record<string, never>, ListAppV2ResponseType>(
+      handler,
+      { auth: member, body: { pageSize: 100 } }
+    );
+    const oldRes = await Call(oldHandler, { auth: member, body: {} });
+
+    expect(res.code).toBe(200);
+    const v2Ids = res.data.list.map((item) => String(item._id));
+    const oldIds = oldRes.data.map((item: { _id: string }) => String(item._id));
+    // v2 显示跨目录无记录创建者，旧不显示
+    expect(v2Ids.length).toBeGreaterThan(oldIds.length);
+  });
+
+  it('分页：total 为全量 match 计数，total > list.length（25 条 / pageSize 10）', async () => {
+    const owner = await getUser(`listv2-app-paging-${getNanoid(6)}`);
+    const apps = await Promise.all(
+      Array.from({ length: 25 }, (_, i) =>
+        createApp({ name: `App ${i}`, teamId: owner.teamId, tmbId: owner.tmbId })
+      )
+    );
+
+    const res = await Call<ListAppV2BodyType, Record<string, never>, ListAppV2ResponseType>(
+      handler,
+      { auth: owner, body: { pageSize: 10, pageNum: 1 } }
+    );
+
+    expect(res.code).toBe(200);
+    expect(res.data.total).toBe(25);
+    expect(res.data.list).toHaveLength(10);
+    expect(res.data.total).toBeGreaterThan(res.data.list.length);
+
+    // 第二页不重复、不遗漏
+    const res2 = await Call<ListAppV2BodyType, Record<string, never>, ListAppV2ResponseType>(
+      handler,
+      { auth: owner, body: { pageSize: 10, pageNum: 2 } }
+    );
+    const page1Ids = res.data.list.map((item) => String(item._id));
+    const page2Ids = res2.data.list.map((item) => String(item._id));
+    expect(page1Ids).not.toEqual(page2Ids);
+    const allIds = [...page1Ids, ...page2Ids];
+    expect(new Set(allIds).size).toBe(20);
+    expect(apps.length).toBe(25);
+  });
+
+  it('orphan（tmbId 指向不存在成员）：v2 保留 + 占位，旧接口丢项', async () => {
+    const owner = await getUser(`listv2-app-orphan-${getNanoid(6)}`);
+    const orphanApp = await createApp({
+      name: 'Orphan App',
+      teamId: owner.teamId,
+      tmbId: new Types.ObjectId().toString()
+    });
+
+    const res = await Call<ListAppV2BodyType, Record<string, never>, ListAppV2ResponseType>(
+      handler,
+      { auth: owner, body: { pageSize: 100 } }
+    );
+    const oldRes = await Call(oldHandler, { auth: owner, body: {} });
+
+    expect(res.code).toBe(200);
+    const v2Orphan = res.data.list.find((item) => String(item._id) === String(orphanApp._id));
+    expect(v2Orphan).toBeDefined();
+    expect(v2Orphan!.sourceMember).toEqual({ name: '未知成员', avatar: null, status: null });
+    // 旧接口 addSourceMember 丢项
+    const oldIds = oldRes.data.map((item: { _id: string }) => String(item._id));
+    expect(oldIds).not.toContain(String(orphanApp._id));
+  });
+
+  it('fail-fast：非 owner 可读资源超过阈值 → 明确错误码', async () => {
+    const owner = await getUser(`listv2-app-limit-owner-${getNanoid(6)}`);
+    const member = await getUser(`listv2-app-limit-m-${getNanoid(6)}`, owner.teamId);
+
+    // 一次性插入 10001 条成员直授记录（超过 READABLE_IDS_LIMIT=10000）
+    const resourceIds = Array.from({ length: 10001 }, () => new Types.ObjectId());
+    await MongoResourcePermission.insertMany(
+      resourceIds.map((resourceId) => ({
+        resourceType: PerResourceTypeEnum.app,
+        teamId: owner.teamId,
+        resourceId,
+        tmbId: member.tmbId,
+        permission: ReadPermissionVal
+      }))
+    );
+
+    const res = await Call<ListAppV2BodyType, Record<string, never>, ListAppV2ResponseType>(
+      handler,
+      { auth: member, body: {} }
+    );
+
+    expect(res.code).not.toBe(200);
+    expect(res.error).toBe(CommonErrEnum.tooManyReadableResources);
+  });
+});

--- a/projects/app/test/api/core/dataset/listV2.test.ts
+++ b/projects/app/test/api/core/dataset/listV2.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { Types } from 'mongoose';
+import handler from '@/pages/api/core/dataset/listV2';
+import oldHandler from '@/pages/api/core/dataset/list';
+import { MongoDataset } from '@fastgpt/service/core/dataset/schema';
+import { MongoResourcePermission } from '@fastgpt/service/support/permission/schema';
+import { DatasetTypeEnum } from '@fastgpt/global/core/dataset/constants';
+import { ModelTypeEnum } from '@fastgpt/global/core/ai/constants';
+import type { EmbeddingModelItemType } from '@fastgpt/global/core/ai/model.schema';
+import { PerResourceTypeEnum } from '@fastgpt/global/support/permission/constant';
+import { ReadRoleVal } from '@fastgpt/global/support/permission/constant';
+import { getNanoid } from '@fastgpt/global/common/string/tools';
+import { getUser } from '@test/datas/users';
+import { Call } from '@test/utils/request';
+import type {
+  ListDatasetV2Body,
+  ListDatasetV2Response
+} from '@fastgpt/global/openapi/core/dataset/api';
+
+// 测试环境无系统模型配置，初始化 global 模型 map 使 v2 响应 schema 的 vectorModel 可 parse（生产由启动时配置加载）
+const testEmbeddingModel: EmbeddingModelItemType = {
+  model: 'text-embedding-3',
+  name: 'Embedding',
+  provider: 'openai',
+  type: ModelTypeEnum.embedding,
+  defaultToken: 1000,
+  maxToken: 8000,
+  weight: 100
+};
+
+beforeAll(() => {
+  globalThis.embeddingModelMap = new Map([['text-embedding-3', testEmbeddingModel]]);
+  globalThis.systemDefaultModel = { embedding: testEmbeddingModel };
+});
+
+const createDataset = (data: {
+  name: string;
+  teamId: string;
+  tmbId: string;
+  type?: DatasetTypeEnum;
+  parentId?: string | null;
+  inheritPermission?: boolean;
+  updateTime?: Date;
+}) =>
+  MongoDataset.create({
+    name: data.name,
+    type: data.type ?? DatasetTypeEnum.dataset,
+    teamId: data.teamId,
+    tmbId: data.tmbId,
+    vectorModel: testEmbeddingModel.model,
+    ...(data.parentId !== undefined
+      ? { parentId: data.parentId ? new Types.ObjectId(data.parentId) : null }
+      : {}),
+    ...(data.inheritPermission !== undefined ? { inheritPermission: data.inheritPermission } : {}),
+    ...(data.updateTime !== undefined ? { updateTime: data.updateTime } : {})
+  });
+
+describe('POST /api/core/dataset/listV2', () => {
+  it('owner + 无 parentId：v2 与旧接口均返回全团队（相等）', async () => {
+    const owner = await getUser(`listv2-ds-owner-${getNanoid(6)}`);
+    await createDataset({ name: 'D1', teamId: owner.teamId, tmbId: owner.tmbId });
+
+    const res = await Call<ListDatasetV2Body, Record<string, never>, ListDatasetV2Response>(
+      handler,
+      { auth: owner, body: { pageSize: 100 } }
+    );
+    const oldRes = await Call(oldHandler, { auth: owner, body: {} });
+
+    expect(res.code).toBe(200);
+    expect(res.data.list.map((item) => String(item._id))).toEqual(
+      oldRes.data.map((item: { _id: string }) => String(item._id))
+    );
+  });
+
+  it('owner + parentId：目录过滤，与旧接口一致（相等）', async () => {
+    const owner = await getUser(`listv2-ds-dir-${getNanoid(6)}`);
+    const folder = await createDataset({
+      name: 'Folder',
+      type: DatasetTypeEnum.folder,
+      teamId: owner.teamId,
+      tmbId: owner.tmbId
+    });
+    await createDataset({
+      name: 'In Folder',
+      teamId: owner.teamId,
+      tmbId: owner.tmbId,
+      parentId: String(folder._id)
+    });
+    await createDataset({ name: 'Root', teamId: owner.teamId, tmbId: owner.tmbId });
+
+    const res = await Call<ListDatasetV2Body, Record<string, never>, ListDatasetV2Response>(
+      handler,
+      { auth: owner, body: { parentId: String(folder._id), pageSize: 100 } }
+    );
+    const oldRes = await Call(oldHandler, { auth: owner, body: { parentId: String(folder._id) } });
+
+    expect(res.code).toBe(200);
+    expect(res.data.list.map((item) => String(item._id))).toEqual(
+      oldRes.data.map((item: { _id: string }) => String(item._id))
+    );
+  });
+
+  it('searchKey：搜索不带 type 过滤（复刻旧语义），v2 与旧一致', async () => {
+    const owner = await getUser(`listv2-ds-search-${getNanoid(6)}`);
+    await createDataset({
+      name: 'Searchable DS',
+      type: DatasetTypeEnum.websiteDataset,
+      teamId: owner.teamId,
+      tmbId: owner.tmbId
+    });
+
+    const res = await Call<ListDatasetV2Body, Record<string, never>, ListDatasetV2Response>(
+      handler,
+      { auth: owner, body: { searchKey: 'Searchable' } }
+    );
+    const oldRes = await Call(oldHandler, { auth: owner, body: { searchKey: 'Searchable' } });
+
+    expect(res.code).toBe(200);
+    // websiteDataset 类型在搜索中不被 type 过滤掉（旧语义）
+    expect(res.data.total).toBe(1);
+    expect(res.data.list.map((item) => String(item._id))).toEqual(
+      oldRes.data.map((item: { _id: string }) => String(item._id))
+    );
+  });
+
+  it('非 owner tmb 直授：v2 与旧一致（相等）', async () => {
+    const owner = await getUser(`listv2-ds-nonowner-${getNanoid(6)}`);
+    const member = await getUser(`listv2-ds-nonowner-m-${getNanoid(6)}`, owner.teamId);
+
+    const granted = await createDataset({
+      name: 'Granted',
+      teamId: owner.teamId,
+      tmbId: owner.tmbId
+    });
+    await createDataset({ name: 'Not Granted', teamId: owner.teamId, tmbId: owner.tmbId });
+    await MongoResourcePermission.create({
+      resourceType: PerResourceTypeEnum.dataset,
+      teamId: owner.teamId,
+      resourceId: granted._id,
+      tmbId: member.tmbId,
+      permission: ReadRoleVal
+    });
+
+    const res = await Call<ListDatasetV2Body, Record<string, never>, ListDatasetV2Response>(
+      handler,
+      { auth: member, body: { pageSize: 100 } }
+    );
+    const oldRes = await Call(oldHandler, { auth: member, body: {} });
+
+    expect(res.code).toBe(200);
+    const v2Ids = res.data.list.map((item) => String(item._id));
+    const oldIds = oldRes.data.map((item: { _id: string }) => String(item._id));
+    expect(v2Ids).toEqual(oldIds);
+    expect(v2Ids).toContain(String(granted._id));
+  });
+
+  it('非 owner + 目录继承（父文件夹 read → 子 dataset 可见），与旧一致', async () => {
+    const owner = await getUser(`listv2-ds-inherit-${getNanoid(6)}`);
+    const member = await getUser(`listv2-ds-inherit-m-${getNanoid(6)}`, owner.teamId);
+
+    const folder = await createDataset({
+      name: 'Folder',
+      type: DatasetTypeEnum.folder,
+      teamId: owner.teamId,
+      tmbId: owner.tmbId
+    });
+    const child = await createDataset({
+      name: 'Child',
+      teamId: owner.teamId,
+      tmbId: owner.tmbId,
+      parentId: String(folder._id),
+      inheritPermission: true
+    });
+    await MongoResourcePermission.create({
+      resourceType: PerResourceTypeEnum.dataset,
+      teamId: owner.teamId,
+      resourceId: folder._id,
+      tmbId: member.tmbId,
+      permission: ReadRoleVal
+    });
+
+    const res = await Call<ListDatasetV2Body, Record<string, never>, ListDatasetV2Response>(
+      handler,
+      { auth: member, body: { parentId: String(folder._id), pageSize: 100 } }
+    );
+    const oldRes = await Call(oldHandler, { auth: member, body: { parentId: String(folder._id) } });
+
+    expect(res.code).toBe(200);
+    const v2Ids = res.data.list.map((item) => String(item._id));
+    expect(v2Ids).toContain(String(child._id));
+    expect(v2Ids).toEqual(oldRes.data.map((item: { _id: string }) => String(item._id)));
+  });
+
+  it('分页：total 为全量计数（25 条 / pageSize 10 → total 25、list 10）', async () => {
+    const owner = await getUser(`listv2-ds-paging-${getNanoid(6)}`);
+    await Promise.all(
+      Array.from({ length: 25 }, (_, i) =>
+        createDataset({ name: `DS ${i}`, teamId: owner.teamId, tmbId: owner.tmbId })
+      )
+    );
+
+    const res = await Call<ListDatasetV2Body, Record<string, never>, ListDatasetV2Response>(
+      handler,
+      { auth: owner, body: { pageSize: 10, pageNum: 1 } }
+    );
+
+    expect(res.code).toBe(200);
+    expect(res.data.total).toBe(25);
+    expect(res.data.list).toHaveLength(10);
+    expect(res.data.total).toBeGreaterThan(res.data.list.length);
+  });
+
+  it('orphan（tmbId 不存在）：v2 保留 + 占位，旧接口丢项', async () => {
+    const owner = await getUser(`listv2-ds-orphan-${getNanoid(6)}`);
+    await createDataset({
+      name: 'Orphan DS',
+      teamId: owner.teamId,
+      tmbId: new Types.ObjectId().toString()
+    });
+
+    const res = await Call<ListDatasetV2Body, Record<string, never>, ListDatasetV2Response>(
+      handler,
+      { auth: owner, body: { pageSize: 100 } }
+    );
+    const oldRes = await Call(oldHandler, { auth: owner, body: {} });
+
+    expect(res.code).toBe(200);
+    const v2Orphan = res.data.list.find((item) => item.name === 'Orphan DS');
+    expect(v2Orphan).toBeDefined();
+    expect(v2Orphan!.sourceMember).toEqual({ name: '未知成员', avatar: null, status: null });
+    const oldIds = oldRes.data.map((item: { _id: string }) => String(item._id));
+    expect(oldIds).not.toContain(String(v2Orphan!._id));
+  });
+});

--- a/projects/app/test/openapi/v2Pagination.test.ts
+++ b/projects/app/test/openapi/v2Pagination.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from 'vitest';
+import { Types } from 'mongoose';
+import { AppTypeEnum } from '@fastgpt/global/core/app/constants';
+import { DatasetTypeEnum } from '@fastgpt/global/core/dataset/constants';
+import { TeamMemberStatusEnum } from '@fastgpt/global/support/user/team/constant';
+import { ReadRoleVal } from '@fastgpt/global/support/permission/constant';
+import { parseV2Pagination } from '@fastgpt/service/common/api/paginationV2';
+import {
+  ListAppV2BodySchema,
+  ListAppV2ItemSchema
+} from '@fastgpt/global/openapi/core/app/common/api';
+import {
+  ListDatasetV2BodySchema,
+  ListDatasetV2ItemSchema
+} from '@fastgpt/global/openapi/core/dataset/api';
+import {
+  ListSkillsV2QuerySchema,
+  ListSkillsV2ItemSchema
+} from '@fastgpt/global/openapi/core/ai/skill/api';
+
+describe('parseV2Pagination', () => {
+  it('全缺省时 pageSize=10、offset=0（第一页）', () => {
+    expect(parseV2Pagination({})).toEqual({ pageSize: 10, offset: 0 });
+  });
+
+  it('仅给 pageSize 时 offset=0', () => {
+    expect(parseV2Pagination({ pageSize: 20 })).toEqual({ pageSize: 20, offset: 0 });
+  });
+
+  it('offset=0 正确生效（?? 语义，非 truthy 判断）', () => {
+    expect(parseV2Pagination({ pageSize: 20, offset: 0 })).toEqual({ pageSize: 20, offset: 0 });
+  });
+
+  it('pageNum 换算为 offset=(pageNum-1)*pageSize', () => {
+    expect(parseV2Pagination({ pageSize: 20, pageNum: 3 })).toEqual({ pageSize: 20, offset: 40 });
+  });
+
+  it('pageNum 缺省视为 1', () => {
+    expect(parseV2Pagination({ offset: 5 })).toEqual({ pageSize: 10, offset: 5 });
+  });
+});
+
+describe('v2 分页参数边界（numbers-only + 互斥）', () => {
+  const baseAppBody = { type: AppTypeEnum.workflow };
+
+  it('pageSize 边界：0/负数/101 被拒，100 通过', () => {
+    expect(ListAppV2BodySchema.safeParse({ ...baseAppBody, pageSize: 0 }).success).toBe(false);
+    expect(ListAppV2BodySchema.safeParse({ ...baseAppBody, pageSize: -1 }).success).toBe(false);
+    expect(ListAppV2BodySchema.safeParse({ ...baseAppBody, pageSize: 101 }).success).toBe(false);
+    expect(ListAppV2BodySchema.safeParse({ ...baseAppBody, pageSize: 100 }).success).toBe(true);
+  });
+
+  it('数字字符串被拒（v2 只接受 number，无 coerce）', () => {
+    expect(ListAppV2BodySchema.safeParse({ ...baseAppBody, pageSize: '10' }).success).toBe(false);
+    expect(ListAppV2BodySchema.safeParse({ ...baseAppBody, offset: '0' }).success).toBe(false);
+    expect(ListAppV2BodySchema.safeParse({ ...baseAppBody, pageNum: '1' }).success).toBe(false);
+  });
+
+  it('NaN 与 Infinity 被拒（z.number().int() 语义）', () => {
+    expect(ListAppV2BodySchema.safeParse({ ...baseAppBody, pageSize: NaN }).success).toBe(false);
+    expect(ListAppV2BodySchema.safeParse({ ...baseAppBody, pageSize: Infinity }).success).toBe(
+      false
+    );
+    expect(ListAppV2BodySchema.safeParse({ ...baseAppBody, offset: -Infinity }).success).toBe(
+      false
+    );
+  });
+
+  it('offset 负数被拒、0 通过；pageNum 0 被拒、1 通过', () => {
+    expect(ListAppV2BodySchema.safeParse({ ...baseAppBody, offset: -1 }).success).toBe(false);
+    expect(ListAppV2BodySchema.safeParse({ ...baseAppBody, offset: 0 }).success).toBe(true);
+    expect(ListAppV2BodySchema.safeParse({ ...baseAppBody, pageNum: 0 }).success).toBe(false);
+    expect(ListAppV2BodySchema.safeParse({ ...baseAppBody, pageNum: 1 }).success).toBe(true);
+  });
+
+  it('offset 与 pageNum 同时给出被拒（superRefine 互斥）', () => {
+    const result = ListAppV2BodySchema.safeParse({ ...baseAppBody, offset: 0, pageNum: 1 });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('offset 与 pageNum 互斥，二选一');
+    }
+  });
+
+  it('空对象通过（全缺省）', () => {
+    expect(ListAppV2BodySchema.safeParse({}).success).toBe(true);
+  });
+
+  it('dataset type 数组被拒（仅单值 enum）', () => {
+    expect(ListDatasetV2BodySchema.safeParse({ type: [DatasetTypeEnum.dataset] }).success).toBe(
+      false
+    );
+    expect(ListDatasetV2BodySchema.safeParse({ type: DatasetTypeEnum.dataset }).success).toBe(true);
+  });
+
+  it('skill v2 query 同样执行分页边界与互斥', () => {
+    expect(ListSkillsV2QuerySchema.safeParse({ pageSize: -5 }).success).toBe(false);
+    expect(ListSkillsV2QuerySchema.safeParse({ offset: 10, pageNum: 2 }).success).toBe(false);
+    expect(ListSkillsV2QuerySchema.safeParse({ pageSize: 50, pageNum: 2 }).success).toBe(true);
+  });
+});
+
+describe('app v2 body type 语义（复用旧 preprocess）', () => {
+  it('type 空字符串按全部类型处理', () => {
+    expect(ListAppV2BodySchema.parse({ type: '' })).toEqual({});
+  });
+
+  it('支持单类型与类型数组，非法类型被忽略', () => {
+    expect(ListAppV2BodySchema.parse({ type: AppTypeEnum.workflow }).type).toBe(
+      AppTypeEnum.workflow
+    );
+    expect(
+      ListAppV2BodySchema.parse({ type: [AppTypeEnum.folder, AppTypeEnum.workflow] }).type
+    ).toEqual([AppTypeEnum.folder, AppTypeEnum.workflow]);
+    expect(ListAppV2BodySchema.parse({ type: ['unknown', AppTypeEnum.workflow] }).type).toEqual([
+      AppTypeEnum.workflow
+    ]);
+  });
+});
+
+describe('v2 item schema 解析', () => {
+  const oid = () => new Types.ObjectId().toString();
+  const skillPermission = {
+    role: ReadRoleVal,
+    isOwner: false,
+    hasManagePer: false,
+    hasWritePer: false,
+    hasReadPer: true,
+    hasManageRole: false,
+    hasWriteRole: false,
+    hasReadRole: true
+  };
+  const appPermission = {
+    role: ReadRoleVal,
+    isOwner: false,
+    hasManagePer: false,
+    hasWritePer: false,
+    hasReadPer: true,
+    hasManageRole: false,
+    hasWriteRole: false,
+    hasReadRole: true,
+    hasReadChatLogPer: false,
+    hasReadChatLogRole: false
+  };
+  const vectorModel = {
+    model: 'text-embedding-3',
+    name: 'Embedding',
+    provider: 'openai',
+    type: 'embedding',
+    defaultToken: 1000,
+    maxToken: 8000,
+    weight: 100
+  };
+
+  it('skill item：ObjectId/null 双形态与 Date 通过', () => {
+    const item = {
+      _id: new Types.ObjectId(),
+      parentId: oid(),
+      tmbId: oid(),
+      source: 'personal',
+      type: 'skill',
+      name: 'Test Skill',
+      description: '',
+      category: [],
+      inheritPermission: true,
+      createTime: new Date(),
+      updateTime: new Date(),
+      permission: skillPermission,
+      private: false
+    };
+    const parsed = ListSkillsV2ItemSchema.parse(item);
+    expect(parsed._id).toBe(String(item._id));
+    expect(parsed.createTime).toBeInstanceOf(Date);
+  });
+
+  it('skill item：system skill tmbId=null、根级 parentId=null 通过（owner store 场景）', () => {
+    const item = {
+      _id: oid(),
+      parentId: null,
+      tmbId: null,
+      source: 'system',
+      type: 'skill',
+      name: 'System Skill',
+      description: '',
+      category: [],
+      createTime: new Date(),
+      updateTime: new Date(),
+      permission: skillPermission
+    };
+    const parsed = ListSkillsV2ItemSchema.parse(item);
+    expect(parsed.tmbId).toBeNull();
+    expect(parsed.parentId).toBeNull();
+  });
+
+  it('skill item：sourceMember.status 可为 null（缺成员占位），非法 status 被拒', () => {
+    const base = {
+      _id: oid(),
+      parentId: null,
+      tmbId: oid(),
+      source: 'personal',
+      type: 'skill',
+      name: 'S',
+      description: '',
+      category: [],
+      createTime: new Date(),
+      updateTime: new Date(),
+      permission: skillPermission
+    };
+    expect(
+      ListSkillsV2ItemSchema.safeParse({
+        ...base,
+        sourceMember: { name: '未知成员', avatar: null, status: null }
+      }).success
+    ).toBe(true);
+    expect(
+      ListSkillsV2ItemSchema.safeParse({
+        ...base,
+        sourceMember: { name: '张三', avatar: null, status: TeamMemberStatusEnum.active }
+      }).success
+    ).toBe(true);
+    expect(
+      ListSkillsV2ItemSchema.safeParse({
+        ...base,
+        sourceMember: { name: '张三', avatar: null, status: 'unknown' }
+      }).success
+    ).toBe(false);
+  });
+
+  it('app/dataset item：sourceMember.status null 通过（缺成员占位）', () => {
+    const appItem = {
+      _id: oid(),
+      parentId: null,
+      tmbId: oid(),
+      name: 'A',
+      avatar: '',
+      intro: '',
+      type: AppTypeEnum.workflow,
+      updateTime: new Date(),
+      pluginData: {},
+      permission: appPermission,
+      sourceMember: { name: '未知成员', avatar: null, status: null }
+    };
+    expect(ListAppV2ItemSchema.safeParse(appItem).success).toBe(true);
+
+    const datasetItem = {
+      _id: oid(),
+      tmbId: oid(),
+      avatar: '',
+      updateTime: new Date(),
+      name: 'D',
+      intro: '',
+      type: DatasetTypeEnum.dataset,
+      permission: appPermission,
+      vectorModel,
+      inheritPermission: true,
+      sourceMember: { name: '未知成员', avatar: null, status: null }
+    };
+    expect(ListDatasetV2ItemSchema.safeParse(datasetItem).success).toBe(true);
+  });
+});

--- a/projects/app/test/service/support/permission/resource/readable.test.ts
+++ b/projects/app/test/service/support/permission/resource/readable.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from 'vitest';
+import { Types } from 'mongoose';
+import { getUser } from '@test/datas/users';
+import { getNanoid } from '@fastgpt/global/common/string/tools';
+import { PerResourceTypeEnum } from '@fastgpt/global/support/permission/constant';
+import {
+  ReadRoleVal,
+  WriteRoleVal,
+  ManageRoleVal,
+  OwnerRoleVal
+} from '@fastgpt/global/support/permission/constant';
+import { AppPermission } from '@fastgpt/global/support/permission/app/controller';
+import { MongoResourcePermission } from '@fastgpt/service/support/permission/schema';
+import { MongoMemberGroupModel } from '@fastgpt/service/support/permission/memberGroup/memberGroupSchema';
+import { MongoGroupMemberModel } from '@fastgpt/service/support/permission/memberGroup/groupMemberSchema';
+import { MongoOrgModel } from '@fastgpt/service/support/permission/org/orgSchema';
+import { MongoOrgMemberModel } from '@fastgpt/service/support/permission/org/orgMemberSchema';
+import {
+  getMyResourcePermission,
+  buildReadableMatch,
+  mergeMongoAndQuery,
+  addSourceMemberV2
+} from '@fastgpt/service/support/permission/resource/readable';
+
+const createPermission = (role?: number) => new AppPermission({ role });
+
+describe('buildReadableMatch', () => {
+  it('三分支：直接可读 / 创建者 / 一层继承（排除文件夹）', () => {
+    const match = buildReadableMatch({
+      readableDirectIds: ['a', 'b'],
+      tmbId: 'me',
+      folderTypeList: ['folder']
+    });
+    expect(match).toEqual({
+      $or: [
+        { _id: { $in: ['a', 'b'] } },
+        { tmbId: 'me' },
+        {
+          type: { $nin: ['folder'] },
+          inheritPermission: true,
+          parentId: { $in: ['a', 'b'] }
+        }
+      ]
+    });
+  });
+});
+
+describe('mergeMongoAndQuery', () => {
+  it('空对象被忽略；单条件直接返回；多条件（含多个 $or）用 $and 合并避免覆盖', () => {
+    expect(mergeMongoAndQuery({})).toEqual({});
+    expect(mergeMongoAndQuery({ a: 1 }, {})).toEqual({ a: 1 });
+    expect(mergeMongoAndQuery({ teamId: 't' }, { $or: [{ x: 1 }] }, { $or: [{ y: 2 }] })).toEqual({
+      $and: [{ teamId: 't' }, { $or: [{ x: 1 }] }, { $or: [{ y: 2 }] }]
+    });
+  });
+});
+
+describe('getMyResourcePermission（真实 DB）', () => {
+  it('tmb 直授 read → readableDirectIds 含；anyRecordedIds 含 permission=0 记录', async () => {
+    const user = await getUser(`readable-tmb-${getNanoid(6)}`);
+    const readAppId = new Types.ObjectId();
+    const zeroAppId = new Types.ObjectId();
+
+    await MongoResourcePermission.create([
+      {
+        resourceType: PerResourceTypeEnum.app,
+        teamId: user.teamId,
+        resourceId: readAppId,
+        tmbId: user.tmbId,
+        permission: ReadRoleVal
+      },
+      {
+        resourceType: PerResourceTypeEnum.app,
+        teamId: user.teamId,
+        resourceId: zeroAppId,
+        tmbId: user.tmbId,
+        permission: 0
+      }
+    ]);
+
+    const result = await getMyResourcePermission({
+      teamId: user.teamId,
+      tmbId: user.tmbId,
+      resourceType: PerResourceTypeEnum.app,
+      createPermission
+    });
+
+    expect(result.readableDirectIds).toContain(String(readAppId));
+    // permission=0 的记录存在但不可读（tmb 直授 0 不回落组角色，?? 语义）
+    expect(result.readableDirectIds).not.toContain(String(zeroAppId));
+    // 但 anyRecordedIds 记录的是「出现过记录」，含 permission=0
+    expect(result.anyRecordedIds).toContain(String(zeroAppId));
+    expect(result.anyRecordedIds).toContain(String(readAppId));
+  });
+
+  it('个人直授优先：tmb write 压过组 manage（?? 语义，非 ||）', async () => {
+    const user = await getUser(`readable-priority-${getNanoid(6)}`);
+    const appId = new Types.ObjectId();
+
+    const group = await MongoMemberGroupModel.create({
+      teamId: user.teamId,
+      name: 'g'
+    });
+    await MongoGroupMemberModel.create({
+      groupId: group._id,
+      tmbId: user.tmbId
+    });
+    await MongoResourcePermission.create([
+      {
+        resourceType: PerResourceTypeEnum.app,
+        teamId: user.teamId,
+        resourceId: appId,
+        tmbId: user.tmbId,
+        permission: WriteRoleVal
+      },
+      {
+        resourceType: PerResourceTypeEnum.app,
+        teamId: user.teamId,
+        resourceId: appId,
+        groupId: group._id,
+        permission: ManageRoleVal
+      }
+    ]);
+
+    const result = await getMyResourcePermission({
+      teamId: user.teamId,
+      tmbId: user.tmbId,
+      resourceType: PerResourceTypeEnum.app,
+      createPermission
+    });
+
+    expect(result.readableDirectIds).toContain(String(appId));
+  });
+
+  it('个人直授 permission=0 压过组 read（0 不回落）', async () => {
+    const user = await getUser(`readable-zero-${getNanoid(6)}`);
+    const appId = new Types.ObjectId();
+
+    const group = await MongoMemberGroupModel.create({
+      teamId: user.teamId,
+      name: 'g'
+    });
+    await MongoGroupMemberModel.create({
+      groupId: group._id,
+      tmbId: user.tmbId
+    });
+    await MongoResourcePermission.create([
+      {
+        resourceType: PerResourceTypeEnum.app,
+        teamId: user.teamId,
+        resourceId: appId,
+        tmbId: user.tmbId,
+        permission: 0
+      },
+      {
+        resourceType: PerResourceTypeEnum.app,
+        teamId: user.teamId,
+        resourceId: appId,
+        groupId: group._id,
+        permission: ReadRoleVal
+      }
+    ]);
+
+    const result = await getMyResourcePermission({
+      teamId: user.teamId,
+      tmbId: user.tmbId,
+      resourceType: PerResourceTypeEnum.app,
+      createPermission
+    });
+
+    // ?? 语义：tmb 记录存在（permission=0）时不回落组角色 → 不可读
+    expect(result.readableDirectIds).not.toContain(String(appId));
+    expect(result.anyRecordedIds).toContain(String(appId));
+  });
+
+  it('组授权 read（组集合展开）→ 可读', async () => {
+    const user = await getUser(`readable-group-${getNanoid(6)}`);
+    const appId = new Types.ObjectId();
+
+    const group = await MongoMemberGroupModel.create({
+      teamId: user.teamId,
+      name: 'g'
+    });
+    await MongoGroupMemberModel.create({
+      groupId: group._id,
+      tmbId: user.tmbId
+    });
+    await MongoResourcePermission.create({
+      resourceType: PerResourceTypeEnum.app,
+      teamId: user.teamId,
+      resourceId: appId,
+      groupId: group._id,
+      permission: ReadRoleVal
+    });
+
+    const result = await getMyResourcePermission({
+      teamId: user.teamId,
+      tmbId: user.tmbId,
+      resourceType: PerResourceTypeEnum.app,
+      createPermission
+    });
+
+    expect(result.readableDirectIds).toContain(String(appId));
+  });
+
+  it('组织授权 read（组织含父级路径展开）→ 可读', async () => {
+    const user = await getUser(`readable-org-${getNanoid(6)}`);
+    const appId = new Types.ObjectId();
+
+    const org = await MongoOrgModel.create({
+      teamId: user.teamId,
+      pathId: `path-${getNanoid(6)}`,
+      path: '/',
+      name: 'org'
+    });
+    await MongoOrgMemberModel.create({
+      teamId: user.teamId,
+      orgId: org._id,
+      tmbId: user.tmbId
+    });
+    await MongoResourcePermission.create({
+      resourceType: PerResourceTypeEnum.app,
+      teamId: user.teamId,
+      resourceId: appId,
+      orgId: org._id,
+      permission: ReadRoleVal
+    });
+
+    const result = await getMyResourcePermission({
+      teamId: user.teamId,
+      tmbId: user.tmbId,
+      resourceType: PerResourceTypeEnum.app,
+      createPermission
+    });
+
+    expect(result.readableDirectIds).toContain(String(appId));
+  });
+
+  it('OwnerRoleVal 记录 → 可读', async () => {
+    const user = await getUser(`readable-owner-${getNanoid(6)}`);
+    const appId = new Types.ObjectId();
+
+    await MongoResourcePermission.create({
+      resourceType: PerResourceTypeEnum.app,
+      teamId: user.teamId,
+      resourceId: appId,
+      tmbId: user.tmbId,
+      permission: OwnerRoleVal
+    });
+
+    const result = await getMyResourcePermission({
+      teamId: user.teamId,
+      tmbId: user.tmbId,
+      resourceType: PerResourceTypeEnum.app,
+      createPermission
+    });
+
+    expect(result.readableDirectIds).toContain(String(appId));
+  });
+});
+
+describe('addSourceMemberV2（缺成员占位不丢项）', () => {
+  it('正常成员返回真实 sourceMember', async () => {
+    const user = await getUser(`sourcemember-ok-${getNanoid(6)}`);
+    const list = await addSourceMemberV2({ list: [{ _id: 'x', tmbId: user.tmbId }] });
+    expect(list[0].sourceMember.name).toBeDefined();
+    expect(list[0].sourceMember.status).not.toBeNull();
+  });
+
+  it('缺成员（tmbId 不存在）保留资源 + 占位（status null，不作虚假陈述）', async () => {
+    const list = await addSourceMemberV2({
+      list: [{ _id: 'x', tmbId: new Types.ObjectId().toString() }]
+    });
+    expect(list).toHaveLength(1);
+    expect(list[0].sourceMember).toEqual({
+      name: '未知成员',
+      avatar: null,
+      status: null
+    });
+  });
+
+  it('tmbId 为 null（system skill）保留资源 + 占位', async () => {
+    const list = await addSourceMemberV2({ list: [{ _id: 'x', tmbId: null }] });
+    expect(list).toHaveLength(1);
+    expect(list[0].sourceMember.status).toBeNull();
+  });
+});


### PR DESCRIPTION
## 背景与问题

`/core/app/list`、`/core/dataset/list`、`/core/ai/skill/list` 三个核心资源列表接口是伪分页：DB 层全量 find（无 skip/limit），分页（如果有）在内存 slice 完成；且最终可见集合依赖内存权限计算（tmb 直授 + 成员组/组织展开 + 目录 inheritPermission 继承 + hasReadPer 过滤），countDocuments 无法直接对「权限过滤后」的集合计数。

## 方案简述

1. **请求内先算可读集合**：`getMyResourcePermission` 复用现有权限拉取 + 组/组织展开，新增 `readableDirectIds`（按资源聚合角色位 `tmbRole ?? groupAndOrgRole`，复用对应 Permission 类判定 read 位），纯内存可计算量；
2. **三层权限谓词**：`$or: [{_id ∈ readableDirectIds}, {tmbId}(创建者), {type ∉ folder, inheritPermission, parentId ∈ readableDirectIds}(一层继承)]` —— 由位运算分配律证明与内存过滤逐条等价（继承判定中父权限为直接权限、非递归，无需 $graphLookup）；
3. **count 与 find 严格同 match**：`find(match).sort({updateTime:-1,_id:-1}).skip(offset).limit(pageSize)` 与 `countDocuments(match)` 并行，同一 match 常量 + 同一读偏好，total == 权限过滤后可见集合数量，杜绝计数漂移；
4. **分页参数统一**：pageSize/offset/pageNum 三键、offset 与 pageNum 互斥（superRefine）、numbers-only 严格校验，私有 `parseV2Pagination` 解析（?? 语义正确处理 offset=0）；
5. **页内后处理**：Per/private/hasInteractiveNode/withAppCount 仅对当前页计算；sourceMember 缺成员占位不丢项（status: null）；
6. **大 $in fail-fast**：可读集合超阈值返回明确错误码；
7. **索引补齐**：app/dataset/skill 追加 8 条 defineIndex（含 _id 决胜键、store 创建者单键索引）。

## 向后兼容

- 旧接口契约完全不动：三个旧路由的入参出参 schema、前端调用（web/core/{app,dataset,skill}/api.ts）逐字节零改动（git diff --exit-code 验收）；旧路由文件、被 ChatAgentHelper 复用的 manage/list.ts、公共 parsePaginationRequest 均零改动；
- 新增 v2 端点 `POST /core/{app,dataset,ai/skill}/listV2`，返回 `{list, total}`，前端迁移字段形状零适配；
- 行为差异契约（v2 为权限引擎语义，均为「显示更多权限可见资源」，无越权）：① 无 parentId 模式跨目录的无记录创建者/继承资源；② searchKey 模式同上；③ searchKey+parentId 的目录外资源；④ app owner 无 parentId 从「仅根目录」改为全团队；⑤ orphan（缺成员 / tmbId=null 的 system skill）保留 + 占位 sourceMember（旧接口丢项）。

## 验证与测试工作

**自动化测试（53 个全部通过）**：
- helper 单测：角色聚合 ?? 优先级（permission=0 压过组 read）、组/组织授权、OwnerRoleVal、缺成员占位；parseV2Pagination（缺省/offset=0/互斥）；
- schema parse：负数/NaN/字符串/Infinity/超上限被拒、offset+pageNum 互斥、ObjectId/null 双形态、system skill tmbId:null、sourceMember.status:null；
- 旧/v2 对账：预期相等（含 permission=0 + parent read 反例）与五项差异「预期不相等」断言；total > list.length 分页用例；fail-fast 阈值用例；
- typecheck（projects/app 0 错误，service/global 无新增）、eslint 全绿。

**端到端验证（chrome-devtools 驱动真实浏览器）**：
- dev server 运行最新代码，页面登录后调用三资源 v2 vs 旧接口：dataset/skill 可见集合完全一致；app 差 2 项（子目录资源，符合差异契约 ④，无漏报）；
- 分页 pageSize:10 两页 total 恒定、零重叠、total > list.length；
- 边界：负数/101/字符串/offset+pageNum/NaN 全部 400 拒绝；
- 控制台无页面 JS 错误，截图留存。