### PR TITLE
fix(docs): prevent stale HTML chunk references

### DIFF
--- a/document/middleware.ts
+++ b/document/middleware.ts
@@ -89,6 +89,7 @@ const prefixMap: Record<string, string> = {
 };
 
 const i18nMiddleware = createI18nMiddleware(i18n);
+const documentCacheControl = 'public, max-age=0, must-revalidate';
 
 function normalizePath(path: string) {
   return path.length > 1 ? path.replace(/\/+$/, '') : path;
@@ -157,6 +158,9 @@ export default function middleware(request: NextRequest) {
   if (hasLangPrefix) {
     // Pass through with x-pathname; sync FD_LOCALE cookie if mismatched.
     const response = NextResponse.next({ request: { headers: requestHeaders } });
+    // Static HTML references build-hashed chunks. Reusing HTML across image rollouts can
+    // point the browser at chunks that only exist in the previous deployment.
+    response.headers.set('Cache-Control', documentCacheControl);
     const currentCookie = request.cookies.get('FD_LOCALE')?.value;
     if (currentCookie !== lang) {
       response.cookies.set('FD_LOCALE', lang, {


### PR DESCRIPTION
## Summary

Prevent localized docs HTML/RSC responses from being cached for a year, while keeping hashed static chunks cacheable.

## Root cause

The live docs page referenced a build-hashed chunk that returned 404, causing a browser `ChunkLoadError` and client-side application error. The document response exposed `s-maxage=31536000`, allowing stale HTML to outlive the deployment that produced its chunks.

## User impact

After deployment, document responses revalidate across image rollouts so stale HTML does not keep pointing at removed chunks.

## Validation

- `pnpm --filter @fastgpt/document build`
- `pnpm exec prettier --check document/middleware.ts`
- `git diff --check`
- Local production response verified `Cache-Control: public, max-age=0, must-revalidate`.
- Local browser load verified the docs page rendered without client errors.