### PR TITLE
fix(global): add .js extension to ajv ESM subpath imports

### DIFF
--- a/packages/global/core/app/tool/runtime.ts
+++ b/packages/global/core/app/tool/runtime.ts
@@ -1,6 +1,6 @@
 import Ajv, { type ErrorObject, type ValidateFunction } from 'ajv';
-import Ajv2019 from 'ajv/dist/2019';
-import Ajv2020 from 'ajv/dist/2020';
+import Ajv2019 from 'ajv/dist/2019.js';
+import Ajv2020 from 'ajv/dist/2020.js';
 import type { ChatCompletionTool } from '../../ai/llm/type';
 import { FlowNodeInputTypeEnum } from '../../workflow/node/constant';
 import type { FlowNodeInputItemType } from '../../workflow/type/io';


### PR DESCRIPTION
Node native ESM cannot resolve extensionless subpaths like 'ajv/dist/2019' when the package is loaded by a plain ESM runtime. Adding the .js extension keeps webpack/Next.js and tsx working while fixing native ESM resolution.

Ref: https://github.com/labring/FastGPT/pull/7348