### PR TITLE
fix(workflow): preload workflow i18n on app creation

### DIFF
--- a/projects/app/src/pages/dashboard/create/index.tsx
+++ b/projects/app/src/pages/dashboard/create/index.tsx
@@ -616,7 +616,7 @@ export default CreateAppsPage;
 export async function getServerSideProps(content: any) {
   return {
     props: {
-      ...(await serviceSideProps(content, ['app', 'user']))
+      ...(await serviceSideProps(content, ['app', 'user', 'workflow']))
     }
   };
 }

--- a/projects/app/test/web/core/app/templates.test.ts
+++ b/projects/app/test/web/core/app/templates.test.ts
@@ -12,6 +12,10 @@ describe('getEmptyAppsTemplate', () => {
     ];
 
     expect(nodes.every((node) => node.name.startsWith('translated:'))).toBe(true);
+    expect(templates[AppTypeEnum.workflowTool].nodes[0]).toMatchObject({
+      nodeId: 'pluginInput',
+      name: 'translated:workflow:template.plugin_start'
+    });
     expect(nodes.filter((node) => node.intro).map((node) => node.intro)).toEqual([
       'translated:common:core.module.template.config_params',
       'translated:common:core.module.template.ai_chat_intro',


### PR DESCRIPTION
## Summary

- preload the `workflow` i18n namespace on the app creation page
- cover `template.plugin_start` initialization for workflow tools after refresh/cold start
