### PR TITLE
Update admin modal migration

### DIFF
--- a/packages/service/core/workflow/dispatch/plugin/runInput.ts
+++ b/packages/service/core/workflow/dispatch/plugin/runInput.ts
@@ -57,8 +57,17 @@ export const dispatchPluginInput = async (
       const val = params[key];
       const maxFiles = fileInputMaxFiles.get(key);
       if (maxFiles !== undefined && Array.isArray(val)) {
+        // 文件选择器未选文件时可能提交无 key/url 的占位项，应按空输入处理。
+        const fileItems = val
+          .filter((fileItem) => {
+            if (typeof fileItem === 'string') return fileItem.trim().length > 0;
+            return (
+              !!fileItem && typeof fileItem === 'object' && Boolean(fileItem.key || fileItem.url)
+            );
+          })
+          .slice(0, maxFiles);
         const fileUrls = await Promise.all(
-          val.slice(0, maxFiles).map(async (fileItem) => {
+          fileItems.map(async (fileItem) => {
             const storeValue =
               typeof fileItem === 'string'
                 ? normalizeChatFileStoreValue({ url: fileItem })

--- a/packages/service/test/core/workflow/dispatch/plugin/runInput.test.ts
+++ b/packages/service/test/core/workflow/dispatch/plugin/runInput.test.ts
@@ -204,6 +204,21 @@ describe('dispatchPluginInput', () => {
     expect(result.data?.upload).toEqual(['https://external.example.com/1.pdf']);
   });
 
+  it('treats empty file selector placeholders as no file input', async () => {
+    const result = await runWithMockFileContext(() =>
+      dispatchPluginInput({
+        params: {
+          upload: [{ type: ChatFileTypeEnum.file }]
+        },
+        query: [],
+        node: pluginInputNode
+      } as any)
+    );
+
+    expect(result.data?.upload).toEqual([]);
+    expect(mockRegisterInputFile).not.toHaveBeenCalled();
+  });
+
   it('reuses a file already selected in the current child context', async () => {
     mockResolveInputFile.mockReturnValueOnce({
       modelUrl: 'https://parent.example.com/signed.pdf'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,7 +269,7 @@ importers:
         version: 9.39.4(jiti@2.7.0)
       eslint-config-next:
         specifier: catalog:lint
-        version: 16.3.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+        version: 16.3.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       husky:
         specifier: ^8.0.3
         version: 8.0.3
@@ -979,7 +979,7 @@ importers:
         version: 1.14.3
       '@scalar/api-reference-react':
         specifier: ^0.9.59
-        version: 0.9.60(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(react@18.3.1)(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))(typescript@6.0.3)(zod@4.1.12)
+        version: 0.9.60(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(react@18.3.1)(tailwindcss@4.2.4)(typescript@6.0.3)(zod@4.1.12)
       '@t3-oss/env-core':
         specifier: 'catalog:'
         version: 0.13.10(typescript@6.0.3)(zod@4.1.12)
@@ -1004,9 +1004,6 @@ importers:
       assert:
         specifier: ^2.0.0
         version: 2.1.0
-      autoprefixer:
-        specifier: ^10.4.19
-        version: 10.5.4(postcss@8.5.23)
       axios:
         specifier: 'catalog:'
         version: 1.18.1
@@ -1124,9 +1121,6 @@ importers:
       sass:
         specifier: ^1.58.3
         version: 1.85.1
-      tailwindcss:
-        specifier: ^3.0
-        version: 3.4.18(tsx@4.20.6)(yaml@2.8.4)
       utf-8-validate:
         specifier: ^5.0.10
         version: 5.0.10
@@ -1181,10 +1175,10 @@ importers:
         version: 0.25.12
       eslint:
         specifier: catalog:lint
-        version: 9.39.4(jiti@1.21.7)
+        version: 9.39.4(jiti@2.7.0)
       eslint-config-next:
         specifier: catalog:lint
-        version: 16.3.0(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
+        version: 16.3.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       mongodb-memory-server:
         specifier: 'catalog:'
         version: 10.1.4(gcp-metadata@5.3.0(encoding@0.1.13))(socks@2.8.9)
@@ -1196,7 +1190,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0)(canvas@3.2.3)(utf-8-validate@5.0.10))(vite@6.2.2(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.4))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0)(canvas@3.2.3)(utf-8-validate@5.0.10))(vite@6.2.2(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.4))
 
   pro/browser-sandbox:
     dependencies:
@@ -1605,10 +1599,10 @@ importers:
         version: 15.5.13
       eslint:
         specifier: catalog:lint
-        version: 9.39.4(jiti@2.7.0)
+        version: 9.39.4(jiti@1.21.7)
       eslint-config-next:
         specifier: catalog:lint
-        version: 16.3.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+        version: 16.3.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
       tailwindcss:
         specifier: ^3
         version: 3.4.18(tsx@4.20.6)(yaml@2.8.4)
@@ -1620,10 +1614,10 @@ importers:
         version: 6.0.3
       typescript-eslint:
         specifier: catalog:lint
-        version: 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+        version: 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0)(canvas@3.2.3)(utf-8-validate@5.0.10))(vite@6.2.2(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.4))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0)(canvas@3.2.3)(utf-8-validate@5.0.10))(vite@6.2.2(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.4))
 
   projects/code-sandbox:
     dependencies:
@@ -1781,7 +1775,7 @@ importers:
         version: 9.39.4(jiti@2.7.0)
       eslint-config-next:
         specifier: catalog:lint
-        version: 16.3.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+        version: 16.3.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       postcss:
         specifier: 'catalog:'
         version: 8.5.22
@@ -7680,13 +7674,6 @@ packages:
     resolution: {integrity: sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==}
     engines: {node: '>=10.12.0'}
 
-  autoprefixer@10.5.4:
-    resolution: {integrity: sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==}
-    engines: {node: ^10 || ^12 || >=14}
-    hasBin: true
-    peerDependencies:
-      postcss: ^8.1.0
-
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -7880,11 +7867,6 @@ packages:
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
-  browserslist@4.28.7:
-    resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -8961,9 +8943,6 @@ packages:
   electron-to-chromium@1.5.341:
     resolution: {integrity: sha512-1sZTssferjgDgaqRTc0ieP+ozzpOy7LQTPTtEW3yQFn4+ORdIAZWV5BthXPyHF7YqLvFJCUPhNhdAJQYlYUgiw==}
 
-  electron-to-chromium@1.5.396:
-    resolution: {integrity: sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==}
-
   elkjs@0.9.3:
     resolution: {integrity: sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==}
 
@@ -9613,9 +9592,6 @@ packages:
   frac@1.1.2:
     resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
     engines: {node: '>=0.8'}
-
-  fraction.js@5.3.4:
-    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
   framer-motion@9.1.7:
     resolution: {integrity: sha512-nKxBkIO4IPkMEqcBbbATxsVjwPYShKl051yhBv9628iAH6JLeHD0siBHxkL62oQzMC1+GNX73XtPjgP753ufuw==}
@@ -11929,10 +11905,6 @@ packages:
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
-
-  node-releases@2.0.51:
-    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
-    engines: {node: '>=18'}
 
   nodemailer@7.0.13:
     resolution: {integrity: sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==}
@@ -18013,6 +17985,10 @@ snapshots:
     dependencies:
       tailwindcss: 3.4.18(tsx@4.20.6)(yaml@2.8.4)
 
+  '@headlessui/tailwindcss@0.2.2(tailwindcss@4.2.4)':
+    dependencies:
+      tailwindcss: 4.2.4
+
   '@headlessui/vue@1.7.23(vue@3.5.40(typescript@6.0.3))':
     dependencies:
       '@tanstack/vue-virtual': 3.13.12(vue@3.5.40(typescript@6.0.3))
@@ -19999,6 +19975,44 @@ snapshots:
       - universal-cookie
       - zod
 
+  '@scalar/agent-chat@0.12.23(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(tailwindcss@4.2.4)(typescript@6.0.3)(zod@4.1.12)':
+    dependencies:
+      '@ai-sdk/vue': 3.0.33(vue@3.5.40(typescript@6.0.3))(zod@4.1.12)
+      '@scalar/api-client': 3.14.0(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(tailwindcss@4.2.4)(typescript@6.0.3)
+      '@scalar/components': 0.27.10(tailwindcss@4.2.4)(typescript@6.0.3)
+      '@scalar/helpers': 0.9.2
+      '@scalar/icons': 0.7.5(typescript@6.0.3)
+      '@scalar/json-magic': 0.12.19
+      '@scalar/openapi-types': 0.9.4
+      '@scalar/schemas': 0.8.0
+      '@scalar/themes': 0.17.2
+      '@scalar/types': 0.17.0
+      '@scalar/use-toasts': 0.10.4(typescript@6.0.3)
+      '@scalar/validation': 0.6.2
+      '@scalar/workspace-store': 0.56.0(typescript@6.0.3)
+      '@vueuse/core': 13.9.0(vue@3.5.40(typescript@6.0.3))
+      ai: 6.0.33(zod@4.1.12)
+      js-base64: 3.7.8
+      neverpanic: 0.0.8
+      truncate-json: 3.0.1
+      vue: 3.5.40(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+      - zod
+
   '@scalar/api-client@3.14.0(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))(typescript@6.0.3)':
     dependencies:
       '@headlessui/tailwindcss': 0.2.2(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))
@@ -20047,9 +20061,79 @@ snapshots:
       - typescript
       - universal-cookie
 
+  '@scalar/api-client@3.14.0(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(tailwindcss@4.2.4)(typescript@6.0.3)':
+    dependencies:
+      '@headlessui/tailwindcss': 0.2.2(tailwindcss@4.2.4)
+      '@headlessui/vue': 1.7.23(vue@3.5.40(typescript@6.0.3))
+      '@scalar/blocks': 0.1.9(tailwindcss@4.2.4)(typescript@6.0.3)
+      '@scalar/components': 0.27.10(tailwindcss@4.2.4)(typescript@6.0.3)
+      '@scalar/helpers': 0.9.2
+      '@scalar/icons': 0.7.5(typescript@6.0.3)
+      '@scalar/oas-utils': 0.19.9(typescript@6.0.3)
+      '@scalar/openapi-types': 0.9.4
+      '@scalar/sidebar': 0.9.34(tailwindcss@4.2.4)(typescript@6.0.3)
+      '@scalar/snippetz': 0.9.24
+      '@scalar/themes': 0.17.2
+      '@scalar/typebox': 0.1.3
+      '@scalar/types': 0.17.0
+      '@scalar/use-codemirror': 0.14.14(typescript@6.0.3)
+      '@scalar/use-hooks': 0.4.9(typescript@6.0.3)
+      '@scalar/use-toasts': 0.10.4(typescript@6.0.3)
+      '@scalar/workspace-store': 0.56.0(typescript@6.0.3)
+      '@vueuse/core': 13.9.0(vue@3.5.40(typescript@6.0.3))
+      '@vueuse/integrations': 13.9.0(axios@1.18.1)(focus-trap@7.8.0)(fuse.js@7.1.0)(nprogress@0.2.0)(qrcode@1.5.4)(vue@3.5.40(typescript@6.0.3))
+      focus-trap: 7.8.0
+      fuse.js: 7.1.0
+      js-base64: 3.7.8
+      jsonc-parser: 3.3.1
+      nanoid: 5.1.16
+      pretty-ms: 9.3.0
+      radix-vue: 1.9.17(vue@3.5.40(typescript@6.0.3))
+      set-cookie-parser: 3.1.0
+      vue: 3.5.40(typescript@6.0.3)
+      yaml: 2.8.4
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+
   '@scalar/api-reference-react@0.9.60(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(react@18.3.1)(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))(typescript@6.0.3)(zod@4.1.12)':
     dependencies:
       '@scalar/api-reference': 1.64.0(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))(typescript@6.0.3)(zod@4.1.12)
+      '@scalar/types': 0.17.0
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+      - zod
+
+  '@scalar/api-reference-react@0.9.60(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(react@18.3.1)(tailwindcss@4.2.4)(typescript@6.0.3)(zod@4.1.12)':
+    dependencies:
+      '@scalar/api-reference': 1.64.0(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(tailwindcss@4.2.4)(typescript@6.0.3)(zod@4.1.12)
       '@scalar/types': 0.17.0
       react: 18.3.1
     transitivePeerDependencies:
@@ -20113,6 +20197,50 @@ snapshots:
       - universal-cookie
       - zod
 
+  '@scalar/api-reference@1.64.0(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(tailwindcss@4.2.4)(typescript@6.0.3)(zod@4.1.12)':
+    dependencies:
+      '@headlessui/vue': 1.7.23(vue@3.5.40(typescript@6.0.3))
+      '@scalar/agent-chat': 0.12.23(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(tailwindcss@4.2.4)(typescript@6.0.3)(zod@4.1.12)
+      '@scalar/api-client': 3.14.0(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(tailwindcss@4.2.4)(typescript@6.0.3)
+      '@scalar/blocks': 0.1.9(tailwindcss@4.2.4)(typescript@6.0.3)
+      '@scalar/code-highlight': 0.4.3
+      '@scalar/components': 0.27.10(tailwindcss@4.2.4)(typescript@6.0.3)
+      '@scalar/helpers': 0.9.2
+      '@scalar/icons': 0.7.5(typescript@6.0.3)
+      '@scalar/oas-utils': 0.19.9(typescript@6.0.3)
+      '@scalar/schemas': 0.8.0
+      '@scalar/sidebar': 0.9.34(tailwindcss@4.2.4)(typescript@6.0.3)
+      '@scalar/snippetz': 0.9.24
+      '@scalar/themes': 0.17.2
+      '@scalar/types': 0.17.0
+      '@scalar/use-hooks': 0.4.9(typescript@6.0.3)
+      '@scalar/use-toasts': 0.10.4(typescript@6.0.3)
+      '@scalar/validation': 0.6.2
+      '@scalar/workspace-store': 0.56.0(typescript@6.0.3)
+      '@unhead/vue': 2.1.17(vue@3.5.40(typescript@6.0.3))
+      '@vueuse/core': 13.9.0(vue@3.5.40(typescript@6.0.3))
+      fuse.js: 7.1.0
+      microdiff: 1.5.0
+      nanoid: 5.1.16
+      vue: 3.5.40(typescript@6.0.3)
+      yaml: 2.8.4
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+      - zod
+
   '@scalar/asyncapi-upgrader@0.1.4':
     dependencies:
       '@scalar/helpers': 0.9.2
@@ -20120,6 +20248,24 @@ snapshots:
   '@scalar/blocks@0.1.9(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))(typescript@6.0.3)':
     dependencies:
       '@scalar/components': 0.27.10(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))(typescript@6.0.3)
+      '@scalar/helpers': 0.9.2
+      '@scalar/icons': 0.7.5(typescript@6.0.3)
+      '@scalar/snippetz': 0.9.24
+      '@scalar/themes': 0.17.2
+      '@scalar/types': 0.17.0
+      '@scalar/workspace-store': 0.56.0(typescript@6.0.3)
+      '@types/har-format': 1.2.16
+      js-base64: 3.7.8
+      vue: 3.5.40(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - supports-color
+      - tailwindcss
+      - typescript
+
+  '@scalar/blocks@0.1.9(tailwindcss@4.2.4)(typescript@6.0.3)':
+    dependencies:
+      '@scalar/components': 0.27.10(tailwindcss@4.2.4)(typescript@6.0.3)
       '@scalar/helpers': 0.9.2
       '@scalar/icons': 0.7.5(typescript@6.0.3)
       '@scalar/snippetz': 0.9.24
@@ -20160,6 +20306,28 @@ snapshots:
       '@floating-ui/utils': 0.2.10
       '@floating-ui/vue': 1.1.9(vue@3.5.40(typescript@6.0.3))
       '@headlessui/tailwindcss': 0.2.2(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))
+      '@headlessui/vue': 1.7.23(vue@3.5.40(typescript@6.0.3))
+      '@scalar/code-highlight': 0.4.3
+      '@scalar/helpers': 0.9.2
+      '@scalar/icons': 0.7.5(typescript@6.0.3)
+      '@scalar/themes': 0.17.2
+      '@scalar/use-hooks': 0.4.9(typescript@6.0.3)
+      '@vueuse/core': 13.9.0(vue@3.5.40(typescript@6.0.3))
+      cva: 1.0.0-beta.4(typescript@6.0.3)
+      radix-vue: 1.9.17(vue@3.5.40(typescript@6.0.3))
+      vue: 3.5.40(typescript@6.0.3)
+      vue-component-type-helpers: 3.3.9
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - supports-color
+      - tailwindcss
+      - typescript
+
+  '@scalar/components@0.27.10(tailwindcss@4.2.4)(typescript@6.0.3)':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+      '@floating-ui/vue': 1.1.9(vue@3.5.40(typescript@6.0.3))
+      '@headlessui/tailwindcss': 0.2.2(tailwindcss@4.2.4)
       '@headlessui/vue': 1.7.23(vue@3.5.40(typescript@6.0.3))
       '@scalar/code-highlight': 0.4.3
       '@scalar/helpers': 0.9.2
@@ -20220,6 +20388,21 @@ snapshots:
   '@scalar/sidebar@0.9.34(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))(typescript@6.0.3)':
     dependencies:
       '@scalar/components': 0.27.10(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))(typescript@6.0.3)
+      '@scalar/helpers': 0.9.2
+      '@scalar/icons': 0.7.5(typescript@6.0.3)
+      '@scalar/themes': 0.17.2
+      '@scalar/use-hooks': 0.4.9(typescript@6.0.3)
+      '@scalar/workspace-store': 0.56.0(typescript@6.0.3)
+      vue: 3.5.40(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - supports-color
+      - tailwindcss
+      - typescript
+
+  '@scalar/sidebar@0.9.34(tailwindcss@4.2.4)(typescript@6.0.3)':
+    dependencies:
+      '@scalar/components': 0.27.10(tailwindcss@4.2.4)(typescript@6.0.3)
       '@scalar/helpers': 0.9.2
       '@scalar/icons': 0.7.5(typescript@6.0.3)
       '@scalar/themes': 0.17.2
@@ -22517,15 +22700,6 @@ snapshots:
 
   atomically@1.7.0: {}
 
-  autoprefixer@10.5.4(postcss@8.5.23):
-    dependencies:
-      browserslist: 4.28.7
-      caniuse-lite: 1.0.30001806
-      fraction.js: 5.3.4
-      picocolors: 1.1.1
-      postcss: 8.5.23
-      postcss-value-parser: 4.2.0
-
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -22742,14 +22916,6 @@ snapshots:
       electron-to-chromium: 1.5.341
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
-
-  browserslist@4.28.7:
-    dependencies:
-      baseline-browser-mapping: 2.11.1
-      caniuse-lite: 1.0.30001806
-      electron-to-chromium: 1.5.396
-      node-releases: 2.0.51
-      update-browserslist-db: 1.2.3(browserslist@4.28.7)
 
   bson@6.10.3: {}
 
@@ -23850,8 +24016,6 @@ snapshots:
 
   electron-to-chromium@1.5.341: {}
 
-  electron-to-chromium@1.5.396: {}
-
   elkjs@0.9.3: {}
 
   emoji-regex@10.4.0: {}
@@ -24114,18 +24278,18 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-next@16.3.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3):
+  eslint-config-next@16.3.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3):
     dependencies:
-      '@next/eslint-plugin-next': 16.3.0(eslint@9.39.4(jiti@2.7.0))
-      eslint: 9.39.4(jiti@2.7.0)
+      '@next/eslint-plugin-next': 16.3.0(eslint@9.39.4(jiti@1.21.7))
+      eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.9.0(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-react: 7.37.4(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.9.0(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-react: 7.37.4(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@1.21.7))
       globals: 16.4.0
-      typescript-eslint: 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      typescript-eslint: 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -24134,18 +24298,18 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-next@16.3.0(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3):
+  eslint-config-next@16.3.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@next/eslint-plugin-next': 16.3.0(eslint@9.39.4(jiti@1.21.7))
-      eslint: 9.39.4(jiti@1.21.7)
+      '@next/eslint-plugin-next': 16.3.0(eslint@9.39.4(jiti@2.7.0))
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.9.0(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-react: 7.37.4(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.9.0(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.9.0(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-react: 7.37.4(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
       globals: 16.4.0
-      typescript-eslint: 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
+      typescript-eslint: 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -24162,6 +24326,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.9.0(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.7.0)
+      get-tsconfig: 4.14.0
+      is-bun-module: 1.3.0
+      oxc-resolver: 5.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.9.0(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.9.0(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -24173,47 +24352,32 @@ snapshots:
       stable-hash: 0.0.5
       tinyglobby: 0.2.16
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.9.0(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@2.7.0)
-      get-tsconfig: 4.14.0
-      is-bun-module: 1.3.0
-      oxc-resolver: 5.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
-      eslint: 9.39.4(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.9.0(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
       eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.9.0(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.0(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.9.0(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -24222,9 +24386,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -24236,13 +24400,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.9.0(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -24251,9 +24415,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.0(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -24938,8 +25102,6 @@ snapshots:
   forwarded@0.2.0: {}
 
   frac@1.1.2: {}
-
-  fraction.js@5.3.4: {}
 
   framer-motion@9.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -27912,8 +28074,6 @@ snapshots:
   node-hex@1.0.1: {}
 
   node-releases@2.0.37: {}
-
-  node-releases@2.0.51: {}
 
   nodemailer@7.0.13: {}
 
@@ -31091,12 +31251,6 @@ snapshots:
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
-  update-browserslist-db@1.2.3(browserslist@4.28.7):
-    dependencies:
-      browserslist: 4.28.7
       escalade: 3.2.0
       picocolors: 1.1.1
 

--- a/projects/app/src/components/core/chat/ChatContainer/PluginRunBox/components/RenderInput.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/PluginRunBox/components/RenderInput.tsx
@@ -131,7 +131,7 @@ const RenderInput = () => {
   const isDisabledInput = !!hasHistory;
 
   return (
-    <Box>
+    <>
       {/* instruction */}
       {instruction && (
         <Box
@@ -273,7 +273,7 @@ const RenderInput = () => {
           </Button>
         </Flex>
       )}
-    </Box>
+    </>
   );
 };
 

--- a/projects/app/src/components/core/chat/ChatContainer/PluginRunBox/components/RenderResponseDetail.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/PluginRunBox/components/RenderResponseDetail.tsx
@@ -1,8 +1,7 @@
-import { ResponseBox } from '../../../components/WholeResponseModal';
-import React, { useMemo } from 'react';
+import { WorkflowToolResponseBox } from '../../../components/WholeResponseModal/WorkflowToolResponseBox';
+import React from 'react';
 import { useContextSelector } from 'use-context-selector';
 import { PluginRunContext } from '../context';
-import { Box } from '@chakra-ui/react';
 import { useTranslation } from 'next-i18next';
 import { ChatRecordContext } from '@/web/core/chat/context/chatRecordContext';
 import { ChatRoleEnum } from '@fastgpt/global/core/chat/constants';
@@ -14,22 +13,20 @@ const RenderResponseDetail = () => {
   const chatRecords = useContextSelector(ChatRecordContext, (v) => v.chatRecords);
   const isChatting = useContextSelector(PluginRunContext, (v) => v.isChatting);
 
-  const aiRecord = useMemo(
-    () => [...chatRecords].reverse().find((item) => item.obj === ChatRoleEnum.AI),
-    [chatRecords]
-  );
-  const responseData = aiRecord?.responseData || [];
+  // 流式响应可能更新记录对象本身，直接读取最新的 AI 记录，避免按数组引用缓存旧结果。
+  const aiRecord = [...chatRecords].reverse().find((item) => item.obj === ChatRoleEnum.AI);
+  const responseData = aiRecord?.responseData ?? [];
 
   return isChatting ? (
     <>{t('chat:in_progress')}</>
   ) : (
-    <Box flex={'1 0 0'} h={'100%'} overflow={'auto'}>
+    <>
       {responseData.length > 0 ? (
-        <ResponseBox useMobile={true} response={responseData} dataId={aiRecord?.dataId} />
+        <WorkflowToolResponseBox response={responseData} dataId={aiRecord?.dataId} />
       ) : (
         <EmptyTip text={t('chat:response.no_workflow_response')} />
       )}
-    </Box>
+    </>
   );
 };
 

--- a/projects/app/src/components/core/chat/ChatContainer/PluginRunBox/context.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/PluginRunBox/context.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode, useCallback, useMemo, useRef } from 'react';
+import React, { type ReactNode, useCallback, useRef } from 'react';
 import { createContext, useContextSelector } from 'use-context-selector';
 import { type PluginRunBoxProps } from './type';
 import { type AIChatItemValueItemType } from '@fastgpt/global/core/chat/type';
@@ -150,12 +150,8 @@ const PluginRunContextProvider = ({
     [setChatRecords, resetVariables]
   );
 
-  const isChatting = useMemo(
-    () =>
-      chatRecords[chatRecords.length - 1] &&
-      chatRecords[chatRecords.length - 1]?.status !== 'finish',
-    [chatRecords]
-  );
+  const isChatting =
+    chatRecords[chatRecords.length - 1] && chatRecords[chatRecords.length - 1]?.status !== 'finish';
 
   const onSubmit = useCallback(
     async ({ variables }: ChatBoxInputFormType) => {
@@ -243,7 +239,8 @@ const PluginRunContextProvider = ({
           })
         );
       } catch (err: any) {
-        toast({ title: err.message, status: 'error' });
+        const errorMsg = t(getErrText(err, t('common:core.chat.error.Chat error') as any));
+        toast({ title: errorMsg, status: 'error' });
         setChatRecords((state) =>
           state.map((item, index) => {
             if (index !== state.length - 1) return item;

--- a/projects/app/src/components/core/chat/ChatContainer/PluginRunBox/index.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/PluginRunBox/index.tsx
@@ -7,7 +7,6 @@ import { useContextSelector } from 'use-context-selector';
 import RenderOutput from './components/RenderOutput';
 import RenderResponseDetail from './components/RenderResponseDetail';
 import { ChatItemContext } from '@/web/core/chat/context/chatItemContext';
-import { Box } from '@chakra-ui/react';
 
 const PluginRunBox = (props: PluginRunBoxProps) => {
   const tab = useContextSelector(ChatItemContext, (v) => v.pluginRunTab);
@@ -15,11 +14,11 @@ const PluginRunBox = (props: PluginRunBoxProps) => {
 
   return (
     <PluginRunContextProvider {...props}>
-      <Box h={'100%'} minH={0} display={'flex'} flexDirection={'column'}>
+      <>
         {formatTab === PluginRunBoxTabEnum.input && <RenderInput />}
         {formatTab === PluginRunBoxTabEnum.output && <RenderOutput />}
         {formatTab === PluginRunBoxTabEnum.detail && <RenderResponseDetail />}
-      </Box>
+      </>
     </PluginRunContextProvider>
   );
 };

--- a/projects/app/src/components/core/chat/components/WholeResponseModal/ResponseBox.tsx
+++ b/projects/app/src/components/core/chat/components/WholeResponseModal/ResponseBox.tsx
@@ -20,13 +20,11 @@ const sideTabDeepTreeMinDepth = 4;
 export const ResponseBox = React.memo(function ResponseBox({
   response,
   dataId,
-  hideTabs = false,
-  useMobile = false
+  hideTabs = false
 }: {
   response: ChatHistoryItemResType[];
   dataId?: string;
   hideTabs?: boolean;
-  useMobile?: boolean;
 }) {
   const { t } = useSafeTranslation();
   const { isPc } = useSystem();
@@ -79,7 +77,7 @@ export const ResponseBox = React.memo(function ResponseBox({
 
   return (
     <>
-      {isPc && !useMobile ? (
+      {isPc ? (
         <Flex
           overflow={'hidden'}
           height={'100%'}

--- a/projects/app/src/components/core/chat/components/WholeResponseModal/WholeResponseContent.tsx
+++ b/projects/app/src/components/core/chat/components/WholeResponseModal/WholeResponseContent.tsx
@@ -32,7 +32,9 @@ export const WholeResponseContent = ({
       minH={0}
       ref={contentRef}
       py={3}
-      px={hideTabs ? 4 : 3}
+      // 详情页移动端需要让内容贴合滚动容器，水平留白由外层面板负责。
+      // 桌面端保留原有留白，避免改变完整结果的布局。
+      px={hideTabs ? [0, 4] : 3}
       display={'flex'}
       flexDirection={'column'}
       gap={3}

--- a/projects/app/src/components/core/chat/components/WholeResponseModal/WorkflowToolResponseBox.tsx
+++ b/projects/app/src/components/core/chat/components/WholeResponseModal/WorkflowToolResponseBox.tsx
@@ -1,0 +1,136 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Box, Flex, useDisclosure } from '@chakra-ui/react';
+import dynamic from 'next/dynamic';
+import type { ChatHistoryItemResType } from '@fastgpt/global/core/chat/type';
+import { moduleTemplatesFlat } from '@fastgpt/global/core/workflow/template/constants';
+import Avatar from '@fastgpt/web/components/common/Avatar';
+import MyIcon from '@fastgpt/web/components/common/Icon';
+import { useSafeTranslation } from '@fastgpt/web/hooks/useSafeTranslation';
+import { WholeResponseSideTab } from './SideTab';
+import { WholeResponseContent } from './WholeResponseContent';
+import { flattenResponse, getSideTabItems } from './responseData';
+
+const RequestIdDetailModal = dynamic(() => import('@/components/core/ai/requestId'));
+
+/**
+ * 工作流工具专用完整结果：列表沿用工具面板的父级滚动，详情覆盖整个结果区域。
+ */
+export const WorkflowToolResponseBox = React.memo(function WorkflowToolResponseBox({
+  response,
+  dataId
+}: {
+  response: ChatHistoryItemResType[];
+  dataId?: string;
+}) {
+  const { t } = useSafeTranslation();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [selectedRequestId, setSelectedRequestId] = useState<string>();
+
+  // 流式运行期间 response 可能原地追加内容，不能按数组引用缓存计算结果。
+  const flattedResponse = flattenResponse(response);
+  const [currentNodeId, setCurrentNodeId] = useState(
+    flattedResponse[0]?.id ?? flattedResponse[0]?.nodeId ?? ''
+  );
+
+  const firstNodeId = flattedResponse[0]?.id ?? flattedResponse[0]?.nodeId ?? '';
+  const hasCurrentNode = flattedResponse.some((item) => item.id === currentNodeId);
+
+  useEffect(() => {
+    if (!firstNodeId) {
+      setCurrentNodeId('');
+      return;
+    }
+    if (hasCurrentNode) return;
+
+    setCurrentNodeId(firstNodeId);
+  }, [currentNodeId, firstNodeId, hasCurrentNode]);
+
+  const activeModule = (flattedResponse.find((item) => item.id === currentNodeId) ||
+    flattedResponse[0]) as ChatHistoryItemResType;
+  // 流式响应会暂时按 parentId 挂成树，工具面板需要和历史结果保持一致，逐节点展示完整执行链路。
+  const sliderResponseList = getSideTabItems(flattedResponse);
+
+  const { isOpen: isOpenDetail, onOpen: onOpenDetail, onClose: onCloseDetail } = useDisclosure();
+
+  const handleOpenRequestIdDetail = useCallback((requestId: string) => {
+    setSelectedRequestId(requestId);
+  }, []);
+
+  return (
+    <Box ref={rootRef} minH={'100%'} h={'100%'}>
+      {isOpenDetail ? (
+        <Flex bg={'white'} flexDirection={'column'} h={'100%'} minH={0}>
+          <Flex
+            align={'center'}
+            justifyContent={'center'}
+            px={2}
+            py={2}
+            borderBottom={'sm'}
+            position={'relative'}
+            height={'40px'}
+            flexShrink={0}
+          >
+            <MyIcon
+              width={4}
+              height={4}
+              name="common/backLight"
+              onClick={(e) => {
+                e.stopPropagation();
+                onCloseDetail();
+              }}
+              position={'absolute'}
+              left={2}
+              top={'50%'}
+              transform={'translateY(-50%)'}
+              cursor={'pointer'}
+              _hover={{ color: 'primary.500' }}
+            />
+
+            <Avatar
+              src={
+                activeModule.moduleLogo ||
+                moduleTemplatesFlat.find(
+                  (template) => activeModule.moduleType === template.flowNodeType
+                )?.avatar
+              }
+              w={'1.25rem'}
+              h={'1.25rem'}
+              borderRadius={'sm'}
+            />
+
+            <Box ml={1.5} lineHeight={'1.25rem'} alignItems={'center'}>
+              {t(activeModule.moduleName as any, activeModule.moduleNameArgs)}
+            </Box>
+          </Flex>
+
+          <Box flex={'1 1 0'} minH={0} overflowY={'auto'}>
+            <WholeResponseContent
+              dataId={dataId}
+              activeModule={activeModule}
+              hideTabs={true}
+              onOpenRequestIdDetail={handleOpenRequestIdDetail}
+            />
+          </Box>
+        </Flex>
+      ) : (
+        <WholeResponseSideTab
+          response={sliderResponseList}
+          value={currentNodeId}
+          onChange={(item: string) => {
+            setCurrentNodeId(item);
+            rootRef.current?.parentElement?.scrollTo({ top: 0 });
+            onOpenDetail();
+          }}
+          isMobile={true}
+        />
+      )}
+
+      {selectedRequestId && (
+        <RequestIdDetailModal
+          onClose={() => setSelectedRequestId(undefined)}
+          requestId={selectedRequestId}
+        />
+      )}
+    </Box>
+  );
+});

--- a/projects/app/src/pageComponents/app/detail/Logs/DetailLogsModal.tsx
+++ b/projects/app/src/pageComponents/app/detail/Logs/DetailLogsModal.tsx
@@ -193,7 +193,16 @@ const DetailLogsModal = ({
           <Flex flex={'1 0 0'} h={0}>
             <Box flex={'1 0 0'} h={'100%'} minH={0} overflow={isPlugin ? 'hidden' : 'auto'}>
               {isPlugin ? (
-                <Box px={5} py={2} h={'100%'} minH={0} display={'flex'} flexDirection={'column'}>
+                <Box
+                  px={5}
+                  py={2}
+                  h={'100%'}
+                  minH={0}
+                  minW={0}
+                  overflowY={'auto'}
+                  display={'flex'}
+                  flexDirection={'column'}
+                >
                   <PluginRunBox appId={appId} chatId={chatId} />
                 </Box>
               ) : (

--- a/projects/app/src/pageComponents/app/detail/useChatTest.tsx
+++ b/projects/app/src/pageComponents/app/detail/useChatTest.tsx
@@ -10,7 +10,6 @@ import { type StoreEdgeItemType } from '@fastgpt/global/core/workflow/type/edge'
 import { FlowNodeTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
 import { AppTypeEnum } from '@fastgpt/global/core/app/constants';
 import dynamic from 'next/dynamic';
-import { Box } from '@chakra-ui/react';
 import { type AppChatConfigType } from '@fastgpt/global/core/app/type';
 import ChatBox from '@/components/core/chat/ChatContainer/ChatBox';
 import { useChatStore } from '@/web/core/chat/context/useChatStore';
@@ -21,6 +20,7 @@ import { useTranslation } from 'next-i18next';
 import { ChatTypeEnum } from '@/components/core/chat/ChatContainer/ChatBox/constants';
 import { ChatSourceTypeEnum } from '@fastgpt/global/core/chat/constants';
 import { getAppChatSourceKey } from '@/web/core/chat/utils';
+import { Box } from '@chakra-ui/react';
 
 const PluginRunBox = dynamic(() => import('@/components/core/chat/ChatContainer/PluginRunBox'));
 
@@ -172,7 +172,15 @@ export const useChatTest = ({
 
   const CustomChatContainer = useMemoizedFn(() =>
     appDetail.type === AppTypeEnum.workflowTool ? (
-      <Box p={5} h={'100%'} minH={0} display={'flex'} flexDirection={'column'}>
+      <Box
+        p={5}
+        h={'100%'}
+        minH={0}
+        minW={0}
+        overflowY={'auto'}
+        display={'flex'}
+        flexDirection={'column'}
+      >
         <PluginRunBox
           appId={appId}
           chatId={chatId}

--- a/projects/app/src/pageComponents/chat/ChatWindow/AppChatWindow.tsx
+++ b/projects/app/src/pageComponents/chat/ChatWindow/AppChatWindow.tsx
@@ -174,7 +174,7 @@ const AppChatWindow = () => {
   );
 
   return (
-    <Flex h={'100%'} flexDirection={['column', 'row']}>
+    <Flex h={'100%'} minH={0} minW={0} flexDirection={['column', 'row']}>
       {/* set window title and icon */}
       <NextHead
         title={isCurrentChatReady ? chatBoxData.app.name : undefined}
@@ -202,64 +202,69 @@ const AppChatWindow = () => {
       <Flex
         position={'relative'}
         h={[0, '100%']}
+        minH={0}
+        minW={0}
         w={['100%', 0]}
         flex={'1 0 0'}
         flexDirection={'column'}
       >
-        {isPc ? (
-          <ChatWindowHeader
-            title={chatWindowTitle}
-            history={chatRecords}
-            chatType={ChatTypeEnum.chat}
-            rightActions={<SandboxEntryIcon onOpen={onOpenSandboxModal} />}
-          />
-        ) : (
-          <Flex
-            h="48px"
-            px={4}
-            bg="white"
-            alignItems="center"
-            justifyContent="space-between"
-            color="myGray.600"
-          >
-            <IconButton
-              aria-label="Open history"
-              icon={<MyIcon name="core/chat/sidebar/menu" w="20px" h="20px" color="currentColor" />}
-              variant="unstyled"
-              {...mobileChatHeaderIconButtonStyle}
-              onClick={onOpenSlider}
+        {!isPlugin &&
+          (isPc ? (
+            <ChatWindowHeader
+              title={chatWindowTitle}
+              history={chatRecords}
+              chatType={ChatTypeEnum.chat}
+              rightActions={<SandboxEntryIcon onOpen={onOpenSandboxModal} />}
             />
+          ) : (
+            <Flex
+              h="48px"
+              px={4}
+              bg="white"
+              alignItems="center"
+              justifyContent="space-between"
+              color="myGray.600"
+            >
+              <IconButton
+                aria-label="Open history"
+                icon={
+                  <MyIcon name="core/chat/sidebar/menu" w="20px" h="20px" color="currentColor" />
+                }
+                variant="unstyled"
+                {...mobileChatHeaderIconButtonStyle}
+                onClick={onOpenSlider}
+              />
 
-            <Flex alignItems="center" minW={0} flex="1" justifyContent="center" px={3} gap={2}>
-              {isCurrentChatReady && (
-                <Avatar
-                  src={chatBoxData.app.avatar}
-                  w="24px"
-                  h="24px"
-                  borderRadius="6px"
-                  flexShrink={0}
-                />
-              )}
-              <Box
-                minW={0}
-                fontSize="16px"
-                fontWeight={500}
-                color="myGray.900"
-                overflow="hidden"
-                whiteSpace="nowrap"
-                textOverflow="clip"
-              >
-                {mobileHeaderTitle}
+              <Flex alignItems="center" minW={0} flex="1" justifyContent="center" px={3} gap={2}>
+                {isCurrentChatReady && (
+                  <Avatar
+                    src={chatBoxData.app.avatar}
+                    w="24px"
+                    h="24px"
+                    borderRadius="6px"
+                    flexShrink={0}
+                  />
+                )}
+                <Box
+                  minW={0}
+                  fontSize="16px"
+                  fontWeight={500}
+                  color="myGray.900"
+                  overflow="hidden"
+                  whiteSpace="nowrap"
+                  textOverflow="clip"
+                >
+                  {mobileHeaderTitle}
+                </Box>
+              </Flex>
+
+              <Box minW="36px">
+                <ToolMenu history={chatRecords} chatType={ChatTypeEnum.chat} />
               </Box>
             </Flex>
+          ))}
 
-            <Box minW="36px">
-              <ToolMenu history={chatRecords} chatType={ChatTypeEnum.chat} />
-            </Box>
-          </Flex>
-        )}
-
-        <Box flex={'1 0 0'} bg={'white'}>
+        <Box flex={'1 0 0'} minH={0} minW={0} overflow={'hidden'} bg={'white'}>
           {isPlugin ? (
             <CustomPluginRunBox
               appId={appId}

--- a/projects/app/src/pageComponents/chat/CustomPluginRunBox.tsx
+++ b/projects/app/src/pageComponents/chat/CustomPluginRunBox.tsx
@@ -23,14 +23,32 @@ const CustomPluginRunBox = (props: PluginRunBoxProps) => {
   }, [isPc, setTab, tab]);
 
   return isPc ? (
-    <Grid gridTemplateColumns={'450px 1fr'} h={'100%'}>
-      <Box px={3} py={4} borderRight={'base'} h={'100%'} overflowY={'auto'} w={'100%'}>
+    <Grid gridTemplateColumns={'450px 1fr'} h={'100%'} minH={0} minW={0}>
+      <Box
+        px={3}
+        py={4}
+        borderRight={'base'}
+        h={'100%'}
+        minH={0}
+        minW={0}
+        overflowY={'auto'}
+        w={'100%'}
+      >
         <Box color={'myGray.900'} pb={5}>
           {t('common:Input')}
         </Box>
         <PluginRunBox {...props} showTab={PluginRunBoxTabEnum.input} />
       </Box>
-      <Stack px={3} py={4} h={'100%'} alignItems={'flex-start'} w={'100%'} overflow={'auto'}>
+      <Stack
+        px={3}
+        py={4}
+        h={'100%'}
+        minH={0}
+        minW={0}
+        alignItems={'flex-start'}
+        w={'100%'}
+        overflow={'hidden'}
+      >
         <Box display={'inline-block'}>
           <LightRowTabs<PluginRunBoxTabEnum>
             list={[
@@ -48,31 +66,35 @@ const CustomPluginRunBox = (props: PluginRunBoxProps) => {
             fontSize={'sm'}
           />
         </Box>
-        <Box flex={'1 0 0'} overflow={'auto'} w={'100%'}>
+        <Box flex={'1 0 0'} minH={0} minW={0} overflowY={'auto'} w={'100%'}>
           <PluginRunBox {...props} />
         </Box>
       </Stack>
     </Grid>
   ) : (
-    <Stack py={2} px={4} h={'100%'}>
-      <LightRowTabs<PluginRunBoxTabEnum>
-        list={[
-          { label: t('common:Input'), value: PluginRunBoxTabEnum.input },
-          { label: t('common:Output'), value: PluginRunBoxTabEnum.output },
-          { label: t('common:all_result'), value: PluginRunBoxTabEnum.detail }
-        ]}
-        value={tab}
-        onChange={setTab}
-        inlineStyles={{ px: 0.5, pt: 0 }}
-        outerPadding="4px"
-        outerHeight="40px"
-        itemHeight="32px"
-        gap={5}
-        py={0}
-        fontSize={'sm'}
-      />
-      <Box flex={'1 0 0'} w={'100%'}>
-        <PluginRunBox {...props} />
+    <Stack pt={2} h={'100%'} minH={0} minW={0} overflow={'hidden'}>
+      <Box px={4}>
+        <LightRowTabs<PluginRunBoxTabEnum>
+          list={[
+            { label: t('common:Input'), value: PluginRunBoxTabEnum.input },
+            { label: t('common:Output'), value: PluginRunBoxTabEnum.output },
+            { label: t('common:all_result'), value: PluginRunBoxTabEnum.detail }
+          ]}
+          value={tab}
+          onChange={setTab}
+          inlineStyles={{ px: 0.5, pt: 0 }}
+          outerPadding="4px"
+          outerHeight="40px"
+          itemHeight="32px"
+          gap={5}
+          py={0}
+          fontSize={'sm'}
+        />
+      </Box>
+      <Box flex={'1 0 0'} minH={0} minW={0} overflowY={'auto'} w={'100%'}>
+        <Box px={4} pb={2}>
+          <PluginRunBox {...props} />
+        </Box>
       </Box>
     </Stack>
   );

--- a/projects/app/src/pages/api/core/chat/record/getPaginationRecords.ts
+++ b/projects/app/src/pages/api/core/chat/record/getPaginationRecords.ts
@@ -53,15 +53,17 @@ export async function handler(req: ApiRequestProps): Promise<GetPaginationRecord
     chatId,
     outLinkAuthData
   });
+  // 后续查询统一使用鉴权解析后的来源，避免分享链接请求体缺少 sourceType 时降级为普通对话。
+  const resolvedSourceType = authRes.sourceType;
   const resolvedSourceId = authRes.sourceId;
 
   const [app] = await Promise.all([
-    sourceType === ChatSourceTypeEnum.app
+    resolvedSourceType === ChatSourceTypeEnum.app
       ? MongoApp.findById(resolvedSourceId, 'type').lean()
       : null
   ]);
 
-  if (sourceType === ChatSourceTypeEnum.app && !app) {
+  if (resolvedSourceType === ChatSourceTypeEnum.app && !app) {
     return Promise.reject(AppErrEnum.unExist);
   }
   const isPlugin = app?.type === AppTypeEnum.workflowTool;
@@ -76,7 +78,7 @@ export async function handler(req: ApiRequestProps): Promise<GetPaginationRecord
   };
 
   const { total, histories: sourceHistories } = await getChatItems({
-    sourceType,
+    sourceType: resolvedSourceType,
     sourceId: resolvedSourceId,
     chatId,
     field: fieldMap[type],

--- a/projects/app/src/pages/api/core/chat/record/getRecords_v2.ts
+++ b/projects/app/src/pages/api/core/chat/record/getRecords_v2.ts
@@ -55,14 +55,16 @@ async function handler(req: ApiRequestProps): Promise<GetRecordsV2ResponseType> 
     sourceId,
     chatId
   });
+  // 后续查询统一使用鉴权解析后的来源，避免分享链接请求体缺少 sourceType 时降级为普通对话。
+  const resolvedSourceType = authRes.sourceType;
   const resolvedSourceId = authRes.sourceId;
 
   const app =
-    sourceType === ChatSourceTypeEnum.app
+    resolvedSourceType === ChatSourceTypeEnum.app
       ? await MongoApp.findById(resolvedSourceId, 'type').lean()
       : null;
 
-  if (sourceType === ChatSourceTypeEnum.app && !app) {
+  if (resolvedSourceType === ChatSourceTypeEnum.app && !app) {
     return Promise.reject(AppErrEnum.unExist);
   }
   const isPlugin = app?.type === AppTypeEnum.workflowTool;
@@ -78,7 +80,7 @@ async function handler(req: ApiRequestProps): Promise<GetRecordsV2ResponseType> 
 
   const result = await getChatItems({
     includeDeleted,
-    sourceType,
+    sourceType: resolvedSourceType,
     sourceId: resolvedSourceId,
     chatId,
     field: fieldMap[type],

--- a/projects/app/src/pages/api/v1/chat/completions.ts
+++ b/projects/app/src/pages/api/v1/chat/completions.ts
@@ -632,7 +632,8 @@ const authShareChat = async ({
     app,
     apikey: '',
     authType,
-    responseAllData: false,
+    // 工作流工具的分享运行需要把完整节点链路返回给运行面板；普通对话仍按公开字段过滤。
+    responseAllData: app.type === AppTypeEnum.workflowTool,
     showCite,
     outLinkUserId: uid,
     showRunningStatus,

--- a/projects/app/src/pages/api/v2/chat/completions.ts
+++ b/projects/app/src/pages/api/v2/chat/completions.ts
@@ -632,7 +632,8 @@ const authShareChat = async ({
     app,
     apikey: '',
     authType,
-    responseAllData: false,
+    // 工作流工具的分享运行需要把完整节点链路返回给运行面板；普通对话仍按公开字段过滤。
+    responseAllData: app.type === AppTypeEnum.workflowTool,
     showCite,
     outLinkUserId: uid,
     showRunningStatus,

--- a/projects/app/src/pages/chat/share.tsx
+++ b/projects/app/src/pages/chat/share.tsx
@@ -304,6 +304,8 @@ const OutLink = (props: Props) => {
       />
       <Flex
         h={'full'}
+        minH={0}
+        minW={0}
         gap={datasetCiteData ? 0 : 4}
         {...(isEmbed ? { p: '0 !important', borderRadius: '0', boxShadow: 'none' } : { p: [0, 5] })}
       >
@@ -311,6 +313,8 @@ const OutLink = (props: Props) => {
           <PageContainer
             flex={'1 0 0'}
             w={0}
+            minH={0}
+            minW={0}
             p={'0 !important'}
             insertProps={
               datasetCiteData
@@ -320,19 +324,22 @@ const OutLink = (props: Props) => {
                 : undefined
             }
           >
-            <Flex h={'100%'} flexDirection={['column', 'row']}>
+            <Flex h={'100%'} minH={0} minW={0} flexDirection={['column', 'row']}>
               {RenderHistoryList}
 
               {/* chat container */}
               <Flex
                 position={'relative'}
                 h={[0, '100%']}
+                minH={0}
+                minW={0}
                 w={['100%', 0]}
                 flex={'1 0 0'}
                 flexDirection={'column'}
               >
                 {/* header */}
                 {showHead === '1' &&
+                  !isPlugin &&
                   (isPc ? (
                     <ChatWindowHeader
                       title={chatWindowTitle}
@@ -414,7 +421,7 @@ const OutLink = (props: Props) => {
                     </Flex>
                   ))}
                 {/* chat box */}
-                <Box flex={1} bg={'white'}>
+                <Box flex={1} minH={0} minW={0} overflow={'hidden'} bg={'white'}>
                   {isPlugin ? (
                     <CustomPluginRunBox
                       appId={appId}


### PR DESCRIPTION
## What changed

- Updated the admin submodule to the v2 modal and Chakra styling migration commit.
- Regenerated the workspace lockfile after removing the admin Tailwind/PostCSS dependencies.

## Impact

The main repository now references the complete admin migration and has a consistent dependency lockfile.

## Validation

- Admin `pnpm run typecheck` passed.
- `git diff --check` passed in both repositories.
- Admin changed-file ESLint review completed; three pre-existing effect lint errors remain in unchanged logic.
