### PR TITLE
fix(docs): handle missing static assets correctly

### DIFF
--- a/document/app/[lang]/layout.tsx
+++ b/document/app/[lang]/layout.tsx
@@ -5,7 +5,9 @@ import type { Translations } from 'fumadocs-ui/i18n';
 import CustomSearchDialog from '@/components/CustomSearchDialog';
 import Script from 'next/script';
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import { getFastGPTDocsOrigin } from '@/lib/fastgpt-home-url';
+import { i18n } from '@/lib/i18n';
 
 const zh_CN: Partial<Translations> = {
   search: '搜索',
@@ -47,6 +49,8 @@ export async function generateMetadata({
   params: Promise<{ lang: string }>;
 }): Promise<Metadata> {
   const { lang } = await params;
+  if (!i18n.languages.includes(lang)) notFound();
+
   const domain = getFastGPTDocsOrigin();
 
   const title = lang === 'zh-CN' ? 'FastGPT 文档 - 快速开始' : 'FastGPT Documentation - Getting Started';
@@ -130,6 +134,7 @@ export default async function Layout({
   params: Promise<{ lang: string }>;
 }) {
   const { lang } = await params;
+  if (!i18n.languages.includes(lang)) notFound();
 
   // Get tracking config from env (site ID is injected per-build by CI)
   const trackSrc = process.env.NEXT_PUBLIC_DOC_TRACK_SRC;

--- a/document/middleware.ts
+++ b/document/middleware.ts
@@ -182,6 +182,6 @@ export default function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    '/((?!api|_next/static|_next/image|favicon.ico|robots\\.txt|sitemap.*\\.xml|.*\\.svg|.*\\.png|deploy/.*).*)'
+    '/((?!api|_next/static|_next/image|favicon(?:\\.ico|/)|robots\\.txt|sitemap.*\\.xml|.*\\.svg|.*\\.png|deploy/.*).*)'
   ]
 };


### PR DESCRIPTION
## What changed

- Reject unsupported locale segments in the root documentation layout so missing static assets resolve to 404 instead of rendering a localized HTML page.
- Exclude the full `/favicon/` directory from locale middleware handling so the web manifest is served directly.

## Root cause

Missing `/_next/static` files could fall through to the dynamic `[lang]` route, where `_next` was accepted as a locale and rendered as HTML with a long cache lifetime. When that HTML was cached under a JavaScript chunk URL, browsers failed with `Unexpected token <` and `ChunkLoadError`. The manifest path was also redirected through locale middleware and returned HTML.

## Impact

- Missing chunk requests now return a real 404 instead of cacheable document HTML.
- `/favicon/site.webmanifest` returns the manifest directly without a locale redirect.

## Validation

- `pnpm build` in `document/`
- Local production server: valid documentation page returned 200.
- Local production server: `/favicon/site.webmanifest` returned `200 application/manifest+json`.
- Local production server: a nonexistent chunk returned 404.
