### PR TITLE
fix(workflow): preserve explicit external variable input modes

### DIFF
--- a/packages/global/core/workflow/utils.ts
+++ b/packages/global/core/workflow/utils.ts
@@ -422,6 +422,7 @@ const agentGeneratedExternalVariableValueTypes = new Set<WorkflowIOValueTypeEnum
 /**
  * 将子工作流外部变量投影为父工作流可配置的节点输入。
  * customVariable 只描述子工作流的外部注入语义；进入父工作流后由引用或类型匹配的手动控件提供值。
+ * 已保存且投影后仍有效的输入方式必须保留，只有未选择或仍为 customVariable 时才应用 Agent 默认值。
  */
 export const projectExternalVariableInput = <T extends FlowNodeInputItemType>(input: T): T => {
   const isExternalVariable =
@@ -469,10 +470,14 @@ export const projectExternalVariableInput = <T extends FlowNodeInputItemType>(in
   if (!projectedRenderTypeList.includes(manualRenderType)) {
     projectedRenderTypeList.push(manualRenderType);
   }
-  const selectedType = canAgentGenerated
-    ? FlowNodeInputTypeEnum.agentGenerated
-    : input.selectedType && projectedRenderTypeList.includes(input.selectedType)
-      ? input.selectedType
+  const hasExplicitProjectedSelection =
+    input.selectedType !== undefined &&
+    input.selectedType !== FlowNodeInputTypeEnum.customVariable &&
+    projectedRenderTypeList.includes(input.selectedType);
+  const selectedType = hasExplicitProjectedSelection
+    ? input.selectedType
+    : canAgentGenerated
+      ? FlowNodeInputTypeEnum.agentGenerated
       : FlowNodeInputTypeEnum.reference;
   const projectedInput = {
     ...input,

--- a/packages/global/test/core/app/tool/type.test.ts
+++ b/packages/global/test/core/app/tool/type.test.ts
@@ -31,6 +31,23 @@ describe('AgentToolSchema', () => {
     expect(result.inputs).toEqual([{ key: 'query', mode: AgentToolInputModeEnum.agentGenerated }]);
   });
 
+  it('preserves a transitional manual workflow input snapshot', () => {
+    const result = AgentToolSchema.parse({
+      id: 'workflow-tool',
+      inputs: [
+        {
+          key: 'query',
+          renderTypeList: [FlowNodeInputTypeEnum.input, FlowNodeInputTypeEnum.agentGenerated],
+          selectedTypeIndex: 0,
+          toolDescription: 'Search query'
+        }
+      ],
+      config: { query: 'fixed query' }
+    });
+
+    expect(result.inputs).toEqual([{ key: 'query', mode: AgentToolInputModeEnum.manual }]);
+  });
+
   it('preserves missing inputs as the legacy Agent marker', () => {
     const result = AgentToolSchema.parse({
       id: 'systemTool-search',

--- a/packages/global/test/core/workflow/utils.test.ts
+++ b/packages/global/test/core/workflow/utils.test.ts
@@ -162,6 +162,41 @@ describe('projectExternalVariableInput', () => {
     expect(result.selectedType).toBe(FlowNodeInputTypeEnum.agentGenerated);
   });
 
+  it.each([FlowNodeInputTypeEnum.reference, FlowNodeInputTypeEnum.input])(
+    'should preserve an explicit %s selection when projecting an external variable',
+    (selectedType) => {
+      const result = projectExternalVariableInput({
+        key: 'externalVariable',
+        label: 'External variable',
+        valueType: WorkflowIOValueTypeEnum.string,
+        renderTypeList: [
+          FlowNodeInputTypeEnum.customVariable,
+          FlowNodeInputTypeEnum.reference,
+          FlowNodeInputTypeEnum.input
+        ],
+        selectedType
+      });
+
+      expect(result.renderTypeList).toEqual([
+        FlowNodeInputTypeEnum.agentGenerated,
+        FlowNodeInputTypeEnum.reference,
+        FlowNodeInputTypeEnum.input
+      ]);
+      expect(result.selectedType).toBe(selectedType);
+    }
+  );
+
+  it('should default a projected external variable without a saved selection to AI generation', () => {
+    const result = projectExternalVariableInput({
+      key: 'externalVariable',
+      label: 'External variable',
+      valueType: WorkflowIOValueTypeEnum.string,
+      renderTypeList: [FlowNodeInputTypeEnum.customVariable]
+    });
+
+    expect(result.selectedType).toBe(FlowNodeInputTypeEnum.agentGenerated);
+  });
+
   it('should keep complex external variables manual-only', () => {
     const result = projectExternalVariableInput({
       key: 'externalVariable',

--- a/projects/app/test/service/core/app/rewriteAppWorkflowToDetail.test.ts
+++ b/projects/app/test/service/core/app/rewriteAppWorkflowToDetail.test.ts
@@ -296,6 +296,75 @@ describe('rewriteAppWorkflowToDetail - legacy workflow tool inputs', () => {
     expect(nodes[0].inputs[0]).not.toHaveProperty('selectedTypeIndex');
   });
 
+  it.each([FlowNodeInputTypeEnum.reference, FlowNodeInputTypeEnum.input])(
+    '投影外部变量时保留旧节点显式选择的 %s 类型',
+    async (selectedType) => {
+      const toolAppId = '507f1f77bcf86cd799439011';
+      getClientToolPreviewNodeMock.mockResolvedValue({
+        id: toolAppId,
+        pluginId: toolAppId,
+        flowNodeType: FlowNodeTypeEnum.pluginModule,
+        name: 'Workflow tool',
+        avatar: '',
+        intro: '',
+        inputs: [
+          {
+            key: 'externalVariable',
+            label: 'External variable',
+            valueType: WorkflowIOValueTypeEnum.string,
+            renderTypeList: [FlowNodeInputTypeEnum.customVariable]
+          }
+        ],
+        outputs: [],
+        version: '',
+        isLatestVersion: true
+      });
+      authAppByTmbIdMock.mockResolvedValue({});
+      const nodes = [
+        {
+          nodeId: 'workflow-tool',
+          flowNodeType: FlowNodeTypeEnum.pluginModule,
+          pluginId: toolAppId,
+          version: '',
+          inputs: [
+            {
+              key: 'externalVariable',
+              label: 'External variable',
+              valueType: WorkflowIOValueTypeEnum.string,
+              value:
+                selectedType === FlowNodeInputTypeEnum.reference
+                  ? ['workflowStart', 'userChatInput']
+                  : 'fixed value',
+              renderTypeList: [
+                FlowNodeInputTypeEnum.customVariable,
+                FlowNodeInputTypeEnum.reference,
+                FlowNodeInputTypeEnum.input
+              ],
+              selectedType
+            }
+          ],
+          outputs: []
+        } as StoreNodeItemType
+      ];
+
+      await rewriteAppWorkflowToDetail({
+        nodes,
+        teamId: 'team-1',
+        ownerTmbId: 'tmb-1',
+        isRoot: false
+      });
+
+      expect(nodes[0].inputs[0]).toMatchObject({
+        renderTypeList: [
+          FlowNodeInputTypeEnum.agentGenerated,
+          FlowNodeInputTypeEnum.reference,
+          FlowNodeInputTypeEnum.input
+        ],
+        selectedType
+      });
+    }
+  );
+
   it.each([
     ['工作流工具', FlowNodeTypeEnum.pluginModule],
     ['嵌套工作流', FlowNodeTypeEnum.appModule]


### PR DESCRIPTION
## What changed

- Preserve an explicit projected input mode when converting workflow external variables for parent workflows.
- Apply the Agent-generated default only when no mode is saved, the saved mode is still `customVariable`, or the saved mode is no longer valid after projection.
- Add regression coverage for manual/reference workflow inputs and transitional Agent tool snapshots.

## Root cause

`rewriteAppWorkflowToDetail` normalizes legacy `selectedTypeIndex` values into `selectedType` before calling `projectExternalVariableInput`. However, the projection function ignored that normalized explicit selection and unconditionally selected `agentGenerated` for every supported primitive external variable. Loading an existing workflow could therefore turn a fixed or referenced parameter into a model-generated parameter.

## Impact

Existing workflow tool nodes keep their saved manual or reference behavior after upgrade. Newly projected inputs and legacy inputs that still select `customVariable` continue to use the Agent-generated default for supported value types.

## Validation

- `pnpm --filter @fastgpt/global test test/core/workflow/utils.test.ts test/core/app/tool/type.test.ts` (132 tests passed)
- `pnpm --filter @fastgpt/app exec vitest run -c vitest.config.ts test/service/core/app/rewriteAppWorkflowToDetail.test.ts` (26 tests passed)
- ESLint, Prettier check, and `git diff --check` passed.

Full workspace tests were also attempted. Relevant suites passed, but the run was interrupted after unrelated dataset tests timed out/faulted under the shared Mongo test run.
