### PR TITLE
fix(app): make dataset search configurable in agent v2

### DIFF
--- a/projects/app/src/pageComponents/app/detail/Edit/ChatAgent/EditForm.tsx
+++ b/projects/app/src/pageComponents/app/detail/Edit/ChatAgent/EditForm.tsx
@@ -130,7 +130,15 @@ const EditForm = ({
       appForm.chatConfig.fileSelectConfig?.canSelectCustomFileExtension
     ),
     hasSelectedDataset: (appForm.dataset.datasets?.length || 0) > 0,
-    useAgentSandbox: !!appForm.aiSettings.useAgentSandbox
+    useAgentSandbox: !!appForm.aiSettings.useAgentSandbox,
+    onClickDatasetSearch: () => {
+      if (appForm.dataset.datasets?.length > 0) {
+        onOpenDatasetParams();
+        return;
+      }
+
+      onOpenKbSelect();
+    }
   });
 
   const {

--- a/projects/app/src/pageComponents/app/detail/Edit/ChatAgent/hooks/useSkillManager.tsx
+++ b/projects/app/src/pageComponents/app/detail/Edit/ChatAgent/hooks/useSkillManager.tsx
@@ -92,7 +92,8 @@ export const useSkillManager = ({
   onAddAgentSkill,
   canUploadFile,
   hasSelectedDataset,
-  useAgentSandbox
+  useAgentSandbox,
+  onClickDatasetSearch
 }: {
   selectedTools: SelectedToolItemType[];
   selectedAgentSkills?: SelectedAgentSkillItemType[];
@@ -102,6 +103,7 @@ export const useSkillManager = ({
   canUploadFile: boolean;
   hasSelectedDataset: boolean;
   useAgentSandbox: boolean;
+  onClickDatasetSearch?: () => void;
 }) => {
   const { t, i18n } = useTranslation();
   const { toast } = useToast();
@@ -309,7 +311,10 @@ export const useSkillManager = ({
       // Check tool exists, if exists, not update/add tool
       const existsTool = lastSelectedTools.current?.find((tool) => tool.pluginId === toolId);
       if (existsTool) {
-        const skill = toSkillLabelItem(existsTool, getToolConfigStatus({ tool: existsTool }).status);
+        const skill = toSkillLabelItem(
+          existsTool,
+          getToolConfigStatus({ tool: existsTool }).status
+        );
 
         return {
           id: skill.id,
@@ -325,7 +330,7 @@ export const useSkillManager = ({
 
         const configStatus: SkillLabelItemType['configStatus'] = (() => {
           if (toolId === SubAppIds.datasetSearch) {
-            return hasSelectedDataset ? 'configured' : 'invalid';
+            return hasSelectedDataset ? 'configured' : 'waitingForConfig';
           }
 
           if (toolId === SubAppIds.readFiles) {
@@ -493,7 +498,7 @@ export const useSkillManager = ({
           return 'invalid';
         }
         if (tool.pluginId === SubAppIds.datasetSearch) {
-          return hasSelectedDataset ? 'configured' : 'invalid';
+          return hasSelectedDataset ? 'configured' : 'waitingForConfig';
         }
         return getToolConfigStatus({ tool }).status;
       })();
@@ -518,7 +523,7 @@ export const useSkillManager = ({
         templateType: FlowNodeTemplateTypeEnum.tools,
         inputs: [],
         outputs: [],
-        configStatus: hasSelectedDataset ? 'configured' : 'invalid'
+        configStatus: hasSelectedDataset ? 'configured' : 'waitingForConfig'
       });
     }
 
@@ -572,6 +577,11 @@ export const useSkillManager = ({
         return;
       }
 
+      if (id === SubAppIds.datasetSearch) {
+        onClickDatasetSearch?.();
+        return;
+      }
+
       const tool = selectedTools.find((tool) => tool.pluginId === id);
       if (!tool) return;
 
@@ -579,7 +589,7 @@ export const useSkillManager = ({
         setConfigTool(tool);
       }
     },
-    [selectedAgentSkills, selectedTools]
+    [onClickDatasetSearch, selectedAgentSkills, selectedTools]
   );
   const onRemoveSkill = useCallback(() => {}, []);
 

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeAgent/index.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeAgent/index.tsx
@@ -121,18 +121,6 @@ const NodeAgent = ({ data, selected }: NodeProps<FlowNodeItemType>) => {
     [splitOutput, outputs]
   );
 
-  // Skill manager (for PromptEditor @ integration)
-  const {
-    selectedTools,
-    skillOption,
-    selectedSkills,
-    onClickSkill,
-    onRemoveSkill,
-    onUpdateOrAddTool,
-    onDeleteTool,
-    SkillModal
-  } = useAgentSkillManager({ nodeId, inputs });
-
   // Editor variables for PromptEditor
   const editorVariables = useMemoEnhance(
     () =>
@@ -262,6 +250,25 @@ const NodeAgent = ({ data, selected }: NodeProps<FlowNodeItemType>) => {
     () => (Array.isArray(datasetSelectInput?.value) ? datasetSelectInput!.value : []),
     [datasetSelectInput]
   );
+  const onClickDatasetSearch = useCallback(() => {
+    if (selectedDatasets.length > 0) {
+      onOpenDatasetParams();
+      return;
+    }
+
+    onOpenDatasetSelect();
+  }, [onOpenDatasetParams, onOpenDatasetSelect, selectedDatasets.length]);
+  // Skill manager (for PromptEditor @ integration)
+  const {
+    selectedTools,
+    skillOption,
+    selectedSkills,
+    onClickSkill,
+    onRemoveSkill,
+    onUpdateOrAddTool,
+    onDeleteTool,
+    SkillModal
+  } = useAgentSkillManager({ nodeId, inputs, onClickDatasetSearch });
   const datasetOtherInputs = useMemo(
     () =>
       datasetInputs.filter(

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeAgent/useAgentSkillManager.ts
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeAgent/useAgentSkillManager.ts
@@ -12,10 +12,12 @@ import type { SelectedToolItemType } from '@fastgpt/global/core/app/formEdit/typ
  */
 export const useAgentSkillManager = ({
   nodeId,
-  inputs
+  inputs,
+  onClickDatasetSearch
 }: {
   nodeId: string;
   inputs: FlowNodeInputItemType[];
+  onClickDatasetSearch?: () => void;
 }) => {
   const onChangeNode = useContextSelector(WorkflowActionsContext, (v) => v.onChangeNode);
 
@@ -88,7 +90,8 @@ export const useAgentSkillManager = ({
     onDeleteTool,
     canUploadFile,
     hasSelectedDataset,
-    useAgentSandbox
+    useAgentSandbox,
+    onClickDatasetSearch
   });
 
   return {


### PR DESCRIPTION
## Summary
- mark dataset search as waiting for configuration instead of invalid when no dataset is selected
- open dataset selection first, then dataset parameter configuration after datasets are selected
- keep ChatAgent edit form and workflow Agent node behavior aligned

## Verification
- pnpm exec eslint projects/app/src/pageComponents/app/detail/Edit/ChatAgent/EditForm.tsx projects/app/src/pageComponents/app/detail/Edit/ChatAgent/hooks/useSkillManager.tsx projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeAgent/index.tsx projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeAgent/useAgentSkillManager.ts

Note: pnpm --filter @fastgpt/app lint is currently blocked by existing unrelated lint errors in the app package.