### PR TITLE
fix(workflow): avoid duplicate tool parameter rendering

### DIFF
--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/context/workflowUtilsContext.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/context/workflowUtilsContext.tsx
@@ -74,6 +74,31 @@ type WorkflowUtilsContextValue = {
     errorOutputs: FlowNodeOutputItemType[];
   };
 };
+
+/** 将工具输入和普通节点输入分开，避免 Agent 生成参数在节点内重复渲染。 */
+export const splitToolInputsByMode = (inputs: FlowNodeInputItemType[], isTool: boolean) => {
+  const toolInputs: FlowNodeInputItemType[] = [];
+  const commonInputs: FlowNodeInputItemType[] = [];
+
+  inputs.forEach((item) => {
+    const normalizedInput = normalizeFlowNodeInputType(item, { isTool });
+    const isAgentGeneratedInput =
+      isAgentGeneratedToolInput(normalizedInput) && canInputBeAgentGenerated(normalizedInput);
+
+    if (isTool && isAgentGeneratedInput && item.canEdit) {
+      toolInputs.push(item);
+      return;
+    }
+
+    commonInputs.push(normalizedInput);
+  });
+
+  return {
+    toolInputs,
+    commonInputs
+  };
+};
+
 export const WorkflowUtilsContext = createContext<WorkflowUtilsContextValue>({
   initData: (...args: Parameters<WorkflowUtilsContextValue['initData']>) => {
     void args;
@@ -148,18 +173,7 @@ export const WorkflowUtilsProvider = ({ children }: { children: ReactNode }) => 
   const splitToolInputs = useCallback(
     (inputs: FlowNodeInputItemType[], nodeId: string) => {
       const isTool = toolNodesMap[nodeId] ?? false;
-
-      const toolInputs: FlowNodeInputItemType[] = [];
-      const commonInputs: FlowNodeInputItemType[] = [];
-      inputs.forEach((item) => {
-        const normalizedInput = normalizeFlowNodeInputType(item, { isTool });
-        const isAgentGeneratedInput =
-          isAgentGeneratedToolInput(normalizedInput) && canInputBeAgentGenerated(normalizedInput);
-        if (isTool && isAgentGeneratedInput && item.canEdit) {
-          toolInputs.push(item);
-        }
-        commonInputs.push(normalizedInput);
-      });
+      const { toolInputs, commonInputs } = splitToolInputsByMode(inputs, isTool);
 
       return {
         isTool,

--- a/projects/app/test/pageComponents/app/detail/WorkflowComponents/context/workflowUtilsContext.test.ts
+++ b/projects/app/test/pageComponents/app/detail/WorkflowComponents/context/workflowUtilsContext.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { splitToolInputsByMode } from '@/pageComponents/app/detail/WorkflowComponents/context/workflowUtilsContext';
+import { FlowNodeInputTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
+
+describe('splitToolInputsByMode', () => {
+  it('keeps Agent-generated editable inputs out of common inputs', () => {
+    const toolInput = {
+      key: 'query',
+      label: 'query',
+      canEdit: true,
+      toolDescription: 'Search query',
+      isToolParam: true,
+      renderTypeList: [FlowNodeInputTypeEnum.reference]
+    };
+    const commonInput = {
+      key: 'url',
+      label: 'url',
+      renderTypeList: [FlowNodeInputTypeEnum.reference]
+    };
+
+    const result = splitToolInputsByMode([toolInput, commonInput], true);
+
+    expect(result.toolInputs).toEqual([toolInput]);
+    expect(result.commonInputs.map((input) => input.key)).toEqual(['url']);
+  });
+
+  it('keeps the same input in common inputs when it is not a tool', () => {
+    const input = {
+      key: 'query',
+      label: 'query',
+      canEdit: true,
+      toolDescription: 'Search query',
+      isToolParam: true,
+      renderTypeList: [FlowNodeInputTypeEnum.reference]
+    };
+
+    const result = splitToolInputsByMode([input], false);
+
+    expect(result.toolInputs).toEqual([]);
+    expect(result.commonInputs).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## 变更
- 修复 Agent 工具参数同时出现在工具参数表和自定义变量区域的问题
- 保留普通节点输入分组行为
- 添加前端分组回归测试

## 范围
- 本 PR 不处理代码执行节点，代码执行节点后续会进行较大改造

## 验证
- workflowUtilsContext focused tests
- app typecheck
- focused ESLint
- Prettier