### PR TITLE
fix(workflow): node debug file upload uses draft config and session chatId

### DIFF
--- a/packages/global/openapi/core/workflow/api.ts
+++ b/packages/global/openapi/core/workflow/api.ts
@@ -83,6 +83,10 @@ export const WorkflowDebugBodySchema = z.object({
   usageId: z.string().optional().meta({
     example: 'usage_debug_123',
     description: '连续调试复用的用量记录 ID；不传时自动创建'
+  }),
+  chatId: z.string().min(1).optional().meta({
+    example: 'debug-session-chat-id',
+    description: '调试会话内文件上传使用的 chatId；调试运行会沿用该值，保证上传文件归属校验通过'
   })
 });
 export type WorkflowDebugBody = z.input<typeof WorkflowDebugBodySchema>;

--- a/packages/global/test/openapi/core/workflow-mcp.test.ts
+++ b/packages/global/test/openapi/core/workflow-mcp.test.ts
@@ -49,6 +49,15 @@ describe('Workflow debug and MCP runtime OpenAPI contracts', () => {
       history: []
     });
 
+    expect(
+      WorkflowDebugBodySchema.parse({
+        appId: '68ad85a7463006c963799a05',
+        chatId: 'debug-session-chat-id'
+      })
+    ).toMatchObject({
+      chatId: 'debug-session-chat-id'
+    });
+
     const result = WorkflowDebugResponseSchema.parse({
       memoryEdges: [],
       memoryNodes: [],

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useDebug.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/hooks/useDebug.tsx
@@ -30,6 +30,7 @@ import {
 import { useSafeTranslation } from '@fastgpt/web/hooks/useSafeTranslation';
 import { WorkflowActionsContext } from '../../context/workflowActionsContext';
 import { WorkflowDebugContext } from '../../context/workflowDebugContext';
+import { getNanoid } from '@fastgpt/global/common/string/tools';
 import {
   checkInputShouldRenderInDebug,
   getDebugInputFormProps,
@@ -66,6 +67,7 @@ export const useDebug = () => {
     (v) => v
   );
   const onStartNodeDebug = useContextSelector(WorkflowDebugContext, (v) => v.onStartNodeDebug);
+  const setDebugChatId = useContextSelector(WorkflowDebugContext, (v) => v.setDebugChatId);
 
   const appDetail = useContextSelector(AppContext, (v) => v.appDetail);
 
@@ -150,6 +152,9 @@ export const useDebug = () => {
 
   const openDebugNode = useCallback(
     async ({ entryNodeId }: { entryNodeId: string }) => {
+      // 每次打开调试弹窗生成独立的会话 chatId，文件上传与调试运行共用，保证文件归属校验通过
+      setDebugChatId(getNanoid());
+
       setNodes((state) =>
         state.map((node) => ({
           ...node,
@@ -184,7 +189,7 @@ export const useDebug = () => {
       setRuntimeNodes(runtimeNodes);
       setRuntimeEdges(runtimeEdges);
     },
-    [flowData2StoreDataAndCheck, setNodes]
+    [flowData2StoreDataAndCheck, setNodes, setDebugChatId]
   );
 
   const DebugInputModal = useCallback(() => {

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/context/workflowDebugContext.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/context/workflowDebugContext.tsx
@@ -15,6 +15,8 @@ import type { WorkflowDebugResponse } from '@fastgpt/service/core/workflow/dispa
 import type { WorkflowInteractiveResponseType } from '@fastgpt/global/core/workflow/template/system/interactive/type';
 import { WorkflowActionsContext } from './workflowActionsContext';
 import { useMemoEnhance } from '@fastgpt/web/hooks/useMemoEnhance';
+import { WorkflowRuntimeContextProvider } from '@/components/core/chat/ChatContainer/context/workflowRuntimeContext';
+import { ChatSourceTypeEnum } from '@fastgpt/global/core/chat/constants';
 
 export type DebugDataType = {
   runtimeNodes: RuntimeNodeItemType[];
@@ -27,6 +29,8 @@ export type DebugDataType = {
   query?: UserChatItemValueItemType[];
   workflowInteractiveResponse?: WorkflowInteractiveResponseType;
   usageId?: string;
+  /** 调试会话内文件上传与调试运行共用的 chatId */
+  chatId?: string;
 };
 
 // 创建 Context
@@ -45,6 +49,7 @@ type WorkflowDebugContextValue = {
     variables: Record<string, any>;
     query?: UserChatItemValueItemType[];
     history?: ChatItemMiniType[];
+    chatId?: string;
   }) => Promise<void>;
 
   /** 停止节点调试 */
@@ -55,6 +60,12 @@ type WorkflowDebugContextValue = {
 
   /** 设置调试模式 */
   setDebugMode: (enabled: boolean) => void;
+
+  /** 当前调试会话的文件上传 chatId */
+  debugChatId?: string;
+
+  /** 设置调试会话的文件上传 chatId */
+  setDebugChatId: (chatId: string) => void;
 };
 export const WorkflowDebugContext = createContext<WorkflowDebugContextValue>({
   onNextNodeDebug: function (debugData: DebugDataType): Promise<void> {
@@ -67,6 +78,7 @@ export const WorkflowDebugContext = createContext<WorkflowDebugContextValue>({
     variables: Record<string, any>;
     query?: UserChatItemValueItemType[];
     history?: ChatItemMiniType[];
+    chatId?: string;
   }): Promise<void> {
     throw new Error('Function not implemented.');
   },
@@ -75,6 +87,10 @@ export const WorkflowDebugContext = createContext<WorkflowDebugContextValue>({
   },
   debugMode: false,
   setDebugMode: function (enabled: boolean): void {
+    throw new Error('Function not implemented.');
+  },
+  debugChatId: '',
+  setDebugChatId: function (): void {
     throw new Error('Function not implemented.');
   }
 });
@@ -89,6 +105,8 @@ export const WorkflowDebugProvider = ({ children }: { children: React.ReactNode 
   // 调试状态
   const [workflowDebugData, setWorkflowDebugData] = useState<DebugDataType>();
   const [debugMode, setDebugMode] = useState(false);
+  // 调试会话内文件上传的 chatId，打开调试弹窗时生成，调试运行沿用同一值
+  const [debugChatId, setDebugChatId] = useState<string>();
 
   // 单步调试 - 执行下一步节点
   const onNextNodeDebug = useCallback(
@@ -151,7 +169,8 @@ export const WorkflowDebugProvider = ({ children }: { children: React.ReactNode 
           history: debugData.history,
           appId,
           chatConfig: appDetail.chatConfig,
-          usageId: debugData.usageId
+          usageId: debugData.usageId,
+          chatId: debugData.chatId
         });
 
         // 4. Store debug result
@@ -162,7 +181,8 @@ export const WorkflowDebugProvider = ({ children }: { children: React.ReactNode 
           entryNodeIds,
           skipNodeQueue,
           variables: newVariables,
-          usageId
+          usageId,
+          chatId: debugData.chatId
         });
 
         // 5. selected entry node and Update entry node debug result
@@ -235,7 +255,8 @@ export const WorkflowDebugProvider = ({ children }: { children: React.ReactNode 
       runtimeEdges,
       variables,
       query,
-      history
+      history,
+      chatId = debugChatId
     }: Parameters<WorkflowDebugContextValue['onStartNodeDebug']>[0]) => {
       const data: DebugDataType = {
         runtimeNodes,
@@ -246,14 +267,15 @@ export const WorkflowDebugProvider = ({ children }: { children: React.ReactNode 
         skipNodeQueue: [],
         variables,
         query,
-        history
+        history,
+        chatId
       };
       onStopNodeDebug();
       setWorkflowDebugData(data);
 
       onNextNodeDebug(data);
     },
-    [onNextNodeDebug, onStopNodeDebug]
+    [debugChatId, onNextNodeDebug, onStopNodeDebug]
   );
 
   const contextValue = useMemoEnhance(() => {
@@ -265,11 +287,28 @@ export const WorkflowDebugProvider = ({ children }: { children: React.ReactNode 
       onStartNodeDebug,
       onStopNodeDebug,
       debugMode,
-      setDebugMode
+      setDebugMode,
+      debugChatId,
+      setDebugChatId
     };
-  }, [workflowDebugData, onNextNodeDebug, onStartNodeDebug, onStopNodeDebug, debugMode]);
+  }, [
+    workflowDebugData,
+    onNextNodeDebug,
+    onStartNodeDebug,
+    onStopNodeDebug,
+    debugMode,
+    debugChatId,
+    setDebugChatId
+  ]);
 
   return (
-    <WorkflowDebugContext.Provider value={contextValue}>{children}</WorkflowDebugContext.Provider>
+    <WorkflowRuntimeContextProvider
+      sourceTarget={{ sourceType: ChatSourceTypeEnum.app, sourceId: appId }}
+      chatId={debugChatId ?? ''}
+      outLinkAuthData={{}}
+      fileUploadMode="draft"
+    >
+      <WorkflowDebugContext.Provider value={contextValue}>{children}</WorkflowDebugContext.Provider>
+    </WorkflowRuntimeContextProvider>
   );
 };

--- a/projects/app/src/pages/api/core/workflow/debug.ts
+++ b/projects/app/src/pages/api/core/workflow/debug.ts
@@ -34,7 +34,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse): Promise<Workf
     query = [],
     history = [],
     chatConfig,
-    usageId
+    usageId,
+    chatId: debugChatId
   } = parseApiInput({ req, bodySchema: WorkflowDebugBodySchema }).body;
 
   /* user auth */
@@ -84,7 +85,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse): Promise<Workf
       tmbId: app.tmbId
     },
     runningUserInfo: await getRunningUserInfoByTmbId(tmbId),
-    chatId: getNanoid(),
+    chatId: debugChatId ?? getNanoid(),
     responseChatItemId,
     runtimeNodes: nodes,
     runtimeEdges: edges,


### PR DESCRIPTION
### 问题
工作流节点点击「调试」时，文件上传报 `Data validation error`。对比「运行」的请求 payload，调试请求缺少 `fileSelectConfig` 等参数。

### 根因
节点调试弹窗里的 `FileSelector` 不在 `WorkflowRuntimeContextProvider` 内，落到了默认 context（`fileUploadMode: 'runtime'`、`chatId: ''`），文件上传打到了正式接口 `presignChatFilePostUrl` 而不是编辑态草稿接口 `presignDraftChatFilePostUrl`，payload 缺少 `fileSelectConfig` 且 `chatId` 为空，服务端 zod 校验失败返回 `Data validation error`。

### 修复
- `WorkflowDebugProvider` 用 `WorkflowRuntimeContextProvider` 包裹调试子树（`fileUploadMode: "draft"`、`sourceType: app`），调试弹窗与交互表单内的文件上传改走草稿接口并携带 `fileSelectConfig`。
- 打开调试弹窗时生成会话 `chatId`，上传与调试运行共用同一值；`WorkflowDebugBodySchema` 新增可选 `chatId`，调试 dispatch 优先使用该值，保证上传文件 key 的 chatId 与调试运行 chatId 一致、通过归属校验（不传时仍自动生成，向后兼容）。
- 补充 schema 透传 `chatId` 的测试用例。

### 测试
- `@fastgpt/global` 全量测试通过。
- `@fastgpt/app` 全量测试通过（198 个测试文件 / 1513 个用例）。
- `projects/app` `tsc --noEmit` 与 eslint 无错误。