### PR TITLE
fix(app): show image recognition for vision-only models

### DIFF
--- a/projects/app/src/components/core/ai/AISettingModal/index.tsx
+++ b/projects/app/src/components/core/ai/AISettingModal/index.tsx
@@ -389,7 +389,7 @@ const AIChatSettingsModal = ({
             )}
             {showMultimodalSetting && (
               <SettingRow
-                label={t('app:llm_use_multimodal')}
+                label={multimodalSettingLabel}
                 switchControl={
                   !supportParams.multimodal ? (
                     <Box fontSize={'sm'} color={'myGray.500'}>


### PR DESCRIPTION
## What

- Use the existing capability-aware label in the AI settings modal
- Show image recognition when the selected model only supports image input
- Keep multimodal recognition when audio or video capabilities are configured

## Why

A modal layout refactor replaced the capability-aware label with a fixed multimodal label, leaving `multimodalSettingLabel` unused and causing vision-only models to display the wrong text.

## Testing

- `pnpm --dir projects/app typecheck`
- `pnpm exec eslint projects/app/src/components/core/ai/AISettingModal/index.tsx` (0 errors; one pre-existing React Hook Form compiler warning)
- `git diff --check`