### PR TITLE
fix: do not treat reasoning-only tool_calls finish as empty response

### DIFF
--- a/packages/service/core/ai/llm/request/createLLMResponse.ts
+++ b/packages/service/core/ai/llm/request/createLLMResponse.ts
@@ -214,6 +214,7 @@ export const createLLMResponse = async <T extends ChatCompletionCreateParams>(
     const isEmptyToolCallsFinish = finish_reason === 'tool_calls' && !toolCalls?.length;
     const isNotResponse =
       !answerText &&
+      !reasoningText &&
       !toolCalls?.length &&
       !error &&
       (finish_reason === 'stop' || !finish_reason || isEmptyToolCallsFinish);

--- a/packages/service/test/core/ai/llm/request/createLLMResponse.test.ts
+++ b/packages/service/test/core/ai/llm/request/createLLMResponse.test.ts
@@ -1243,6 +1243,69 @@ describe('createLLMResponse', () => {
       );
     });
 
+    it('should not treat reasoning-only tool_calls finish as empty response', async () => {
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: null,
+              reasoning_content: 'I already have enough context to answer.',
+              tool_calls: []
+            },
+            finish_reason: 'tool_calls'
+          }
+        ],
+        usage: {
+          prompt_tokens: 20,
+          completion_tokens: 12,
+          total_tokens: 32
+        }
+      };
+
+      const mockAI = {
+        chat: {
+          completions: {
+            create: vi.fn().mockResolvedValue(mockResponse)
+          }
+        }
+      };
+      mockGetAIApi.mockReturnValue(createMockAIApiResult(mockAI));
+
+      const result = await createLLMResponse({
+        body: {
+          model: 'gpt-4',
+          messages: [
+            {
+              role: ChatCompletionRequestMessageRoleEnum.User,
+              content: "What's the weather in Beijing?"
+            }
+          ],
+          tools: [
+            {
+              type: 'function' as const,
+              function: {
+                name: 'get_weather',
+                description: 'Get weather information',
+                parameters: {
+                  type: 'object',
+                  properties: {
+                    location: { type: 'string' }
+                  }
+                }
+              }
+            }
+          ],
+          stream: false
+        }
+      });
+
+      expect(result.finish_reason).toBe('tool_calls');
+      expect(result.responseEmptyTip).toBeUndefined();
+      expect(result.reasoningText).toBe('I already have enough context to answer.');
+      expect(result.error).toBeUndefined();
+    });
+
     it('should handle stream tool call response', async () => {
       const chunks = [
         {


### PR DESCRIPTION
## Summary
- After `tool_choice: none`, some reasoning models still return `finish_reason: tool_calls` with empty `tool_calls` and empty `answerText`, but non-empty `reasoningText`. That was classified as `chat:LLM_model_response_empty` even though `hasResponse` already counted reasoning.
- Treat non-empty `reasoningText` as a real response, matching the existing finish-reason normalization.

Fixes https://github.com/labring/FastGPT/issues/7339

## Test plan
- [ ] `pnpm --filter @fastgpt/service test -- createLLMResponse.test.ts`
- [ ] Agent loop: after 5+ tool calls, a reasoning-only forced-finish turn should not surface `LLM_model_response_empty`

Made with [Cursor](https://cursor.com)