### PR TITLE
fix(docs): include SWC ESM helpers in standalone output

### DIFF
--- a/document/next.config.ts
+++ b/document/next.config.ts
@@ -5,6 +5,13 @@ const withMDX = createMDX();
 
 const config: NextConfig = {
   output: 'standalone',
+  outputFileTracingIncludes: {
+    // Node 24 resolves @swc/helpers through module-sync, but Next 15 does not trace all ESM helpers.
+    '*': [
+      './node_modules/.pnpm/@swc+helpers@*/node_modules/@swc/helpers/esm/**/*',
+      '../node_modules/.pnpm/@swc+helpers@*/node_modules/@swc/helpers/esm/**/*',
+    ],
+  },
   reactStrictMode: true,
   compress: true,
   skipTrailingSlashRedirect: true,


### PR DESCRIPTION
## What changed

- Include the pnpm-backed `@swc/helpers` ESM files in the document standalone output.
- Cover both the repository workspace layout and the isolated document Docker build layout.

## Why

Node.js 24 resolves `@swc/helpers` through the `module-sync` export condition. Next.js 15 standalone tracing only copied the CommonJS helpers, so the production document container failed at startup with `MODULE_NOT_FOUND` for `esm/_interop_require_default.js`.

## Impact

The document image now contains the runtime helper files required by Next.js. Application behavior and dependency versions are unchanged.

## Validation

- `pnpm --filter @fastgpt/document build`
- Confirmed all 108 `@swc/helpers` ESM files are present in `.next/standalone`
- Started the standalone server and verified `/zh-CN` returns HTTP 200
