### PR TITLE
ci: optimize preview image workflows

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -5,6 +5,7 @@ on:
       - main
     paths:
       - 'document/**'
+      - 'pnpm-workspace.yaml'
   workflow_dispatch:
 
 permissions:
@@ -83,16 +84,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Prepare Docker workspace catalog
+        run: cp pnpm-workspace.yaml document/pnpm-workspace.yaml
+
       - name: Rewrite image paths
         if: matrix.domain_config.suffix == 'io'
         run: |
-          find document/content/docs -name "*.mdx" -type f | while read file; do
+          set -euo pipefail
+          find document/content -name "*.mdx" -type f | while read -r file; do
             sed -i 's|](/imgs/|](https://cdn.jsdelivr.net/gh/labring/fastgpt-img@main/|g' "$file"
           done
       - name: Rewrite domain links for CN
         if: matrix.domain_config.suffix == 'cn'
         run: |
-          find document/content/docs -name "*.mdx" -type f | while read file; do
+          set -euo pipefail
+          find document/content -name "*.mdx" -type f | while read -r file; do
             sed -i 's|doc\.fastgpt\.io|doc.fastgpt.cn|g' "$file"
           done
 

--- a/.github/workflows/preview-admin-build.yml
+++ b/.github/workflows/preview-admin-build.yml
@@ -17,7 +17,7 @@ on:
       - ".github/workflows/preview-admin-push.yml"
 
 concurrency:
-  group: 'preview-admin-build-${{ github.head_ref || github.ref }}'
+  group: 'preview-admin-build-${{ github.event.pull_request.number || github.run_id }}'
   cancel-in-progress: true
 
 permissions:
@@ -35,6 +35,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           allow-unsafe-pr-checkout: true
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Update submodules
@@ -67,9 +68,9 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/FastGPT
             org.opencontainers.image.description=fastgpt-pro admin image
             org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
+          provenance: false
+          sbom: false
           outputs: type=docker,dest=/tmp/fastgpt-pro-image.tar
-          cache-from: type=gha,scope=fastgpt-pro
-          cache-to: type=gha,mode=max,scope=fastgpt-pro,ignore-error=true
 
       - name: Save PR metadata
         run: |
@@ -84,4 +85,6 @@ jobs:
             /tmp/fastgpt-pro-image.tar
             /tmp/pr-number.txt
             /tmp/pr-sha.txt
+          compression-level: 0
+          if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/preview-docs-build.yml
+++ b/.github/workflows/preview-docs-build.yml
@@ -9,7 +9,7 @@ on:
 
 # Only one build per PR branch at a time.
 concurrency:
-  group: 'preview-docs-build-${{ github.head_ref }}'
+  group: 'preview-docs-build-${{ github.event.pull_request.number }}'
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/preview-docs-build.yml
+++ b/.github/workflows/preview-docs-build.yml
@@ -4,9 +4,10 @@ on:
   pull_request:
     paths:
       - 'document/**'
+      - 'pnpm-workspace.yaml'
     types: [opened, synchronize, reopened]
 
-# Only one build per PR branch at a time
+# Only one build per PR branch at a time.
 concurrency:
   group: 'preview-docs-build-${{ github.head_ref }}'
   cancel-in-progress: true
@@ -24,6 +25,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -39,26 +41,20 @@ jobs:
           platforms: linux/amd64
           push: false
           tags: fastgpt-docs-pr:${{ github.event.pull_request.head.sha }}
+          provenance: false
+          sbom: false
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/FastGPT
             org.opencontainers.image.description=FastGPT Docs Preview
           build-args: |
             FASTGPT_HOME_DOMAIN=https://fastgpt.io
           outputs: type=docker,dest=/tmp/docs-image.tar
-          cache-from: type=gha,scope=docs
-          cache-to: type=gha,mode=max,scope=docs
-
-      - name: Save PR metadata
-        run: |
-          echo "${{ github.event.pull_request.number }}" > /tmp/pr-number.txt
-          echo "${{ github.event.pull_request.head.sha }}" > /tmp/pr-sha.txt
 
       - name: Upload Docker image artifact
         uses: actions/upload-artifact@v4
         with:
           name: preview-docs-image
-          path: |
-            /tmp/docs-image.tar
-            /tmp/pr-number.txt
-            /tmp/pr-sha.txt
+          path: /tmp/docs-image.tar
+          compression-level: 0
+          if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/preview-docs-push.yml
+++ b/.github/workflows/preview-docs-push.yml
@@ -7,10 +7,10 @@ on:
   issue_comment:
     types: [created]
 
-# The deployment target is shared by all PRs, so keep preview deployments serialized.
+# A newer automatic preview cancels an older deployment; untrusted comments cannot cancel a running publish.
 concurrency:
   group: 'preview-docs-push'
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'workflow_run' }}
 
 permissions:
   contents: read
@@ -87,7 +87,7 @@ jobs:
             };
 
             const findBuildRun = async (sha) => {
-              const { data } = await github.rest.actions.listWorkflowRuns({
+              const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 workflow_id: 'preview-docs-build.yml',
@@ -95,7 +95,7 @@ jobs:
                 status: 'completed',
                 per_page: 100
               });
-              return data.workflow_runs.find((run) =>
+              return workflowRuns.find((run) =>
                 run.head_sha === sha && run.conclusion === 'success'
               );
             };
@@ -153,6 +153,10 @@ jobs:
                 repo: context.repo.repo,
                 pull_number: prNumber
               });
+              if (pullRequest.state !== 'open' || pullRequest.head.sha !== sha) {
+                core.info(`Skipping stale docs preview build ${sha}; the current PR head is ${pullRequest.head.sha}.`);
+                return;
+              }
               if (!await hasPublishPermission(pullRequest.user.login)) {
                 await upsertComment(prNumber, `${manualMarker}
             ✅ Docs preview image built successfully for \`${sha}\`.

--- a/.github/workflows/preview-docs-push.yml
+++ b/.github/workflows/preview-docs-push.yml
@@ -4,88 +4,217 @@ on:
   workflow_run:
     workflows: ['Preview Docs Image — Build']
     types: [completed]
+  issue_comment:
+    types: [created]
 
-# Only one push at a time
+# The deployment target is shared by all PRs, so keep preview deployments serialized.
 concurrency:
   group: 'preview-docs-push'
   cancel-in-progress: false
 
 permissions:
   contents: read
+  actions: read
+  pull-requests: write
+  issues: write
 
 jobs:
-  check_pr_author:
+  prepare:
     runs-on: ubuntu-24.04
-    # Only inspect the upstream PR when the build succeeded.
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
-      pull-requests: read
+      actions: read
+      pull-requests: write
+      issues: write
     outputs:
-      trusted: ${{ steps.trust.outputs.trusted }}
-      number: ${{ steps.trust.outputs.number }}
-      sha: ${{ steps.trust.outputs.sha }}
+      should_publish: ${{ steps.prepare.outputs.should_publish }}
+      number: ${{ steps.prepare.outputs.number }}
+      sha: ${{ steps.prepare.outputs.sha }}
+      run_id: ${{ steps.prepare.outputs.run_id }}
+      manual: ${{ steps.prepare.outputs.manual }}
 
     steps:
-      - name: Check trusted PR author
-        id: trust
+      - name: Resolve preview build and publish permission
+        id: prepare
         uses: actions/github-script@v7
         with:
           script: |
-            const allowedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
-            const workflowRun = context.payload.workflow_run;
-            let prNumber = workflowRun.pull_requests?.[0]?.number;
+            const manualMarker = '<!-- fastgpt-doc-preview-manual -->';
 
-            if (!prNumber) {
-              const headOwner = workflowRun.head_repository?.owner?.login;
-              const headBranch = workflowRun.head_branch;
-
-              if (headOwner && headBranch) {
-                core.info(`workflow_run payload did not include a PR number; looking up PR by ${headOwner}:${headBranch}.`);
-                const { data: pullRequests } = await github.rest.pulls.list({
+            const hasPublishPermission = async (username) => {
+              if (!username) return false;
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  state: 'open',
-                  head: `${headOwner}:${headBranch}`
+                  username
                 });
-                const matchedPullRequest = pullRequests.find((pullRequest) => pullRequest.head.sha === workflowRun.head_sha) ?? pullRequests[0];
-                prNumber = matchedPullRequest?.number;
+                return ['admin', 'maintain', 'write'].includes(data.permission);
+              } catch (error) {
+                core.warning(`Unable to resolve repository permission for ${username}: ${error.message}`);
+                return false;
               }
-            }
+            };
 
-            if (!prNumber) {
-              core.warning('No pull request was found on the workflow_run payload. Skipping privileged docs preview publish.');
-              core.setOutput('trusted', 'false');
+            const setDefaultOutputs = () => {
+              core.setOutput('should_publish', 'false');
+              core.setOutput('manual', 'false');
+            };
+
+            const upsertComment = async (issueNumber, body) => {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+              });
+              const existingComment = comments.find((comment) => comment.body.includes(manualMarker));
+
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existingComment.id,
+                  body
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body
+                });
+              }
+            };
+
+            const findBuildRun = async (sha) => {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'preview-docs-build.yml',
+                event: 'pull_request',
+                status: 'completed',
+                per_page: 100
+              });
+              return data.workflow_runs.find((run) =>
+                run.head_sha === sha && run.conclusion === 'success'
+              );
+            };
+
+            const hasArtifact = async (runId) => {
+              const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+                per_page: 100
+              });
+              return artifacts.some((artifact) => artifact.name === 'preview-docs-image');
+            };
+
+            setDefaultOutputs();
+
+            let prNumber;
+            let sha;
+            let runId;
+            let manual = false;
+
+            if (context.eventName === 'workflow_run') {
+              const workflowRun = context.payload.workflow_run;
+              if (workflowRun.conclusion !== 'success') {
+                core.info(`Build workflow concluded with ${workflowRun.conclusion}; skipping docs preview publish.`);
+                return;
+              }
+
+              runId = workflowRun.id;
+              sha = workflowRun.head_sha;
+              prNumber = workflowRun.pull_requests?.[0]?.number;
+
+              if (!prNumber) {
+                const headOwner = workflowRun.head_repository?.owner?.login;
+                const headBranch = workflowRun.head_branch;
+                if (headOwner && headBranch) {
+                  const { data: pullRequests } = await github.rest.pulls.list({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    state: 'open',
+                    head: `${headOwner}:${headBranch}`
+                  });
+                  const matchedPullRequest = pullRequests.find((pullRequest) => pullRequest.head.sha === sha) ?? pullRequests[0];
+                  prNumber = matchedPullRequest?.number;
+                }
+              }
+
+              if (!prNumber) {
+                core.warning('No pull request was found for the completed docs preview build.');
+                return;
+              }
+
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              if (!await hasPublishPermission(pullRequest.user.login)) {
+                await upsertComment(prNumber, `${manualMarker}
+            ✅ Docs preview image built successfully for \`${sha}\`.
+
+            Automatic publishing is disabled for this PR. A maintainer can comment:
+
+            \`/preview push\`
+
+            to publish the image from this exact build.`);
+                core.warning(`PR #${prNumber} author association is ${pullRequest.author_association}; waiting for a maintainer comment before publishing.`);
+                return;
+              }
+            } else if (context.eventName === 'issue_comment') {
+              const issue = context.payload.issue;
+              const comment = context.payload.comment;
+              if (!issue.pull_request || comment.body.trim() !== '/preview push') {
+                return;
+              }
+
+              if (!await hasPublishPermission(comment.user.login)) {
+                core.warning(`Comment author ${comment.user.login} does not have repository publish permission.`);
+                return;
+              }
+
+              prNumber = issue.number;
+              manual = true;
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              sha = pullRequest.head.sha;
+              const buildRun = await findBuildRun(sha);
+
+              if (!buildRun) {
+                await upsertComment(prNumber, `${manualMarker}
+            ⚠️ No successful docs preview build was found for the current PR commit \`${sha}\`. Please wait for the build workflow to finish, then comment \`/preview push\` again.`);
+                return;
+              }
+              runId = buildRun.id;
+            } else {
               return;
             }
 
-            const { data: pullRequest } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber
-            });
-
-            const trusted = allowedAssociations.has(pullRequest.author_association);
-            core.setOutput('trusted', trusted ? 'true' : 'false');
-            core.setOutput('number', String(pullRequest.number));
-            core.setOutput('sha', pullRequest.head.sha);
-
-            if (trusted) {
-              core.info(`PR #${pullRequest.number} author association is ${pullRequest.author_association}; privileged docs preview publish is allowed.`);
-            } else {
-              core.warning(`PR #${pullRequest.number} author association is ${pullRequest.author_association}; skipping privileged docs preview publish.`);
+            if (!await hasArtifact(runId)) {
+              core.warning(`No docs preview artifact was found for workflow run ${runId}.`);
+              return;
             }
 
+            core.setOutput('should_publish', 'true');
+            core.setOutput('number', String(prNumber));
+            core.setOutput('sha', sha);
+            core.setOutput('run_id', String(runId));
+            core.setOutput('manual', manual ? 'true' : 'false');
+
   push:
-    needs: check_pr_author
+    needs: prepare
+    if: ${{ needs.prepare.outputs.should_publish == 'true' }}
     runs-on: ubuntu-24.04
-    # Only trusted repository members/collaborators can promote PR-built artifacts.
-    if: ${{ needs.check_pr_author.outputs.trusted == 'true' }}
     permissions:
       contents: read
       packages: write
-      attestations: write
-      id-token: write
       pull-requests: write
       issues: write
       actions: read
@@ -96,14 +225,11 @@ jobs:
         with:
           name: preview-docs-image
           path: /tmp
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ needs.prepare.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Load Docker image
         run: docker load --input /tmp/docs-image.tar
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -114,13 +240,15 @@ jobs:
 
       - name: Tag and push Docker image
         run: |
-          docker tag fastgpt-docs-pr:${{ needs.check_pr_author.outputs.sha }} \
-            ghcr.io/${{ github.repository_owner }}/fastgpt-docs-pr:${{ needs.check_pr_author.outputs.sha }}
-          docker push ghcr.io/${{ github.repository_owner }}/fastgpt-docs-pr:${{ needs.check_pr_author.outputs.sha }}
+          SHA="${{ needs.prepare.outputs.sha }}"
+          docker tag fastgpt-docs-pr:${SHA} \
+            ghcr.io/${{ github.repository_owner }}/fastgpt-docs-pr:${SHA}
+          docker push ghcr.io/${{ github.repository_owner }}/fastgpt-docs-pr:${SHA}
 
       - name: Update deployment image
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG_CN }}
+          IMAGE: ghcr.io/${{ github.repository_owner }}/fastgpt-docs-pr:${{ needs.prepare.outputs.sha }}
         run: |
           KUBECONFIG_FILE=$(mktemp)
           trap "rm -f $KUBECONFIG_FILE" EXIT
@@ -128,10 +256,10 @@ jobs:
           chmod 600 "$KUBECONFIG_FILE"
 
           kubectl --kubeconfig "$KUBECONFIG_FILE" set image deployment/fastgpt-doc-preview \
-            fastgpt-doc-preview=ghcr.io/${{ github.repository_owner }}/fastgpt-docs-pr:${{ needs.check_pr_author.outputs.sha }}
+            fastgpt-doc-preview="$IMAGE"
 
           kubectl --kubeconfig "$KUBECONFIG_FILE" annotate deployment/fastgpt-doc-preview \
-            originImageName="ghcr.io/${{ github.repository_owner }}/fastgpt-docs-pr:${{ needs.check_pr_author.outputs.sha }}" --overwrite
+            originImageName="$IMAGE" --overwrite
 
       - name: Format preview timestamp
         id: preview_time
@@ -139,34 +267,30 @@ jobs:
           echo "value=$(TZ='Asia/Shanghai' date '+%Y-%m-%d %H:%M:%S (UTC+8)')" >> "$GITHUB_OUTPUT"
 
       - name: Add PR comment on success
-        if: success() && needs.check_pr_author.outputs.number != ''
+        if: success() && needs.prepare.outputs.number != ''
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumber = parseInt('${{ needs.check_pr_author.outputs.number }}');
+            const prNumber = parseInt('${{ needs.prepare.outputs.number }}');
             const marker = '<!-- fastgpt-doc-preview -->';
+            const mode = '${{ needs.prepare.outputs.manual }}' === 'true' ? 'Manual publish successful' : 'Docs preview deployed';
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
             });
-
-            const existingComment = comments.find(comment =>
-              comment.body.includes(marker)
-            );
-
+            const existingComment = comments.find((comment) => comment.body.includes(marker));
             const commentBody = `${marker}
-            ✅ **Docs Preview Deployed!**
+            ✅ **${mode}**
 
             🔗 [👀 Click here to visit preview](https://xcldnthwehkh.sealoshzh.site)
 
             \`\`\`
-            ghcr.io/${{ github.repository_owner }}/fastgpt-docs-pr:${{ needs.check_pr_author.outputs.sha }}
+            ghcr.io/${{ github.repository_owner }}/fastgpt-docs-pr:${{ needs.prepare.outputs.sha }}
             \`\`\`
 
-            🕒 Time: ${{ steps.preview_time.outputs.value }}
-            `;
+            🕒 Time: ${{ steps.preview_time.outputs.value }}`;
 
             if (existingComment) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/preview-fastgpt-build.yml
+++ b/.github/workflows/preview-fastgpt-build.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
     branches: ['*']
 
-# Only one build per PR branch at a time
+# Only one build per PR branch at a time.
 concurrency:
   group: 'preview-fastgpt-build-${{ github.head_ref }}'
   cancel-in-progress: true
@@ -96,6 +96,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.detect_changes.outputs.matrix) }}
       fail-fast: false
+      max-parallel: 3
 
     steps:
       - name: Checkout PR code
@@ -103,6 +104,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -115,27 +117,19 @@ jobs:
           platforms: linux/amd64
           push: false
           tags: ${{ matrix.image_name }}-pr:${{ github.event.pull_request.head.sha }}
+          provenance: false
+          sbom: false
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/FastGPT
             org.opencontainers.image.description=${{ matrix.description }}
             org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
           outputs: type=docker,dest=/tmp/${{ matrix.image_name }}-image.tar
-          cache-from: type=gha,scope=${{ matrix.image }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.image }},ignore-error=true
-
-      - name: Save PR metadata
-        run: |
-          echo "${{ github.event.pull_request.number }}" > /tmp/pr-number.txt
-          echo "${{ github.event.pull_request.head.sha }}" > /tmp/pr-sha.txt
-          echo "${{ matrix.image }}" > /tmp/image-type.txt
 
       - name: Upload Docker image artifact
         uses: actions/upload-artifact@v4
         with:
           name: preview-${{ matrix.image }}-image
-          path: |
-            /tmp/${{ matrix.image_name }}-image.tar
-            /tmp/pr-number.txt
-            /tmp/pr-sha.txt
-            /tmp/image-type.txt
+          path: /tmp/${{ matrix.image_name }}-image.tar
+          compression-level: 0
+          if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/preview-fastgpt-build.yml
+++ b/.github/workflows/preview-fastgpt-build.yml
@@ -7,7 +7,7 @@ on:
 
 # Only one build per PR branch at a time.
 concurrency:
-  group: 'preview-fastgpt-build-${{ github.head_ref }}'
+  group: 'preview-fastgpt-build-${{ github.event.pull_request.number }}'
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/preview-fastgpt-push.yml
+++ b/.github/workflows/preview-fastgpt-push.yml
@@ -4,123 +4,237 @@ on:
   workflow_run:
     workflows: ['Preview FastGPT Image — Build']
     types: [completed]
+  issue_comment:
+    types: [created]
 
-# Only one push at a time
+# Keep publication order stable across PR updates; matrix jobs within one run stay parallel.
 concurrency:
   group: 'preview-fastgpt-push'
   cancel-in-progress: false
 
 permissions:
   contents: read
+  actions: read
+  pull-requests: write
+  issues: write
 
 jobs:
-  check_pr_author:
+  prepare:
     runs-on: ubuntu-24.04
-    # Only inspect the upstream PR when the build succeeded.
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
-      pull-requests: read
       actions: read
+      pull-requests: write
+      issues: write
     outputs:
-      trusted: ${{ steps.trust.outputs.trusted }}
-      should_publish: ${{ steps.trust.outputs.should_publish }}
-      number: ${{ steps.trust.outputs.number }}
-      sha: ${{ steps.trust.outputs.sha }}
-      matrix: ${{ steps.trust.outputs.matrix }}
+      should_publish: ${{ steps.prepare.outputs.should_publish }}
+      number: ${{ steps.prepare.outputs.number }}
+      sha: ${{ steps.prepare.outputs.sha }}
+      run_id: ${{ steps.prepare.outputs.run_id }}
+      manual: ${{ steps.prepare.outputs.manual }}
+      matrix: ${{ steps.prepare.outputs.matrix }}
 
     steps:
-      - name: Check trusted PR author
-        id: trust
+      - name: Resolve preview build and publish permission
+        id: prepare
         uses: actions/github-script@v7
         with:
           script: |
-            const allowedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
             const emptyMatrix = JSON.stringify({
               include: [{ image: 'noop', artifact_name: 'noop', image_name: 'noop' }]
             });
-            const workflowRun = context.payload.workflow_run;
-            let prNumber = workflowRun.pull_requests?.[0]?.number;
-
-            core.setOutput('trusted', 'false');
-            core.setOutput('should_publish', 'false');
-            core.setOutput('matrix', emptyMatrix);
-
-            if (!prNumber) {
-              const headOwner = workflowRun.head_repository?.owner?.login;
-              const headBranch = workflowRun.head_branch;
-
-              if (headOwner && headBranch) {
-                core.info(`workflow_run payload did not include a PR number; looking up PR by ${headOwner}:${headBranch}.`);
-                const { data: pullRequests } = await github.rest.pulls.list({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  state: 'open',
-                  head: `${headOwner}:${headBranch}`
-                });
-                const matchedPullRequest = pullRequests.find((pullRequest) => pullRequest.head.sha === workflowRun.head_sha) ?? pullRequests[0];
-                prNumber = matchedPullRequest?.number;
-              }
-            }
-
-            if (!prNumber) {
-              core.warning('No pull request was found on the workflow_run payload. Skipping privileged FastGPT preview publish.');
-              return;
-            }
-
-            const { data: pullRequest } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber
-            });
-
-            const trusted = allowedAssociations.has(pullRequest.author_association);
-            core.setOutput('trusted', trusted ? 'true' : 'false');
-            core.setOutput('number', String(pullRequest.number));
-            core.setOutput('sha', pullRequest.head.sha);
-
-            if (!trusted) {
-              core.warning(`PR #${pullRequest.number} author association is ${pullRequest.author_association}; skipping privileged FastGPT preview publish.`);
-              return;
-            }
-
             const artifactConfigs = [
               { image: 'fastgpt', artifact_name: 'preview-fastgpt-image', image_name: 'fastgpt' },
               { image: 'code-sandbox', artifact_name: 'preview-code-sandbox-image', image_name: 'fastgpt-code-sandbox' },
               { image: 'mcp_server', artifact_name: 'preview-mcp_server-image', image_name: 'fastgpt-mcp-server' }
             ];
-            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: workflowRun.id,
-              per_page: 100
-            });
-            const artifactNames = new Set(artifacts.map((artifact) => artifact.name));
-            const images = artifactConfigs.filter((artifactConfig) =>
-              artifactNames.has(artifactConfig.artifact_name)
-            );
-            const matrix = images.length > 0 ? { include: images } : JSON.parse(emptyMatrix);
 
-            core.setOutput('should_publish', images.length > 0 ? 'true' : 'false');
-            core.setOutput('matrix', JSON.stringify(matrix));
-            core.info(`PR #${pullRequest.number} author association is ${pullRequest.author_association}; preview images to publish: ${images.map((image) => image.image).join(', ') || 'none'}.`);
+            const hasPublishPermission = async (username) => {
+              if (!username) return false;
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username
+                });
+                return ['admin', 'maintain', 'write'].includes(data.permission);
+              } catch (error) {
+                core.warning(`Unable to resolve repository permission for ${username}: ${error.message}`);
+                return false;
+              }
+            };
+
+            const setDefaultOutputs = () => {
+              core.setOutput('should_publish', 'false');
+              core.setOutput('matrix', emptyMatrix);
+              core.setOutput('manual', 'false');
+            };
+
+            const upsertComment = async (issueNumber, marker, body) => {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+              });
+              const existingComment = comments.find((comment) => comment.body.includes(marker));
+
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existingComment.id,
+                  body
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body
+                });
+              }
+            };
+
+            const findBuildRun = async (sha) => {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'preview-fastgpt-build.yml',
+                event: 'pull_request',
+                status: 'completed',
+                per_page: 100
+              });
+              return data.workflow_runs.find((run) =>
+                run.head_sha === sha && run.conclusion === 'success'
+              );
+            };
+
+            const getArtifacts = async (runId) => {
+              const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+                per_page: 100
+              });
+              const artifactNames = new Set(artifacts.map((artifact) => artifact.name));
+              return artifactConfigs.filter((config) => artifactNames.has(config.artifact_name));
+            };
+
+            setDefaultOutputs();
+
+            let prNumber;
+            let sha;
+            let runId;
+            let manual = false;
+
+            if (context.eventName === 'workflow_run') {
+              const workflowRun = context.payload.workflow_run;
+              if (workflowRun.conclusion !== 'success') {
+                core.info(`Build workflow concluded with ${workflowRun.conclusion}; skipping preview publish.`);
+                return;
+              }
+
+              runId = workflowRun.id;
+              sha = workflowRun.head_sha;
+              prNumber = workflowRun.pull_requests?.[0]?.number;
+
+              if (!prNumber) {
+                const headOwner = workflowRun.head_repository?.owner?.login;
+                const headBranch = workflowRun.head_branch;
+                if (headOwner && headBranch) {
+                  const { data: pullRequests } = await github.rest.pulls.list({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    state: 'open',
+                    head: `${headOwner}:${headBranch}`
+                  });
+                  const matchedPullRequest = pullRequests.find((pullRequest) => pullRequest.head.sha === sha) ?? pullRequests[0];
+                  prNumber = matchedPullRequest?.number;
+                }
+              }
+
+              if (!prNumber) {
+                core.warning('No pull request was found for the completed preview build.');
+                return;
+              }
+
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              if (!await hasPublishPermission(pullRequest.user.login)) {
+                await upsertComment(prNumber, '<!-- fastgpt-preview-manual -->', `<!-- fastgpt-preview-manual -->
+            ✅ Preview images built successfully for \`${sha}\`.
+
+            Automatic publishing is disabled for this PR. A maintainer can comment:
+
+            \`/preview push\`
+
+            to publish the images from this exact build.`);
+                core.warning(`PR #${prNumber} author association is ${pullRequest.author_association}; waiting for a maintainer comment before publishing.`);
+                return;
+              }
+            } else if (context.eventName === 'issue_comment') {
+              const issue = context.payload.issue;
+              const comment = context.payload.comment;
+              if (!issue.pull_request || comment.body.trim() !== '/preview push') {
+                return;
+              }
+
+              if (!await hasPublishPermission(comment.user.login)) {
+                core.warning(`Comment author ${comment.user.login} does not have repository publish permission.`);
+                return;
+              }
+
+              prNumber = issue.number;
+              manual = true;
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              sha = pullRequest.head.sha;
+              const buildRun = await findBuildRun(sha);
+
+              if (!buildRun) {
+                await upsertComment(prNumber, '<!-- fastgpt-preview-manual -->', `<!-- fastgpt-preview-manual -->
+            ⚠️ No successful preview build was found for the current PR commit \`${sha}\`. Please wait for the build workflow to finish, then comment \`/preview push\` again.`);
+                return;
+              }
+              runId = buildRun.id;
+            } else {
+              return;
+            }
+
+            const images = await getArtifacts(runId);
+            if (images.length === 0) {
+              core.warning(`No preview image artifacts were found for workflow run ${runId}.`);
+              return;
+            }
+
+            core.setOutput('should_publish', 'true');
+            core.setOutput('number', String(prNumber));
+            core.setOutput('sha', sha);
+            core.setOutput('run_id', String(runId));
+            core.setOutput('manual', manual ? 'true' : 'false');
+            core.setOutput('matrix', JSON.stringify({ include: images }));
+            core.info(`Preview images to publish: ${images.map((image) => image.image).join(', ')}`);
 
   push:
-    needs: check_pr_author
+    needs: prepare
+    if: ${{ needs.prepare.outputs.should_publish == 'true' }}
     runs-on: ubuntu-24.04
-    # Only trusted repository members/collaborators can promote PR-built artifacts.
-    if: ${{ needs.check_pr_author.outputs.trusted == 'true' && needs.check_pr_author.outputs.should_publish == 'true' }}
     permissions:
       contents: read
       packages: write
-      attestations: write
-      id-token: write
       pull-requests: write
       issues: write
       actions: read
     strategy:
-      matrix: ${{ fromJSON(needs.check_pr_author.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
       fail-fast: false
+      max-parallel: 3
 
     steps:
       - name: Download build artifact
@@ -128,14 +242,11 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: /tmp
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ needs.prepare.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Load Docker image
         run: docker load --input /tmp/${{ matrix.image_name }}-image.tar
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -146,7 +257,7 @@ jobs:
 
       - name: Tag and push Docker image
         run: |
-          SHA="${{ needs.check_pr_author.outputs.sha }}"
+          SHA="${{ needs.prepare.outputs.sha }}"
           docker tag ${{ matrix.image_name }}-pr:${SHA} \
             ghcr.io/${{ github.repository_owner }}/fastgpt-pr:${{ matrix.image }}_${SHA}
           docker push ghcr.io/${{ github.repository_owner }}/fastgpt-pr:${{ matrix.image }}_${SHA}
@@ -157,32 +268,28 @@ jobs:
           echo "value=$(TZ='Asia/Shanghai' date '+%Y-%m-%d %H:%M:%S (UTC+8)')" >> "$GITHUB_OUTPUT"
 
       - name: Add PR comment on success
-        if: success() && needs.check_pr_author.outputs.number != ''
+        if: success() && needs.prepare.outputs.number != ''
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumber = parseInt('${{ needs.check_pr_author.outputs.number }}');
+            const prNumber = parseInt('${{ needs.prepare.outputs.number }}');
             const marker = '<!-- fastgpt-preview-${{ matrix.image }} -->';
+            const mode = '${{ needs.prepare.outputs.manual }}' === 'true' ? 'Manual publish successful' : 'Build and publish successful';
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
             });
-
-            const existingComment = comments.find(comment =>
-              comment.body.includes(marker)
-            );
-
+            const existingComment = comments.find((comment) => comment.body.includes(marker));
             const commentBody = `${marker}
-            ✅ **Build Successful** - Preview ${{ matrix.image }} Image for this PR:
+            ✅ **${mode}** - Preview ${{ matrix.image }} Image:
 
             \`\`\`
-            ghcr.io/${{ github.repository_owner }}/fastgpt-pr:${{ matrix.image }}_${{ needs.check_pr_author.outputs.sha }}
+            ghcr.io/${{ github.repository_owner }}/fastgpt-pr:${{ matrix.image }}_${{ needs.prepare.outputs.sha }}
             \`\`\`
 
-            🕒 Time: ${{ steps.preview_time.outputs.value }}
-            `;
+            🕒 Time: ${{ steps.preview_time.outputs.value }}`;
 
             if (existingComment) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/preview-fastgpt-push.yml
+++ b/.github/workflows/preview-fastgpt-push.yml
@@ -7,10 +7,10 @@ on:
   issue_comment:
     types: [created]
 
-# Keep publication order stable across PR updates; matrix jobs within one run stay parallel.
+# A newer automatic preview cancels an older publication; untrusted comments cannot cancel a running publish.
 concurrency:
-  group: 'preview-fastgpt-push'
-  cancel-in-progress: false
+  group: 'preview-fastgpt-push-${{ github.event.issue.number || github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_branch || github.run_id }}'
+  cancel-in-progress: ${{ github.event_name == 'workflow_run' }}
 
 permissions:
   contents: read
@@ -96,7 +96,7 @@ jobs:
             };
 
             const findBuildRun = async (sha) => {
-              const { data } = await github.rest.actions.listWorkflowRuns({
+              const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 workflow_id: 'preview-fastgpt-build.yml',
@@ -104,7 +104,7 @@ jobs:
                 status: 'completed',
                 per_page: 100
               });
-              return data.workflow_runs.find((run) =>
+              return workflowRuns.find((run) =>
                 run.head_sha === sha && run.conclusion === 'success'
               );
             };
@@ -163,6 +163,10 @@ jobs:
                 repo: context.repo.repo,
                 pull_number: prNumber
               });
+              if (pullRequest.state !== 'open' || pullRequest.head.sha !== sha) {
+                core.info(`Skipping stale preview build ${sha}; the current PR head is ${pullRequest.head.sha}.`);
+                return;
+              }
               if (!await hasPublishPermission(pullRequest.user.login)) {
                 await upsertComment(prNumber, '<!-- fastgpt-preview-manual -->', `<!-- fastgpt-preview-manual -->
             ✅ Preview images built successfully for \`${sha}\`.

--- a/document/package.json
+++ b/document/package.json
@@ -47,7 +47,7 @@
     "@types/node": "24.0.13",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
-    "postcss": "^8.5.12",
+    "postcss": "catalog:",
     "tailwindcss": "^4.1.11",
     "textlint": "catalog:lint",
     "textlint-plugin-mdx": "catalog:lint",

--- a/document/package.json
+++ b/document/package.json
@@ -47,7 +47,7 @@
     "@types/node": "24.0.13",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
-    "postcss": "catalog:",
+    "postcss": "^8.5.12",
     "tailwindcss": "^4.1.11",
     "textlint": "catalog:lint",
     "textlint-plugin-mdx": "catalog:lint",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21346,7 +21346,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.4
       '@tailwindcss/oxide': 4.2.4
-      postcss: 8.5.22
+      postcss: 8.5.23
       tailwindcss: 4.2.4
 
   '@tanstack/query-core@4.36.1': {}
@@ -22232,7 +22232,7 @@ snapshots:
       '@vue/shared': 3.5.40
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.22
+      postcss: 8.5.23
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.40':
@@ -28677,30 +28677,30 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-import@15.1.0(postcss@8.5.22):
+  postcss-import@15.1.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.22
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.10
 
-  postcss-js@4.1.0(postcss@8.5.22):
+  postcss-js@4.1.0(postcss@8.5.23):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.22
+      postcss: 8.5.23
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.22)(tsx@4.20.6)(yaml@2.8.4):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.20.6)(yaml@2.8.4):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.22
+      postcss: 8.5.23
       tsx: 4.20.6
       yaml: 2.8.4
 
-  postcss-nested@6.2.0(postcss@8.5.22):
+  postcss-nested@6.2.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.22
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -30592,11 +30592,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.22
-      postcss-import: 15.1.0(postcss@8.5.22)
-      postcss-js: 4.1.0(postcss@8.5.22)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.22)(tsx@4.20.6)(yaml@2.8.4)
-      postcss-nested: 6.2.0(postcss@8.5.22)
+      postcss: 8.5.23
+      postcss-import: 15.1.0(postcss@8.5.23)
+      postcss-js: 4.1.0(postcss@8.5.23)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.20.6)(yaml@2.8.4)
+      postcss-nested: 6.2.0(postcss@8.5.23)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
       sucrase: 3.35.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,7 +398,7 @@ importers:
         specifier: ^18
         version: 18.3.0
       postcss:
-        specifier: ^8.5.12
+        specifier: 'catalog:'
         version: 8.5.22
       tailwindcss:
         specifier: ^4.1.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,7 +398,7 @@ importers:
         specifier: ^18
         version: 18.3.0
       postcss:
-        specifier: 'catalog:'
+        specifier: ^8.5.12
         version: 8.5.22
       tailwindcss:
         specifier: ^4.1.11


### PR DESCRIPTION
## What changed

- Optimize public FastGPT and Docs preview builds:
  - run untrusted pull requests with `pull_request` and no write credentials;
  - build the FastGPT image matrix in parallel, including Code Sandbox;
  - remove the GitHub Actions build cache and upload only Docker artifacts;
  - publish automatically for authorized PR authors;
  - allow an authorized maintainer to publish an untrusted PR by commenting `/preview push`;
  - publish artifacts for the exact PR head SHA.
- Optimize the Admin preview build:
  - keep the existing trusted-author `pull_request_target` flow because it needs the private `pro` submodule;
  - disable the build cache and provenance/SBOM metadata;
  - avoid persisting checkout credentials and upload the Docker artifact without compression;
  - cancel the previous Admin build when the same PR receives a newer commit.
- Cancel stale automatic publication/deployment runs, while untrusted comments cannot cancel a running publish.
- Skip an automatic FastGPT or Docs publish when its build SHA is no longer the current PR head.
- Paginate successful build-run lookup; comment lookup remains a simple single-page request because PR comment volume is expected to stay small.
- Copy the root `pnpm-workspace.yaml` into `document` before the Docs Docker build so catalog dependencies, including `postcss: catalog:`, resolve correctly.
- Keep the existing Admin preview push workflow and Docs deployment-specific steps unchanged.

## Why

The previous public preview path mixed untrusted PR builds with registry publishing and cache/artifact overhead. This separates build and publication permissions for public images, ensures a newer commit supersedes stale preview work, and keeps maintainer-approved publication available. Admin retains its trusted build boundary because the private `pro` submodule is required.

## Validation

- Parsed all preview workflow YAML files.
- Checked embedded GitHub Script JavaScript syntax.
- Ran `git diff --check`.
- Ran `pnpm install --frozen-lockfile --ignore-scripts`; the lockfile is up to date.
- Confirmed unrelated sandbox workflows are not included.