### PR TITLE
perf: publish multi-arch images directly to aliyun

### DIFF
--- a/.forgejo/workflows/build-agent-sandbox.yml
+++ b/.forgejo/workflows/build-agent-sandbox.yml
@@ -38,6 +38,7 @@ jobs:
           - arch: arm64
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -146,6 +147,7 @@ jobs:
       contents: read
     needs: [validate-version, build-fastgpt-agent-sandbox-images]
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Capture proxy envs from variables
         run: |
@@ -203,7 +205,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: |
-            network=host
             env.GODEBUG=madvdontneed=0
             env.HTTP_PROXY=${{ env.HTTP_PROXY }}
             env.HTTPS_PROXY=${{ env.HTTPS_PROXY }}
@@ -259,6 +260,7 @@ jobs:
           - arch: arm64
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -368,6 +370,7 @@ jobs:
       contents: read
     needs: [validate-version, build-fastgpt-volume-manager-images]
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Capture proxy envs from variables
         run: |
@@ -425,7 +428,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: |
-            network=host
             env.GODEBUG=madvdontneed=0
             env.HTTP_PROXY=${{ env.HTTP_PROXY }}
             env.HTTPS_PROXY=${{ env.HTTPS_PROXY }}

--- a/.forgejo/workflows/build-code-sandbox.yml
+++ b/.forgejo/workflows/build-code-sandbox.yml
@@ -56,6 +56,7 @@ jobs:
           - arch: arm64
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 120
     steps:
       # install env
       - name: Checkout
@@ -166,6 +167,7 @@ jobs:
       contents: read
     needs: [validate-version, build-fastgpt-code-sandbox-images]
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Set platform variables
         run: |
@@ -223,7 +225,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: |
-            network=host
             env.GODEBUG=madvdontneed=0
             env.HTTP_PROXY=${{ env.HTTP_PROXY }}
             env.HTTPS_PROXY=${{ env.HTTPS_PROXY }}

--- a/.forgejo/workflows/build-fastgpt-ide-agent.yml
+++ b/.forgejo/workflows/build-fastgpt-ide-agent.yml
@@ -47,6 +47,7 @@ jobs:
             arch: arm64
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 120
     steps:
       # install env
       - name: Checkout
@@ -164,6 +165,7 @@ jobs:
           - image: fastgpt-agent-sandbox-proxy
             tag: ${{ inputs.agent_sandbox_proxy_tag || 'latest' }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Set platform variables
         run: |
@@ -221,7 +223,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: |
-            network=host
             env.GODEBUG=madvdontneed=0
             env.HTTP_PROXY=${{ env.HTTP_PROXY }}
             env.HTTPS_PROXY=${{ env.HTTPS_PROXY }}

--- a/.forgejo/workflows/build-fastgpt.yml
+++ b/.forgejo/workflows/build-fastgpt.yml
@@ -54,14 +54,13 @@ jobs:
             base_url: ''
           - repo: fastgpt-sub-route
             base_url: '/fastai'
-          - repo: fastgpt-sub-route-gchat
-            base_url: '/gchat'
         archs:
           - arch: amd64
             runs-on: ubuntu-24.04
           - arch: arm64
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.archs.runs-on }}
+    timeout-minutes: 120
     steps:
       # install env
       - name: Checkout
@@ -178,8 +177,8 @@ jobs:
         sub_routes:
           - repo: fastgpt
           - repo: fastgpt-sub-route
-          - repo: fastgpt-sub-route-gchat
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Set platform variables
         run: |
@@ -237,7 +236,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: |
-            network=host
             env.GODEBUG=madvdontneed=0
             env.HTTP_PROXY=${{ env.HTTP_PROXY }}
             env.HTTPS_PROXY=${{ env.HTTPS_PROXY }}
@@ -252,6 +250,7 @@ jobs:
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
+        timeout-minutes: 120
         run: |
           retry_imagetools_create() {
             local tag="$1"

--- a/.forgejo/workflows/build-marketplace.yml
+++ b/.forgejo/workflows/build-marketplace.yml
@@ -19,6 +19,7 @@ jobs:
           - arch: arm64
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 120
     steps:
       # install env
       - name: Checkout
@@ -130,6 +131,7 @@ jobs:
       contents: read
     needs: build-fastgpt-marketplace-images
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Set platform variables
         run: |
@@ -187,7 +189,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: |
-            network=host
             env.GODEBUG=madvdontneed=0
             env.HTTP_PROXY=${{ env.HTTP_PROXY }}
             env.HTTPS_PROXY=${{ env.HTTPS_PROXY }}

--- a/.forgejo/workflows/build-mcp-server.yml
+++ b/.forgejo/workflows/build-mcp-server.yml
@@ -36,6 +36,7 @@ jobs:
           - arch: arm64
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 120
     steps:
       # install env
       - name: Checkout
@@ -147,6 +148,7 @@ jobs:
       contents: read
     needs: [validate-version, build-fastgpt-mcp_server-images]
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Set platform variables
         run: |
@@ -203,7 +205,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: |
-            network=host
             env.GODEBUG=madvdontneed=0
             env.HTTP_PROXY=${{ env.HTTP_PROXY }}
             env.HTTPS_PROXY=${{ env.HTTPS_PROXY }}

--- a/.github/workflows/build-admin.yml
+++ b/.github/workflows/build-admin.yml
@@ -39,13 +39,12 @@ jobs:
             base_url: ""
           - repo: fastgpt-pro-sub-route
             base_url: "/fastaipro"
-          - repo: fastgpt-pro-sub-route-gchat
-            base_url: "/gchat-admin"
         archs:
           - arch: amd64
           - arch: arm64
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.archs.runs-on || 'ubuntu-24.04' }}
+    timeout-minutes: 120
     steps:
       # install env
       - name: Checkout
@@ -69,7 +68,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: network=host
+          driver-opts: |
+            network=host
 
       - name: Cache Docker layers
         uses: actions/cache@v4
@@ -88,8 +88,15 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Ali Hub
+        uses: docker/login-action@v3
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
+          password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
+
       - name: Build for ${{ matrix.archs.arch }}
-        id: build
+        id: build-ghcr
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -105,18 +112,47 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
+      - name: Build for Ali Hub ${{ matrix.archs.arch }}
+        id: build-aliyun
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: pro/admin/Dockerfile
+          platforms: linux/${{ matrix.archs.arch }}
+          build-args: |
+            ${{ matrix.sub_routes.base_url && format('base_url={0}', matrix.sub_routes.base_url) || '' }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=${{ matrix.sub_routes.repo }} image
+          provenance: false
+          sbom: false
+          outputs: type=image,"name=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/${{ matrix.sub_routes.repo }}",push-by-digest=true,push=true
+          cache-from: type=local,src=/tmp/.buildx-cache
+
       - name: Export digest
         run: |
-          mkdir -p ${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}/${digest#sha256:}"
+          mkdir -p ${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}/ghcr
+          mkdir -p ${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}/aliyun
+          ghcr_digest="${{ steps.build-ghcr.outputs.digest }}"
+          aliyun_digest="${{ steps.build-aliyun.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}/ghcr/${ghcr_digest#sha256:}"
+          touch "${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}/aliyun/${aliyun_digest#sha256:}"
 
-      - name: Upload digest
+      - name: Upload GHCR digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.sub_routes.repo }}-${{ github.sha }}-${{
+          name: ghcr-digests-${{ matrix.sub_routes.repo }}-${{ github.sha }}-${{
             matrix.archs.arch }}
-          path: ${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}/*
+          path: ${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}/ghcr/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload Ali Hub digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: aliyun-digests-${{ matrix.sub_routes.repo }}-${{ github.sha }}-${{
+            matrix.archs.arch }}
+          path: ${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}/aliyun/*
           if-no-files-found: error
           retention-days: 1
 
@@ -132,8 +168,8 @@ jobs:
         sub_routes:
           - repo: fastgpt-pro
           - repo: fastgpt-pro-sub-route
-          - repo: fastgpt-pro-sub-route-gchat
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -152,7 +188,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digests-${{ matrix.sub_routes.repo }}-${{ github.sha }}-*
+          pattern: ghcr-digests-${{ matrix.sub_routes.repo }}-${{ github.sha }}-*
+          merge-multiple: true
+
+      - name: Download Ali Hub digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/aliyun
+          pattern: aliyun-digests-${{ matrix.sub_routes.repo }}-${{ github.sha }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -168,14 +211,32 @@ jobs:
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
+        timeout-minutes: 120
         run: |
+          set -euo pipefail
+          GHCR_IMAGE="ghcr.io/${{ github.repository_owner }}/${{ matrix.sub_routes.repo }}"
+          ALI_IMAGE="${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/${{ matrix.sub_routes.repo }}"
+          GHCR_SOURCES=()
+          for digest_file in ./*; do
+            [[ -f "$digest_file" ]] || continue
+            GHCR_SOURCES+=("${GHCR_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+          ALI_SOURCES=()
+          for digest_file in aliyun/*; do
+            [[ -f "$digest_file" ]] || continue
+            ALI_SOURCES+=("${ALI_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+          if [[ "${#GHCR_SOURCES[@]}" -ne 2 || "${#ALI_SOURCES[@]}" -ne 2 ]]; then
+            echo "Expected two GHCR and two Ali Hub digests"
+            exit 1
+          fi
+
           retry_imagetools_create() {
             local tag="$1"
-            local sources
-            sources="$(printf 'ghcr.io/${{ github.repository_owner }}/${{ matrix.sub_routes.repo }}@sha256:%s ' *)"
+            shift
 
             for attempt in 1 2 3 4; do
-              if docker buildx imagetools create -t "$tag" $sources; then
+              if docker buildx imagetools create -t "$tag" "$@"; then
                 return 0
               fi
 
@@ -189,8 +250,18 @@ jobs:
             done
           }
 
-          TAGS="$(echo -e "${Git_Tag}\n${Git_Latest}\n${Ali_Tag}\n${Ali_Latest}")"
-          for TAG in $TAGS; do
-            retry_imagetools_create "$TAG"
+          for TAG in "${Git_Tag}" "${Git_Latest}"; do
+            retry_imagetools_create "$TAG" "${GHCR_SOURCES[@]}"
             sleep 5
           done
+          for TAG in "${Ali_Tag}" "${Ali_Latest}"; do
+            retry_imagetools_create "$TAG" "${ALI_SOURCES[@]}"
+            sleep 5
+          done
+
+          manifest="$(docker buildx imagetools inspect --raw "${Ali_Tag}")"
+          jq -e '
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "amd64")] | length == 1) and
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "arm64")] | length == 1) and
+            ([.manifests[]?.platform | select(.os == "linux" and (.architecture != "amd64" and .architecture != "arm64"))] | length == 0)
+          ' <<<"$manifest" >/dev/null

--- a/.github/workflows/build-agent-sandbox.yml
+++ b/.github/workflows/build-agent-sandbox.yml
@@ -39,6 +39,7 @@ jobs:
           - arch: arm64
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on || 'ubuntu-24.04' }}
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,7 +48,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: network=host
+          driver-opts: |
+            network=host
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
@@ -63,8 +65,15 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Ali Hub
+        uses: docker/login-action@v3
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
+          password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
+
       - name: Build for ${{ matrix.arch }}
-        id: build
+        id: build-ghcr
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -77,17 +86,43 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
+      - name: Build for Ali Hub ${{ matrix.arch }}
+        id: build-aliyun
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: projects/agent-sandbox/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=fastgpt-agent-sandbox image
+          provenance: false
+          sbom: false
+          outputs: type=image,"name=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-agent-sandbox",push-by-digest=true,push=true
+          cache-from: type=local,src=/tmp/.buildx-cache
+
       - name: Export digest
         run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          mkdir -p ${{ runner.temp }}/digests/ghcr
+          mkdir -p ${{ runner.temp }}/digests/aliyun
+          ghcr_digest="${{ steps.build-ghcr.outputs.digest }}"
+          aliyun_digest="${{ steps.build-aliyun.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/ghcr/${ghcr_digest#sha256:}"
+          touch "${{ runner.temp }}/digests/aliyun/${aliyun_digest#sha256:}"
 
-      - name: Upload digest
+      - name: Upload GHCR digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-fastgpt-agent-sandbox-${{ github.sha }}-${{ matrix.arch }}
-          path: ${{ runner.temp }}/digests/*
+          name: ghcr-digests-fastgpt-agent-sandbox-${{ github.sha }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/ghcr/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload Ali Hub digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: aliyun-digests-fastgpt-agent-sandbox-${{ github.sha }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/aliyun/*
           if-no-files-found: error
           retention-days: 1
 
@@ -99,6 +134,7 @@ jobs:
       id-token: write
     needs: [validate-version, build-fastgpt-agent-sandbox-images]
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -122,7 +158,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digests-fastgpt-agent-sandbox-${{ github.sha }}-*
+          pattern: ghcr-digests-fastgpt-agent-sandbox-${{ github.sha }}-*
+          merge-multiple: true
+
+      - name: Download Ali Hub digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/aliyun
+          pattern: aliyun-digests-fastgpt-agent-sandbox-${{ github.sha }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -141,13 +184,30 @@ jobs:
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
+          set -euo pipefail
+          GHCR_IMAGE="ghcr.io/${{ github.repository_owner }}/fastgpt-agent-sandbox"
+          ALI_IMAGE="${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-agent-sandbox"
+          GHCR_SOURCES=()
+          for digest_file in ./*; do
+            [[ -f "$digest_file" ]] || continue
+            GHCR_SOURCES+=("${GHCR_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+          ALI_SOURCES=()
+          for digest_file in aliyun/*; do
+            [[ -f "$digest_file" ]] || continue
+            ALI_SOURCES+=("${ALI_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+          if [[ "${#GHCR_SOURCES[@]}" -ne 2 || "${#ALI_SOURCES[@]}" -ne 2 ]]; then
+            echo "Expected two GHCR and two Ali Hub digests"
+            exit 1
+          fi
+
           retry_imagetools_create() {
             local tag="$1"
-            local sources
-            sources="$(printf 'ghcr.io/${{ github.repository_owner }}/fastgpt-agent-sandbox@sha256:%s ' *)"
+            shift
 
             for attempt in 1 2 3 4; do
-              if docker buildx imagetools create -t "$tag" $sources; then
+              if docker buildx imagetools create -t "$tag" "$@"; then
                 return 0
               fi
 
@@ -161,11 +221,21 @@ jobs:
             done
           }
 
-          TAGS="$(echo -e "${Git_Tag}\n${Git_Latest}\n${Ali_Tag}\n${Ali_Latest}\n${Docker_Hub_Tag}\n${Docker_Hub_Latest}")"
-          for TAG in $TAGS; do
-            retry_imagetools_create "$TAG"
+          for TAG in "${Git_Tag}" "${Git_Latest}" "${Docker_Hub_Tag}" "${Docker_Hub_Latest}"; do
+            retry_imagetools_create "$TAG" "${GHCR_SOURCES[@]}"
             sleep 5
           done
+          for TAG in "${Ali_Tag}" "${Ali_Latest}"; do
+            retry_imagetools_create "$TAG" "${ALI_SOURCES[@]}"
+            sleep 5
+          done
+
+          manifest="$(docker buildx imagetools inspect --raw "${Ali_Tag}")"
+          jq -e '
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "amd64")] | length == 1) and
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "arm64")] | length == 1) and
+            ([.manifests[]?.platform | select(.os == "linux" and (.architecture != "amd64" and .architecture != "arm64"))] | length == 0)
+          ' <<<"$manifest" >/dev/null
 
   # ── volume-manager ─────────────────────────────────────────────────────────
   build-fastgpt-volume-manager-images:
@@ -182,6 +252,7 @@ jobs:
           - arch: arm64
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on || 'ubuntu-24.04' }}
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -190,7 +261,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: network=host
+          driver-opts: |
+            network=host
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
@@ -206,8 +278,15 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Ali Hub
+        uses: docker/login-action@v3
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
+          password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
+
       - name: Build for ${{ matrix.arch }}
-        id: build
+        id: build-ghcr
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -221,17 +300,44 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
+      - name: Build for Ali Hub ${{ matrix.arch }}
+        id: build-aliyun
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: projects/volume-manager/Dockerfile
+          target: runner
+          platforms: linux/${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=fastgpt-agent-volume-manager image
+          provenance: false
+          sbom: false
+          outputs: type=image,"name=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-agent-volume-manager",push-by-digest=true,push=true
+          cache-from: type=local,src=/tmp/.buildx-cache
+
       - name: Export digest
         run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          mkdir -p ${{ runner.temp }}/digests/ghcr
+          mkdir -p ${{ runner.temp }}/digests/aliyun
+          ghcr_digest="${{ steps.build-ghcr.outputs.digest }}"
+          aliyun_digest="${{ steps.build-aliyun.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/ghcr/${ghcr_digest#sha256:}"
+          touch "${{ runner.temp }}/digests/aliyun/${aliyun_digest#sha256:}"
 
-      - name: Upload digest
+      - name: Upload GHCR digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-fastgpt-agent-volume-manager-${{ github.sha }}-${{ matrix.arch }}
-          path: ${{ runner.temp }}/digests/*
+          name: ghcr-digests-fastgpt-agent-volume-manager-${{ github.sha }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/ghcr/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload Ali Hub digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: aliyun-digests-fastgpt-agent-volume-manager-${{ github.sha }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/aliyun/*
           if-no-files-found: error
           retention-days: 1
 
@@ -243,6 +349,7 @@ jobs:
       id-token: write
     needs: [validate-version, build-fastgpt-volume-manager-images]
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -266,7 +373,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digests-fastgpt-agent-volume-manager-${{ github.sha }}-*
+          pattern: ghcr-digests-fastgpt-agent-volume-manager-${{ github.sha }}-*
+          merge-multiple: true
+
+      - name: Download Ali Hub digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/aliyun
+          pattern: aliyun-digests-fastgpt-agent-volume-manager-${{ github.sha }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -285,13 +399,30 @@ jobs:
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
+          set -euo pipefail
+          GHCR_IMAGE="ghcr.io/${{ github.repository_owner }}/fastgpt-agent-volume-manager"
+          ALI_IMAGE="${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-agent-volume-manager"
+          GHCR_SOURCES=()
+          for digest_file in ./*; do
+            [[ -f "$digest_file" ]] || continue
+            GHCR_SOURCES+=("${GHCR_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+          ALI_SOURCES=()
+          for digest_file in aliyun/*; do
+            [[ -f "$digest_file" ]] || continue
+            ALI_SOURCES+=("${ALI_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+          if [[ "${#GHCR_SOURCES[@]}" -ne 2 || "${#ALI_SOURCES[@]}" -ne 2 ]]; then
+            echo "Expected two GHCR and two Ali Hub digests"
+            exit 1
+          fi
+
           retry_imagetools_create() {
             local tag="$1"
-            local sources
-            sources="$(printf 'ghcr.io/${{ github.repository_owner }}/fastgpt-agent-volume-manager@sha256:%s ' *)"
+            shift
 
             for attempt in 1 2 3 4; do
-              if docker buildx imagetools create -t "$tag" $sources; then
+              if docker buildx imagetools create -t "$tag" "$@"; then
                 return 0
               fi
 
@@ -305,8 +436,18 @@ jobs:
             done
           }
 
-          TAGS="$(echo -e "${Git_Tag}\n${Git_Latest}\n${Ali_Tag}\n${Ali_Latest}\n${Docker_Hub_Tag}\n${Docker_Hub_Latest}")"
-          for TAG in $TAGS; do
-            retry_imagetools_create "$TAG"
+          for TAG in "${Git_Tag}" "${Git_Latest}" "${Docker_Hub_Tag}" "${Docker_Hub_Latest}"; do
+            retry_imagetools_create "$TAG" "${GHCR_SOURCES[@]}"
             sleep 5
           done
+          for TAG in "${Ali_Tag}" "${Ali_Latest}"; do
+            retry_imagetools_create "$TAG" "${ALI_SOURCES[@]}"
+            sleep 5
+          done
+
+          manifest="$(docker buildx imagetools inspect --raw "${Ali_Tag}")"
+          jq -e '
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "amd64")] | length == 1) and
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "arm64")] | length == 1) and
+            ([.manifests[]?.platform | select(.os == "linux" and (.architecture != "amd64" and .architecture != "arm64"))] | length == 0)
+          ' <<<"$manifest" >/dev/null

--- a/.github/workflows/build-browser-sandbox.yml
+++ b/.github/workflows/build-browser-sandbox.yml
@@ -106,6 +106,7 @@ jobs:
           - arch: arm64
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on || 'ubuntu-24.04' }}
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -128,7 +129,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: network=host
+          driver-opts: |
+            network=host
 
       - name: Cache Docker layers
         uses: actions/cache@v4
@@ -145,8 +147,15 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Ali Hub
+        uses: docker/login-action@v3
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
+          password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
+
       - name: Build for ${{ matrix.arch }}
-        id: build
+        id: build-ghcr
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -163,7 +172,7 @@ jobs:
 
       - name: Smoke test pushed image
         env:
-          IMAGE: ghcr.io/${{ github.repository_owner }}/fastgpt-browser-sandbox@${{ steps.build.outputs.digest }}
+          IMAGE: ghcr.io/${{ github.repository_owner }}/fastgpt-browser-sandbox@${{ steps.build-ghcr.outputs.digest }}
           SKIP_BUILD: "true"
           BROWSER_STABILITY_ITERATIONS: "3"
           BROWSER_SANDBOX_REPORT_DIR: pro/browser-sandbox/reports
@@ -181,17 +190,43 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+      - name: Build for Ali Hub ${{ matrix.arch }}
+        id: build-aliyun
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: pro/browser-sandbox/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=fastgpt-browser-sandbox image
+          provenance: false
+          sbom: false
+          outputs: type=image,"name=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-browser-sandbox",push-by-digest=true,push=true
+          cache-from: type=local,src=/tmp/.buildx-cache
+
       - name: Export digest
         run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          mkdir -p ${{ runner.temp }}/digests/ghcr
+          mkdir -p ${{ runner.temp }}/digests/aliyun
+          ghcr_digest="${{ steps.build-ghcr.outputs.digest }}"
+          aliyun_digest="${{ steps.build-aliyun.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/ghcr/${ghcr_digest#sha256:}"
+          touch "${{ runner.temp }}/digests/aliyun/${aliyun_digest#sha256:}"
 
-      - name: Upload digest
+      - name: Upload GHCR digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-fastgpt-browser-sandbox-${{ github.sha }}-${{ matrix.arch }}
-          path: ${{ runner.temp }}/digests/*
+          name: ghcr-digests-fastgpt-browser-sandbox-${{ github.sha }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/ghcr/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload Ali Hub digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: aliyun-digests-fastgpt-browser-sandbox-${{ github.sha }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/aliyun/*
           if-no-files-found: error
           retention-days: 1
 
@@ -203,6 +238,7 @@ jobs:
       id-token: write
     needs: [validate-version, build-fastgpt-browser-sandbox-images]
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -228,7 +264,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digests-fastgpt-browser-sandbox-${{ github.sha }}-*
+          pattern: ghcr-digests-fastgpt-browser-sandbox-${{ github.sha }}-*
+          merge-multiple: true
+
+      - name: Download Ali Hub digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/aliyun
+          pattern: aliyun-digests-fastgpt-browser-sandbox-${{ github.sha }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -244,29 +287,43 @@ jobs:
           echo "Docker_Hub_Tag=${{ secrets.DOCKER_IMAGE_NAME }}/fastgpt-browser-sandbox:${VERSION}" >> $GITHUB_ENV
           echo "Docker_Hub_Latest=${{ secrets.DOCKER_IMAGE_NAME }}/fastgpt-browser-sandbox:latest" >> $GITHUB_ENV
 
-      - name: Create version manifest lists
+      - name: Create manifest lists
         working-directory: ${{ runner.temp }}/digests
         run: |
-          refs=()
-          for digest in *; do
-            refs+=("ghcr.io/${{ github.repository_owner }}/fastgpt-browser-sandbox@sha256:${digest}")
+          set -euo pipefail
+          GHCR_IMAGE="ghcr.io/${{ github.repository_owner }}/fastgpt-browser-sandbox"
+          ALI_IMAGE="${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-browser-sandbox"
+          GHCR_SOURCES=()
+          for digest_file in ./*; do
+            [[ -f "$digest_file" ]] || continue
+            GHCR_SOURCES+=("${GHCR_IMAGE}@sha256:$(basename "$digest_file")")
           done
-
-          for tag in "${Git_Tag}" "${Ali_Tag}" "${Docker_Hub_Tag}"; do
-            docker buildx imagetools create -t "${tag}" "${refs[@]}"
+          ALI_SOURCES=()
+          for digest_file in aliyun/*; do
+            [[ -f "$digest_file" ]] || continue
+            ALI_SOURCES+=("${ALI_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+          if [[ "${#GHCR_SOURCES[@]}" -ne 2 || "${#ALI_SOURCES[@]}" -ne 2 ]]; then
+            echo "Expected two GHCR and two Ali Hub digests"
+            exit 1
+          fi
+          for tag in "${Git_Tag}" "${Docker_Hub_Tag}"; do
+            docker buildx imagetools create -t "${tag}" "${GHCR_SOURCES[@]}"
             sleep 5
           done
+          docker buildx imagetools create -t "${Ali_Tag}" "${ALI_SOURCES[@]}"
 
-      - name: Create latest manifest lists
-        if: needs.validate-version.outputs.stable == 'true'
-        working-directory: ${{ runner.temp }}/digests
-        run: |
-          refs=()
-          for digest in *; do
-            refs+=("ghcr.io/${{ github.repository_owner }}/fastgpt-browser-sandbox@sha256:${digest}")
-          done
+          if [[ "${{ needs.validate-version.outputs.stable }}" == "true" ]]; then
+            for tag in "${Git_Latest}" "${Docker_Hub_Latest}"; do
+              docker buildx imagetools create -t "${tag}" "${GHCR_SOURCES[@]}"
+              sleep 5
+            done
+            docker buildx imagetools create -t "${Ali_Latest}" "${ALI_SOURCES[@]}"
+          fi
 
-          for tag in "${Git_Latest}" "${Ali_Latest}" "${Docker_Hub_Latest}"; do
-            docker buildx imagetools create -t "${tag}" "${refs[@]}"
-            sleep 5
-          done
+          manifest="$(docker buildx imagetools inspect --raw "${Ali_Tag}")"
+          jq -e '
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "amd64")] | length == 1) and
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "arm64")] | length == 1) and
+            ([.manifests[]?.platform | select(.os == "linux" and (.architecture != "amd64" and .architecture != "arm64"))] | length == 0)
+          ' <<<"$manifest" >/dev/null

--- a/.github/workflows/build-code-sandbox.yml
+++ b/.github/workflows/build-code-sandbox.yml
@@ -57,6 +57,7 @@ jobs:
           - arch: arm64
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on || 'ubuntu-24.04' }}
+    timeout-minutes: 120
     steps:
       # install env
       - name: Checkout
@@ -66,7 +67,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: network=host
+          driver-opts: |
+            network=host
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
@@ -75,7 +77,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-sandbox-buildx-
 
-      # ghcr + any extra names in outputs (Ali is pushed only in release via imagetools)
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -83,8 +84,15 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Ali Hub
+        uses: docker/login-action@v3
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
+          password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
+
       - name: Build for ${{ matrix.arch }}
-        id: build
+        id: build-ghcr
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -97,17 +105,43 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
+      - name: Build for Ali Hub ${{ matrix.arch }}
+        id: build-aliyun
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: projects/code-sandbox/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=fastgpt-code-sandbox image
+          provenance: false
+          sbom: false
+          outputs: type=image,"name=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-code-sandbox",push-by-digest=true,push=true
+          cache-from: type=local,src=/tmp/.buildx-cache
+
       - name: Export digest
         run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          mkdir -p ${{ runner.temp }}/digests/ghcr
+          mkdir -p ${{ runner.temp }}/digests/aliyun
+          ghcr_digest="${{ steps.build-ghcr.outputs.digest }}"
+          aliyun_digest="${{ steps.build-aliyun.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/ghcr/${ghcr_digest#sha256:}"
+          touch "${{ runner.temp }}/digests/aliyun/${aliyun_digest#sha256:}"
 
-      - name: Upload digest
+      - name: Upload GHCR digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-fastgpt-code-sandbox-${{ github.sha }}-${{ matrix.arch }}
-          path: ${{ runner.temp }}/digests/*
+          name: ghcr-digests-fastgpt-code-sandbox-${{ github.sha }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/ghcr/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload Ali Hub digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: aliyun-digests-fastgpt-code-sandbox-${{ github.sha }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/aliyun/*
           if-no-files-found: error
           retention-days: 1
 
@@ -119,6 +153,7 @@ jobs:
       id-token: write
     needs: [validate-version, build-fastgpt-code-sandbox-images]
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -135,8 +170,15 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          path: ${{ runner.temp }}/digests
-          pattern: digests-fastgpt-code-sandbox-${{ github.sha }}-*
+          path: ${{ runner.temp }}/digests/ghcr
+          pattern: ghcr-digests-fastgpt-code-sandbox-${{ github.sha }}-*
+          merge-multiple: true
+
+      - name: Download Ali Hub digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/aliyun
+          pattern: aliyun-digests-fastgpt-code-sandbox-${{ github.sha }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -156,9 +198,55 @@ jobs:
         env:
           GODEBUG: http2client=0
         run: |
-          SOURCES="$(printf 'ghcr.io/${{ github.repository_owner }}/fastgpt-code-sandbox@sha256:%s ' *)"
-          TAGS="$(echo -e "${Git_Tag}\n${Git_Latest}\n${Ali_Tag}\n${Ali_Latest}")"
-          for TAG in $TAGS; do
-            docker buildx imagetools create -t "$TAG" $SOURCES
+          set -euo pipefail
+          GHCR_IMAGE="ghcr.io/${{ github.repository_owner }}/fastgpt-code-sandbox"
+          ALI_IMAGE="${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-code-sandbox"
+          GHCR_SOURCES=()
+          for digest_file in ghcr/*; do
+            [[ -f "$digest_file" ]] || continue
+            GHCR_SOURCES+=("${GHCR_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+          ALI_SOURCES=()
+          for digest_file in aliyun/*; do
+            [[ -f "$digest_file" ]] || continue
+            ALI_SOURCES+=("${ALI_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+          if [[ "${#GHCR_SOURCES[@]}" -ne 2 || "${#ALI_SOURCES[@]}" -ne 2 ]]; then
+            echo "Expected two GHCR and two Ali Hub digests"
+            exit 1
+          fi
+
+          retry_imagetools_create() {
+            local tag="$1"
+            shift
+
+            for attempt in 1 2 3 4; do
+              if docker buildx imagetools create -t "$tag" "$@"; then
+                return 0
+              fi
+
+              if [ "$attempt" -eq 4 ]; then
+                echo "::error::Failed to push manifest ${tag} after 3 retries."
+                return 1
+              fi
+
+              echo "::warning::Failed to push manifest ${tag}; retrying in $((attempt * 15)) seconds (${attempt}/3)."
+              sleep $((attempt * 15))
+            done
+          }
+
+          for TAG in "${Git_Tag}" "${Git_Latest}"; do
+            retry_imagetools_create "$TAG" "${GHCR_SOURCES[@]}"
             sleep 5
           done
+          for TAG in "${Ali_Tag}" "${Ali_Latest}"; do
+            retry_imagetools_create "$TAG" "${ALI_SOURCES[@]}"
+            sleep 5
+          done
+
+          manifest="$(docker buildx imagetools inspect --raw "${Ali_Tag}")"
+          jq -e '
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "amd64")] | length == 1) and
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "arm64")] | length == 1) and
+            ([.manifests[]?.platform | select(.os == "linux" and (.architecture != "amd64" and .architecture != "arm64"))] | length == 0)
+          ' <<<"$manifest" >/dev/null

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -65,7 +65,8 @@ jobs:
 
   build-images:
     needs: generate-timestamp
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.arch.runs-on || 'ubuntu-latest' }}
+    timeout-minutes: 120
     strategy:
       matrix:
         domain_config:
@@ -73,6 +74,10 @@ jobs:
             suffix: 'io'
           - domain: 'https://fastgpt.cn'
             suffix: 'cn'
+        arch:
+          - arch: amd64
+          - arch: arm64
+            runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Checkout
@@ -90,6 +95,12 @@ jobs:
           find document/content/docs -name "*.mdx" -type f | while read file; do
             sed -i 's|doc\.fastgpt\.io|doc.fastgpt.cn|g' "$file"
           done
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            network=host
 
       - name: Docker meta
         id: meta
@@ -109,19 +120,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Prepare Docker workspace catalog
-        run: cp pnpm-workspace.yaml document/pnpm-workspace.yaml
-
       - name: Build and push Docker images (CN)
         if: matrix.domain_config.suffix == 'cn'
-        uses: docker/build-push-action@v5
+        id: build-cn
+        uses: docker/build-push-action@v6
         with:
           context: ./document
           file: ./document/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/${{ matrix.arch.arch }}
+          provenance: false
+          sbom: false
+          outputs: type=image,"name=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-docs",push-by-digest=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
           build-args: |
             FASTGPT_HOME_DOMAIN=${{ matrix.domain_config.domain }}
             DOC_TRACK_SRC=${{ secrets.DOC_TRACK_SRC }}
@@ -129,21 +139,89 @@ jobs:
 
       - name: Build and push Docker images (IO)
         if: matrix.domain_config.suffix == 'io'
-        uses: docker/build-push-action@v5
+        id: build-io
+        uses: docker/build-push-action@v6
         with:
           context: ./document
           file: ./document/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/${{ matrix.arch.arch }}
+          provenance: false
+          sbom: false
+          outputs: type=image,"name=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-docs",push-by-digest=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
           build-args: |
             FASTGPT_HOME_DOMAIN=${{ matrix.domain_config.domain }}
             DOC_TRACK_SRC=${{ secrets.DOC_TRACK_SRC }}
             DOC_TRACK_SITE_ID=${{ secrets.DOC_TRACK_IO }}
 
-  update-images:
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build-cn.outputs.digest || steps.build-io.outputs.digest }}
+        run: |
+          mkdir -p "${{ runner.temp }}/digests/aliyun"
+          touch "${{ runner.temp }}/digests/aliyun/${DIGEST#sha256:}"
+
+      - name: Upload Ali Hub digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: aliyun-digests-fastgpt-docs-${{ matrix.domain_config.suffix }}-${{ github.sha }}-${{ matrix.arch.arch }}
+          path: ${{ runner.temp }}/digests/aliyun/*
+          if-no-files-found: error
+          retention-days: 1
+
+  release-images:
     needs: [generate-timestamp, build-images]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    strategy:
+      matrix:
+        domain_config:
+          - suffix: 'io'
+          - suffix: 'cn'
+    steps:
+      - name: Login to Aliyun
+        uses: docker/login-action@v3
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
+          password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
+
+      - name: Download Ali Hub digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/aliyun
+          pattern: aliyun-digests-fastgpt-docs-${{ matrix.domain_config.suffix }}-${{ github.sha }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create manifest list and push
+        env:
+          ALI_TAG: ${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-docs:${{ matrix.domain_config.suffix }}-${{ needs.generate-timestamp.outputs.datetime }}
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          set -euo pipefail
+          ALI_IMAGE="${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-docs"
+          ALI_SOURCES=()
+          for digest_file in aliyun/*; do
+            [[ -f "$digest_file" ]] || continue
+            ALI_SOURCES+=("${ALI_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+          if [[ "${#ALI_SOURCES[@]}" -ne 2 ]]; then
+            echo "Expected two Ali Hub digests"
+            exit 1
+          fi
+          docker buildx imagetools create -t "${ALI_TAG}" "${ALI_SOURCES[@]}"
+
+          manifest="$(docker buildx imagetools inspect --raw "${ALI_TAG}")"
+          jq -e '
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "amd64")] | length > 0) and
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "arm64")] | length > 0)
+          ' <<<"$manifest" >/dev/null
+
+  update-images:
+    needs: [generate-timestamp, release-images]
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/build-fastgpt-ide-agent.yml
+++ b/.github/workflows/build-fastgpt-ide-agent.yml
@@ -45,6 +45,7 @@ jobs:
             arch: arm64
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on || 'ubuntu-24.04' }}
+    timeout-minutes: 120
     steps:
       # install env
       - name: Checkout
@@ -54,7 +55,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: network=host
+          driver-opts: |
+            network=host
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
@@ -63,7 +65,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.image }}-buildx-
 
-      # Push per-arch images by digest first; the release job publishes the final manifest tag.
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -71,8 +72,16 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Ali Hub
+        if: matrix.image == 'fastgpt-agent-sandbox-proxy'
+        uses: docker/login-action@v3
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
+          password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
+
       - name: Build for ${{ matrix.arch }}
-        id: build
+        id: build-ghcr
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
@@ -85,17 +94,47 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
+      - name: Build for Ali Hub ${{ matrix.arch }}
+        if: matrix.image == 'fastgpt-agent-sandbox-proxy'
+        id: build-aliyun
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=${{ matrix.description }}
+          provenance: false
+          sbom: false
+          outputs: type=image,"name=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/${{ matrix.image }}",push-by-digest=true,push=true
+          cache-from: type=local,src=/tmp/.buildx-cache
+
       - name: Export digest
         run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          mkdir -p ${{ runner.temp }}/digests/ghcr
+          ghcr_digest="${{ steps.build-ghcr.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/ghcr/${ghcr_digest#sha256:}"
+          if [[ "${{ matrix.image }}" == "fastgpt-agent-sandbox-proxy" ]]; then
+            mkdir -p ${{ runner.temp }}/digests/aliyun
+            aliyun_digest="${{ steps.build-aliyun.outputs.digest }}"
+            touch "${{ runner.temp }}/digests/aliyun/${aliyun_digest#sha256:}"
+          fi
 
-      - name: Upload digest
+      - name: Upload GHCR digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.image }}-${{ github.sha }}-${{ matrix.arch }}
-          path: ${{ runner.temp }}/digests/*
+          name: ghcr-digests-${{ matrix.image }}-${{ github.sha }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/ghcr/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload Ali Hub digest
+        if: matrix.image == 'fastgpt-agent-sandbox-proxy'
+        uses: actions/upload-artifact@v4
+        with:
+          name: aliyun-digests-${{ matrix.image }}-${{ github.sha }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/aliyun/*
           if-no-files-found: error
           retention-days: 1
 
@@ -112,6 +151,7 @@ jobs:
           - image: fastgpt-agent-sandbox-proxy
             tag: ${{ inputs.agent_sandbox_proxy_tag || 'latest' }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -130,7 +170,15 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digests-${{ matrix.image }}-${{ github.sha }}-*
+          pattern: ghcr-digests-${{ matrix.image }}-${{ github.sha }}-*
+          merge-multiple: true
+
+      - name: Download Ali Hub digests
+        if: matrix.image == 'fastgpt-agent-sandbox-proxy'
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/aliyun
+          pattern: aliyun-digests-${{ matrix.image }}-${{ github.sha }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -146,13 +194,36 @@ jobs:
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
-          TAGS="${Git_Tag}"
-          if [[ -n "${Ali_Tag:-}" ]]; then
-            TAGS="$(echo -e "${TAGS}\n${Ali_Tag}")"
-          fi
-
-          for TAG in $TAGS; do
-            docker buildx imagetools create -t "${TAG}" \
-              $(printf 'ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}@sha256:%s ' *)
-            sleep 5
+          set -euo pipefail
+          GHCR_IMAGE="ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"
+          GHCR_SOURCES=()
+          for digest_file in ghcr/*; do
+            [[ -f "$digest_file" ]] || continue
+            GHCR_SOURCES+=("${GHCR_IMAGE}@sha256:$(basename "$digest_file")")
           done
+          if [[ "${#GHCR_SOURCES[@]}" -ne 2 ]]; then
+            echo "Expected two GHCR digests"
+            exit 1
+          fi
+          docker buildx imagetools create -t "${Git_Tag}" "${GHCR_SOURCES[@]}"
+          sleep 5
+
+          if [[ -n "${Ali_Tag:-}" ]]; then
+            ALI_IMAGE="${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/${{ matrix.image }}"
+            ALI_SOURCES=()
+            for digest_file in aliyun/*; do
+              [[ -f "$digest_file" ]] || continue
+              ALI_SOURCES+=("${ALI_IMAGE}@sha256:$(basename "$digest_file")")
+            done
+            if [[ "${#ALI_SOURCES[@]}" -ne 2 ]]; then
+              echo "Expected two Ali Hub digests"
+              exit 1
+            fi
+            docker buildx imagetools create -t "${Ali_Tag}" "${ALI_SOURCES[@]}"
+            manifest="$(docker buildx imagetools inspect --raw "${Ali_Tag}")"
+            jq -e '
+              ([.manifests[]?.platform | select(.os == "linux" and .architecture == "amd64")] | length == 1) and
+              ([.manifests[]?.platform | select(.os == "linux" and .architecture == "arm64")] | length == 1) and
+              ([.manifests[]?.platform | select(.os == "linux" and (.architecture != "amd64" and .architecture != "arm64"))] | length == 0)
+            ' <<<"$manifest" >/dev/null
+          fi

--- a/.github/workflows/build-fastgpt.yml
+++ b/.github/workflows/build-fastgpt.yml
@@ -42,13 +42,12 @@ jobs:
             base_url: ''
           - repo: fastgpt-sub-route
             base_url: '/fastai'
-          - repo: fastgpt-sub-route-gchat
-            base_url: '/gchat'
         archs:
           - arch: amd64
           - arch: arm64
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.archs.runs-on || 'ubuntu-24.04' }}
+    timeout-minutes: 120
     steps:
       # install env
       - name: Checkout
@@ -59,7 +58,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: network=host
+          driver-opts: |
+            network=host
 
       - name: Cache Docker layers
         uses: actions/cache@v4
@@ -77,8 +77,15 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Ali Hub
+        uses: docker/login-action@v3
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
+          password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
+
       - name: Build for ${{ matrix.archs.arch }}
-        id: build
+        id: build-ghcr
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -93,17 +100,45 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
+      - name: Build for Ali Hub ${{ matrix.archs.arch }}
+        id: build-aliyun
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: projects/app/Dockerfile
+          platforms: linux/${{ matrix.archs.arch }}
+          build-args: |
+            ${{ matrix.sub_routes.base_url && format('base_url={0}', matrix.sub_routes.base_url) || '' }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=${{ matrix.sub_routes.repo }} image
+          provenance: false
+          sbom: false
+          outputs: type=image,"name=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/${{ matrix.sub_routes.repo }}",push-by-digest=true,push=true
+          cache-from: type=local,src=/tmp/.buildx-cache
+
       - name: Export digest
         run: |
-          mkdir -p ${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}/${digest#sha256:}"
+          mkdir -p ${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}/ghcr
+          mkdir -p ${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}/aliyun
+          ghcr_digest="${{ steps.build-ghcr.outputs.digest }}"
+          aliyun_digest="${{ steps.build-aliyun.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}/ghcr/${ghcr_digest#sha256:}"
+          touch "${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}/aliyun/${aliyun_digest#sha256:}"
 
-      - name: Upload digest
+      - name: Upload GHCR digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.sub_routes.repo }}-${{ github.sha }}-${{ matrix.archs.arch }}
-          path: ${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}/*
+          name: ghcr-digests-${{ matrix.sub_routes.repo }}-${{ github.sha }}-${{ matrix.archs.arch }}
+          path: ${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}/ghcr/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload Ali Hub digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: aliyun-digests-${{ matrix.sub_routes.repo }}-${{ github.sha }}-${{ matrix.archs.arch }}
+          path: ${{ runner.temp }}/digests/${{ matrix.sub_routes.repo }}/aliyun/*
           if-no-files-found: error
           retention-days: 1
 
@@ -119,8 +154,8 @@ jobs:
         sub_routes:
           - repo: fastgpt
           - repo: fastgpt-sub-route
-          - repo: fastgpt-sub-route-gchat
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -144,7 +179,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digests-${{ matrix.sub_routes.repo }}-${{ github.sha }}-*
+          pattern: ghcr-digests-${{ matrix.sub_routes.repo }}-${{ github.sha }}-*
+          merge-multiple: true
+
+      - name: Download Ali Hub digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/aliyun
+          pattern: aliyun-digests-${{ matrix.sub_routes.repo }}-${{ github.sha }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -162,14 +204,32 @@ jobs:
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
+        timeout-minutes: 120
         run: |
+          set -euo pipefail
+          GHCR_IMAGE="ghcr.io/${{ github.repository_owner }}/${{ matrix.sub_routes.repo }}"
+          ALI_IMAGE="${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/${{ matrix.sub_routes.repo }}"
+          GHCR_SOURCES=()
+          for digest_file in ./*; do
+            [[ -f "$digest_file" ]] || continue
+            GHCR_SOURCES+=("${GHCR_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+          ALI_SOURCES=()
+          for digest_file in aliyun/*; do
+            [[ -f "$digest_file" ]] || continue
+            ALI_SOURCES+=("${ALI_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+          if [[ "${#GHCR_SOURCES[@]}" -ne 2 || "${#ALI_SOURCES[@]}" -ne 2 ]]; then
+            echo "Expected two GHCR and two Ali Hub digests"
+            exit 1
+          fi
+
           retry_imagetools_create() {
             local tag="$1"
-            local sources
-            sources="$(printf 'ghcr.io/${{ github.repository_owner }}/${{ matrix.sub_routes.repo }}@sha256:%s ' *)"
+            shift
 
             for attempt in 1 2 3 4; do
-              if docker buildx imagetools create -t "$tag" $sources; then
+              if docker buildx imagetools create -t "$tag" "$@"; then
                 return 0
               fi
 
@@ -183,8 +243,18 @@ jobs:
             done
           }
 
-          TAGS="$(echo -e "${Git_Tag}\n${Git_Latest}\n${Ali_Tag}\n${Ali_Latest}\n${Docker_Hub_Tag}\n${Docker_Hub_Latest}")"
-          for TAG in $TAGS; do
-            retry_imagetools_create "$TAG"
+          for TAG in "${Git_Tag}" "${Git_Latest}" "${Docker_Hub_Tag}" "${Docker_Hub_Latest}"; do
+            retry_imagetools_create "$TAG" "${GHCR_SOURCES[@]}"
             sleep 5
           done
+          for TAG in "${Ali_Tag}" "${Ali_Latest}"; do
+            retry_imagetools_create "$TAG" "${ALI_SOURCES[@]}"
+            sleep 5
+          done
+
+          manifest="$(docker buildx imagetools inspect --raw "${Ali_Tag}")"
+          jq -e '
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "amd64")] | length == 1) and
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "arm64")] | length == 1) and
+            ([.manifests[]?.platform | select(.os == "linux" and (.architecture != "amd64" and .architecture != "arm64"))] | length == 0)
+          ' <<<"$manifest" >/dev/null

--- a/.github/workflows/build-marketplace.yml
+++ b/.github/workflows/build-marketplace.yml
@@ -15,6 +15,7 @@ jobs:
           - arch: arm64
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on || 'ubuntu-24.04' }}
+    timeout-minutes: 120
     steps:
       # install env
       - name: Checkout
@@ -24,7 +25,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: network=host
+          driver-opts: |
+            network=host
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
@@ -41,8 +43,15 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Ali Hub
+        uses: docker/login-action@v3
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
+          password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
+
       - name: Build for ${{ matrix.arch }}
-        id: build
+        id: build-ghcr
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -55,17 +64,43 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
+      - name: Build for Ali Hub ${{ matrix.arch }}
+        id: build-aliyun
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: projects/marketplace/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=fastgpt-marketplace image
+          provenance: false
+          sbom: false
+          outputs: type=image,"name=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-marketplace",push-by-digest=true,push=true
+          cache-from: type=local,src=/tmp/.buildx-cache
+
       - name: Export digest
         run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          mkdir -p ${{ runner.temp }}/digests/ghcr
+          mkdir -p ${{ runner.temp }}/digests/aliyun
+          ghcr_digest="${{ steps.build-ghcr.outputs.digest }}"
+          aliyun_digest="${{ steps.build-aliyun.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/ghcr/${ghcr_digest#sha256:}"
+          touch "${{ runner.temp }}/digests/aliyun/${aliyun_digest#sha256:}"
 
-      - name: Upload digest
+      - name: Upload GHCR digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-fastgpt-marketplace-${{ github.sha }}-${{ matrix.arch }}
-          path: ${{ runner.temp }}/digests/*
+          name: ghcr-digests-fastgpt-marketplace-${{ github.sha }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/ghcr/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload Ali Hub digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: aliyun-digests-fastgpt-marketplace-${{ github.sha }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/aliyun/*
           if-no-files-found: error
           retention-days: 1
 
@@ -77,6 +112,7 @@ jobs:
       id-token: write
     needs: build-fastgpt-marketplace-images
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -94,8 +130,15 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          path: ${{ runner.temp }}/digests
-          pattern: digests-fastgpt-marketplace-${{ github.sha }}-*
+          path: ${{ runner.temp }}/digests/ghcr
+          pattern: ghcr-digests-fastgpt-marketplace-${{ github.sha }}-*
+          merge-multiple: true
+
+      - name: Download Ali Hub digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/aliyun
+          pattern: aliyun-digests-fastgpt-marketplace-${{ github.sha }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -117,25 +160,30 @@ jobs:
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
-          echo "Pushing image with tag: ${{ env.RANDOM_TAG }}"
-          echo "Available digests:"
-          ls -la
-          echo ""
-
-          # Create manifest for GitHub Container Registry
-          echo "Creating manifest for GitHub: ${Git_Tag}"
-          docker buildx imagetools create -t ${Git_Tag} \
-            $(printf 'ghcr.io/${{ github.repository_owner }}/fastgpt-marketplace@sha256:%s ' *)
-          echo "✅ GitHub manifest created"
+          set -euo pipefail
+          GHCR_IMAGE="ghcr.io/${{ github.repository_owner }}/fastgpt-marketplace"
+          ALI_IMAGE="${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-marketplace"
+          GHCR_SOURCES=()
+          for digest_file in ghcr/*; do
+            [[ -f "$digest_file" ]] || continue
+            GHCR_SOURCES+=("${GHCR_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+          ALI_SOURCES=()
+          for digest_file in aliyun/*; do
+            [[ -f "$digest_file" ]] || continue
+            ALI_SOURCES+=("${ALI_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+          if [[ "${#GHCR_SOURCES[@]}" -ne 2 || "${#ALI_SOURCES[@]}" -ne 2 ]]; then
+            echo "Expected two GHCR and two Ali Hub digests"
+            exit 1
+          fi
+          docker buildx imagetools create -t "${Git_Tag}" "${GHCR_SOURCES[@]}"
           sleep 5
+          docker buildx imagetools create -t "${Ali_Tag}" "${ALI_SOURCES[@]}"
 
-          # Create manifest for Ali Cloud
-          echo "Creating manifest for Ali Cloud: ${Ali_Tag}"
-          docker buildx imagetools create -t ${Ali_Tag} \
-            $(printf 'ghcr.io/${{ github.repository_owner }}/fastgpt-marketplace@sha256:%s ' *)
-          echo "✅ Ali Cloud manifest created"
-
-          echo ""
-          echo "✅ All images pushed successfully:"
-          echo "  - ${{ env.Git_Tag }}"
-          echo "  - ${{ env.Ali_Tag }}"
+          manifest="$(docker buildx imagetools inspect --raw "${Ali_Tag}")"
+          jq -e '
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "amd64")] | length == 1) and
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "arm64")] | length == 1) and
+            ([.manifests[]?.platform | select(.os == "linux" and (.architecture != "amd64" and .architecture != "arm64"))] | length == 0)
+          ' <<<"$manifest" >/dev/null

--- a/.github/workflows/build-mcp-server.yml
+++ b/.github/workflows/build-mcp-server.yml
@@ -37,6 +37,7 @@ jobs:
           - arch: arm64
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on || 'ubuntu-24.04' }}
+    timeout-minutes: 120
     steps:
       # install env
       - name: Checkout
@@ -46,7 +47,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: network=host
+          driver-opts: |
+            network=host
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
@@ -63,8 +65,15 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Ali Hub
+        uses: docker/login-action@v3
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
+          password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
+
       - name: Build for ${{ matrix.arch }}
-        id: build
+        id: build-ghcr
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -77,17 +86,43 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
+      - name: Build for Ali Hub ${{ matrix.arch }}
+        id: build-aliyun
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: projects/mcp_server/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=fastgpt-mcp_server image
+          provenance: false
+          sbom: false
+          outputs: type=image,"name=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-mcp_server",push-by-digest=true,push=true
+          cache-from: type=local,src=/tmp/.buildx-cache
+
       - name: Export digest
         run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          mkdir -p ${{ runner.temp }}/digests/ghcr
+          mkdir -p ${{ runner.temp }}/digests/aliyun
+          ghcr_digest="${{ steps.build-ghcr.outputs.digest }}"
+          aliyun_digest="${{ steps.build-aliyun.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/ghcr/${ghcr_digest#sha256:}"
+          touch "${{ runner.temp }}/digests/aliyun/${aliyun_digest#sha256:}"
 
-      - name: Upload digest
+      - name: Upload GHCR digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-fastgpt-mcp_server-${{ github.sha }}-${{ matrix.arch }}
-          path: ${{ runner.temp }}/digests/*
+          name: ghcr-digests-fastgpt-mcp_server-${{ github.sha }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/ghcr/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload Ali Hub digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: aliyun-digests-fastgpt-mcp_server-${{ github.sha }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/aliyun/*
           if-no-files-found: error
           retention-days: 1
 
@@ -99,6 +134,7 @@ jobs:
       id-token: write
     needs: [validate-version, build-fastgpt-mcp_server-images]
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -121,8 +157,15 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          path: ${{ runner.temp }}/digests
-          pattern: digests-fastgpt-mcp_server-${{ github.sha }}-*
+          path: ${{ runner.temp }}/digests/ghcr
+          pattern: ghcr-digests-fastgpt-mcp_server-${{ github.sha }}-*
+          merge-multiple: true
+
+      - name: Download Ali Hub digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/aliyun
+          pattern: aliyun-digests-fastgpt-mcp_server-${{ github.sha }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -141,9 +184,36 @@ jobs:
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
-          TAGS="$(echo -e "${Git_Tag}\n${Git_Latest}\n${Ali_Tag}\n${Ali_Latest}\n${Docker_Hub_Tag}\n${Docker_Hub_Latest}")"
-          for TAG in $TAGS; do
-            docker buildx imagetools create -t $TAG \
-              $(printf 'ghcr.io/${{ github.repository_owner }}/fastgpt-mcp_server@sha256:%s ' *)
+          set -euo pipefail
+          GHCR_IMAGE="ghcr.io/${{ github.repository_owner }}/fastgpt-mcp_server"
+          ALI_IMAGE="${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-mcp_server"
+          GHCR_SOURCES=()
+          for digest_file in ghcr/*; do
+            [[ -f "$digest_file" ]] || continue
+            GHCR_SOURCES+=("${GHCR_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+          ALI_SOURCES=()
+          for digest_file in aliyun/*; do
+            [[ -f "$digest_file" ]] || continue
+            ALI_SOURCES+=("${ALI_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+          if [[ "${#GHCR_SOURCES[@]}" -ne 2 || "${#ALI_SOURCES[@]}" -ne 2 ]]; then
+            echo "Expected two GHCR and two Ali Hub digests"
+            exit 1
+          fi
+
+          for TAG in "${Git_Tag}" "${Git_Latest}" "${Docker_Hub_Tag}" "${Docker_Hub_Latest}"; do
+            docker buildx imagetools create -t "$TAG" "${GHCR_SOURCES[@]}"
             sleep 5
           done
+          for TAG in "${Ali_Tag}" "${Ali_Latest}"; do
+            docker buildx imagetools create -t "$TAG" "${ALI_SOURCES[@]}"
+            sleep 5
+          done
+
+          manifest="$(docker buildx imagetools inspect --raw "${Ali_Tag}")"
+          jq -e '
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "amd64")] | length == 1) and
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "arm64")] | length == 1) and
+            ([.manifests[]?.platform | select(.os == "linux" and (.architecture != "amd64" and .architecture != "arm64"))] | length == 0)
+          ' <<<"$manifest" >/dev/null

--- a/.github/workflows/build-sso-service-image.yml
+++ b/.github/workflows/build-sso-service-image.yml
@@ -6,6 +6,9 @@ on:
         description: 'Image version tag (e.g. v1.0.0)'
         required: true
         type: string
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   contents: read
@@ -22,22 +25,40 @@ jobs:
       - name: Validate release version
         id: version
         env:
-          VERSION: ${{ github.event.inputs.version }}
+          VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          CURRENT_REF: ${{ github.ref }}
         run: |
           if [[ ! "$VERSION" =~ ^v ]]; then
             echo "::error::Image version must start with v. Current value: ${VERSION}"
+            exit 1
+          fi
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" && "$REF_TYPE" != "tag" ]]; then
+            echo "::error::Release workflow must run on a tag starting with v. Current ref: ${CURRENT_REF}"
             exit 1
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
   build-fastgpt-sso-service-images:
     needs: validate-version
-    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+          - arch: arm64
+            runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runs-on || 'ubuntu-24.04' }}
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - name: Update submodules
         env:
           PRO_SUBMODULE_TOKEN: ${{ secrets.PRO_SUBMODULE_TOKEN }}
@@ -48,27 +69,103 @@ jobs:
             fi
             git submodule update --init --recursive
           fi
-      - name: Install Dependencies
-        run: |
-          sudo apt update && sudo apt install -y nodejs npm
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: network=host
+          driver-opts: |
+            network=host
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-sso-service-buildx-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-sso-service-buildx-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: labring
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Ali Hub
+        uses: docker/login-action@v3
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
+          password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
+
+      - name: Build for ${{ matrix.arch }}
+        id: build-ghcr
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: pro/sso/Dockerfile
+          build-args: name=sso
+          platforms: linux/${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=fastgpt-sso-service image
+          outputs: type=image,"name=ghcr.io/${{ github.repository_owner }}/fastgpt-sso-service",push-by-digest=true,push=true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Build for Ali Hub ${{ matrix.arch }}
+        id: build-aliyun
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: pro/sso/Dockerfile
+          build-args: name=sso
+          platforms: linux/${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=fastgpt-sso-service image
+          provenance: false
+          sbom: false
+          outputs: type=image,"name=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-sso-service",push-by-digest=true,push=true
+          cache-from: type=local,src=/tmp/.buildx-cache
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests/ghcr
+          mkdir -p ${{ runner.temp }}/digests/aliyun
+          ghcr_digest="${{ steps.build-ghcr.outputs.digest }}"
+          aliyun_digest="${{ steps.build-aliyun.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/ghcr/${ghcr_digest#sha256:}"
+          touch "${{ runner.temp }}/digests/aliyun/${aliyun_digest#sha256:}"
+
+      - name: Upload GHCR digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: ghcr-digests-fastgpt-sso-service-${{ github.sha }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/ghcr/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload Ali Hub digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: aliyun-digests-fastgpt-sso-service-${{ github.sha }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/aliyun/*
+          if-no-files-found: error
+          retention-days: 1
+
+  release-fastgpt-sso-service-images:
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    needs: [validate-version, build-fastgpt-sso-service-images]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Ali Hub
         uses: docker/login-action@v3
@@ -76,27 +173,64 @@ jobs:
           registry: registry.cn-hangzhou.aliyuncs.com
           username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
           password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
-      - name: Set image tags
+
+      - name: Download GHCR digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: ghcr-digests-fastgpt-sso-service-${{ github.sha }}-*
+          merge-multiple: true
+
+      - name: Download Ali Hub digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/aliyun
+          pattern: aliyun-digests-fastgpt-sso-service-${{ github.sha }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set image name and tag
         run: |
           VERSION="${{ needs.validate-version.outputs.version }}"
-          echo "Git_Tag=ghcr.io/labring/fastgpt-sso-service:${VERSION}" >> $GITHUB_ENV
-          echo "Git_Latest=ghcr.io/labring/fastgpt-sso-service:latest" >> $GITHUB_ENV
+          echo "Git_Tag=ghcr.io/${{ github.repository_owner }}/fastgpt-sso-service:${VERSION}" >> $GITHUB_ENV
+          echo "Git_Latest=ghcr.io/${{ github.repository_owner }}/fastgpt-sso-service:latest" >> $GITHUB_ENV
           echo "Ali_Tag=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-sso-service:${VERSION}" >> $GITHUB_ENV
           echo "Ali_Latest=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-sso-service:latest" >> $GITHUB_ENV
 
-      - name: Build and publish image
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
         run: |
-          docker buildx build \
-          -f pro/sso/Dockerfile \
-          --build-arg name=sso \
-          --platform linux/amd64,linux/arm64 \
-          --label "org.opencontainers.image.source=https://github.com/labring/FastGPT" \
-          --label "org.opencontainers.image.description=fastgpt-sso-service image" \
-          --push \
-          --cache-from=type=local,src=/tmp/.buildx-cache \
-          --cache-to=type=local,dest=/tmp/.buildx-cache \
-          -t ${Git_Tag} \
-          -t ${Git_Latest} \
-          -t ${Ali_Tag} \
-          -t ${Ali_Latest} \
-          .
+          set -euo pipefail
+          GHCR_IMAGE="ghcr.io/${{ github.repository_owner }}/fastgpt-sso-service"
+          ALI_IMAGE="${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-sso-service"
+          GHCR_SOURCES=()
+          for digest_file in ./*; do
+            [[ -f "$digest_file" ]] || continue
+            GHCR_SOURCES+=("${GHCR_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+          ALI_SOURCES=()
+          for digest_file in aliyun/*; do
+            [[ -f "$digest_file" ]] || continue
+            ALI_SOURCES+=("${ALI_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+          if [[ "${#GHCR_SOURCES[@]}" -ne 2 || "${#ALI_SOURCES[@]}" -ne 2 ]]; then
+            echo "Expected two GHCR and two Ali Hub digests"
+            exit 1
+          fi
+
+          for TAG in "${Git_Tag}" "${Git_Latest}"; do
+            docker buildx imagetools create -t "$TAG" "${GHCR_SOURCES[@]}"
+            sleep 5
+          done
+          for TAG in "${Ali_Tag}" "${Ali_Latest}"; do
+            docker buildx imagetools create -t "$TAG" "${ALI_SOURCES[@]}"
+            sleep 5
+          done
+
+          manifest="$(docker buildx imagetools inspect --raw "${Ali_Tag}")"
+          jq -e '
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "amd64")] | length > 0) and
+            ([.manifests[]?.platform | select(.os == "linux" and .architecture == "arm64")] | length > 0)
+          ' <<<"$manifest" >/dev/null


### PR DESCRIPTION
## Summary
- Publish each amd64/arm64 image directly to Aliyun by digest.
- Keep GHCR and Aliyun digest artifacts separate, then assemble manifests from the matching registry.
- Disable provenance/SBOM on the Aliyun path to avoid OCI attestation compatibility issues.
- Validate the final Aliyun manifest contains amd64 and arm64 only.
- Add the same build workflow adjustments for Docs, Browser Sandbox, SSO, and paired Forgejo workflows.

## Validation
- GitHub Actions workflow actionlint
- YAML parsing for all changed GitHub and Forgejo workflows
- git diff --check