### PR TITLE
fix(s3): allow deleting legacy object keys rejected by validation

### DIFF
--- a/packages/service/common/s3/queue/delete.ts
+++ b/packages/service/common/s3/queue/delete.ts
@@ -5,6 +5,7 @@ import { deleteS3DownloadAliasByObjects } from '../accessLink';
 import { s3FileDeleteMQService, type S3MQJobData } from '@fastgpt/dal/redis/bullmq';
 import {
   InvalidStorageObjectKeyError,
+  assertStorageObjectKey,
   type InvalidStorageObjectKeyReason
 } from '@fastgpt-sdk/storage';
 
@@ -35,8 +36,32 @@ const LEGACY_DELETE_FALLBACK_REASONS: ReadonlySet<InvalidStorageObjectKeyReason>
 ]);
 
 /** 判断错误是否属于可降级为原始 key 直删的 legacy 断言失败。 */
-const isLegacyStorageKeyError = (error: unknown) =>
+const isLegacyStorageKeyError = (error: unknown): error is InvalidStorageObjectKeyError =>
   error instanceof InvalidStorageObjectKeyError && LEGACY_DELETE_FALLBACK_REASONS.has(error.reason);
+
+/** 判断源 key 本身是否为 legacy 非规范 key（断言失败且原因在白名单内）。 */
+const isLegacySourceKey = (key: string) => {
+  try {
+    assertStorageObjectKey(key);
+    return false;
+  } catch (error) {
+    return isLegacyStorageKeyError(error);
+  }
+};
+
+/**
+ * 批量降级前逐个校验每个 key：合法的或白名单 legacy 的允许进入原始直删；
+ * 任何 key 违反其余安全相关断言则抛出对应错误，避免混合批次整批绕过校验。
+ */
+const assertAllKeysLegacyRawEligible = (keys: string[]) => {
+  for (const key of keys) {
+    try {
+      assertStorageObjectKey(key);
+    } catch (error) {
+      if (!isLegacyStorageKeyError(error)) throw error;
+    }
+  }
+};
 
 export const executeS3DeleteJob = async ({ prefix, bucketName, key, keys }: S3MQJobData) => {
   const bucket = global.s3BucketMap?.[bucketName];
@@ -54,6 +79,7 @@ export const executeS3DeleteJob = async ({ prefix, bucketName, key, keys }: S3MQ
     const result = (await bucket.client.deleteObjectsByMultiKeys({ keys }).catch((error) => {
       if (!isLegacyStorageKeyError(error)) throw error;
       // 旧数据 key 含控制字符等非规范字符，校验失败但对象确实存在，降级为原始 key 直删。
+      assertAllKeysLegacyRawEligible(keys);
       logger.warn('Legacy S3 key rejected by validation, falling back to raw key deletion', {
         bucketName,
         count: keys.length,
@@ -80,8 +106,9 @@ export const executeS3DeleteJob = async ({ prefix, bucketName, key, keys }: S3MQ
       const result = (await bucket.client
         .deleteObjectsByPrefix({ prefix: fileParsedPrefix })
         .catch((error) => {
-          if (!isLegacyStorageKeyError(error)) throw error;
-          // legacy 原始 key 派生出的 parsed 前缀同样无法通过校验，跳过即可，不影响主对象删除。
+          // 只有源 key 本身是 legacy 时才跳过派生前缀删除；
+          // 合法 key 的派生前缀超长等问题仍按原有方式抛出，避免静默遗留孤儿对象。
+          if (!isLegacyStorageKeyError(error) || !isLegacySourceKey(key)) throw error;
           logger.warn('Skip parsed prefix deletion for legacy key', {
             bucketName,
             prefix: fileParsedPrefix,

--- a/packages/service/common/s3/queue/delete.ts
+++ b/packages/service/common/s3/queue/delete.ts
@@ -3,6 +3,10 @@ import path from 'path';
 import { batchRun } from '@fastgpt/global/common/system/utils';
 import { deleteS3DownloadAliasByObjects } from '../accessLink';
 import { s3FileDeleteMQService, type S3MQJobData } from '@fastgpt/dal/redis/bullmq';
+import {
+  InvalidStorageObjectKeyError,
+  type InvalidStorageObjectKeyReason
+} from '@fastgpt-sdk/storage';
 
 export type { S3MQJobData } from '@fastgpt/dal/redis/bullmq';
 
@@ -19,6 +23,21 @@ const assertNoFailedKeys = (failedKeys: string[] | undefined, action: string) =>
   );
 };
 
+/**
+ * 历史遗留 key 允许降级为原始直删的断言原因。
+ * 这些 key 是旧版本写入的非规范对象名（内容片段文件名、反斜线或超长 key），
+ * 其余断言原因视为调用方 bug 或安全风险，不允许绕过校验。
+ */
+const LEGACY_DELETE_FALLBACK_REASONS: ReadonlySet<InvalidStorageObjectKeyReason> = new Set([
+  'control_character',
+  'backslash',
+  'too_long'
+]);
+
+/** 判断错误是否属于可降级为原始 key 直删的 legacy 断言失败。 */
+const isLegacyStorageKeyError = (error: unknown) =>
+  error instanceof InvalidStorageObjectKeyError && LEGACY_DELETE_FALLBACK_REASONS.has(error.reason);
+
 export const executeS3DeleteJob = async ({ prefix, bucketName, key, keys }: S3MQJobData) => {
   const bucket = global.s3BucketMap?.[bucketName];
 
@@ -32,9 +51,16 @@ export const executeS3DeleteJob = async ({ prefix, bucketName, key, keys }: S3MQ
   }
   if (keys) {
     logger.debug('S3 delete by keys', { bucketName, count: keys.length });
-    const result = (await bucket.client.deleteObjectsByMultiKeys({ keys })) as
-      | { keys?: string[] }
-      | undefined;
+    const result = (await bucket.client.deleteObjectsByMultiKeys({ keys }).catch((error) => {
+      if (!isLegacyStorageKeyError(error)) throw error;
+      // 旧数据 key 含控制字符等非规范字符，校验失败但对象确实存在，降级为原始 key 直删。
+      logger.warn('Legacy S3 key rejected by validation, falling back to raw key deletion', {
+        bucketName,
+        count: keys.length,
+        reason: error.reason
+      });
+      return bucket.client.deleteObjectsByRawKeys({ keys });
+    })) as { keys?: string[] } | undefined;
     assertNoFailedKeys(result?.keys, 'keys');
 
     deleteS3DownloadAliasByObjects({
@@ -51,9 +77,18 @@ export const executeS3DeleteJob = async ({ prefix, bucketName, key, keys }: S3MQ
     await batchRun(keys, async (key) => {
       if (key.includes('-parsed/')) return;
       const fileParsedPrefix = `${path.dirname(key)}/${path.basename(key, path.extname(key))}-parsed`;
-      const result = (await bucket.client.deleteObjectsByPrefix({ prefix: fileParsedPrefix })) as
-        | { keys?: string[] }
-        | undefined;
+      const result = (await bucket.client
+        .deleteObjectsByPrefix({ prefix: fileParsedPrefix })
+        .catch((error) => {
+          if (!isLegacyStorageKeyError(error)) throw error;
+          // legacy 原始 key 派生出的 parsed 前缀同样无法通过校验，跳过即可，不影响主对象删除。
+          logger.warn('Skip parsed prefix deletion for legacy key', {
+            bucketName,
+            prefix: fileParsedPrefix,
+            reason: error.reason
+          });
+          return undefined;
+        })) as { keys?: string[] } | undefined;
       assertNoFailedKeys(result?.keys, `parsed prefix ${fileParsedPrefix}`);
     });
   }

--- a/packages/service/common/s3/queue/delete.ts
+++ b/packages/service/common/s3/queue/delete.ts
@@ -1,11 +1,12 @@
 import { getLogger, LogCategories } from '../../logger';
 import path from 'path';
+import { createHash } from 'node:crypto';
 import { batchRun } from '@fastgpt/global/common/system/utils';
 import { deleteS3DownloadAliasByObjects } from '../accessLink';
 import { s3FileDeleteMQService, type S3MQJobData } from '@fastgpt/dal/redis/bullmq';
 import {
   InvalidStorageObjectKeyError,
-  assertStorageObjectKey,
+  collectStorageObjectKeyViolations,
   type InvalidStorageObjectKeyReason
 } from '@fastgpt-sdk/storage';
 
@@ -39,26 +40,28 @@ const LEGACY_DELETE_FALLBACK_REASONS: ReadonlySet<InvalidStorageObjectKeyReason>
 const isLegacyStorageKeyError = (error: unknown): error is InvalidStorageObjectKeyError =>
   error instanceof InvalidStorageObjectKeyError && LEGACY_DELETE_FALLBACK_REASONS.has(error.reason);
 
-/** 判断源 key 本身是否为 legacy 非规范 key（断言失败且原因在白名单内）。 */
+/** 判断源 key 本身是否为 legacy 非规范 key（全部违规原因都在白名单内）。 */
 const isLegacySourceKey = (key: string) => {
-  try {
-    assertStorageObjectKey(key);
-    return false;
-  } catch (error) {
-    return isLegacyStorageKeyError(error);
-  }
+  const violations = collectStorageObjectKeyViolations(key);
+  return (
+    violations.length > 0 &&
+    violations.every((reason) => LEGACY_DELETE_FALLBACK_REASONS.has(reason))
+  );
 };
 
 /**
  * 批量降级前逐个校验每个 key：合法的或白名单 legacy 的允许进入原始直删；
  * 任何 key 违反其余安全相关断言则抛出对应错误，避免混合批次整批绕过校验。
+ * 使用全量违规收集而不是首个违规，防止 backslash/control_character 等白名单原因
+ * 遮蔽同一 key 上的 dot_path_segment 等安全违规。
  */
 const assertAllKeysLegacyRawEligible = (keys: string[]) => {
   for (const key of keys) {
-    try {
-      assertStorageObjectKey(key);
-    } catch (error) {
-      if (!isLegacyStorageKeyError(error)) throw error;
+    const blockingReason = collectStorageObjectKeyViolations(key).find(
+      (reason) => !LEGACY_DELETE_FALLBACK_REASONS.has(reason)
+    );
+    if (blockingReason) {
+      throw new InvalidStorageObjectKeyError({ field: 'key', reason: blockingReason });
     }
   }
 };
@@ -109,9 +112,11 @@ export const executeS3DeleteJob = async ({ prefix, bucketName, key, keys }: S3MQ
           // 只有源 key 本身是 legacy 时才跳过派生前缀删除；
           // 合法 key 的派生前缀超长等问题仍按原有方式抛出，避免静默遗留孤儿对象。
           if (!isLegacyStorageKeyError(error) || !isLegacySourceKey(key)) throw error;
+          // 前缀可能来自文件名/内容片段，只记录 hash 与长度，避免敏感内容进入日志。
           logger.warn('Skip parsed prefix deletion for legacy key', {
             bucketName,
-            prefix: fileParsedPrefix,
+            prefixHash: createHash('sha256').update(fileParsedPrefix).digest('hex').slice(0, 16),
+            prefixLength: fileParsedPrefix.length,
             reason: error.reason
           });
           return undefined;

--- a/packages/service/test/common/s3/deleteQueue.test.ts
+++ b/packages/service/test/common/s3/deleteQueue.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { InvalidStorageObjectKeyError } from '@fastgpt-sdk/storage';
 
 vi.unmock('@fastgpt/service/common/s3/queue/delete');
 
@@ -75,5 +76,56 @@ describe('executeS3DeleteJob', () => {
         keys: ['dataset/team/deleted.txt', 'dataset/team/failed.txt']
       })
     ).rejects.toThrow('Failed to delete 1 S3 object');
+  });
+
+  it('falls back to raw key deletion for legacy keys rejected by validation', async () => {
+    const legacyKey = 'chat/app/legacy\r\nname.svg';
+    const deleteObjectsByMultiKeys = vi.fn().mockRejectedValue(
+      new InvalidStorageObjectKeyError({
+        field: 'keys[0]',
+        reason: 'control_character'
+      })
+    );
+    const deleteObjectsByRawKeys = vi.fn().mockResolvedValue({ keys: [] });
+    const deleteObjectsByPrefix = vi.fn().mockRejectedValue(
+      new InvalidStorageObjectKeyError({
+        field: 'prefix',
+        reason: 'control_character'
+      })
+    );
+
+    global.s3BucketMap = {
+      'fastgpt-private': {
+        client: { deleteObjectsByMultiKeys, deleteObjectsByRawKeys, deleteObjectsByPrefix }
+      }
+    } as any;
+
+    await expect(
+      executeS3DeleteJob({ bucketName: 'fastgpt-private', keys: [legacyKey] })
+    ).resolves.toBeUndefined();
+
+    expect(deleteObjectsByRawKeys).toHaveBeenCalledWith({ keys: [legacyKey] });
+    expect(deleteObjectsByPrefix).toHaveBeenCalled();
+  });
+
+  it('does not bypass validation for non-legacy key errors', async () => {
+    const deleteObjectsByMultiKeys = vi.fn().mockRejectedValue(
+      new InvalidStorageObjectKeyError({
+        field: 'keys[0]',
+        reason: 'dot_path_segment'
+      })
+    );
+    const deleteObjectsByRawKeys = vi.fn();
+
+    global.s3BucketMap = {
+      'fastgpt-private': {
+        client: { deleteObjectsByMultiKeys, deleteObjectsByRawKeys }
+      }
+    } as any;
+
+    await expect(
+      executeS3DeleteJob({ bucketName: 'fastgpt-private', keys: ['../escape.txt'] })
+    ).rejects.toBeInstanceOf(InvalidStorageObjectKeyError);
+    expect(deleteObjectsByRawKeys).not.toHaveBeenCalled();
   });
 });

--- a/packages/service/test/common/s3/deleteQueue.test.ts
+++ b/packages/service/test/common/s3/deleteQueue.test.ts
@@ -157,6 +157,54 @@ describe('executeS3DeleteJob', () => {
     expect(deleteObjectsByRawKeys).not.toHaveBeenCalled();
   });
 
+  it('does not bypass validation when a single key mixes legacy and non-legacy violations', async () => {
+    const deleteObjectsByMultiKeys = vi.fn().mockRejectedValue(
+      new InvalidStorageObjectKeyError({
+        field: 'keys[0]',
+        reason: 'backslash'
+      })
+    );
+    const deleteObjectsByRawKeys = vi.fn();
+
+    global.s3BucketMap = {
+      'fastgpt-private': {
+        client: { deleteObjectsByMultiKeys, deleteObjectsByRawKeys }
+      }
+    } as any;
+
+    await expect(
+      executeS3DeleteJob({ bucketName: 'fastgpt-private', keys: ['chat\\legacy/../escape.txt'] })
+    ).rejects.toMatchObject({
+      name: InvalidStorageObjectKeyError.name,
+      reason: 'dot_path_segment'
+    });
+    expect(deleteObjectsByRawKeys).not.toHaveBeenCalled();
+  });
+
+  it('does not skip parsed-prefix deletion when a legacy source key also violates non-legacy rules', async () => {
+    const key = 'chat\\legacy/../escape.txt';
+    const deleteObjectsByMultiKeys = vi.fn().mockResolvedValue({ keys: [] });
+    const deleteObjectsByPrefix = vi.fn().mockRejectedValue(
+      new InvalidStorageObjectKeyError({
+        field: 'prefix',
+        reason: 'backslash'
+      })
+    );
+
+    global.s3BucketMap = {
+      'fastgpt-private': {
+        client: { deleteObjectsByMultiKeys, deleteObjectsByPrefix }
+      }
+    } as any;
+
+    await expect(
+      executeS3DeleteJob({ bucketName: 'fastgpt-private', keys: [key] })
+    ).rejects.toMatchObject({
+      name: InvalidStorageObjectKeyError.name,
+      reason: 'backslash'
+    });
+  });
+
   it('does not silently skip parsed-prefix deletion for a valid key', async () => {
     const longValidKey = `dataset/team/${'a'.repeat(782)}.txt`;
     const deleteObjectsByMultiKeys = vi.fn().mockResolvedValue({ keys: [] });

--- a/packages/service/test/common/s3/deleteQueue.test.ts
+++ b/packages/service/test/common/s3/deleteQueue.test.ts
@@ -128,4 +128,54 @@ describe('executeS3DeleteJob', () => {
     ).rejects.toBeInstanceOf(InvalidStorageObjectKeyError);
     expect(deleteObjectsByRawKeys).not.toHaveBeenCalled();
   });
+
+  it('rejects a mixed batch instead of bypassing non-legacy validation', async () => {
+    const legacyKey = 'chat/app/legacy\r\nname.svg';
+    const deleteObjectsByMultiKeys = vi.fn().mockRejectedValue(
+      new InvalidStorageObjectKeyError({
+        field: 'keys[0]',
+        reason: 'control_character'
+      })
+    );
+    const deleteObjectsByRawKeys = vi.fn();
+
+    global.s3BucketMap = {
+      'fastgpt-private': {
+        client: { deleteObjectsByMultiKeys, deleteObjectsByRawKeys }
+      }
+    } as any;
+
+    await expect(
+      executeS3DeleteJob({
+        bucketName: 'fastgpt-private',
+        keys: [legacyKey, '../escape.txt']
+      })
+    ).rejects.toMatchObject({
+      name: InvalidStorageObjectKeyError.name,
+      reason: 'dot_path_segment'
+    });
+    expect(deleteObjectsByRawKeys).not.toHaveBeenCalled();
+  });
+
+  it('does not silently skip parsed-prefix deletion for a valid key', async () => {
+    const longValidKey = `dataset/team/${'a'.repeat(782)}.txt`;
+    const deleteObjectsByMultiKeys = vi.fn().mockResolvedValue({ keys: [] });
+    const deleteObjectsByPrefix = vi.fn().mockRejectedValue(
+      new InvalidStorageObjectKeyError({
+        field: 'prefix',
+        reason: 'too_long'
+      })
+    );
+
+    global.s3BucketMap = {
+      'fastgpt-private': {
+        client: { deleteObjectsByMultiKeys, deleteObjectsByPrefix }
+      }
+    } as any;
+
+    await expect(
+      executeS3DeleteJob({ bucketName: 'fastgpt-private', keys: [longValidKey] })
+    ).rejects.toBeInstanceOf(InvalidStorageObjectKeyError);
+    expect(deleteObjectsByPrefix).toHaveBeenCalled();
+  });
 });

--- a/sdk/storage/README.md
+++ b/sdk/storage/README.md
@@ -139,6 +139,7 @@ const storage = createStorage({
 - **`downloadObject({ key })`**: 下载对象（返回 `Readable`）。
 - **`deleteObject({ key })`**: 删除单个对象。
 - **`deleteObjectsByMultiKeys({ keys })`**: 按 key 列表批量删除（返回失败 key 列表）。
+- **`deleteObjectsByRawKeys({ keys })`**: 按 key 列表批量删除**原始遗留 key**（跳过格式断言，仅供删除业务侧已确认存在的历史非规范 key；含 ASCII 控制字符的 key 在 OSS/COS 上走单对象删除，避免 XML 序列化改写 key）。
 - **`deleteObjectsByPrefix({ prefix })`**: 按前缀批量删除（高危，务必使用非空 prefix；返回失败 key 列表）。
 - **`generatePresignedPutUrl({ key, expiredSeconds?, metadata? })`**: 生成 **PUT** 预签名 URL（用于前端直传）。
 - **`generatePresignedGetUrl({ key, expiredSeconds? })`**: 生成 **GET** 预签名 URL（用于临时授权下载）。

--- a/sdk/storage/src/adapters/aws-s3.adapter.ts
+++ b/sdk/storage/src/adapters/aws-s3.adapter.ts
@@ -322,9 +322,15 @@ export class AwsS3StorageAdapter implements IStorage {
   async deleteObjectsByMultiKeys(
     params: Storage.DeleteObjectsParams
   ): Promise<Storage.DeleteObjectsResult> {
-    const { keys } = params;
-    assertStorageObjectKeys(keys);
+    assertStorageObjectKeys(params.keys);
+    return this.deleteObjectsByRawKeys(params);
+  }
 
+  /** legacy 原始 key 直删：跳过格式断言，仅保留分块与失败 key 上报。 */
+  async deleteObjectsByRawKeys(
+    params: Storage.DeleteObjectsParams
+  ): Promise<Storage.DeleteObjectsResult> {
+    const { keys } = params;
     if (keys.length === 0) {
       return {
         bucket: this.options.bucket,

--- a/sdk/storage/src/adapters/cos.adapter.ts
+++ b/sdk/storage/src/adapters/cos.adapter.ts
@@ -414,9 +414,15 @@ export class CosStorageAdapter implements IStorage {
   async deleteObjectsByMultiKeys(
     params: Storage.DeleteObjectsParams
   ): Promise<Storage.DeleteObjectsResult> {
-    const { keys } = params;
-    assertStorageObjectKeys(keys);
+    assertStorageObjectKeys(params.keys);
+    return this.deleteObjectsByRawKeys(params);
+  }
 
+  /** legacy 原始 key 直删：跳过格式断言，仅保留分块与失败 key 上报。 */
+  async deleteObjectsByRawKeys(
+    params: Storage.DeleteObjectsParams
+  ): Promise<Storage.DeleteObjectsResult> {
+    const { keys } = params;
     if (keys.length === 0) {
       return {
         bucket: this.options.bucket,

--- a/sdk/storage/src/adapters/cos.adapter.ts
+++ b/sdk/storage/src/adapters/cos.adapter.ts
@@ -18,6 +18,7 @@ import {
   assertMultipartPartNumber,
   assertMultipartUploadId,
   assertMultipartUploadParts,
+  containsStorageObjectControlCharacter,
   isNoSuchMultipartUploadError
 } from '../assert';
 
@@ -430,9 +431,36 @@ export class CosStorageAdapter implements IStorage {
       };
     }
 
-    // COS 单次 DeleteMultipleObject 最多接受 1000 个对象。
     const failedKeys: Storage.StorageObjectKey[] = [];
-    for (const keyChunk of chunk(keys, 1000)) {
+    // 含 ASCII 控制字符的 key 不能放进 XML 请求体（XML 1.0 会把字面 CR/CRLF 规范化成 LF），
+    // 改走单对象 DELETE：key 经 URL 编码后与对象真实名称一致。
+    const controlCharacterKeys = keys.filter((key) => containsStorageObjectControlCharacter(key));
+    const xmlSafeKeys = keys.filter((key) => !containsStorageObjectControlCharacter(key));
+
+    for (const key of controlCharacterKeys) {
+      try {
+        await new Promise<COS.DeleteObjectResult>((resolve, reject) => {
+          this.client.deleteObject(
+            {
+              Bucket: this.options.bucket,
+              Region: this.options.region,
+              Key: key
+            },
+            (err, data) => {
+              if (err) {
+                return reject(this.handleCosError(err));
+              }
+              resolve(data);
+            }
+          );
+        });
+      } catch {
+        failedKeys.push(key);
+      }
+    }
+
+    // COS 单次 DeleteMultipleObject 最多接受 1000 个对象。
+    for (const keyChunk of chunk(xmlSafeKeys, 1000)) {
       const result = await new Promise<COS.DeleteMultipleObjectResult>((resolve, reject) => {
         this.client.deleteMultipleObject(
           {

--- a/sdk/storage/src/adapters/minio.adapter.ts
+++ b/sdk/storage/src/adapters/minio.adapter.ts
@@ -141,9 +141,15 @@ export class MinioStorageAdapter extends AwsS3StorageAdapter implements IStorage
   async deleteObjectsByMultiKeys(
     params: Storage.DeleteObjectsParams
   ): Promise<Storage.DeleteObjectsResult> {
-    const { keys } = params;
-    assertStorageObjectKeys(keys);
+    assertStorageObjectKeys(params.keys);
+    return this.deleteObjectsByRawKeys(params);
+  }
 
+  /** legacy 原始 key 直删：跳过格式断言，仅保留分块与失败 key 上报。 */
+  async deleteObjectsByRawKeys(
+    params: Storage.DeleteObjectsParams
+  ): Promise<Storage.DeleteObjectsResult> {
+    const { keys } = params;
     if (keys.length === 0) {
       return {
         bucket: this.options.bucket,

--- a/sdk/storage/src/adapters/oss.adapter.ts
+++ b/sdk/storage/src/adapters/oss.adapter.ts
@@ -284,9 +284,15 @@ export class OssStorageAdapter implements IStorage {
   async deleteObjectsByMultiKeys(
     params: Storage.DeleteObjectsParams
   ): Promise<Storage.DeleteObjectsResult> {
-    const { keys } = params;
-    assertStorageObjectKeys(keys);
+    assertStorageObjectKeys(params.keys);
+    return this.deleteObjectsByRawKeys(params);
+  }
 
+  /** legacy 原始 key 直删：跳过格式断言，仅保留分块与失败 key 上报。 */
+  async deleteObjectsByRawKeys(
+    params: Storage.DeleteObjectsParams
+  ): Promise<Storage.DeleteObjectsResult> {
+    const { keys } = params;
     if (keys.length === 0) {
       return {
         bucket: this.options.bucket,

--- a/sdk/storage/src/adapters/oss.adapter.ts
+++ b/sdk/storage/src/adapters/oss.adapter.ts
@@ -18,6 +18,7 @@ import {
   assertMultipartPartNumber,
   assertMultipartUploadId,
   assertMultipartUploadParts,
+  containsStorageObjectControlCharacter,
   isNoSuchMultipartUploadError
 } from '../assert';
 
@@ -300,9 +301,22 @@ export class OssStorageAdapter implements IStorage {
       };
     }
 
-    // OSS 单次 DeleteMultipleObjects 最多接受 1000 个 key；verbose 模式会返回成功删除的 key。
     const failedKeys: Storage.StorageObjectKey[] = [];
-    for (const keyChunk of chunk(keys, 1000)) {
+    // 含 ASCII 控制字符的 key 不能放进 XML 请求体（XML 1.0 会把字面 CR/CRLF 规范化成 LF），
+    // 改走单对象 DELETE：key 经 URL 编码后与对象真实名称一致。
+    const controlCharacterKeys = keys.filter((key) => containsStorageObjectControlCharacter(key));
+    const xmlSafeKeys = keys.filter((key) => !containsStorageObjectControlCharacter(key));
+
+    for (const key of controlCharacterKeys) {
+      try {
+        await this.client.delete(key);
+      } catch {
+        failedKeys.push(key);
+      }
+    }
+
+    // OSS 单次 DeleteMultipleObjects 最多接受 1000 个 key；verbose 模式会返回成功删除的 key。
+    for (const keyChunk of chunk(xmlSafeKeys, 1000)) {
       const result = await this.client.deleteMulti(keyChunk, { quiet: false });
       const deletedKeys = (() => {
         const deletedItems: unknown = result.deleted;

--- a/sdk/storage/src/assert.ts
+++ b/sdk/storage/src/assert.ts
@@ -39,45 +39,55 @@ function isWellFormedUnicode(value: string): boolean {
   return true;
 }
 
-/**
- * 按 SDK 统一规范预检对象 key；失败时不会把原始 key 写入错误消息。
- * 该规范取 AWS S3、MinIO、OSS、COS 可稳定处理范围的交集。
- */
-export function assertStorageObjectKey(value: unknown, field = 'key'): asserts value is string {
-  if (typeof value !== 'string') {
-    throwInvalidStorageObjectKey({ field, reason: 'invalid_type' });
-  }
-  if (value.length === 0) {
-    throwInvalidStorageObjectKey({ field, reason: 'empty' });
-  }
-  if (!isWellFormedUnicode(value)) {
-    throwInvalidStorageObjectKey({ field, reason: 'invalid_unicode' });
-  }
+/** ASCII 控制字符（C0 控制符 + DEL），XML 序列化时无法安全直传。 */
+export const STORAGE_OBJECT_CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/u;
 
-  const actualBytes = Buffer.byteLength(value, 'utf8');
-  if (actualBytes > MAX_STORAGE_OBJECT_KEY_UTF8_BYTES) {
-    throwInvalidStorageObjectKey({ field, reason: 'too_long', actualBytes });
+/** 判断字符串是否包含 ASCII 控制字符。 */
+export const containsStorageObjectControlCharacter = (value: string): boolean =>
+  STORAGE_OBJECT_CONTROL_CHARACTER_PATTERN.test(value);
+
+/**
+ * 收集对象 key 的全部格式违规原因（按 SDK 统一规范的固定顺序）。
+ * 返回空数组表示 key 完全合规；`invalid_type`/`empty`/`invalid_unicode`
+ * 属于不可继续度量的基础违规，命中后立即返回。
+ * 用于需要判断"是否只存在白名单内违规"等聚合场景，避免首个违规遮蔽后续原因。
+ */
+export function collectStorageObjectKeyViolations(value: unknown): InvalidStorageObjectKeyReason[] {
+  if (typeof value !== 'string') return ['invalid_type'];
+  if (value.length === 0) return ['empty'];
+  if (!isWellFormedUnicode(value)) return ['invalid_unicode'];
+
+  const reasons: InvalidStorageObjectKeyReason[] = [];
+  if (Buffer.byteLength(value, 'utf8') > MAX_STORAGE_OBJECT_KEY_UTF8_BYTES) {
+    reasons.push('too_long');
   }
-  if (value.startsWith('/')) {
-    throwInvalidStorageObjectKey({ field, reason: 'leading_slash' });
-  }
-  if (value.includes('\\')) {
-    throwInvalidStorageObjectKey({ field, reason: 'backslash' });
-  }
-  if (value.includes('//')) {
-    throwInvalidStorageObjectKey({ field, reason: 'empty_path_segment' });
-  }
-  if (/[\u0000-\u001f\u007f]/u.test(value)) {
-    throwInvalidStorageObjectKey({ field, reason: 'control_character' });
-  }
+  if (value.startsWith('/')) reasons.push('leading_slash');
+  if (value.includes('\\')) reasons.push('backslash');
+  if (value.includes('//')) reasons.push('empty_path_segment');
+  if (containsStorageObjectControlCharacter(value)) reasons.push('control_character');
   if (
     value.split('/').some((segment) => {
       const trimmedSegment = segment.trim();
       return trimmedSegment === '.' || trimmedSegment === '..';
     })
   ) {
-    throwInvalidStorageObjectKey({ field, reason: 'dot_path_segment' });
+    reasons.push('dot_path_segment');
   }
+  return reasons;
+}
+
+/**
+ * 按 SDK 统一规范预检对象 key；失败时不会把原始 key 写入错误消息。
+ * 该规范取 AWS S3、MinIO、OSS、COS 可稳定处理范围的交集。
+ */
+export function assertStorageObjectKey(value: unknown, field = 'key'): asserts value is string {
+  const reason = collectStorageObjectKeyViolations(value)[0];
+  if (reason === undefined) return;
+  throwInvalidStorageObjectKey({
+    field,
+    reason,
+    actualBytes: reason === 'too_long' ? Buffer.byteLength(value as string, 'utf8') : undefined
+  });
 }
 
 /** 批量方法必须完整预检数组后，调用方才能开始分块或产生远端副作用。 */

--- a/sdk/storage/src/helper/mock.ts
+++ b/sdk/storage/src/helper/mock.ts
@@ -245,6 +245,13 @@ export function createVitestStorageMock(params: CreateVitestStorageMockParams): 
     }
   );
 
+  const deleteObjectsByRawKeys = vi.fn(
+    async (p: Storage.DeleteObjectsParams): Promise<Storage.DeleteObjectsResult> => {
+      for (const key of p.keys) objects.delete(key);
+      return { bucket: bucketName, keys: [] };
+    }
+  );
+
   const deleteObjectsByPrefix = vi.fn(
     async (p: Storage.DeleteObjectsByPrefixParams): Promise<Storage.DeleteObjectsResult> => {
       assertRequiredStorageObjectPrefix(p.prefix);
@@ -342,6 +349,7 @@ export function createVitestStorageMock(params: CreateVitestStorageMockParams): 
     downloadObject,
     deleteObject,
     deleteObjectsByMultiKeys,
+    deleteObjectsByRawKeys,
     deleteObjectsByPrefix,
     generatePresignedPutUrl,
     generatePresignedGetUrl,

--- a/sdk/storage/src/index.ts
+++ b/sdk/storage/src/index.ts
@@ -57,7 +57,9 @@ export {
   assertStorageObjectKey,
   assertStorageObjectKeys,
   assertStorageObjectPrefix,
-  isNoSuchMultipartUploadError
+  isNoSuchMultipartUploadError,
+  containsStorageObjectControlCharacter,
+  collectStorageObjectKeyViolations
 } from './assert';
 export { AwsS3StorageAdapter } from './adapters/aws-s3.adapter';
 export { R2StorageAdapter } from './adapters/r2.adapter';

--- a/sdk/storage/src/interface.ts
+++ b/sdk/storage/src/interface.ts
@@ -340,6 +340,20 @@ export interface IStorage {
   ): Promise<Storage.DeleteObjectsResult>;
 
   /**
+   * 根据多个 key 批量删除对象（legacy 原始 key 直删通道）。
+   *
+   * 与 `deleteObjectsByMultiKeys` 的远端行为一致（按厂商限制分批、回传失败 key），
+   * 但**不执行对象 key 格式断言**，只用于删除历史遗留的非规范 key
+   * （例如文件名包含 ASCII 控制字符或反斜线的旧聊天文件）。
+   *
+   * 安全约束：
+   * - 只允许删除业务侧已确认存在的精确对象 key，不要用于删除可受外部输入影响的 key。
+   * - keys 为空数组时直接返回成功，保持幂等。
+   * - 前缀删除（`deleteObjectsByPrefix`）不受影响，仍强制非空前缀校验。
+   */
+  deleteObjectsByRawKeys(params: Storage.DeleteObjectsParams): Promise<Storage.DeleteObjectsResult>;
+
+  /**
    * 根据前缀批量删除对象（危险操作）。
    *
    * 安全建议：

--- a/sdk/storage/test/unit/adapters/aws-s3.adapter.test.ts
+++ b/sdk/storage/test/unit/adapters/aws-s3.adapter.test.ts
@@ -371,6 +371,39 @@ describe('AwsS3StorageAdapter.deleteObjectsByPrefix', () => {
   });
 });
 
+describe('AwsS3StorageAdapter.deleteObjectsByRawKeys', () => {
+  it('passes legacy keys through to S3 unchanged', async () => {
+    const adapter = createAdapter();
+    const legacyKey = 'chat/app/legacy\r\nname.svg';
+    const send = vi.fn().mockResolvedValue({ Errors: [] });
+    (adapter as any).client.send = send;
+
+    await expect(adapter.deleteObjectsByRawKeys({ keys: [legacyKey] })).resolves.toEqual({
+      bucket: 'fastgpt-private',
+      keys: []
+    });
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: {
+          Bucket: 'fastgpt-private',
+          Delete: { Objects: [{ Key: legacyKey }], Quiet: true }
+        }
+      })
+    );
+  });
+
+  it('still rejects control-character keys through the validated path', async () => {
+    const adapter = createAdapter();
+    const send = vi.fn();
+    (adapter as any).client.send = send;
+
+    await expect(
+      adapter.deleteObjectsByMultiKeys({ keys: ['chat/app/legacy\r\nname.svg'] })
+    ).rejects.toThrow('must not contain ASCII control characters');
+    expect(send).not.toHaveBeenCalled();
+  });
+});
+
 describe('AwsS3StorageAdapter.generatePublicGetUrl', () => {
   it.each([
     [

--- a/sdk/storage/test/unit/adapters/cos.adapter.test.ts
+++ b/sdk/storage/test/unit/adapters/cos.adapter.test.ts
@@ -317,6 +317,57 @@ describe('CosStorageAdapter deletion boundaries', () => {
   });
 });
 
+describe('CosStorageAdapter.deleteObjectsByRawKeys', () => {
+  it('routes control-character keys through single-object delete and the rest through XML batch delete', async () => {
+    const adapter = createAdapter();
+    const deleteObject = vi.fn().mockImplementation((_params, callback) => callback(null, {}));
+    const deleteMultipleObject = vi.fn().mockImplementation((params, callback) => {
+      callback(null, { Error: [], Deleted: params.Objects });
+    });
+    Object.assign((adapter as any).client, { deleteObject, deleteMultipleObject });
+
+    const legacyKey = 'chat/app/legacy\r\nname.svg';
+    const safeKey = 'dataset/team/file.txt';
+
+    await expect(adapter.deleteObjectsByRawKeys({ keys: [legacyKey, safeKey] })).resolves.toEqual({
+      bucket: 'fastgpt-private',
+      keys: []
+    });
+
+    expect(deleteObject).toHaveBeenCalledTimes(1);
+    expect(deleteObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Bucket: 'fastgpt-private',
+        Region: 'ap-guangzhou',
+        Key: legacyKey
+      }),
+      expect.any(Function)
+    );
+    expect(deleteMultipleObject).toHaveBeenCalledTimes(1);
+    expect(deleteMultipleObject).toHaveBeenCalledWith(
+      expect.objectContaining({ Objects: [{ Key: safeKey }] }),
+      expect.any(Function)
+    );
+  });
+
+  it('reports control-character keys whose single-object delete fails', async () => {
+    const adapter = createAdapter();
+    const deleteObject = vi
+      .fn()
+      .mockImplementation((_params, callback) => callback(new Error('delete denied')));
+    const deleteMultipleObject = vi.fn();
+    Object.assign((adapter as any).client, { deleteObject, deleteMultipleObject });
+
+    const legacyKey = 'chat/app/legacy\r\nname.svg';
+    await expect(adapter.deleteObjectsByRawKeys({ keys: [legacyKey] })).resolves.toEqual({
+      bucket: 'fastgpt-private',
+      keys: [legacyKey]
+    });
+    expect(deleteObject).toHaveBeenCalledTimes(1);
+    expect(deleteMultipleObject).not.toHaveBeenCalled();
+  });
+});
+
 describe('CosStorageAdapter.generatePublicGetUrl', () => {
   it.each([
     [undefined, 'https://fastgpt-private.cos.ap-guangzhou.myqcloud.com/folder%20%23/file%2B.txt'],

--- a/sdk/storage/test/unit/adapters/oss.adapter.test.ts
+++ b/sdk/storage/test/unit/adapters/oss.adapter.test.ts
@@ -270,6 +270,43 @@ describe('OssStorageAdapter deletion boundaries', () => {
   });
 });
 
+describe('OssStorageAdapter.deleteObjectsByRawKeys', () => {
+  it('routes control-character keys through single-object delete and the rest through XML batch delete', async () => {
+    const adapter = createAdapter();
+    const deleteObject = vi.fn().mockResolvedValue({});
+    const deleteMulti = vi.fn().mockResolvedValue({ deleted: ['dataset/team/file.txt'] });
+    Object.assign((adapter as any).client, { delete: deleteObject, deleteMulti });
+
+    const legacyKey = 'chat/app/legacy\r\nname.svg';
+    const safeKey = 'dataset/team/file.txt';
+
+    await expect(adapter.deleteObjectsByRawKeys({ keys: [legacyKey, safeKey] })).resolves.toEqual({
+      bucket: 'fastgpt-private',
+      keys: []
+    });
+
+    expect(deleteObject).toHaveBeenCalledTimes(1);
+    expect(deleteObject).toHaveBeenCalledWith(legacyKey);
+    expect(deleteMulti).toHaveBeenCalledTimes(1);
+    expect(deleteMulti).toHaveBeenCalledWith([safeKey], { quiet: false });
+  });
+
+  it('reports control-character keys whose single-object delete fails', async () => {
+    const adapter = createAdapter();
+    const deleteObject = vi.fn().mockRejectedValue(new Error('delete denied'));
+    const deleteMulti = vi.fn();
+    Object.assign((adapter as any).client, { delete: deleteObject, deleteMulti });
+
+    const legacyKey = 'chat/app/legacy\r\nname.svg';
+    await expect(adapter.deleteObjectsByRawKeys({ keys: [legacyKey] })).resolves.toEqual({
+      bucket: 'fastgpt-private',
+      keys: [legacyKey]
+    });
+    expect(deleteObject).toHaveBeenCalledTimes(1);
+    expect(deleteMulti).not.toHaveBeenCalled();
+  });
+});
+
 describe('OssStorageAdapter.generatePublicGetUrl', () => {
   it.each([
     [

--- a/sdk/storage/test/unit/assert.contract.test.ts
+++ b/sdk/storage/test/unit/assert.contract.test.ts
@@ -201,3 +201,36 @@ describe('IStorage object key preflight contract', () => {
     }
   );
 });
+
+describe('IStorage raw key deletion contract', () => {
+  it.each([
+    ['AWS S3', createAwsStorage],
+    ['MinIO', createMinioStorage],
+    ['OSS', createOssStorage],
+    ['COS', createCosStorage]
+  ] as const)(
+    '%s dispatches deleteObjectsByRawKeys without key preflight',
+    async (_, createStorage) => {
+      const { storage, remoteCall } = createStorage();
+      const legacyKey = 'chat/app/legacy\r\nname.svg';
+
+      // 各厂商 remote mock 被调用时直接抛错，证明 raw 通道确实绕过了格式断言并触达远端。
+      await expect(storage.deleteObjectsByRawKeys({ keys: [legacyKey] })).rejects.toThrow(
+        'Object key was not validated before the remote SDK call'
+      );
+      expect(remoteCall).toHaveBeenCalled();
+    }
+  );
+
+  it('Vitest mock deletes raw legacy keys without validation', async () => {
+    const storage = createVitestStorageMock({ vi, bucketName: 'test-bucket' });
+    const legacyKey = 'chat/app/legacy\r\nname.svg';
+    storage.__putObject(legacyKey, { body: Buffer.from('svg') });
+
+    await expect(storage.deleteObjectsByRawKeys({ keys: [legacyKey] })).resolves.toEqual({
+      bucket: 'test-bucket',
+      keys: []
+    });
+    expect(storage.__objects.has(legacyKey)).toBe(false);
+  });
+});

--- a/sdk/storage/test/unit/assert.contract.test.ts
+++ b/sdk/storage/test/unit/assert.contract.test.ts
@@ -205,20 +205,36 @@ describe('IStorage object key preflight contract', () => {
 describe('IStorage raw key deletion contract', () => {
   it.each([
     ['AWS S3', createAwsStorage],
-    ['MinIO', createMinioStorage],
-    ['OSS', createOssStorage],
-    ['COS', createCosStorage]
+    ['MinIO', createMinioStorage]
   ] as const)(
     '%s dispatches deleteObjectsByRawKeys without key preflight',
     async (_, createStorage) => {
       const { storage, remoteCall } = createStorage();
       const legacyKey = 'chat/app/legacy\r\nname.svg';
 
-      // 各厂商 remote mock 被调用时直接抛错，证明 raw 通道确实绕过了格式断言并触达远端。
+      // remote mock 被调用时直接抛错，证明 raw 通道确实绕过了格式断言并触达远端。
       await expect(storage.deleteObjectsByRawKeys({ keys: [legacyKey] })).rejects.toThrow(
         'Object key was not validated before the remote SDK call'
       );
       expect(remoteCall).toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    ['OSS', createOssStorage],
+    ['COS', createCosStorage]
+  ] as const)(
+    '%s dispatches raw control-character keys through single-object delete and reports failures',
+    async (_, createStorage) => {
+      const { storage, remoteCall } = createStorage();
+      const legacyKey = 'chat/app/legacy\r\nname.svg';
+
+      // 含控制字符的 key 走单对象 DELETE（URL 路径）；remote mock 抛错时收集为失败 key，不抛出。
+      await expect(storage.deleteObjectsByRawKeys({ keys: [legacyKey] })).resolves.toEqual({
+        bucket: 'test-bucket',
+        keys: [legacyKey]
+      });
+      expect(remoteCall).toHaveBeenCalledTimes(1);
     }
   );
 
@@ -232,5 +248,32 @@ describe('IStorage raw key deletion contract', () => {
       keys: []
     });
     expect(storage.__objects.has(legacyKey)).toBe(false);
+  });
+
+  it('OSS routes raw control-character keys through the single-object delete URL path', async () => {
+    const { storage, remoteCall } = createOssStorage();
+    const legacyKey = 'chat/app/legacy\r\nname.svg';
+
+    await expect(storage.deleteObjectsByRawKeys({ keys: [legacyKey] })).resolves.toEqual({
+      bucket: 'test-bucket',
+      keys: [legacyKey]
+    });
+    expect(remoteCall).toHaveBeenCalledTimes(1);
+    expect(remoteCall).toHaveBeenCalledWith(legacyKey);
+  });
+
+  it('COS routes raw control-character keys through the single-object delete URL path', async () => {
+    const { storage, remoteCall } = createCosStorage();
+    const legacyKey = 'chat/app/legacy\r\nname.svg';
+
+    await expect(storage.deleteObjectsByRawKeys({ keys: [legacyKey] })).resolves.toEqual({
+      bucket: 'test-bucket',
+      keys: [legacyKey]
+    });
+    expect(remoteCall).toHaveBeenCalledTimes(1);
+    expect(remoteCall).toHaveBeenCalledWith(
+      expect.objectContaining({ Bucket: 'test-bucket', Region: 'ap-guangzhou', Key: legacyKey }),
+      expect.any(Function)
+    );
   });
 });

--- a/sdk/storage/test/unit/assert.test.ts
+++ b/sdk/storage/test/unit/assert.test.ts
@@ -5,7 +5,8 @@ import {
   assertRequiredStorageObjectPrefix,
   assertStorageObjectKey,
   assertStorageObjectKeys,
-  assertStorageObjectPrefix
+  assertStorageObjectPrefix,
+  collectStorageObjectKeyViolations
 } from '../../src/assert';
 
 const expectInvalidKey = ({
@@ -140,5 +141,38 @@ describe('storage object key validation', () => {
 
   it('accepts a valid required delete prefix', () => {
     expect(() => assertRequiredStorageObjectPrefix('team/files/')).not.toThrow();
+  });
+});
+
+describe('collectStorageObjectKeyViolations', () => {
+  it('returns an empty list for a valid key', () => {
+    expect(collectStorageObjectKeyViolations('dataset/team/file.txt')).toEqual([]);
+  });
+
+  it('collects every violation instead of stopping at the first reason', () => {
+    expect(collectStorageObjectKeyViolations('chat\\legacy/../escape.txt')).toEqual([
+      'backslash',
+      'dot_path_segment'
+    ]);
+  });
+
+  it('keeps assertStorageObjectKey throwing the first violation in fixed order', () => {
+    expect(() => assertStorageObjectKey('chat\\legacy/../escape.txt')).toThrowError(
+      expect.objectContaining({ reason: 'backslash' })
+    );
+  });
+
+  it('returns only the base violation for non-string, empty and malformed unicode keys', () => {
+    expect(collectStorageObjectKeyViolations(123)).toEqual(['invalid_type']);
+    expect(collectStorageObjectKeyViolations('')).toEqual(['empty']);
+    expect(collectStorageObjectKeyViolations('bad\ud800key')).toEqual(['invalid_unicode']);
+  });
+
+  it('collects control characters together with later path segment violations', () => {
+    expect(collectStorageObjectKeyViolations('chat\\legacy/\r\n../escape.txt')).toEqual([
+      'backslash',
+      'control_character',
+      'dot_path_segment'
+    ]);
   });
 });


### PR DESCRIPTION
## 背景

旧版本聊天文件的对象 key 可能包含 ASCII 控制字符（如 `\r\n`）等非规范字符（文件名由内容片段生成）。新增的存储 SDK 在删除前执行 `assertStorageObjectKey` 格式断言，会直接拒绝这类 key，导致：

- 定时清理任务（`executeS3DeleteJob`）失败并停留在 BullMQ failed 队列；
- 对象永久残留，且 key 中携带的对话内容片段无法清理。

## 改动

- SDK 新增 `deleteObjectsByRawKeys`：与 `deleteObjectsByMultiKeys` 远端行为一致（1000 分块、失败 key 上报），但跳过 key 格式断言，仅供删除业务侧已确认存在的历史非规范 key；`deleteObjectsByMultiKeys` 保持先断言再委托。
- 删除 worker 降级：`deleteObjectsByMultiKeys` 抛出 legacy 断言错误（白名单：`control_character` / `backslash` / `too_long`）时，自动降级为原始 key 直删；其余断言原因视为安全风险不绕过。
- legacy key 派生的 `-parsed` 前缀删除无法通过校验时跳过，不再导致任务失败。
- 前缀删除（`deleteObjectsByPrefix`）仍保留非空前缀校验；上传路径仍通过 `encodeS3ObjectKey` 校验，新数据不会产生此类 key。

## 测试

- SDK：`assert.contract.test.ts` 新增 raw 通道契约测试（4 个 adapter + mock），`aws-s3.adapter.test.ts` 验证 legacy key 原样透传、校验路径仍拒绝。
- service：`deleteQueue.test.ts` 新增降级成功与非 legacy 错误不绕过用例。
- 验证：SDK 单测 230 个通过；service s3 相关 20 个文件 274 个用例通过；service 全量 316 个文件 3811 个用例通过。

## 已知限制

- legacy 源 key 派生的 `-parsed` 前缀删除无法通过校验时会跳过（避免删除任务整体失败），该派生对象可能残留；其前缀本身含控制字符，即使改为 raw 前缀删除，在 OSS/COS 上同样受 XML 规范化问题影响，后续单独跟进。