### PR TITLE
feat(dataset): update training status api

### DIFF
--- a/packages/global/openapi/admin/core/index.ts
+++ b/packages/global/openapi/admin/core/index.ts
@@ -2,11 +2,13 @@ import { DashboardPath } from './dashboard';
 import { AdminAppPath } from './app';
 import { AdminRoutesPath } from '../routes';
 import { AdminCommonPath } from '../common';
+import { StatusPath } from './status';
 import type { OpenAPIPath } from '../../type';
 
 export const AdminCorePath: OpenAPIPath = {
   ...DashboardPath,
   ...AdminAppPath,
   ...AdminRoutesPath,
-  ...AdminCommonPath
+  ...AdminCommonPath,
+  ...StatusPath
 };

--- a/packages/global/openapi/admin/core/status/api.ts
+++ b/packages/global/openapi/admin/core/status/api.ts
@@ -1,0 +1,78 @@
+import z from 'zod';
+import { ObjectIdSchema } from '../../../../common/type/mongo';
+import { PaginationResponseSchema, PaginationSchema } from '../../../api';
+
+export const TrainingRecordStateEnumSchema = z.enum([
+  'queued',
+  'processing',
+  'retrying',
+  'final_error',
+  'blocked',
+  'exhausted_without_error'
+]);
+export type TrainingRecordState = z.infer<typeof TrainingRecordStateEnumSchema>;
+
+export const TrainingRecordStateFilterEnumSchema = z.enum(['queued', 'processing', 'error']);
+export type TrainingRecordStateFilter = z.infer<typeof TrainingRecordStateFilterEnumSchema>;
+
+export const TrainingRecordActionEnumSchema = z.enum(['retry', 'delete']);
+export type TrainingRecordAction = z.infer<typeof TrainingRecordActionEnumSchema>;
+
+export const TrainingTaskSummarySchema = z.object({
+  mode: z.literal('chunk').meta({ description: '固定为 Chunk 向量训练' }),
+  queued: z.number().meta({ description: '排队任务数' }),
+  processing: z.number().meta({ description: '处理中任务数' }),
+  retrying: z.number().meta({ description: '自动重试任务数' }),
+  finalError: z.number().meta({ description: '最终失败任务数' }),
+  blocked: z.number().meta({ description: '永久阻塞任务数' }),
+  exhaustedWithoutError: z.number().meta({ description: '无错误但重试耗尽任务数' }),
+  total: z.number().meta({ description: '当前训练任务总数' }),
+  completed: z.number().meta({ description: '已完成 Chunk 数量' }),
+  severity: z.enum(['normal', 'warning', 'severe']).meta({ description: '运维告警等级' })
+});
+export type TrainingTaskSummaryType = z.infer<typeof TrainingTaskSummarySchema>;
+
+export const GetTrainingTaskListResponseSchema = TrainingTaskSummarySchema;
+export type GetTrainingTaskListResponseType = z.infer<typeof GetTrainingTaskListResponseSchema>;
+
+export const GetTrainingRecordListBodySchema = PaginationSchema.extend({
+  search: z.string().trim().min(1).optional().meta({ description: '训练 ID、知识库或团队名称' }),
+  state: TrainingRecordStateFilterEnumSchema.optional().meta({ description: '训练状态筛选' })
+});
+export type GetTrainingRecordListBody = z.infer<typeof GetTrainingRecordListBodySchema>;
+
+export const TrainingRecordSchema = z.object({
+  id: ObjectIdSchema.meta({ description: '训练任务 ID' }),
+  datasetId: ObjectIdSchema.meta({ description: '知识库 ID' }),
+  collectionId: ObjectIdSchema.meta({ description: '集合 ID' }),
+  datasetName: z.string().meta({ description: '知识库名称' }),
+  collectionName: z.string().optional().meta({ description: '集合名称' }),
+  teamName: z.string().optional().meta({ description: '团队名称' }),
+  model: z.string().optional().meta({ description: 'Embedding 模型' }),
+  chunkIndex: z.number().optional().meta({ description: '分块序号' }),
+  dataId: ObjectIdSchema.optional().meta({ description: '重建关联的数据 ID' }),
+  q: z.string().optional().meta({ description: '分块主文本' }),
+  a: z.string().optional().meta({ description: '分块补充文本' }),
+  retryCount: z.number().meta({ description: '剩余重试次数' }),
+  state: TrainingRecordStateEnumSchema.meta({ description: '训练状态' }),
+  actions: z
+    .array(TrainingRecordActionEnumSchema)
+    .meta({ description: '当前状态允许的管理员操作' }),
+  error: z.string().optional().meta({ description: '最近错误信息' }),
+  lockTime: z.string().optional().meta({ description: '任务租约时间' })
+});
+export type TrainingRecordType = z.infer<typeof TrainingRecordSchema>;
+
+export const GetTrainingRecordListResponseSchema = PaginationResponseSchema(TrainingRecordSchema);
+export type GetTrainingRecordListResponseType = z.infer<typeof GetTrainingRecordListResponseSchema>;
+
+export const TrainingActionBodySchema = z.object({
+  id: ObjectIdSchema.meta({ description: '训练任务 ID' }),
+  action: z.enum(['retry', 'delete']).meta({ description: '管理员操作' })
+});
+export type TrainingActionBody = z.infer<typeof TrainingActionBodySchema>;
+
+export const TrainingActionResponseSchema = z.object({
+  affectedCount: z.number().meta({ description: '实际影响的任务数量' })
+});
+export type TrainingActionResponseType = z.infer<typeof TrainingActionResponseSchema>;

--- a/packages/global/openapi/admin/core/status/api.ts
+++ b/packages/global/openapi/admin/core/status/api.ts
@@ -76,3 +76,19 @@ export const TrainingActionResponseSchema = z.object({
   affectedCount: z.number().meta({ description: '实际影响的任务数量' })
 });
 export type TrainingActionResponseType = z.infer<typeof TrainingActionResponseSchema>;
+
+export const StatusOverviewAlertSchema = z.object({
+  level: z.literal('warning').meta({ description: '告警等级' }),
+  title: z.string().meta({ description: '告警标题' }),
+  description: z.string().meta({ description: '告警描述' }),
+  source: z.string().meta({ description: '告警来源' }),
+  scope: z.string().meta({ description: '告警范围' }),
+  count: z.number().meta({ description: '异常数量' })
+});
+export type StatusOverviewAlertType = z.infer<typeof StatusOverviewAlertSchema>;
+
+export const GetStatusOverviewResponseSchema = z.object({
+  unresolvedCount: z.number().meta({ description: '未恢复告警数' }),
+  alerts: z.array(StatusOverviewAlertSchema).meta({ description: '告警消息列表' })
+});
+export type GetStatusOverviewResponseType = z.infer<typeof GetStatusOverviewResponseSchema>;

--- a/packages/global/openapi/admin/core/status/index.ts
+++ b/packages/global/openapi/admin/core/status/index.ts
@@ -1,0 +1,54 @@
+import type { OpenAPIPath } from '../../../type';
+import {
+  GetTrainingRecordListBodySchema,
+  GetTrainingRecordListResponseSchema,
+  GetTrainingTaskListResponseSchema,
+  TrainingActionBodySchema,
+  TrainingActionResponseSchema
+} from './api';
+import { DevApiTagsMap } from '../../../tag';
+
+export const StatusPath: OpenAPIPath = {
+  '/admin/status/dataset/tasks': {
+    get: {
+      summary: '获取 Chunk 训练状态汇总',
+      tags: [DevApiTagsMap.adminStatus],
+      responses: {
+        200: {
+          description: '成功获取训练状态汇总',
+          content: { 'application/json': { schema: GetTrainingTaskListResponseSchema } }
+        }
+      }
+    }
+  },
+  '/admin/status/dataset/training': {
+    post: {
+      summary: '获取 Chunk 训练任务列表',
+      tags: [DevApiTagsMap.adminStatus],
+      requestBody: {
+        content: { 'application/json': { schema: GetTrainingRecordListBodySchema } }
+      },
+      responses: {
+        200: {
+          description: '成功获取训练任务列表',
+          content: { 'application/json': { schema: GetTrainingRecordListResponseSchema } }
+        }
+      }
+    }
+  },
+  '/admin/status/dataset/training/action': {
+    post: {
+      summary: '重试或删除 Chunk 训练任务',
+      tags: [DevApiTagsMap.adminStatus],
+      requestBody: {
+        content: { 'application/json': { schema: TrainingActionBodySchema } }
+      },
+      responses: {
+        200: {
+          description: '成功执行训练任务操作',
+          content: { 'application/json': { schema: TrainingActionResponseSchema } }
+        }
+      }
+    }
+  }
+};

--- a/packages/global/openapi/admin/core/status/index.ts
+++ b/packages/global/openapi/admin/core/status/index.ts
@@ -1,5 +1,6 @@
 import type { OpenAPIPath } from '../../../type';
 import {
+  GetStatusOverviewResponseSchema,
   GetTrainingRecordListBodySchema,
   GetTrainingRecordListResponseSchema,
   GetTrainingTaskListResponseSchema,
@@ -9,6 +10,18 @@ import {
 import { DevApiTagsMap } from '../../../tag';
 
 export const StatusPath: OpenAPIPath = {
+  '/admin/status/overview': {
+    get: {
+      summary: '获取 Chunk 训练总览告警',
+      tags: [DevApiTagsMap.adminStatus],
+      responses: {
+        200: {
+          description: '成功获取训练总览告警',
+          content: { 'application/json': { schema: GetStatusOverviewResponseSchema } }
+        }
+      }
+    }
+  },
   '/admin/status/dataset/tasks': {
     get: {
       summary: '获取 Chunk 训练状态汇总',

--- a/packages/global/openapi/path.ts
+++ b/packages/global/openapi/path.ts
@@ -115,7 +115,12 @@ export const adminOpenAPIPaths: NonNullable<OpenAPIPath> = {
 export const adminOpenAPITagGroups = [
   {
     name: '管理员-系统概览',
-    tags: [DevApiTagsMap.adminDashboard, DevApiTagsMap.adminLogs, DevApiTagsMap.adminLicense]
+    tags: [
+      DevApiTagsMap.adminDashboard,
+      DevApiTagsMap.adminStatus,
+      DevApiTagsMap.adminLogs,
+      DevApiTagsMap.adminLicense
+    ]
   },
   {
     name: '管理员-资源管理',

--- a/packages/global/openapi/tag.ts
+++ b/packages/global/openapi/tag.ts
@@ -70,6 +70,7 @@ export const DevApiTagsMap = {
 
   /* 管理员-系统管理 */
   adminDashboard: '仪表盘',
+  adminStatus: '运维数据',
   adminInform: '通知管理',
   adminApps: '应用管理',
   adminWalletCoupon: '兑换码管理',

--- a/packages/service/core/dataset/training/query.ts
+++ b/packages/service/core/dataset/training/query.ts
@@ -3,6 +3,7 @@ import {
   TrainingModeEnum
 } from '@fastgpt/global/core/dataset/constants';
 import type { DatasetTrainingSchemaType } from '@fastgpt/global/core/dataset/type';
+import { subMinutes } from 'date-fns';
 
 type TrainingStatusCount = {
   activeCount: number;
@@ -10,6 +11,18 @@ type TrainingStatusCount = {
 };
 
 export const BLOCKED_LOCK_TIME = new Date('2050-01-01');
+
+export const trainingModeLockTimeoutMinutes: Record<TrainingModeEnum, number> = {
+  [TrainingModeEnum.parse]: 10,
+  [TrainingModeEnum.imageParse]: 10,
+  [TrainingModeEnum.qa]: 10,
+  [TrainingModeEnum.image]: 10,
+  [TrainingModeEnum.auto]: 10,
+  [TrainingModeEnum.chunk]: 3
+};
+
+export const getTrainingLockExpireTime = (mode: TrainingModeEnum, now = new Date()) =>
+  subMinutes(now, trainingModeLockTimeoutMinutes[mode]);
 
 export const trainingModeRankMap: Record<TrainingModeEnum, number> = {
   [TrainingModeEnum.parse]: 0,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,7 +269,7 @@ importers:
         version: 9.39.4(jiti@2.7.0)
       eslint-config-next:
         specifier: catalog:lint
-        version: 16.3.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+        version: 16.3.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       husky:
         specifier: ^8.0.3
         version: 8.0.3
@@ -979,7 +979,7 @@ importers:
         version: 1.14.3
       '@scalar/api-reference-react':
         specifier: ^0.9.59
-        version: 0.9.60(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(react@18.3.1)(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))(typescript@6.0.3)(zod@4.1.12)
+        version: 0.9.60(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(react@18.3.1)(tailwindcss@4.2.4)(typescript@6.0.3)(zod@4.1.12)
       '@t3-oss/env-core':
         specifier: 'catalog:'
         version: 0.13.10(typescript@6.0.3)(zod@4.1.12)
@@ -1004,9 +1004,6 @@ importers:
       assert:
         specifier: ^2.0.0
         version: 2.1.0
-      autoprefixer:
-        specifier: ^10.4.19
-        version: 10.5.4(postcss@8.5.23)
       axios:
         specifier: 'catalog:'
         version: 1.18.1
@@ -1124,9 +1121,6 @@ importers:
       sass:
         specifier: ^1.58.3
         version: 1.85.1
-      tailwindcss:
-        specifier: ^3.0
-        version: 3.4.18(tsx@4.20.6)(yaml@2.8.4)
       utf-8-validate:
         specifier: ^5.0.10
         version: 5.0.10
@@ -1181,10 +1175,10 @@ importers:
         version: 0.25.12
       eslint:
         specifier: catalog:lint
-        version: 9.39.4(jiti@1.21.7)
+        version: 9.39.4(jiti@2.7.0)
       eslint-config-next:
         specifier: catalog:lint
-        version: 16.3.0(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
+        version: 16.3.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       mongodb-memory-server:
         specifier: 'catalog:'
         version: 10.1.4(gcp-metadata@5.3.0(encoding@0.1.13))(socks@2.8.9)
@@ -1196,7 +1190,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0)(canvas@3.2.3)(utf-8-validate@5.0.10))(vite@6.2.2(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.4))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0)(canvas@3.2.3)(utf-8-validate@5.0.10))(vite@6.2.2(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.4))
 
   pro/browser-sandbox:
     dependencies:
@@ -1605,10 +1599,10 @@ importers:
         version: 15.5.13
       eslint:
         specifier: catalog:lint
-        version: 9.39.4(jiti@2.7.0)
+        version: 9.39.4(jiti@1.21.7)
       eslint-config-next:
         specifier: catalog:lint
-        version: 16.3.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+        version: 16.3.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
       tailwindcss:
         specifier: ^3
         version: 3.4.18(tsx@4.20.6)(yaml@2.8.4)
@@ -1620,10 +1614,10 @@ importers:
         version: 6.0.3
       typescript-eslint:
         specifier: catalog:lint
-        version: 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+        version: 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0)(canvas@3.2.3)(utf-8-validate@5.0.10))(vite@6.2.2(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.4))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0)(canvas@3.2.3)(utf-8-validate@5.0.10))(vite@6.2.2(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.4))
 
   projects/code-sandbox:
     dependencies:
@@ -1781,7 +1775,7 @@ importers:
         version: 9.39.4(jiti@2.7.0)
       eslint-config-next:
         specifier: catalog:lint
-        version: 16.3.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+        version: 16.3.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       postcss:
         specifier: 'catalog:'
         version: 8.5.22
@@ -7680,13 +7674,6 @@ packages:
     resolution: {integrity: sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==}
     engines: {node: '>=10.12.0'}
 
-  autoprefixer@10.5.4:
-    resolution: {integrity: sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==}
-    engines: {node: ^10 || ^12 || >=14}
-    hasBin: true
-    peerDependencies:
-      postcss: ^8.1.0
-
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -7880,11 +7867,6 @@ packages:
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
-  browserslist@4.28.7:
-    resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -8961,9 +8943,6 @@ packages:
   electron-to-chromium@1.5.341:
     resolution: {integrity: sha512-1sZTssferjgDgaqRTc0ieP+ozzpOy7LQTPTtEW3yQFn4+ORdIAZWV5BthXPyHF7YqLvFJCUPhNhdAJQYlYUgiw==}
 
-  electron-to-chromium@1.5.396:
-    resolution: {integrity: sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==}
-
   elkjs@0.9.3:
     resolution: {integrity: sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==}
 
@@ -9613,9 +9592,6 @@ packages:
   frac@1.1.2:
     resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
     engines: {node: '>=0.8'}
-
-  fraction.js@5.3.4:
-    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
   framer-motion@9.1.7:
     resolution: {integrity: sha512-nKxBkIO4IPkMEqcBbbATxsVjwPYShKl051yhBv9628iAH6JLeHD0siBHxkL62oQzMC1+GNX73XtPjgP753ufuw==}
@@ -11929,10 +11905,6 @@ packages:
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
-
-  node-releases@2.0.51:
-    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
-    engines: {node: '>=18'}
 
   nodemailer@7.0.13:
     resolution: {integrity: sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==}
@@ -18013,6 +17985,10 @@ snapshots:
     dependencies:
       tailwindcss: 3.4.18(tsx@4.20.6)(yaml@2.8.4)
 
+  '@headlessui/tailwindcss@0.2.2(tailwindcss@4.2.4)':
+    dependencies:
+      tailwindcss: 4.2.4
+
   '@headlessui/vue@1.7.23(vue@3.5.40(typescript@6.0.3))':
     dependencies:
       '@tanstack/vue-virtual': 3.13.12(vue@3.5.40(typescript@6.0.3))
@@ -19999,6 +19975,44 @@ snapshots:
       - universal-cookie
       - zod
 
+  '@scalar/agent-chat@0.12.23(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(tailwindcss@4.2.4)(typescript@6.0.3)(zod@4.1.12)':
+    dependencies:
+      '@ai-sdk/vue': 3.0.33(vue@3.5.40(typescript@6.0.3))(zod@4.1.12)
+      '@scalar/api-client': 3.14.0(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(tailwindcss@4.2.4)(typescript@6.0.3)
+      '@scalar/components': 0.27.10(tailwindcss@4.2.4)(typescript@6.0.3)
+      '@scalar/helpers': 0.9.2
+      '@scalar/icons': 0.7.5(typescript@6.0.3)
+      '@scalar/json-magic': 0.12.19
+      '@scalar/openapi-types': 0.9.4
+      '@scalar/schemas': 0.8.0
+      '@scalar/themes': 0.17.2
+      '@scalar/types': 0.17.0
+      '@scalar/use-toasts': 0.10.4(typescript@6.0.3)
+      '@scalar/validation': 0.6.2
+      '@scalar/workspace-store': 0.56.0(typescript@6.0.3)
+      '@vueuse/core': 13.9.0(vue@3.5.40(typescript@6.0.3))
+      ai: 6.0.33(zod@4.1.12)
+      js-base64: 3.7.8
+      neverpanic: 0.0.8
+      truncate-json: 3.0.1
+      vue: 3.5.40(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+      - zod
+
   '@scalar/api-client@3.14.0(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))(typescript@6.0.3)':
     dependencies:
       '@headlessui/tailwindcss': 0.2.2(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))
@@ -20047,9 +20061,79 @@ snapshots:
       - typescript
       - universal-cookie
 
+  '@scalar/api-client@3.14.0(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(tailwindcss@4.2.4)(typescript@6.0.3)':
+    dependencies:
+      '@headlessui/tailwindcss': 0.2.2(tailwindcss@4.2.4)
+      '@headlessui/vue': 1.7.23(vue@3.5.40(typescript@6.0.3))
+      '@scalar/blocks': 0.1.9(tailwindcss@4.2.4)(typescript@6.0.3)
+      '@scalar/components': 0.27.10(tailwindcss@4.2.4)(typescript@6.0.3)
+      '@scalar/helpers': 0.9.2
+      '@scalar/icons': 0.7.5(typescript@6.0.3)
+      '@scalar/oas-utils': 0.19.9(typescript@6.0.3)
+      '@scalar/openapi-types': 0.9.4
+      '@scalar/sidebar': 0.9.34(tailwindcss@4.2.4)(typescript@6.0.3)
+      '@scalar/snippetz': 0.9.24
+      '@scalar/themes': 0.17.2
+      '@scalar/typebox': 0.1.3
+      '@scalar/types': 0.17.0
+      '@scalar/use-codemirror': 0.14.14(typescript@6.0.3)
+      '@scalar/use-hooks': 0.4.9(typescript@6.0.3)
+      '@scalar/use-toasts': 0.10.4(typescript@6.0.3)
+      '@scalar/workspace-store': 0.56.0(typescript@6.0.3)
+      '@vueuse/core': 13.9.0(vue@3.5.40(typescript@6.0.3))
+      '@vueuse/integrations': 13.9.0(axios@1.18.1)(focus-trap@7.8.0)(fuse.js@7.1.0)(nprogress@0.2.0)(qrcode@1.5.4)(vue@3.5.40(typescript@6.0.3))
+      focus-trap: 7.8.0
+      fuse.js: 7.1.0
+      js-base64: 3.7.8
+      jsonc-parser: 3.3.1
+      nanoid: 5.1.16
+      pretty-ms: 9.3.0
+      radix-vue: 1.9.17(vue@3.5.40(typescript@6.0.3))
+      set-cookie-parser: 3.1.0
+      vue: 3.5.40(typescript@6.0.3)
+      yaml: 2.8.4
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+
   '@scalar/api-reference-react@0.9.60(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(react@18.3.1)(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))(typescript@6.0.3)(zod@4.1.12)':
     dependencies:
       '@scalar/api-reference': 1.64.0(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))(typescript@6.0.3)(zod@4.1.12)
+      '@scalar/types': 0.17.0
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+      - zod
+
+  '@scalar/api-reference-react@0.9.60(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(react@18.3.1)(tailwindcss@4.2.4)(typescript@6.0.3)(zod@4.1.12)':
+    dependencies:
+      '@scalar/api-reference': 1.64.0(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(tailwindcss@4.2.4)(typescript@6.0.3)(zod@4.1.12)
       '@scalar/types': 0.17.0
       react: 18.3.1
     transitivePeerDependencies:
@@ -20113,6 +20197,50 @@ snapshots:
       - universal-cookie
       - zod
 
+  '@scalar/api-reference@1.64.0(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(tailwindcss@4.2.4)(typescript@6.0.3)(zod@4.1.12)':
+    dependencies:
+      '@headlessui/vue': 1.7.23(vue@3.5.40(typescript@6.0.3))
+      '@scalar/agent-chat': 0.12.23(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(tailwindcss@4.2.4)(typescript@6.0.3)(zod@4.1.12)
+      '@scalar/api-client': 3.14.0(axios@1.18.1)(nprogress@0.2.0)(qrcode@1.5.4)(tailwindcss@4.2.4)(typescript@6.0.3)
+      '@scalar/blocks': 0.1.9(tailwindcss@4.2.4)(typescript@6.0.3)
+      '@scalar/code-highlight': 0.4.3
+      '@scalar/components': 0.27.10(tailwindcss@4.2.4)(typescript@6.0.3)
+      '@scalar/helpers': 0.9.2
+      '@scalar/icons': 0.7.5(typescript@6.0.3)
+      '@scalar/oas-utils': 0.19.9(typescript@6.0.3)
+      '@scalar/schemas': 0.8.0
+      '@scalar/sidebar': 0.9.34(tailwindcss@4.2.4)(typescript@6.0.3)
+      '@scalar/snippetz': 0.9.24
+      '@scalar/themes': 0.17.2
+      '@scalar/types': 0.17.0
+      '@scalar/use-hooks': 0.4.9(typescript@6.0.3)
+      '@scalar/use-toasts': 0.10.4(typescript@6.0.3)
+      '@scalar/validation': 0.6.2
+      '@scalar/workspace-store': 0.56.0(typescript@6.0.3)
+      '@unhead/vue': 2.1.17(vue@3.5.40(typescript@6.0.3))
+      '@vueuse/core': 13.9.0(vue@3.5.40(typescript@6.0.3))
+      fuse.js: 7.1.0
+      microdiff: 1.5.0
+      nanoid: 5.1.16
+      vue: 3.5.40(typescript@6.0.3)
+      yaml: 2.8.4
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+      - zod
+
   '@scalar/asyncapi-upgrader@0.1.4':
     dependencies:
       '@scalar/helpers': 0.9.2
@@ -20120,6 +20248,24 @@ snapshots:
   '@scalar/blocks@0.1.9(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))(typescript@6.0.3)':
     dependencies:
       '@scalar/components': 0.27.10(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))(typescript@6.0.3)
+      '@scalar/helpers': 0.9.2
+      '@scalar/icons': 0.7.5(typescript@6.0.3)
+      '@scalar/snippetz': 0.9.24
+      '@scalar/themes': 0.17.2
+      '@scalar/types': 0.17.0
+      '@scalar/workspace-store': 0.56.0(typescript@6.0.3)
+      '@types/har-format': 1.2.16
+      js-base64: 3.7.8
+      vue: 3.5.40(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - supports-color
+      - tailwindcss
+      - typescript
+
+  '@scalar/blocks@0.1.9(tailwindcss@4.2.4)(typescript@6.0.3)':
+    dependencies:
+      '@scalar/components': 0.27.10(tailwindcss@4.2.4)(typescript@6.0.3)
       '@scalar/helpers': 0.9.2
       '@scalar/icons': 0.7.5(typescript@6.0.3)
       '@scalar/snippetz': 0.9.24
@@ -20160,6 +20306,28 @@ snapshots:
       '@floating-ui/utils': 0.2.10
       '@floating-ui/vue': 1.1.9(vue@3.5.40(typescript@6.0.3))
       '@headlessui/tailwindcss': 0.2.2(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))
+      '@headlessui/vue': 1.7.23(vue@3.5.40(typescript@6.0.3))
+      '@scalar/code-highlight': 0.4.3
+      '@scalar/helpers': 0.9.2
+      '@scalar/icons': 0.7.5(typescript@6.0.3)
+      '@scalar/themes': 0.17.2
+      '@scalar/use-hooks': 0.4.9(typescript@6.0.3)
+      '@vueuse/core': 13.9.0(vue@3.5.40(typescript@6.0.3))
+      cva: 1.0.0-beta.4(typescript@6.0.3)
+      radix-vue: 1.9.17(vue@3.5.40(typescript@6.0.3))
+      vue: 3.5.40(typescript@6.0.3)
+      vue-component-type-helpers: 3.3.9
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - supports-color
+      - tailwindcss
+      - typescript
+
+  '@scalar/components@0.27.10(tailwindcss@4.2.4)(typescript@6.0.3)':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+      '@floating-ui/vue': 1.1.9(vue@3.5.40(typescript@6.0.3))
+      '@headlessui/tailwindcss': 0.2.2(tailwindcss@4.2.4)
       '@headlessui/vue': 1.7.23(vue@3.5.40(typescript@6.0.3))
       '@scalar/code-highlight': 0.4.3
       '@scalar/helpers': 0.9.2
@@ -20220,6 +20388,21 @@ snapshots:
   '@scalar/sidebar@0.9.34(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))(typescript@6.0.3)':
     dependencies:
       '@scalar/components': 0.27.10(tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.4))(typescript@6.0.3)
+      '@scalar/helpers': 0.9.2
+      '@scalar/icons': 0.7.5(typescript@6.0.3)
+      '@scalar/themes': 0.17.2
+      '@scalar/use-hooks': 0.4.9(typescript@6.0.3)
+      '@scalar/workspace-store': 0.56.0(typescript@6.0.3)
+      vue: 3.5.40(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - supports-color
+      - tailwindcss
+      - typescript
+
+  '@scalar/sidebar@0.9.34(tailwindcss@4.2.4)(typescript@6.0.3)':
+    dependencies:
+      '@scalar/components': 0.27.10(tailwindcss@4.2.4)(typescript@6.0.3)
       '@scalar/helpers': 0.9.2
       '@scalar/icons': 0.7.5(typescript@6.0.3)
       '@scalar/themes': 0.17.2
@@ -22517,15 +22700,6 @@ snapshots:
 
   atomically@1.7.0: {}
 
-  autoprefixer@10.5.4(postcss@8.5.23):
-    dependencies:
-      browserslist: 4.28.7
-      caniuse-lite: 1.0.30001806
-      fraction.js: 5.3.4
-      picocolors: 1.1.1
-      postcss: 8.5.23
-      postcss-value-parser: 4.2.0
-
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -22742,14 +22916,6 @@ snapshots:
       electron-to-chromium: 1.5.341
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
-
-  browserslist@4.28.7:
-    dependencies:
-      baseline-browser-mapping: 2.11.1
-      caniuse-lite: 1.0.30001806
-      electron-to-chromium: 1.5.396
-      node-releases: 2.0.51
-      update-browserslist-db: 1.2.3(browserslist@4.28.7)
 
   bson@6.10.3: {}
 
@@ -23850,8 +24016,6 @@ snapshots:
 
   electron-to-chromium@1.5.341: {}
 
-  electron-to-chromium@1.5.396: {}
-
   elkjs@0.9.3: {}
 
   emoji-regex@10.4.0: {}
@@ -24114,18 +24278,18 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-next@16.3.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3):
+  eslint-config-next@16.3.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3):
     dependencies:
-      '@next/eslint-plugin-next': 16.3.0(eslint@9.39.4(jiti@2.7.0))
-      eslint: 9.39.4(jiti@2.7.0)
+      '@next/eslint-plugin-next': 16.3.0(eslint@9.39.4(jiti@1.21.7))
+      eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.9.0(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-react: 7.37.4(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.9.0(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-react: 7.37.4(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@1.21.7))
       globals: 16.4.0
-      typescript-eslint: 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      typescript-eslint: 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -24134,18 +24298,18 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-next@16.3.0(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3):
+  eslint-config-next@16.3.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@next/eslint-plugin-next': 16.3.0(eslint@9.39.4(jiti@1.21.7))
-      eslint: 9.39.4(jiti@1.21.7)
+      '@next/eslint-plugin-next': 16.3.0(eslint@9.39.4(jiti@2.7.0))
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.9.0(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-react: 7.37.4(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.9.0(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.9.0(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-react: 7.37.4(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
       globals: 16.4.0
-      typescript-eslint: 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
+      typescript-eslint: 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -24162,6 +24326,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.9.0(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.7.0)
+      get-tsconfig: 4.14.0
+      is-bun-module: 1.3.0
+      oxc-resolver: 5.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.9.0(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.9.0(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -24173,47 +24352,32 @@ snapshots:
       stable-hash: 0.0.5
       tinyglobby: 0.2.16
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.9.0(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@2.7.0)
-      get-tsconfig: 4.14.0
-      is-bun-module: 1.3.0
-      oxc-resolver: 5.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
-      eslint: 9.39.4(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.9.0(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
       eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.9.0(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.0(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.9.0(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -24222,9 +24386,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -24236,13 +24400,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.9.0(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -24251,9 +24415,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.0)(eslint@9.39.4(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.0(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -24938,8 +25102,6 @@ snapshots:
   forwarded@0.2.0: {}
 
   frac@1.1.2: {}
-
-  fraction.js@5.3.4: {}
 
   framer-motion@9.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -27912,8 +28074,6 @@ snapshots:
   node-hex@1.0.1: {}
 
   node-releases@2.0.37: {}
-
-  node-releases@2.0.51: {}
 
   nodemailer@7.0.13: {}
 
@@ -31091,12 +31251,6 @@ snapshots:
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
-  update-browserslist-db@1.2.3(browserslist@4.28.7):
-    dependencies:
-      browserslist: 4.28.7
       escalade: 3.2.0
       picocolors: 1.1.1
 

--- a/projects/app/src/pages/api/core/dataset/collection/trainingDetail.ts
+++ b/projects/app/src/pages/api/core/dataset/collection/trainingDetail.ts
@@ -14,7 +14,8 @@ import {
 } from '@fastgpt/global/openapi/core/dataset/collection/api';
 import {
   BLOCKED_LOCK_TIME,
-  finalErrorTrainingMatch
+  finalErrorTrainingMatch,
+  trainingModeLockTimeoutMinutes
 } from '@fastgpt/service/core/dataset/training/query';
 import { subMinutes } from 'date-fns';
 
@@ -25,15 +26,6 @@ const defaultCounts: Record<TrainingModeEnum, number> = {
   image: 0,
   auto: 0,
   imageParse: 0
-};
-
-const MODE_LOCK_TIMEOUT_MINUTES: Record<TrainingModeEnum, number> = {
-  parse: 10,
-  qa: 10,
-  chunk: 3,
-  image: 10,
-  auto: 10,
-  imageParse: 10
 };
 
 async function handler(req: ApiRequestProps): Promise<GetCollectionTrainingDetailResponseType> {
@@ -57,7 +49,7 @@ async function handler(req: ApiRequestProps): Promise<GetCollectionTrainingDetai
   };
 
   const now = new Date();
-  const activeTrainingExpr = Object.entries(MODE_LOCK_TIMEOUT_MINUTES).map(
+  const activeTrainingExpr = Object.entries(trainingModeLockTimeoutMinutes).map(
     ([mode, timeoutMinutes]) => ({
       mode,
       lockTime: { $gt: subMinutes(now, timeoutMinutes), $lt: BLOCKED_LOCK_TIME }


### PR DESCRIPTION
## What

What changes did you make at a high level?

- Added OpenAPI schemas and route documentation for admin status APIs.
- Added the `/admin/status/overview` contract for status overview alerts.
- Updated training record responses to include backend-computed `actions`.
- Updated dataset training query helpers to classify Chunk training states more precisely.
- Updated the collection training detail API to use the shared training lock timeout helper.

## How

How did you go about making these changes?

- Reused the existing admin OpenAPI structure under `packages/global/openapi/admin/core/status`.
- Added explicit training record action enums and included `actions` on each training record.
- Reused the existing Chunk training lock timeout logic instead of adding a separate timeout rule.
- Kept the alert contract intentionally small: the overview currently reports only Chunk vector training issues.
- Used existing Zod schemas for request and response validation patterns.

## Other Notes

What, if anything, hasn't been addressed in these code changes but should be in future changes?

- The overview currently supports only the requested Chunk vector training alert.
- Future status alerts can reuse the same overview response shape when additional operational checks are added.