### PR TITLE
fix: localize invalid coupon errors

### DIFF
--- a/packages/global/common/error/code/coupon.ts
+++ b/packages/global/common/error/code/coupon.ts
@@ -1,0 +1,22 @@
+import { i18nT } from '../../i18n/utils';
+import type { ErrType } from '../errorCode';
+
+/* coupon: 512000 */
+export enum CouponErrEnum {
+  invalid = 'invalidCoupon'
+}
+
+const couponErr = [{ statusText: CouponErrEnum.invalid, message: i18nT('common:coupon_invalid') }];
+
+export default couponErr.reduce(
+  (acc, cur, index) => ({
+    ...acc,
+    [cur.statusText]: {
+      code: 512000 + index,
+      statusText: cur.statusText,
+      message: cur.message,
+      data: null
+    }
+  }),
+  {} as ErrType<`${CouponErrEnum}`>
+);

--- a/packages/global/common/error/errorCode.ts
+++ b/packages/global/common/error/errorCode.ts
@@ -11,6 +11,7 @@ import s3Err from './code/s3';
 import SystemErrEnum from './code/system';
 import agentSkillErr from './code/skill';
 import sandboxErr from './code/sandbox';
+import couponErr from './code/coupon';
 import { i18nT } from '../i18n/utils';
 
 export const ERROR_CODE: { [key: number]: string } = {
@@ -131,5 +132,6 @@ export const ERROR_RESPONSE: Record<
   ...s3Err,
   ...SystemErrEnum,
   ...agentSkillErr,
-  ...sandboxErr
+  ...sandboxErr,
+  ...couponErr
 };

--- a/packages/global/openapi/support/wallet/coupon/api.ts
+++ b/packages/global/openapi/support/wallet/coupon/api.ts
@@ -1,0 +1,12 @@
+import z from 'zod';
+
+export const RedeemCouponQuerySchema = z.object({
+  key: z.string().trim().min(1).meta({
+    description: '兑换码',
+    example: 'AbCdEfGhIjKlMnOpQrStUvWx'
+  })
+});
+export type RedeemCouponQueryType = z.infer<typeof RedeemCouponQuerySchema>;
+
+export const RedeemCouponResponseSchema = z.undefined().meta({ description: '兑换成功' });
+export type RedeemCouponResponseType = z.infer<typeof RedeemCouponResponseSchema>;

--- a/packages/global/openapi/support/wallet/coupon/index.ts
+++ b/packages/global/openapi/support/wallet/coupon/index.ts
@@ -1,0 +1,20 @@
+import type { OpenAPIPath } from '../../../type';
+import { DevApiTagsMap } from '../../../tag';
+import { RedeemCouponQuerySchema, RedeemCouponResponseSchema } from './api';
+
+export const CouponPath: OpenAPIPath = {
+  '/support/wallet/coupon/redeem': {
+    get: {
+      summary: '兑换兑换码',
+      description: '使用团队兑换码兑换订阅、积分或数据集容量',
+      tags: [DevApiTagsMap.walletDiscountCoupon],
+      requestParams: { query: RedeemCouponQuerySchema },
+      responses: {
+        200: {
+          description: '兑换成功',
+          content: { 'application/json': { schema: RedeemCouponResponseSchema } }
+        }
+      }
+    }
+  }
+};

--- a/packages/global/openapi/support/wallet/index.ts
+++ b/packages/global/openapi/support/wallet/index.ts
@@ -1,8 +1,10 @@
 import type { OpenAPIPath } from '../../type';
 import { BillPath } from './bill';
 import { DiscountCouponPath } from './discountCoupon';
+import { CouponPath } from './coupon';
 
 export const WalletPath: OpenAPIPath = {
   ...BillPath,
-  ...DiscountCouponPath
+  ...DiscountCouponPath,
+  ...CouponPath
 };

--- a/packages/web/i18n/en/common.json
+++ b/packages/web/i18n/en/common.json
@@ -696,6 +696,7 @@
   "core.workflow.tool.Select Tool": "Select Tool",
   "core.workflow.variable": "Variable",
   "coupon_expired": "Coupon has expired",
+  "coupon_invalid": "Invalid coupon",
   "coupon_not_exist": "Coupon does not exist",
   "coupon_not_start": "Coupon is not yet effective",
   "coupon_redeem_failed": "Coupon redeemed failed",

--- a/packages/web/i18n/zh-CN/common.json
+++ b/packages/web/i18n/zh-CN/common.json
@@ -696,6 +696,7 @@
   "core.workflow.tool.Select Tool": "选择工具",
   "core.workflow.variable": "变量",
   "coupon_expired": "优惠券已过期",
+  "coupon_invalid": "兑换码无效",
   "coupon_not_exist": "优惠券不存在",
   "coupon_not_start": "优惠券未生效",
   "coupon_redeem_failed": "优惠券核销失败",

--- a/packages/web/i18n/zh-Hant/common.json
+++ b/packages/web/i18n/zh-Hant/common.json
@@ -691,6 +691,7 @@
   "core.workflow.tool.Select Tool": "選擇工具",
   "core.workflow.variable": "變數",
   "coupon_expired": "優惠券已過期",
+  "coupon_invalid": "兌換碼無效",
   "coupon_not_exist": "優惠券不存在",
   "coupon_not_start": "優惠券未生效",
   "coupon_redeem_failed": "優惠券核銷失敗",

--- a/projects/app/src/components/Layout/hooks/checkCoupon.ts
+++ b/projects/app/src/components/Layout/hooks/checkCoupon.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { getCouponCode, removeCouponCode } from '@/web/support/marketing/utils';
 import { redeemCoupon } from '@/web/support/user/team/api';
 import { useUserStore } from '@/web/support/user/useUserStore';
+import { CouponErrEnum } from '@fastgpt/global/common/error/code/coupon';
 
 export const useCheckCoupon = () => {
   const { userInfo } = useUserStore();
@@ -15,7 +16,7 @@ export const useCheckCoupon = () => {
     redeemCoupon(couponCode)
       .then(removeCouponCode)
       .catch((err) => {
-        if (err?.message === 'Invalid coupon') {
+        if (err?.statusText === CouponErrEnum.invalid) {
           removeCouponCode();
         }
       });

--- a/projects/app/src/pageComponents/account/info/RedeemCouponModal.tsx
+++ b/projects/app/src/pageComponents/account/info/RedeemCouponModal.tsx
@@ -46,7 +46,7 @@ const RedeemCouponModal = ({
         <Button variant={'whiteBase'} onClick={onClose}>
           {t('account_info:cancel')}
         </Button>
-        <Button ml={2} isLoading={loading} onClick={() => redeemCouponAsync(couponCode)}>
+        <Button ml={2} isLoading={loading} onClick={() => redeemCouponAsync(couponCode.trim())}>
           {t('account_info:confirm')}
         </Button>
       </ModalFooter>

--- a/projects/app/src/web/support/marketing/utils.ts
+++ b/projects/app/src/web/support/marketing/utils.ts
@@ -121,7 +121,9 @@ export const initFastGPTSemSourceDomain = (sourceDomain?: string) => {
 
 export const setCouponCode = (couponCode?: string) => {
   if (!couponCode) return;
-  localStorage.setItem('couponCode', couponCode);
+  const normalizedCouponCode = couponCode.trim();
+  if (!normalizedCouponCode) return;
+  localStorage.setItem('couponCode', normalizedCouponCode);
 };
 
 export const getCouponCode = () => {


### PR DESCRIPTION
## What changed

- Trim manually entered and URL-provided coupon codes.
- Validate the redemption query with `parseApiInput` and document the endpoint schema.
- Return one localized `invalidCoupon` status for all invalid coupon states to avoid exposing redeemability details.
- Clear cached auto-redeem codes by the stable error status.

## Why

Coupon redemption returned a raw English error and accepted unnormalized input. A single localized error keeps the UI clear without revealing whether a code exists, expired, or was already used.

## Related PR

- labring/fastgpt-pro#1056

## Validation

- `pnpm --filter @fastgpt/admin exec vitest run test/api/support/wallet/coupon/redeem.test.ts` (11 passed)
- `pnpm --filter @fastgpt/admin typecheck`
- Prettier and commit hooks passed
