### PR TITLE
ci(docs): publish deployment images to GHCR

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -97,17 +97,17 @@ jobs:
         with:
           # list of Docker images to use as base name for tags
           images: |
-            ${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-docs
+            ghcr.io/${{ github.repository_owner }}/fastgpt-docs
           tags: |
             ${{ matrix.domain_config.suffix }}-${{ needs.generate-timestamp.outputs.datetime }}
           flavor: latest=false
 
-      - name: Login to Aliyun
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: registry.cn-hangzhou.aliyuncs.com
-          username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
-          password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare Docker workspace catalog
         run: cp pnpm-workspace.yaml document/pnpm-workspace.yaml
@@ -169,8 +169,8 @@ jobs:
 
       - name: Update deployment image
         run: |
-          kubectl set image deployment/${{ matrix.domain_config.deployment }} ${{ matrix.domain_config.deployment }}=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-docs:${{ matrix.domain_config.suffix }}-${{ needs.generate-timestamp.outputs.datetime }}
+          kubectl set image deployment/${{ matrix.domain_config.deployment }} ${{ matrix.domain_config.deployment }}=ghcr.io/${{ github.repository_owner }}/fastgpt-docs:${{ matrix.domain_config.suffix }}-${{ needs.generate-timestamp.outputs.datetime }}
 
       - name: Annotate deployment
         run: |
-          kubectl annotate deployment/${{ matrix.domain_config.deployment }} originImageName="${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-docs:${{ matrix.domain_config.suffix }}-${{ needs.generate-timestamp.outputs.datetime }}" --overwrite
+          kubectl annotate deployment/${{ matrix.domain_config.deployment }} originImageName="ghcr.io/${{ github.repository_owner }}/fastgpt-docs:${{ matrix.domain_config.suffix }}-${{ needs.generate-timestamp.outputs.datetime }}" --overwrite


### PR DESCRIPTION
## What changed

- Publish the CN and IO document deployment images to GitHub Container Registry instead of Aliyun.
- Authenticate image builds with `GITHUB_TOKEN` rather than the Aliyun registry credentials.
- Update both Kubernetes deployments and their `originImageName` annotations to use the GHCR image.

## Why

The document deployment pipeline no longer needs the Aliyun registry. Building, publishing, and rollout updates should consistently use the GitHub-hosted image.

## Impact

- Document deployment no longer depends on `FASTGPT_ALI_IMAGE_PREFIX`, `FASTGPT_ALI_IMAGE_USER`, or `FASTGPT_ALI_IMAGE_PSW`.
- Images are published as `ghcr.io/labring/fastgpt-docs:cn-<timestamp>` and `ghcr.io/labring/fastgpt-docs:io-<timestamp>`.
- Existing tag names and deployment selection remain unchanged.

## Validation

- Parsed `.github/workflows/build-docs.yml` successfully as YAML.
- Confirmed the workflow has no remaining Aliyun registry or secret references.
- Confirmed `build-docs.yml` is GitHub-only and has no Forgejo counterpart to synchronize.
