### PR TITLE
fix: fallback tool input descriptions

### DIFF
--- a/packages/global/core/app/jsonschema.ts
+++ b/packages/global/core/app/jsonschema.ts
@@ -819,7 +819,7 @@ export const nodeInput2JsonSchemaProperty = (
   return {
     ...schema,
     title: input.label || input.key,
-    description: input.toolDescription || input.description || '',
+    description: input.toolDescription || input.description || input.label || input.key,
     ...(input.defaultValue !== undefined ? { default: input.defaultValue } : {}),
     ...(typeof input.min === 'number' ? { minimum: input.min } : {}),
     ...(typeof input.max === 'number' ? { maximum: input.max } : {}),

--- a/packages/global/test/core/app/jsonschema.test.ts
+++ b/packages/global/test/core/app/jsonschema.test.ts
@@ -888,6 +888,31 @@ describe('jsonSchema2NodeOutput', () => {
 });
 
 describe('nodeInputs2JsonSchema', () => {
+  it.each([
+    ['tool description', 'Tool description', 'UI description', 'Field label', 'Tool description'],
+    ['UI description', undefined, 'UI description', 'Field label', 'UI description'],
+    ['field label', undefined, undefined, 'Field label', 'Field label'],
+    ['field key', undefined, undefined, '', 'fieldKey']
+  ])(
+    'should fall back to the %s for the property description',
+    (_case, toolDescription, description, label, expected) => {
+      const result = nodeInputs2JsonSchema({
+        inputs: [
+          {
+            key: 'fieldKey',
+            label,
+            valueType: WorkflowIOValueTypeEnum.string,
+            toolDescription,
+            description,
+            renderTypeList: [FlowNodeInputTypeEnum.agentGenerated]
+          }
+        ]
+      });
+
+      expect(result.properties?.fieldKey?.description).toBe(expected);
+    }
+  );
+
   it('should expose only agent generated and schema-only tool parameters to the model', () => {
     const generatedInput: FlowNodeInputItemType = {
       key: 'query',
@@ -1185,31 +1210,31 @@ describe('nodeInputs2JsonSchema', () => {
         type: 'array',
         items: { type: 'object' },
         title: 'Items',
-        description: ''
+        description: 'Items'
       },
       history: {
         type: 'array',
         items: { type: 'object' },
         title: 'History',
-        description: ''
+        description: 'History'
       },
       quote: {
         type: 'array',
         items: { type: 'object' },
         title: 'Quote',
-        description: ''
+        description: 'Quote'
       },
       dynamic: {
         title: 'Dynamic',
-        description: ''
+        description: 'Dynamic'
       },
       dataset: {
         title: 'Dataset',
-        description: ''
+        description: 'Dataset'
       },
       app: {
         title: 'App',
-        description: ''
+        description: 'App'
       }
     });
   });

--- a/packages/global/test/core/app/tool/runtime.test.ts
+++ b/packages/global/test/core/app/tool/runtime.test.ts
@@ -91,7 +91,7 @@ describe('compileToolRuntime', () => {
     expect(compiled.modelTool.function.parameters).toEqual({
       type: 'object',
       properties: {
-        var_ref2: { type: 'string', description: '' }
+        var_ref2: { type: 'string', description: 'var_ref2' }
       }
     });
     expect(compiled.agentGeneratedKeys).toEqual(['var_ref2']);
@@ -198,7 +198,7 @@ describe('compileToolRuntime', () => {
     expect(compiled.modelTool.function.parameters).toEqual({
       type: 'object',
       properties: {
-        query: { type: 'string', description: '' }
+        query: { type: 'string', description: 'Query' }
       }
     });
     expect(compiled.fixedInputBindings).toEqual({ limit: 5 });

--- a/packages/service/test/core/app/tool/systemTool/systemTool.repo.test.ts
+++ b/packages/service/test/core/app/tool/systemTool/systemTool.repo.test.ts
@@ -341,7 +341,7 @@ describe('SystemToolRepo.getSystemToolDetail', () => {
         internal: {
           type: 'string',
           title: 'Internal',
-          description: '',
+          description: 'Internal',
           default: 'internal default',
           'x-fastgpt-node-input': {
             valueType: WorkflowIOValueTypeEnum.string,


### PR DESCRIPTION
## What changed

- fall back tool input JSON Schema descriptions to the field label
- use the field key as the final fallback when no label is available
- cover the complete fallback order with regression tests

## Why

Agent-generated workflow inputs can have random internal keys and no explicit tool description. Model-visible schemas strip the title annotation, so these parameters previously exposed an empty description and gave the model no semantic hint.

The fallback order is now: `toolDescription` → `description` → `label` → `key`.

## Impact

Tool parameters without explicit descriptions remain understandable to the model, while existing dedicated descriptions keep their current priority.

## Validation

- `pnpm --filter @fastgpt/global test test/core/app/jsonschema.test.ts` (94 tests passed)
- `git diff --check`
- commit-time ESLint and Prettier checks