### PR TITLE
feat: deduplicate CRM lifecycle reports

### DIFF
--- a/packages/dal/redis/caches/index.ts
+++ b/packages/dal/redis/caches/index.ts
@@ -1,6 +1,9 @@
 export { DailyActiveDedupeCache } from './dailyActiveDedupe';
 export type { DailyActiveDedupeCacheOptions } from './dailyActiveDedupe';
 
+export { SuccessMarkerCache, successMarkerCache } from './successMarker';
+export type { SuccessMarkerCacheOptions, SuccessMarkerParams } from './successMarker';
+
 export { DingtalkAccessTokenCache } from './dingtalkAccessToken';
 export type { DingtalkAccessTokenCacheOptions } from './dingtalkAccessToken';
 

--- a/packages/dal/redis/caches/successMarker.ts
+++ b/packages/dal/redis/caches/successMarker.ts
@@ -1,0 +1,50 @@
+import { createRedisLogicalKey, redisCacheAdapter, type RedisCacheAdapter } from '../adapter';
+
+export type SuccessMarkerParams = {
+  scope: string;
+  segments: readonly (string | number)[];
+};
+
+export type SuccessMarkerCacheOptions = {
+  redis?: RedisCacheAdapter;
+};
+
+/**
+ * 通用操作成功标记。
+ *
+ * 标记只用于减少已经成功的幂等操作，不承担事实存储职责。默认永久保存；调用方也可以
+ * 为短期结果指定 TTL。Redis 故障的降级策略由业务接口层决定。
+ */
+export class SuccessMarkerCache {
+  private readonly redis: RedisCacheAdapter;
+
+  constructor({ redis = redisCacheAdapter }: SuccessMarkerCacheOptions = {}) {
+    this.redis = redis;
+  }
+
+  private getKey({ scope, segments }: SuccessMarkerParams) {
+    return createRedisLogicalKey({
+      namespace: 'success-marker',
+      version: 1,
+      segments: [scope, ...segments]
+    });
+  }
+
+  async has(params: SuccessMarkerParams): Promise<boolean> {
+    return (await this.redis.get(this.getKey(params))) === '1';
+  }
+
+  mark({ params, ttlMs }: { params: SuccessMarkerParams; ttlMs?: number }): Promise<void> {
+    return this.redis.set({
+      key: this.getKey(params),
+      value: '1',
+      ttlMs
+    });
+  }
+
+  clear(params: SuccessMarkerParams): Promise<boolean> {
+    return this.redis.delete(this.getKey(params));
+  }
+}
+
+export const successMarkerCache = new SuccessMarkerCache();

--- a/packages/dal/test/redis/caches/successMarker.test.ts
+++ b/packages/dal/test/redis/caches/successMarker.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RedisCacheAdapter } from '@fastgpt/dal/redis/adapter';
+import { SuccessMarkerCache } from '@fastgpt/dal/redis/caches';
+
+describe('SuccessMarkerCache', () => {
+  const redis = {
+    delete: vi.fn(),
+    get: vi.fn(),
+    set: vi.fn()
+  };
+
+  const params = {
+    scope: 'integration-report',
+    segments: ['crm', 'lifecycle', 'consumption', 'visitor/1']
+  } as const;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redis.delete.mockResolvedValue(true);
+    redis.get.mockResolvedValue(null);
+    redis.set.mockResolvedValue(undefined);
+  });
+
+  it('uses the shared FastGPT physical prefix and encoded key segments', async () => {
+    const commandClient = {
+      get: vi.fn().mockResolvedValue('1'),
+      set: vi.fn().mockResolvedValue('OK')
+    };
+    const adapter = new RedisCacheAdapter({ getCommandClient: () => commandClient as any });
+    const cache = new SuccessMarkerCache({ redis: adapter });
+
+    await expect(cache.has(params)).resolves.toBe(true);
+    await cache.mark({ params });
+
+    const physicalKey =
+      'fastgpt:success-marker:v1:integration-report:crm:lifecycle:consumption:visitor%2F1';
+    expect(commandClient.get).toHaveBeenCalledWith(physicalKey);
+    expect(commandClient.set).toHaveBeenCalledWith(physicalKey, '1');
+  });
+
+  it('returns false for a missing marker and writes a permanent marker by default', async () => {
+    const cache = new SuccessMarkerCache({ redis: redis as any });
+
+    await expect(cache.has(params)).resolves.toBe(false);
+    await cache.mark({ params });
+
+    expect(redis.set).toHaveBeenCalledWith({
+      key: 'success-marker:v1:integration-report:crm:lifecycle:consumption:visitor%2F1',
+      value: '1',
+      ttlMs: undefined
+    });
+  });
+
+  it('supports temporary markers and explicit clearing', async () => {
+    const cache = new SuccessMarkerCache({ redis: redis as any });
+
+    await cache.mark({ params, ttlMs: 60_000 });
+    await expect(cache.clear(params)).resolves.toBe(true);
+
+    expect(redis.set).toHaveBeenCalledWith(expect.objectContaining({ ttlMs: 60_000 }));
+    expect(redis.delete).toHaveBeenCalledWith(
+      'success-marker:v1:integration-report:crm:lifecycle:consumption:visitor%2F1'
+    );
+  });
+
+  it('propagates Redis failures so the interface layer can choose fail-open behavior', async () => {
+    const error = new Error('redis unavailable');
+    redis.get.mockRejectedValueOnce(error);
+    const cache = new SuccessMarkerCache({ redis: redis as any });
+
+    await expect(cache.has(params)).rejects.toBe(error);
+  });
+});

--- a/packages/service/support/marketing/attribution.ts
+++ b/packages/service/support/marketing/attribution.ts
@@ -12,11 +12,36 @@ type ReportCRMVisitorIdentityProps = {
   contact?: string;
 };
 
+export const CRMLifecycleEvent = {
+  Consumption: 'consumption',
+  Recharge: 'recharge',
+  EnterpriseVerification: 'enterprise_verification'
+} as const;
+
+export type CRMLifecycleEvent = (typeof CRMLifecycleEvent)[keyof typeof CRMLifecycleEvent];
+
+export type ReportCRMVisitorLifecycleProps = {
+  visitorId?: string;
+  event: CRMLifecycleEvent;
+  company?: string;
+  summary?: string;
+};
+
 const getContact = (username: string, contact?: string) => {
   const candidates = [contact, username].map((value) => value?.trim()).filter(Boolean) as string[];
   const email = candidates.find((value) => value.includes('@'));
   if (email) return email;
   return candidates.find((value) => /^\+?[\d\s()-]{6,20}$/.test(value));
+};
+
+const getCRMConfig = () => ({
+  apiUrl: serviceEnv.CRM_API_URL?.replace(/\/$/, ''),
+  apiKey: serviceEnv.CRM_API_KEY
+});
+
+export const isCRMReportingConfigured = () => {
+  const { apiUrl, apiKey } = getCRMConfig();
+  return !!apiUrl && !!apiKey;
 };
 
 export const resolveCRMVisitorId = ({
@@ -51,11 +76,11 @@ export const reportCRMVisitorIdentity = async ({
   username,
   contact
 }: ReportCRMVisitorIdentityProps): Promise<void> => {
-  const crmApiUrl = serviceEnv.CRM_API_URL?.replace(/\/$/, '');
+  const { apiUrl: crmApiUrl, apiKey } = getCRMConfig();
   const visitorId = rawVisitorId?.trim();
 
   if (!crmApiUrl || !visitorId) return;
-  if (!serviceEnv.CRM_API_KEY) {
+  if (!apiKey) {
     logger.warn('Skip CRM visitor identity report: CRM_API_KEY is not configured');
     return;
   }
@@ -71,7 +96,7 @@ export const reportCRMVisitorIdentity = async ({
       },
       {
         headers: {
-          'X-API-Key': serviceEnv.CRM_API_KEY
+          'X-API-Key': apiKey
         },
         timeout: 5000
       }
@@ -82,5 +107,43 @@ export const reportCRMVisitorIdentity = async ({
       visitorId,
       userId
     });
+  }
+};
+
+/** 上报单个 CRM 生命周期事件；返回值只表示本次 HTTP 上报是否成功。 */
+export const reportCRMVisitorLifecycle = async ({
+  visitorId: rawVisitorId,
+  event,
+  company,
+  summary
+}: ReportCRMVisitorLifecycleProps): Promise<boolean> => {
+  const { apiUrl, apiKey } = getCRMConfig();
+  const visitorId = rawVisitorId?.trim();
+
+  if (!apiUrl || !apiKey || !visitorId) return false;
+
+  try {
+    await axiosWithoutSSRF.post(
+      `${apiUrl}/contacts/visitor/${encodeURIComponent(visitorId)}/lifecycle`,
+      {
+        event,
+        ...(company?.trim() && { company: company.trim() }),
+        ...(summary?.trim() && { summary: summary.trim() })
+      },
+      {
+        headers: {
+          'X-API-Key': apiKey
+        },
+        timeout: 5000
+      }
+    );
+    return true;
+  } catch (error) {
+    logger.warn('CRM visitor lifecycle report failed', {
+      error,
+      visitorId,
+      event
+    });
+    return false;
   }
 };

--- a/packages/service/support/marketing/interface/crm.ts
+++ b/packages/service/support/marketing/interface/crm.ts
@@ -1,0 +1,116 @@
+import { successMarkerCache, type SuccessMarkerParams } from '@fastgpt/dal/redis/caches';
+import { FastGPT_SEM_Schema } from '@fastgpt/global/support/marketing/type';
+import { getLogger, LogCategories } from '../../../common/logger';
+import { MongoUser } from '../../user/schema';
+import { MongoTeamMember } from '../../user/team/teamMemberSchema';
+import {
+  isCRMReportingConfigured,
+  reportCRMVisitorLifecycle,
+  type CRMLifecycleEvent
+} from '../attribution';
+
+const logger = getLogger(LogCategories.MODULE.USER.ACCOUNT);
+
+type LifecycleDetails = {
+  event: CRMLifecycleEvent;
+  company?: string;
+  summary?: string;
+};
+
+const getMarkerParams = ({
+  visitorId,
+  event
+}: {
+  visitorId: string;
+  event: CRMLifecycleEvent;
+}): SuccessMarkerParams => ({
+  scope: 'integration-report',
+  segments: ['crm', 'lifecycle', event, visitorId]
+});
+
+const getVisitorId = (fastgptSem: unknown) => {
+  const parsed = FastGPT_SEM_Schema.safeParse(fastgptSem);
+  return parsed.success ? parsed.data.visitor_id : undefined;
+};
+
+/** CRM 生命周期公开接口：Redis 只减少重复请求，故障时 fail-open。 */
+export const reportCRMVisitorLifecycleOnce = async ({
+  visitorId,
+  event,
+  company,
+  summary
+}: LifecycleDetails & { visitorId?: string }): Promise<void> => {
+  const normalizedVisitorId = visitorId?.trim();
+  if (!isCRMReportingConfigured() || !normalizedVisitorId) return;
+
+  const markerParams = getMarkerParams({ visitorId: normalizedVisitorId, event });
+  try {
+    if (await successMarkerCache.has(markerParams)) return;
+  } catch (error) {
+    logger.warn('CRM lifecycle success marker read failed; reporting anyway', {
+      error,
+      visitorId: normalizedVisitorId,
+      event
+    });
+  }
+
+  const success = await reportCRMVisitorLifecycle({
+    visitorId: normalizedVisitorId,
+    event,
+    company,
+    summary
+  });
+  if (!success) return;
+
+  try {
+    await successMarkerCache.mark({ params: markerParams });
+  } catch (error) {
+    logger.warn('CRM lifecycle success marker write failed', {
+      error,
+      visitorId: normalizedVisitorId,
+      event
+    });
+  }
+};
+
+export const reportCRMUserLifecycleOnce = async ({
+  userId,
+  ...details
+}: LifecycleDetails & { userId: string }): Promise<void> => {
+  if (!isCRMReportingConfigured()) return;
+
+  try {
+    const user = await MongoUser.findById(userId, 'fastgpt_sem').lean();
+    return reportCRMVisitorLifecycleOnce({
+      visitorId: getVisitorId(user?.fastgpt_sem),
+      ...details
+    });
+  } catch (error) {
+    logger.warn('CRM user lifecycle resolution failed', { error, userId, event: details.event });
+  }
+};
+
+export const reportCRMTeamMemberLifecycleOnce = async ({
+  tmbId,
+  ...details
+}: LifecycleDetails & { tmbId: string }): Promise<void> => {
+  if (!isCRMReportingConfigured()) return;
+
+  try {
+    const member = await MongoTeamMember.findById(tmbId, 'userId').lean();
+    if (!member?.userId) return;
+
+    return reportCRMUserLifecycleOnce({
+      userId: String(member.userId),
+      ...details
+    });
+  } catch (error) {
+    logger.warn('CRM team member lifecycle resolution failed', {
+      error,
+      tmbId,
+      event: details.event
+    });
+  }
+};
+
+export { CRMLifecycleEvent } from '../attribution';

--- a/packages/service/support/marketing/interface/crm.ts
+++ b/packages/service/support/marketing/interface/crm.ts
@@ -2,7 +2,7 @@ import { successMarkerCache, type SuccessMarkerParams } from '@fastgpt/dal/redis
 import { FastGPT_SEM_Schema } from '@fastgpt/global/support/marketing/type';
 import { getLogger, LogCategories } from '../../../common/logger';
 import { MongoUser } from '../../user/schema';
-import { MongoTeamMember } from '../../user/team/teamMemberSchema';
+import { MongoTeam } from '../../user/team/teamSchema';
 import {
   isCRMReportingConfigured,
   reportCRMVisitorLifecycle,
@@ -90,24 +90,24 @@ export const reportCRMUserLifecycleOnce = async ({
   }
 };
 
-export const reportCRMTeamMemberLifecycleOnce = async ({
-  tmbId,
+export const reportCRMTeamLifecycleOnce = async ({
+  teamId,
   ...details
-}: LifecycleDetails & { tmbId: string }): Promise<void> => {
+}: LifecycleDetails & { teamId: string }): Promise<void> => {
   if (!isCRMReportingConfigured()) return;
 
   try {
-    const member = await MongoTeamMember.findById(tmbId, 'userId').lean();
-    if (!member?.userId) return;
+    const team = await MongoTeam.findById(teamId, 'ownerId').lean();
+    if (!team?.ownerId) return;
 
     return reportCRMUserLifecycleOnce({
-      userId: String(member.userId),
+      userId: String(team.ownerId),
       ...details
     });
   } catch (error) {
-    logger.warn('CRM team member lifecycle resolution failed', {
+    logger.warn('CRM team lifecycle resolution failed', {
       error,
-      tmbId,
+      teamId,
       event: details.event
     });
   }

--- a/packages/service/support/marketing/interface/crm.ts
+++ b/packages/service/support/marketing/interface/crm.ts
@@ -17,15 +17,15 @@ type LifecycleDetails = {
   summary?: string;
 };
 
-const getMarkerParams = ({
-  visitorId,
+const getTeamMarkerParams = ({
+  teamId,
   event
 }: {
-  visitorId: string;
+  teamId: string;
   event: CRMLifecycleEvent;
 }): SuccessMarkerParams => ({
   scope: 'integration-report',
-  segments: ['crm', 'lifecycle', event, visitorId]
+  segments: ['crm', 'lifecycle', event, 'team', teamId]
 });
 
 const getVisitorId = (fastgptSem: unknown) => {
@@ -33,82 +33,57 @@ const getVisitorId = (fastgptSem: unknown) => {
   return parsed.success ? parsed.data.visitor_id : undefined;
 };
 
-/** CRM 生命周期公开接口：Redis 只减少重复请求，故障时 fail-open。 */
-export const reportCRMVisitorLifecycleOnce = async ({
-  visitorId,
+/** CRM 生命周期公开接口：先按 team 去重，再解析其 owner 对应的 visitor_id。 */
+export const reportCRMTeamLifecycleOnce = async ({
+  teamId: rawTeamId,
   event,
   company,
   summary
-}: LifecycleDetails & { visitorId?: string }): Promise<void> => {
-  const normalizedVisitorId = visitorId?.trim();
-  if (!isCRMReportingConfigured() || !normalizedVisitorId) return;
+}: LifecycleDetails & { teamId: string }): Promise<void> => {
+  const teamId = rawTeamId.trim();
+  if (!isCRMReportingConfigured() || !teamId) return;
 
-  const markerParams = getMarkerParams({ visitorId: normalizedVisitorId, event });
+  const markerParams = getTeamMarkerParams({ teamId, event });
   try {
     if (await successMarkerCache.has(markerParams)) return;
   } catch (error) {
-    logger.warn('CRM lifecycle success marker read failed; reporting anyway', {
+    logger.warn('CRM team lifecycle success marker read failed; reporting anyway', {
       error,
-      visitorId: normalizedVisitorId,
+      teamId,
       event
     });
   }
-
-  const success = await reportCRMVisitorLifecycle({
-    visitorId: normalizedVisitorId,
-    event,
-    company,
-    summary
-  });
-  if (!success) return;
-
-  try {
-    await successMarkerCache.mark({ params: markerParams });
-  } catch (error) {
-    logger.warn('CRM lifecycle success marker write failed', {
-      error,
-      visitorId: normalizedVisitorId,
-      event
-    });
-  }
-};
-
-export const reportCRMUserLifecycleOnce = async ({
-  userId,
-  ...details
-}: LifecycleDetails & { userId: string }): Promise<void> => {
-  if (!isCRMReportingConfigured()) return;
-
-  try {
-    const user = await MongoUser.findById(userId, 'fastgpt_sem').lean();
-    return reportCRMVisitorLifecycleOnce({
-      visitorId: getVisitorId(user?.fastgpt_sem),
-      ...details
-    });
-  } catch (error) {
-    logger.warn('CRM user lifecycle resolution failed', { error, userId, event: details.event });
-  }
-};
-
-export const reportCRMTeamLifecycleOnce = async ({
-  teamId,
-  ...details
-}: LifecycleDetails & { teamId: string }): Promise<void> => {
-  if (!isCRMReportingConfigured()) return;
 
   try {
     const team = await MongoTeam.findById(teamId, 'ownerId').lean();
     if (!team?.ownerId) return;
 
-    return reportCRMUserLifecycleOnce({
-      userId: String(team.ownerId),
-      ...details
+    const user = await MongoUser.findById(team.ownerId, 'fastgpt_sem').lean();
+    const visitorId = getVisitorId(user?.fastgpt_sem);
+    if (!visitorId) return;
+
+    const success = await reportCRMVisitorLifecycle({
+      visitorId,
+      event,
+      company,
+      summary
     });
+    if (!success) return;
+
+    try {
+      await successMarkerCache.mark({ params: markerParams });
+    } catch (error) {
+      logger.warn('CRM team lifecycle success marker write failed', {
+        error,
+        teamId,
+        event
+      });
+    }
   } catch (error) {
     logger.warn('CRM team lifecycle resolution failed', {
       error,
       teamId,
-      event: details.event
+      event
     });
   }
 };

--- a/packages/service/support/marketing/interface/index.ts
+++ b/packages/service/support/marketing/interface/index.ts
@@ -1,7 +1,7 @@
 /** CRM 营销与生命周期上报的稳定公开入口。 */
 export {
   CRMLifecycleEvent,
-  reportCRMTeamMemberLifecycleOnce,
+  reportCRMTeamLifecycleOnce,
   reportCRMUserLifecycleOnce,
   reportCRMVisitorLifecycleOnce
 } from './crm';

--- a/packages/service/support/marketing/interface/index.ts
+++ b/packages/service/support/marketing/interface/index.ts
@@ -1,0 +1,7 @@
+/** CRM 营销与生命周期上报的稳定公开入口。 */
+export {
+  CRMLifecycleEvent,
+  reportCRMTeamMemberLifecycleOnce,
+  reportCRMUserLifecycleOnce,
+  reportCRMVisitorLifecycleOnce
+} from './crm';

--- a/packages/service/support/marketing/interface/index.ts
+++ b/packages/service/support/marketing/interface/index.ts
@@ -1,7 +1,2 @@
 /** CRM 营销与生命周期上报的稳定公开入口。 */
-export {
-  CRMLifecycleEvent,
-  reportCRMTeamLifecycleOnce,
-  reportCRMUserLifecycleOnce,
-  reportCRMVisitorLifecycleOnce
-} from './crm';
+export { CRMLifecycleEvent, reportCRMTeamLifecycleOnce } from './crm';

--- a/packages/service/test/support/marketing/attribution.test.ts
+++ b/packages/service/test/support/marketing/attribution.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   patch: vi.fn(),
+  post: vi.fn(),
   warn: vi.fn(),
   serviceEnv: {
     CRM_API_URL: undefined as string | undefined,
@@ -10,7 +11,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@fastgpt/service/common/api/axios', () => ({
-  axiosWithoutSSRF: { patch: mocks.patch }
+  axiosWithoutSSRF: { patch: mocks.patch, post: mocks.post }
 }));
 
 vi.mock('@fastgpt/service/common/logger', () => ({
@@ -23,7 +24,9 @@ vi.mock('@fastgpt/service/env', () => ({
 }));
 
 import {
+  CRMLifecycleEvent,
   reportCRMVisitorIdentity,
+  reportCRMVisitorLifecycle,
   resolveCRMVisitorId
 } from '@fastgpt/service/support/marketing/attribution';
 
@@ -52,6 +55,49 @@ describe('resolveCRMVisitorId', () => {
       shouldPersist: true,
       fastgptSem: { keyword: 'FastGPT', visitor_id: 'incoming-visitor' }
     });
+  });
+});
+
+describe('reportCRMVisitorLifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.serviceEnv.CRM_API_URL = 'https://crm.example.com/api/v1/';
+    mocks.serviceEnv.CRM_API_KEY = 'crm-key';
+  });
+
+  it('reports a lifecycle event and optional opportunity details', async () => {
+    await expect(
+      reportCRMVisitorLifecycle({
+        visitorId: 'visitor/1',
+        event: CRMLifecycleEvent.EnterpriseVerification,
+        company: ' FastGPT ',
+        summary: ' AI platform '
+      })
+    ).resolves.toBe(true);
+
+    expect(mocks.post).toHaveBeenCalledWith(
+      'https://crm.example.com/api/v1/contacts/visitor/visitor%2F1/lifecycle',
+      {
+        event: 'enterprise_verification',
+        company: 'FastGPT',
+        summary: 'AI platform'
+      },
+      {
+        headers: { 'X-API-Key': 'crm-key' },
+        timeout: 5000
+      }
+    );
+  });
+
+  it('returns false so a failed event is not marked as reported', async () => {
+    mocks.post.mockRejectedValueOnce(new Error('CRM unavailable'));
+
+    await expect(
+      reportCRMVisitorLifecycle({
+        visitorId: 'visitor-1',
+        event: CRMLifecycleEvent.Consumption
+      })
+    ).resolves.toBe(false);
   });
 });
 

--- a/packages/service/test/support/marketing/crmInterface.test.ts
+++ b/packages/service/test/support/marketing/crmInterface.test.ts
@@ -46,38 +46,47 @@ vi.mock('@fastgpt/service/support/marketing/attribution', async (importOriginal)
 
 import {
   CRMLifecycleEvent,
-  reportCRMTeamLifecycleOnce,
-  reportCRMVisitorLifecycleOnce
+  reportCRMTeamLifecycleOnce
 } from '@fastgpt/service/support/marketing/interface';
 
-describe('CRM lifecycle interface', () => {
+describe('CRM team lifecycle interface', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.configured.mockReturnValue(true);
     mocks.has.mockResolvedValue(false);
     mocks.mark.mockResolvedValue(undefined);
     mocks.report.mockResolvedValue(true);
+    mocks.findTeam.mockResolvedValue({ ownerId: 'user-1' });
+    mocks.findUser.mockResolvedValue({ fastgpt_sem: { visitor_id: 'stored-visitor' } });
   });
 
-  it('skips an event that already has a success marker', async () => {
+  it('checks the team marker before querying team or user', async () => {
     mocks.has.mockResolvedValueOnce(true);
 
-    await reportCRMVisitorLifecycleOnce({
-      visitorId: 'visitor-1',
+    await reportCRMTeamLifecycleOnce({
+      teamId: 'team-1',
       event: CRMLifecycleEvent.Consumption
     });
 
+    expect(mocks.has).toHaveBeenCalledWith({
+      scope: 'integration-report',
+      segments: ['crm', 'lifecycle', 'consumption', 'team', 'team-1']
+    });
+    expect(mocks.findTeam).not.toHaveBeenCalled();
+    expect(mocks.findUser).not.toHaveBeenCalled();
     expect(mocks.report).not.toHaveBeenCalled();
   });
 
-  it('writes the permanent marker only after CRM succeeds', async () => {
-    await reportCRMVisitorLifecycleOnce({
-      visitorId: 'visitor-1',
+  it('resolves the team owner visitor and marks the team only after CRM succeeds', async () => {
+    await reportCRMTeamLifecycleOnce({
+      teamId: 'team-1',
       event: CRMLifecycleEvent.Recharge
     });
 
+    expect(mocks.findTeam).toHaveBeenCalledWith('team-1', 'ownerId');
+    expect(mocks.findUser).toHaveBeenCalledWith('user-1', 'fastgpt_sem');
     expect(mocks.report).toHaveBeenCalledWith({
-      visitorId: 'visitor-1',
+      visitorId: 'stored-visitor',
       event: 'recharge',
       company: undefined,
       summary: undefined
@@ -85,7 +94,7 @@ describe('CRM lifecycle interface', () => {
     expect(mocks.mark).toHaveBeenCalledWith({
       params: {
         scope: 'integration-report',
-        segments: ['crm', 'lifecycle', 'recharge', 'visitor-1']
+        segments: ['crm', 'lifecycle', 'recharge', 'team', 'team-1']
       }
     });
   });
@@ -93,37 +102,36 @@ describe('CRM lifecycle interface', () => {
   it('does not mark a failed CRM request', async () => {
     mocks.report.mockResolvedValueOnce(false);
 
-    await reportCRMVisitorLifecycleOnce({
-      visitorId: 'visitor-1',
+    await reportCRMTeamLifecycleOnce({
+      teamId: 'team-1',
       event: CRMLifecycleEvent.Consumption
     });
 
     expect(mocks.mark).not.toHaveBeenCalled();
   });
 
-  it('fails open when Redis cannot read the marker', async () => {
+  it('fails open when Redis cannot read the team marker', async () => {
     mocks.has.mockRejectedValueOnce(new Error('redis unavailable'));
-
-    await reportCRMVisitorLifecycleOnce({
-      visitorId: 'visitor-1',
-      event: CRMLifecycleEvent.Consumption
-    });
-
-    expect(mocks.report).toHaveBeenCalledTimes(1);
-    expect(mocks.warn).toHaveBeenCalled();
-  });
-
-  it('resolves the visitor id from the team owner stored user data', async () => {
-    mocks.findTeam.mockResolvedValueOnce({ ownerId: 'user-1' });
-    mocks.findUser.mockResolvedValueOnce({ fastgpt_sem: { visitor_id: 'stored-visitor' } });
 
     await reportCRMTeamLifecycleOnce({
       teamId: 'team-1',
       event: CRMLifecycleEvent.Consumption
     });
 
-    expect(mocks.report).toHaveBeenCalledWith(
-      expect.objectContaining({ visitorId: 'stored-visitor', event: 'consumption' })
-    );
+    expect(mocks.findTeam).toHaveBeenCalledTimes(1);
+    expect(mocks.report).toHaveBeenCalledTimes(1);
+    expect(mocks.warn).toHaveBeenCalled();
+  });
+
+  it('does not mark when the owner has no visitor id', async () => {
+    mocks.findUser.mockResolvedValueOnce({ fastgpt_sem: {} });
+
+    await reportCRMTeamLifecycleOnce({
+      teamId: 'team-1',
+      event: CRMLifecycleEvent.Consumption
+    });
+
+    expect(mocks.report).not.toHaveBeenCalled();
+    expect(mocks.mark).not.toHaveBeenCalled();
   });
 });

--- a/packages/service/test/support/marketing/crmInterface.test.ts
+++ b/packages/service/test/support/marketing/crmInterface.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   report: vi.fn(),
   configured: vi.fn(),
   findUser: vi.fn(),
-  findMember: vi.fn(),
+  findTeam: vi.fn(),
   warn: vi.fn()
 }));
 
@@ -28,9 +28,9 @@ vi.mock('@fastgpt/service/support/user/schema', () => ({
   }
 }));
 
-vi.mock('@fastgpt/service/support/user/team/teamMemberSchema', () => ({
-  MongoTeamMember: {
-    findById: (...args: unknown[]) => ({ lean: () => mocks.findMember(...args) })
+vi.mock('@fastgpt/service/support/user/team/teamSchema', () => ({
+  MongoTeam: {
+    findById: (...args: unknown[]) => ({ lean: () => mocks.findTeam(...args) })
   }
 }));
 
@@ -46,7 +46,7 @@ vi.mock('@fastgpt/service/support/marketing/attribution', async (importOriginal)
 
 import {
   CRMLifecycleEvent,
-  reportCRMTeamMemberLifecycleOnce,
+  reportCRMTeamLifecycleOnce,
   reportCRMVisitorLifecycleOnce
 } from '@fastgpt/service/support/marketing/interface';
 
@@ -113,12 +113,12 @@ describe('CRM lifecycle interface', () => {
     expect(mocks.warn).toHaveBeenCalled();
   });
 
-  it('resolves the visitor id from a team member through the stored user data', async () => {
-    mocks.findMember.mockResolvedValueOnce({ userId: 'user-1' });
+  it('resolves the visitor id from the team owner stored user data', async () => {
+    mocks.findTeam.mockResolvedValueOnce({ ownerId: 'user-1' });
     mocks.findUser.mockResolvedValueOnce({ fastgpt_sem: { visitor_id: 'stored-visitor' } });
 
-    await reportCRMTeamMemberLifecycleOnce({
-      tmbId: 'tmb-1',
+    await reportCRMTeamLifecycleOnce({
+      teamId: 'team-1',
       event: CRMLifecycleEvent.Consumption
     });
 

--- a/packages/service/test/support/marketing/crmInterface.test.ts
+++ b/packages/service/test/support/marketing/crmInterface.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  has: vi.fn(),
+  mark: vi.fn(),
+  report: vi.fn(),
+  configured: vi.fn(),
+  findUser: vi.fn(),
+  findMember: vi.fn(),
+  warn: vi.fn()
+}));
+
+vi.mock('@fastgpt/dal/redis/caches', () => ({
+  successMarkerCache: {
+    has: mocks.has,
+    mark: mocks.mark
+  }
+}));
+
+vi.mock('@fastgpt/service/common/logger', () => ({
+  getLogger: () => ({ warn: mocks.warn }),
+  LogCategories: { MODULE: { USER: { ACCOUNT: ['user', 'account'] } } }
+}));
+
+vi.mock('@fastgpt/service/support/user/schema', () => ({
+  MongoUser: {
+    findById: (...args: unknown[]) => ({ lean: () => mocks.findUser(...args) })
+  }
+}));
+
+vi.mock('@fastgpt/service/support/user/team/teamMemberSchema', () => ({
+  MongoTeamMember: {
+    findById: (...args: unknown[]) => ({ lean: () => mocks.findMember(...args) })
+  }
+}));
+
+vi.mock('@fastgpt/service/support/marketing/attribution', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('@fastgpt/service/support/marketing/attribution')>();
+  return {
+    ...original,
+    isCRMReportingConfigured: mocks.configured,
+    reportCRMVisitorLifecycle: mocks.report
+  };
+});
+
+import {
+  CRMLifecycleEvent,
+  reportCRMTeamMemberLifecycleOnce,
+  reportCRMVisitorLifecycleOnce
+} from '@fastgpt/service/support/marketing/interface';
+
+describe('CRM lifecycle interface', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.configured.mockReturnValue(true);
+    mocks.has.mockResolvedValue(false);
+    mocks.mark.mockResolvedValue(undefined);
+    mocks.report.mockResolvedValue(true);
+  });
+
+  it('skips an event that already has a success marker', async () => {
+    mocks.has.mockResolvedValueOnce(true);
+
+    await reportCRMVisitorLifecycleOnce({
+      visitorId: 'visitor-1',
+      event: CRMLifecycleEvent.Consumption
+    });
+
+    expect(mocks.report).not.toHaveBeenCalled();
+  });
+
+  it('writes the permanent marker only after CRM succeeds', async () => {
+    await reportCRMVisitorLifecycleOnce({
+      visitorId: 'visitor-1',
+      event: CRMLifecycleEvent.Recharge
+    });
+
+    expect(mocks.report).toHaveBeenCalledWith({
+      visitorId: 'visitor-1',
+      event: 'recharge',
+      company: undefined,
+      summary: undefined
+    });
+    expect(mocks.mark).toHaveBeenCalledWith({
+      params: {
+        scope: 'integration-report',
+        segments: ['crm', 'lifecycle', 'recharge', 'visitor-1']
+      }
+    });
+  });
+
+  it('does not mark a failed CRM request', async () => {
+    mocks.report.mockResolvedValueOnce(false);
+
+    await reportCRMVisitorLifecycleOnce({
+      visitorId: 'visitor-1',
+      event: CRMLifecycleEvent.Consumption
+    });
+
+    expect(mocks.mark).not.toHaveBeenCalled();
+  });
+
+  it('fails open when Redis cannot read the marker', async () => {
+    mocks.has.mockRejectedValueOnce(new Error('redis unavailable'));
+
+    await reportCRMVisitorLifecycleOnce({
+      visitorId: 'visitor-1',
+      event: CRMLifecycleEvent.Consumption
+    });
+
+    expect(mocks.report).toHaveBeenCalledTimes(1);
+    expect(mocks.warn).toHaveBeenCalled();
+  });
+
+  it('resolves the visitor id from a team member through the stored user data', async () => {
+    mocks.findMember.mockResolvedValueOnce({ userId: 'user-1' });
+    mocks.findUser.mockResolvedValueOnce({ fastgpt_sem: { visitor_id: 'stored-visitor' } });
+
+    await reportCRMTeamMemberLifecycleOnce({
+      tmbId: 'tmb-1',
+      event: CRMLifecycleEvent.Consumption
+    });
+
+    expect(mocks.report).toHaveBeenCalledWith(
+      expect.objectContaining({ visitorId: 'stored-visitor', event: 'consumption' })
+    );
+  });
+});


### PR DESCRIPTION
## What
- add a reusable Redis success-marker cache with permanent markers by default
- expose CRM lifecycle reporting through the marketing interface facade
- deduplicate before Mongo lookup with a team-level marker keyed by lifecycle event and `teamId`
- resolve the persisted visitor ID through `teamId -> team.ownerId -> user.fastgpt_sem.visitor_id` only on a cache miss
- report only until CRM succeeds; Redis failures fail open and never block business flows
- report consumption only after `pushUsageItemsTimer` persists pushed usage items
- update the Pro submodule with consumption, recharge, and enterprise-verification triggers

Depends on labring/fastgpt-pro#1058.

## Verification
- `pnpm --filter @fastgpt/dal typecheck`
- `pnpm --filter @fastgpt/admin typecheck`
- DAL tests: 388 passed
- Service attribution/interface tests: 14 passed
- Pro wallet and enterprise-auth tests: 71 passed
