### PR TITLE
fix(workflow): refine agent-generated input defaults

### DIFF
--- a/packages/global/core/app/formEdit/utils.ts
+++ b/packages/global/core/app/formEdit/utils.ts
@@ -107,6 +107,7 @@ export const canInputBeAgentGenerated = (
 ) => {
   if (input.canAgentGenerated === false) return false;
   if (input.key === NodeInputKeyEnum.systemInputConfig) return false;
+  if (input.key === NodeInputKeyEnum.forbidStream) return false;
   if (!Array.isArray(input.renderTypeList)) return false;
   return !input.renderTypeList.some((type) => agentGeneratedDenyRenderTypes.has(type));
 };

--- a/packages/global/core/workflow/template/input.ts
+++ b/packages/global/core/workflow/template/input.ts
@@ -119,6 +119,7 @@ export const Input_Template_Stream_MODE: FlowNodeInputItemType = {
   key: NodeInputKeyEnum.forbidStream,
   renderTypeList: [FlowNodeInputTypeEnum.switch],
   valueType: WorkflowIOValueTypeEnum.boolean,
+  canAgentGenerated: false,
   label: i18nT('workflow:template.forbid_stream'),
   description: i18nT('workflow:template.forbid_stream_desc'),
   value: false

--- a/packages/global/core/workflow/utils.ts
+++ b/packages/global/core/workflow/utils.ts
@@ -410,6 +410,15 @@ export const getModuleInputUiField = (input: FlowNodeInputItemType) => {
   return {};
 };
 
+const agentGeneratedExternalVariableValueTypes = new Set<WorkflowIOValueTypeEnum>([
+  WorkflowIOValueTypeEnum.string,
+  WorkflowIOValueTypeEnum.number,
+  WorkflowIOValueTypeEnum.boolean,
+  WorkflowIOValueTypeEnum.arrayString,
+  WorkflowIOValueTypeEnum.arrayNumber,
+  WorkflowIOValueTypeEnum.arrayBoolean
+]);
+
 /**
  * 将子工作流外部变量投影为父工作流可配置的节点输入。
  * customVariable 只描述子工作流的外部注入语义；进入父工作流后由引用或类型匹配的手动控件提供值。
@@ -432,11 +441,9 @@ export const projectExternalVariableInput = <T extends FlowNodeInputItemType>(in
     }
     return FlowNodeInputTypeEnum.JSONEditor;
   })();
-  const canAgentGenerated = [
-    WorkflowIOValueTypeEnum.string,
-    WorkflowIOValueTypeEnum.number,
-    WorkflowIOValueTypeEnum.boolean
-  ].includes(input.valueType as WorkflowIOValueTypeEnum);
+  const canAgentGenerated = agentGeneratedExternalVariableValueTypes.has(
+    input.valueType as WorkflowIOValueTypeEnum
+  );
   const projectedRenderTypeList = Array.from(
     new Set(
       input.renderTypeList.flatMap((type) => {
@@ -462,13 +469,15 @@ export const projectExternalVariableInput = <T extends FlowNodeInputItemType>(in
   if (!projectedRenderTypeList.includes(manualRenderType)) {
     projectedRenderTypeList.push(manualRenderType);
   }
-  const selectedType =
-    input.selectedType && projectedRenderTypeList.includes(input.selectedType)
+  const selectedType = canAgentGenerated
+    ? FlowNodeInputTypeEnum.agentGenerated
+    : input.selectedType && projectedRenderTypeList.includes(input.selectedType)
       ? input.selectedType
       : FlowNodeInputTypeEnum.reference;
   const projectedInput = {
     ...input,
     canAgentGenerated,
+    ...(canAgentGenerated ? { isToolParam: true } : {}),
     renderTypeList: projectedRenderTypeList,
     selectedType
   } as T;
@@ -608,7 +617,17 @@ export const appData2FlowNodeIO = ({
       chatConfig?.fileSelectConfig?.canSelectVideo ||
       chatConfig?.fileSelectConfig?.canSelectAudio ||
       chatConfig?.fileSelectConfig?.canSelectCustomFileExtension
-        ? [Input_Template_File_Link]
+        ? [
+            {
+              ...Input_Template_File_Link,
+              renderTypeList: [
+                ...Input_Template_File_Link.renderTypeList,
+                FlowNodeInputTypeEnum.agentGenerated
+              ],
+              selectedType: FlowNodeInputTypeEnum.agentGenerated,
+              isToolParam: true
+            }
+          ]
         : []),
       {
         ...Input_Template_UserChatInput,

--- a/packages/global/test/core/app/formEdit/utils.test.ts
+++ b/packages/global/test/core/app/formEdit/utils.test.ts
@@ -1116,6 +1116,34 @@ describe('agent generated tool input helpers', () => {
     ).toBe(false);
   });
 
+  it('should apply the projected external variable AI default when creating a tool node', () => {
+    const input = initToolInputTypeByDefaultMode(
+      createMockInput({
+        renderTypeList: [
+          FlowNodeInputTypeEnum.agentGenerated,
+          FlowNodeInputTypeEnum.reference,
+          FlowNodeInputTypeEnum.input
+        ],
+        selectedType: FlowNodeInputTypeEnum.agentGenerated,
+        isToolParam: true
+      }),
+      { forceDefaultMode: true }
+    );
+
+    expect(input.selectedType).toBe(FlowNodeInputTypeEnum.agentGenerated);
+  });
+
+  it('should never allow the forbid stream input to be agent generated', () => {
+    expect(
+      canInputBeAgentGenerated(
+        createMockInput({
+          key: NodeInputKeyEnum.forbidStream,
+          renderTypeList: [FlowNodeInputTypeEnum.switch]
+        })
+      )
+    ).toBe(false);
+  });
+
   it('should identify reference-only inputs as agent-only configuration', () => {
     const input = createMockInput({
       renderTypeList: [FlowNodeInputTypeEnum.reference]

--- a/packages/global/test/core/workflow/utils.test.ts
+++ b/packages/global/test/core/workflow/utils.test.ts
@@ -75,45 +75,45 @@ describe('getHandleId', () => {
 
 describe('projectExternalVariableInput', () => {
   it.each([
-    [WorkflowIOValueTypeEnum.string, FlowNodeInputTypeEnum.input],
-    [WorkflowIOValueTypeEnum.number, FlowNodeInputTypeEnum.numberInput],
-    [WorkflowIOValueTypeEnum.boolean, FlowNodeInputTypeEnum.switch],
-    [WorkflowIOValueTypeEnum.object, FlowNodeInputTypeEnum.JSONEditor],
-    [WorkflowIOValueTypeEnum.arrayString, FlowNodeInputTypeEnum.JSONEditor],
-    [WorkflowIOValueTypeEnum.any, FlowNodeInputTypeEnum.JSONEditor]
-  ])('should project %s external variables to a reference and manual input', (valueType, type) => {
-    const result = projectExternalVariableInput({
-      key: 'externalVariable',
-      label: 'External variable',
-      valueType,
-      renderTypeList: [FlowNodeInputTypeEnum.customVariable],
-      selectedType: FlowNodeInputTypeEnum.customVariable,
-      selectedTypeIndex: 0,
-      defaultValue: 'default-value'
-    });
+    [WorkflowIOValueTypeEnum.string, FlowNodeInputTypeEnum.input, true],
+    [WorkflowIOValueTypeEnum.number, FlowNodeInputTypeEnum.numberInput, true],
+    [WorkflowIOValueTypeEnum.boolean, FlowNodeInputTypeEnum.switch, true],
+    [WorkflowIOValueTypeEnum.arrayString, FlowNodeInputTypeEnum.JSONEditor, true],
+    [WorkflowIOValueTypeEnum.arrayNumber, FlowNodeInputTypeEnum.JSONEditor, true],
+    [WorkflowIOValueTypeEnum.arrayBoolean, FlowNodeInputTypeEnum.JSONEditor, true],
+    [WorkflowIOValueTypeEnum.object, FlowNodeInputTypeEnum.JSONEditor, false],
+    [WorkflowIOValueTypeEnum.arrayObject, FlowNodeInputTypeEnum.JSONEditor, false],
+    [WorkflowIOValueTypeEnum.arrayAny, FlowNodeInputTypeEnum.JSONEditor, false],
+    [WorkflowIOValueTypeEnum.any, FlowNodeInputTypeEnum.JSONEditor, false]
+  ])(
+    'should project %s external variables to a reference and manual input',
+    (valueType, type, canAgentGenerated) => {
+      const result = projectExternalVariableInput({
+        key: 'externalVariable',
+        label: 'External variable',
+        valueType,
+        renderTypeList: [FlowNodeInputTypeEnum.customVariable],
+        selectedType: FlowNodeInputTypeEnum.customVariable,
+        selectedTypeIndex: 0,
+        defaultValue: 'default-value'
+      });
 
-    expect(result).toMatchObject({
-      canAgentGenerated: [
-        WorkflowIOValueTypeEnum.string,
-        WorkflowIOValueTypeEnum.number,
-        WorkflowIOValueTypeEnum.boolean
-      ].includes(valueType),
-      renderTypeList: [
-        ...([
-          WorkflowIOValueTypeEnum.string,
-          WorkflowIOValueTypeEnum.number,
-          WorkflowIOValueTypeEnum.boolean
-        ].includes(valueType)
-          ? [FlowNodeInputTypeEnum.agentGenerated]
-          : []),
-        FlowNodeInputTypeEnum.reference,
-        type
-      ],
-      selectedType: FlowNodeInputTypeEnum.reference,
-      defaultValue: 'default-value'
-    });
-    expect(result).not.toHaveProperty('selectedTypeIndex');
-  });
+      expect(result).toMatchObject({
+        canAgentGenerated,
+        ...(canAgentGenerated ? { isToolParam: true } : {}),
+        renderTypeList: [
+          ...(canAgentGenerated ? [FlowNodeInputTypeEnum.agentGenerated] : []),
+          FlowNodeInputTypeEnum.reference,
+          type
+        ],
+        selectedType: canAgentGenerated
+          ? FlowNodeInputTypeEnum.agentGenerated
+          : FlowNodeInputTypeEnum.reference,
+        defaultValue: 'default-value'
+      });
+      expect(result).not.toHaveProperty('selectedTypeIndex');
+    }
+  );
 
   it('should leave regular inputs unchanged', () => {
     const input: FlowNodeInputItemType = {
@@ -143,6 +143,23 @@ describe('projectExternalVariableInput', () => {
       ],
       selectedType: FlowNodeInputTypeEnum.agentGenerated
     });
+  });
+
+  it('should select AI generation by default without changing its existing position', () => {
+    const result = projectExternalVariableInput({
+      key: 'externalVariable',
+      label: 'External variable',
+      valueType: WorkflowIOValueTypeEnum.string,
+      renderTypeList: [FlowNodeInputTypeEnum.customVariable, FlowNodeInputTypeEnum.agentGenerated],
+      selectedType: FlowNodeInputTypeEnum.customVariable
+    });
+
+    expect(result.renderTypeList).toEqual([
+      FlowNodeInputTypeEnum.reference,
+      FlowNodeInputTypeEnum.input,
+      FlowNodeInputTypeEnum.agentGenerated
+    ]);
+    expect(result.selectedType).toBe(FlowNodeInputTypeEnum.agentGenerated);
   });
 
   it('should keep complex external variables manual-only', () => {
@@ -876,7 +893,7 @@ describe('pluginData2FlowNodeIO', () => {
     expect(result.outputs[0].type).toBe(FlowNodeOutputTypeEnum.static);
   });
 
-  it('should convert customVariable renderType and legacy selection to reference and input', () => {
+  it('should convert customVariable renderType and default to AI generation', () => {
     const nodes: StoreNodeItemType[] = [
       {
         nodeId: 'pluginInput1',
@@ -902,7 +919,7 @@ describe('pluginData2FlowNodeIO', () => {
       FlowNodeInputTypeEnum.reference,
       FlowNodeInputTypeEnum.input
     ]);
-    expect(customVarInput?.selectedType).toBe(FlowNodeInputTypeEnum.reference);
+    expect(customVarInput?.selectedType).toBe(FlowNodeInputTypeEnum.agentGenerated);
     expect(customVarInput).not.toHaveProperty('selectedTypeIndex');
   });
 
@@ -938,6 +955,18 @@ describe('appData2FlowNodeIO', () => {
     ).toMatchObject({
       required: true,
       isToolParam: true
+    });
+  });
+
+  it('should keep forbid stream as a manual-only switch', () => {
+    const result = appData2FlowNodeIO({});
+
+    expect(
+      result.inputs.find((input) => input.key === NodeInputKeyEnum.forbidStream)
+    ).toMatchObject({
+      renderTypeList: [FlowNodeInputTypeEnum.switch],
+      canAgentGenerated: false,
+      value: false
     });
   });
 
@@ -1028,7 +1057,15 @@ describe('appData2FlowNodeIO', () => {
       }
     });
     const fileLinkInput = result.inputs.find((i) => i.key === NodeInputKeyEnum.fileUrlList);
-    expect(fileLinkInput).toBeDefined();
+    expect(fileLinkInput).toMatchObject({
+      renderTypeList: [
+        FlowNodeInputTypeEnum.reference,
+        FlowNodeInputTypeEnum.JSONEditor,
+        FlowNodeInputTypeEnum.agentGenerated
+      ],
+      selectedType: FlowNodeInputTypeEnum.agentGenerated,
+      isToolParam: true
+    });
   });
 
   it('should include file link input when fileSelectConfig allows image selection', () => {

--- a/packages/service/core/app/utils.ts
+++ b/packages/service/core/app/utils.ts
@@ -296,6 +296,13 @@ export async function rewriteAppWorkflowToDetail({
           };
         }
       }
+      // 只有子应用节点消费外部变量；当前工作流入口和其他节点保留原始输入定义。
+      if (
+        node.flowNodeType === FlowNodeTypeEnum.appModule ||
+        node.flowNodeType === FlowNodeTypeEnum.pluginModule
+      ) {
+        node.inputs = node.inputs.map(projectExternalVariableInput);
+      }
       // Agent, parse subapp
       if (node.flowNodeType === FlowNodeTypeEnum.agent) {
         // Tool load

--- a/packages/service/test/core/app/tool/utils/clientSystemTool.test.ts
+++ b/packages/service/test/core/app/tool/utils/clientSystemTool.test.ts
@@ -232,8 +232,9 @@ describe('getClientSystemToolPreviewNode', () => {
       valueType: 'string',
       defaultValue: 'fallback',
       canAgentGenerated: true,
+      isToolParam: true,
       renderTypeList: [FlowNodeInputTypeEnum.agentGenerated, 'reference', 'input'],
-      selectedType: 'reference'
+      selectedType: FlowNodeInputTypeEnum.agentGenerated
     });
     expect(input).not.toHaveProperty('selectedTypeIndex');
   });

--- a/projects/app/test/service/core/app/rewriteAppWorkflowToDetail.test.ts
+++ b/projects/app/test/service/core/app/rewriteAppWorkflowToDetail.test.ts
@@ -42,6 +42,33 @@ vi.mock('@fastgpt/service/support/permission/app/auth', async (importOriginal) =
 const { rewriteAppWorkflowToDetail } = await import('@fastgpt/service/core/app/utils');
 
 describe('rewriteAppWorkflowToDetail - legacy HTTP workflow tool inputs', () => {
+  it('普通节点不投影 customVariable 输入', async () => {
+    const input = {
+      key: 'externalVariable',
+      label: 'External variable',
+      valueType: WorkflowIOValueTypeEnum.string,
+      renderTypeList: [FlowNodeInputTypeEnum.customVariable],
+      selectedType: FlowNodeInputTypeEnum.customVariable
+    };
+    const nodes = [
+      {
+        nodeId: 'ordinary-node',
+        flowNodeType: FlowNodeTypeEnum.textEditor,
+        inputs: [input],
+        outputs: []
+      } as StoreNodeItemType
+    ];
+
+    await rewriteAppWorkflowToDetail({
+      nodes,
+      teamId: 'team-1',
+      ownerTmbId: 'tmb-1',
+      isRoot: false
+    });
+
+    expect(nodes[0].inputs[0]).toEqual(input);
+  });
+
   it('恢复旧版 HTTP 动态工具参数并保留显式手动配置', async () => {
     const nodes = [
       {
@@ -258,12 +285,73 @@ describe('rewriteAppWorkflowToDetail - legacy workflow tool inputs', () => {
       value: 'saved-value',
       defaultValue: 'fallback',
       canAgentGenerated: true,
+      isToolParam: true,
       renderTypeList: [
         FlowNodeInputTypeEnum.agentGenerated,
         FlowNodeInputTypeEnum.reference,
         FlowNodeInputTypeEnum.input
       ],
-      selectedType: FlowNodeInputTypeEnum.reference
+      selectedType: FlowNodeInputTypeEnum.agentGenerated
+    });
+    expect(nodes[0].inputs[0]).not.toHaveProperty('selectedTypeIndex');
+  });
+
+  it.each([
+    ['工作流工具', FlowNodeTypeEnum.pluginModule],
+    ['嵌套工作流', FlowNodeTypeEnum.appModule]
+  ])('将固定版本%s保存的外部变量投影为父工作流可配置输入', async (_, flowNodeType) => {
+    const toolAppId = '507f1f77bcf86cd799439012';
+    getClientToolPreviewNodeMock.mockResolvedValue({
+      id: toolAppId,
+      pluginId: toolAppId,
+      flowNodeType,
+      name: 'Fixed workflow',
+      avatar: '',
+      intro: '',
+      inputs: [],
+      outputs: [],
+      version: 'fixed-version-id',
+      isLatestVersion: false
+    });
+    authAppByTmbIdMock.mockResolvedValue({});
+    const nodes = [
+      {
+        nodeId: 'fixed-workflow',
+        flowNodeType,
+        pluginId: toolAppId,
+        version: 'fixed-version-id',
+        inputs: [
+          {
+            key: 'externalVariable',
+            label: 'External variable',
+            valueType: WorkflowIOValueTypeEnum.string,
+            value: 'saved-value',
+            renderTypeList: [FlowNodeInputTypeEnum.customVariable],
+            selectedType: FlowNodeInputTypeEnum.customVariable,
+            selectedTypeIndex: 0
+          }
+        ],
+        outputs: []
+      } as StoreNodeItemType
+    ];
+
+    await rewriteAppWorkflowToDetail({
+      nodes,
+      teamId: 'team-1',
+      ownerTmbId: 'tmb-1',
+      isRoot: false
+    });
+
+    expect(nodes[0].inputs[0]).toMatchObject({
+      value: 'saved-value',
+      canAgentGenerated: true,
+      isToolParam: true,
+      renderTypeList: [
+        FlowNodeInputTypeEnum.agentGenerated,
+        FlowNodeInputTypeEnum.reference,
+        FlowNodeInputTypeEnum.input
+      ],
+      selectedType: FlowNodeInputTypeEnum.agentGenerated
     });
     expect(nodes[0].inputs[0]).not.toHaveProperty('selectedTypeIndex');
   });


### PR DESCRIPTION
## What changed

- default supported workflow and Chat Agent external variables to Agent-generated input
- allow string, number, boolean, and their array variants to be generated by the Agent
- default app-module file links to Agent generation
- keep forbid-stream as a manual-only switch, including legacy inputs
- limit external-variable projection during detail rewrite to appModule and pluginModule nodes
- cover latest/fixed workflow tools, nested workflows, initialization defaults, and projection boundaries

## Why

PR #7506 projected custom variables into configurable parent inputs, but new nodes recomputed their default mode and fell back to references. Fixed-version child apps also needed projection during detail rewrite. The initialization protocol uses isToolParam as the definition-side Agent-generation recommendation, so projected inputs now carry that recommendation as well as their selected type.

## Impact

New workflow tool and Chat Agent nodes default supported external inputs and file links to Agent generation. Complex external values remain manual/reference-only, and forbid-stream can never enter the Agent schema.

## Validation

- pnpm --filter @fastgpt/global test test/core/workflow/utils.test.ts test/core/app/formEdit/utils.test.ts
- pnpm --filter @fastgpt/service test test/core/app/tool/utils/clientSystemTool.test.ts
- pnpm test test/service/core/app/rewriteAppWorkflowToDetail.test.ts (projects/app)
- pnpm --filter @fastgpt/app typecheck
- Prettier check and git diff --check

