### PR TITLE
feat: sync enterprise verification without visitor id

### DIFF
--- a/packages/service/support/marketing/attribution.ts
+++ b/packages/service/support/marketing/attribution.ts
@@ -27,6 +27,25 @@ export type ReportCRMVisitorLifecycleProps = {
   summary?: string;
 };
 
+export type ReportCRMEnterpriseVerificationProps = {
+  visitorId?: string;
+  cloudUserId: string;
+  submissionId: string;
+  company: string;
+  summary: string;
+  name: string;
+  contact: string;
+  position: string;
+  consultationTopic: 'SaaS 版';
+  details: {
+    team_name?: string;
+    unified_credit_code: string;
+    legal_person_name: string;
+    bank_name: string;
+    bank_account: string;
+  };
+};
+
 const getContact = (username: string, contact?: string) => {
   const candidates = [contact, username].map((value) => value?.trim()).filter(Boolean) as string[];
   const email = candidates.find((value) => value.includes('@'));
@@ -143,6 +162,61 @@ export const reportCRMVisitorLifecycle = async ({
       error,
       visitorId,
       event
+    });
+    return false;
+  }
+};
+
+/** 企业认证可以早于官网 visitor 识别，使用 cloud_user_id 和 submission_id 幂等落库。 */
+export const reportCRMEnterpriseVerification = async ({
+  visitorId: rawVisitorId,
+  cloudUserId: rawCloudUserId,
+  submissionId: rawSubmissionId,
+  company,
+  summary,
+  name,
+  contact,
+  position,
+  consultationTopic,
+  details
+}: ReportCRMEnterpriseVerificationProps): Promise<boolean> => {
+  const { apiUrl, apiKey } = getCRMConfig();
+  const visitorId = rawVisitorId?.trim();
+  const cloudUserId = rawCloudUserId.trim();
+  const submissionId = rawSubmissionId.trim();
+
+  if (!apiUrl || !apiKey || !cloudUserId || !submissionId) return false;
+
+  try {
+    await axiosWithoutSSRF.post(
+      `${apiUrl}/contacts/opportunities/lifecycle`,
+      {
+        event: CRMLifecycleEvent.EnterpriseVerification,
+        ...(visitorId && { visitor_id: visitorId }),
+        cloud_user_id: cloudUserId,
+        submission_id: submissionId,
+        company,
+        summary,
+        name,
+        contact,
+        position,
+        consultation_topic: consultationTopic,
+        details
+      },
+      {
+        headers: {
+          'X-API-Key': apiKey
+        },
+        timeout: 5000
+      }
+    );
+    return true;
+  } catch (error) {
+    logger.warn('CRM enterprise verification report failed', {
+      error,
+      cloudUserId,
+      submissionId,
+      visitorId
     });
     return false;
   }

--- a/packages/service/support/marketing/interface/crm.ts
+++ b/packages/service/support/marketing/interface/crm.ts
@@ -5,16 +5,35 @@ import { MongoUser } from '../../user/schema';
 import { MongoTeam } from '../../user/team/teamSchema';
 import {
   isCRMReportingConfigured,
+  reportCRMEnterpriseVerification,
   reportCRMVisitorLifecycle,
   type CRMLifecycleEvent
 } from '../attribution';
 
 const logger = getLogger(LogCategories.MODULE.USER.ACCOUNT);
 
+type EnterpriseLifecycleDetails = {
+  submissionId: string;
+  company: string;
+  summary: string;
+  name: string;
+  contact: string;
+  position: string;
+  consultationTopic: 'SaaS 版';
+  details: {
+    team_name?: string;
+    unified_credit_code: string;
+    legal_person_name: string;
+    bank_name: string;
+    bank_account: string;
+  };
+};
+
 type LifecycleDetails = {
   event: CRMLifecycleEvent;
   company?: string;
   summary?: string;
+  enterprise?: EnterpriseLifecycleDetails;
 };
 
 const getTeamMarkerParams = ({
@@ -25,7 +44,14 @@ const getTeamMarkerParams = ({
   event: CRMLifecycleEvent;
 }): SuccessMarkerParams => ({
   scope: 'integration-report',
-  segments: ['crm', 'lifecycle', event, 'team', teamId]
+  segments: [
+    'crm',
+    'lifecycle',
+    event,
+    'team',
+    teamId,
+    ...(event === 'enterprise_verification' ? ['details-v2'] : [])
+  ]
 });
 
 const getVisitorId = (fastgptSem: unknown) => {
@@ -33,12 +59,16 @@ const getVisitorId = (fastgptSem: unknown) => {
   return parsed.success ? parsed.data.visitor_id : undefined;
 };
 
-/** CRM 生命周期公开接口：先按 team 去重，再解析其 owner 对应的 visitor_id。 */
+/**
+ * CRM 生命周期公开接口：先按 team 去重，再使用其 owner 作为 cloud_user_id。
+ * 普通生命周期事件仍要求 visitor_id；企业认证允许先无 visitor_id 落库，登录识别时再补关联。
+ */
 export const reportCRMTeamLifecycleOnce = async ({
   teamId: rawTeamId,
   event,
   company,
-  summary
+  summary,
+  enterprise
 }: LifecycleDetails & { teamId: string }): Promise<void> => {
   const teamId = rawTeamId.trim();
   if (!isCRMReportingConfigured() || !teamId) return;
@@ -55,19 +85,32 @@ export const reportCRMTeamLifecycleOnce = async ({
   }
 
   try {
-    const team = await MongoTeam.findById(teamId, 'ownerId').lean();
+    const team = await MongoTeam.findById(teamId, 'ownerId name').lean();
     if (!team?.ownerId) return;
 
     const user = await MongoUser.findById(team.ownerId, 'fastgpt_sem').lean();
     const visitorId = getVisitorId(user?.fastgpt_sem);
-    if (!visitorId) return;
-
-    const success = await reportCRMVisitorLifecycle({
-      visitorId,
-      event,
-      company,
-      summary
-    });
+    let success = false;
+    if (event === 'enterprise_verification') {
+      if (!enterprise) return;
+      success = await reportCRMEnterpriseVerification({
+        ...enterprise,
+        cloudUserId: String(team.ownerId),
+        visitorId,
+        details: {
+          ...enterprise.details,
+          team_name: enterprise.details.team_name || team.name
+        }
+      });
+    } else {
+      if (!visitorId) return;
+      success = await reportCRMVisitorLifecycle({
+        visitorId,
+        event,
+        company,
+        summary
+      });
+    }
     if (!success) return;
 
     try {

--- a/packages/service/support/marketing/interface/crm.ts
+++ b/packages/service/support/marketing/interface/crm.ts
@@ -6,13 +6,12 @@ import { MongoTeam } from '../../user/team/teamSchema';
 import {
   isCRMReportingConfigured,
   reportCRMEnterpriseVerification,
-  reportCRMVisitorLifecycle,
-  type CRMLifecycleEvent
+  reportCRMVisitorLifecycle
 } from '../attribution';
 
 const logger = getLogger(LogCategories.MODULE.USER.ACCOUNT);
 
-type EnterpriseLifecycleDetails = {
+export type CRMEnterpriseVerificationDetails = {
   submissionId: string;
   company: string;
   summary: string;
@@ -30,28 +29,19 @@ type EnterpriseLifecycleDetails = {
 };
 
 type LifecycleDetails = {
-  event: CRMLifecycleEvent;
-  company?: string;
-  summary?: string;
-  enterprise?: EnterpriseLifecycleDetails;
+  teamId: string;
+  event: 'consumption' | 'recharge';
 };
 
 const getTeamMarkerParams = ({
   teamId,
-  event
+  markerKey
 }: {
   teamId: string;
-  event: CRMLifecycleEvent;
+  markerKey: string;
 }): SuccessMarkerParams => ({
   scope: 'integration-report',
-  segments: [
-    'crm',
-    'lifecycle',
-    event,
-    'team',
-    teamId,
-    ...(event === 'enterprise_verification' ? ['details-v2'] : [])
-  ]
+  segments: ['crm', 'lifecycle', markerKey, 'team', teamId]
 });
 
 const getVisitorId = (fastgptSem: unknown) => {
@@ -59,28 +49,32 @@ const getVisitorId = (fastgptSem: unknown) => {
   return parsed.success ? parsed.data.visitor_id : undefined;
 };
 
-/**
- * CRM 生命周期公开接口：先按 team 去重，再使用其 owner 作为 cloud_user_id。
- * 普通生命周期事件仍要求 visitor_id；企业认证允许先无 visitor_id 落库，登录识别时再补关联。
- */
-export const reportCRMTeamLifecycleOnce = async ({
+type TeamOwnerReportContext = {
+  cloudUserId: string;
+  visitorId?: string;
+  teamName?: string;
+};
+
+const reportCRMTeamEventOnce = async ({
   teamId: rawTeamId,
-  event,
-  company,
-  summary,
-  enterprise
-}: LifecycleDetails & { teamId: string }): Promise<void> => {
+  markerKey,
+  report
+}: {
+  teamId: string;
+  markerKey: string;
+  report: (context: TeamOwnerReportContext) => Promise<boolean>;
+}): Promise<void> => {
   const teamId = rawTeamId.trim();
   if (!isCRMReportingConfigured() || !teamId) return;
 
-  const markerParams = getTeamMarkerParams({ teamId, event });
+  const markerParams = getTeamMarkerParams({ teamId, markerKey });
   try {
     if (await successMarkerCache.has(markerParams)) return;
   } catch (error) {
     logger.warn('CRM team lifecycle success marker read failed; reporting anyway', {
       error,
       teamId,
-      event
+      markerKey
     });
   }
 
@@ -90,27 +84,11 @@ export const reportCRMTeamLifecycleOnce = async ({
 
     const user = await MongoUser.findById(team.ownerId, 'fastgpt_sem').lean();
     const visitorId = getVisitorId(user?.fastgpt_sem);
-    let success = false;
-    if (event === 'enterprise_verification') {
-      if (!enterprise) return;
-      success = await reportCRMEnterpriseVerification({
-        ...enterprise,
-        cloudUserId: String(team.ownerId),
-        visitorId,
-        details: {
-          ...enterprise.details,
-          team_name: enterprise.details.team_name || team.name
-        }
-      });
-    } else {
-      if (!visitorId) return;
-      success = await reportCRMVisitorLifecycle({
-        visitorId,
-        event,
-        company,
-        summary
-      });
-    }
+    const success = await report({
+      cloudUserId: String(team.ownerId),
+      visitorId,
+      teamName: team.name
+    });
     if (!success) return;
 
     try {
@@ -119,16 +97,66 @@ export const reportCRMTeamLifecycleOnce = async ({
       logger.warn('CRM team lifecycle success marker write failed', {
         error,
         teamId,
-        event
+        markerKey
       });
     }
   } catch (error) {
     logger.warn('CRM team lifecycle resolution failed', {
       error,
       teamId,
-      event
+      markerKey
     });
   }
 };
+
+const reportCRMTeamVisitorLifecycleOnce = async ({
+  teamId,
+  event
+}: LifecycleDetails): Promise<void> =>
+  reportCRMTeamEventOnce({
+    teamId,
+    markerKey: event,
+    report: async ({ visitorId }) => {
+      if (!visitorId) return false;
+      return reportCRMVisitorLifecycle({
+        visitorId,
+        event
+      });
+    }
+  });
+
+export const reportCRMTeamConsumptionOnce = ({ teamId }: { teamId: string }) =>
+  reportCRMTeamVisitorLifecycleOnce({
+    teamId,
+    event: 'consumption'
+  });
+
+export const reportCRMTeamRechargeOnce = ({ teamId }: { teamId: string }) =>
+  reportCRMTeamVisitorLifecycleOnce({
+    teamId,
+    event: 'recharge'
+  });
+
+export const reportCRMTeamEnterpriseVerificationOnce = ({
+  teamId,
+  enterprise
+}: {
+  teamId: string;
+  enterprise: CRMEnterpriseVerificationDetails;
+}) =>
+  reportCRMTeamEventOnce({
+    teamId,
+    markerKey: 'enterprise_verification_details-v2',
+    report: ({ cloudUserId, visitorId, teamName }) =>
+      reportCRMEnterpriseVerification({
+        ...enterprise,
+        cloudUserId,
+        visitorId,
+        details: {
+          ...enterprise.details,
+          team_name: enterprise.details.team_name || teamName
+        }
+      })
+  });
 
 export { CRMLifecycleEvent } from '../attribution';

--- a/packages/service/support/marketing/interface/index.ts
+++ b/packages/service/support/marketing/interface/index.ts
@@ -1,2 +1,8 @@
 /** CRM 营销与生命周期上报的稳定公开入口。 */
-export { CRMLifecycleEvent, reportCRMTeamLifecycleOnce } from './crm';
+export {
+  CRMLifecycleEvent,
+  reportCRMTeamConsumptionOnce,
+  reportCRMTeamEnterpriseVerificationOnce,
+  reportCRMTeamRechargeOnce
+} from './crm';
+export type { CRMEnterpriseVerificationDetails } from './crm';

--- a/packages/service/test/support/marketing/attribution.test.ts
+++ b/packages/service/test/support/marketing/attribution.test.ts
@@ -25,6 +25,7 @@ vi.mock('@fastgpt/service/env', () => ({
 
 import {
   CRMLifecycleEvent,
+  reportCRMEnterpriseVerification,
   reportCRMVisitorIdentity,
   reportCRMVisitorLifecycle,
   resolveCRMVisitorId
@@ -98,6 +99,45 @@ describe('reportCRMVisitorLifecycle', () => {
         event: CRMLifecycleEvent.Consumption
       })
     ).resolves.toBe(false);
+  });
+});
+
+describe('reportCRMEnterpriseVerification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.serviceEnv.CRM_API_URL = 'https://crm.example.com/api/v1/';
+    mocks.serviceEnv.CRM_API_KEY = 'crm-key';
+  });
+
+  it('reports without a visitor id using cloud user and submission ids', async () => {
+    await expect(
+      reportCRMEnterpriseVerification({
+        cloudUserId: 'cloud-user-1',
+        submissionId: 'enterprise-task-1',
+        company: '认证企业',
+        summary: '企业认证需求',
+        name: '联系人',
+        contact: '13800138000',
+        position: 'CTO',
+        consultationTopic: 'SaaS 版',
+        details: {
+          unified_credit_code: '91310000MA1K000006',
+          legal_person_name: '法人',
+          bank_name: '开户银行',
+          bank_account: '4111111111111111'
+        }
+      })
+    ).resolves.toBe(true);
+
+    expect(mocks.post).toHaveBeenCalledWith(
+      'https://crm.example.com/api/v1/contacts/opportunities/lifecycle',
+      expect.objectContaining({
+        event: 'enterprise_verification',
+        cloud_user_id: 'cloud-user-1',
+        submission_id: 'enterprise-task-1'
+      }),
+      expect.any(Object)
+    );
   });
 });
 

--- a/packages/service/test/support/marketing/crmInterface.test.ts
+++ b/packages/service/test/support/marketing/crmInterface.test.ts
@@ -47,8 +47,9 @@ vi.mock('@fastgpt/service/support/marketing/attribution', async (importOriginal)
 });
 
 import {
-  CRMLifecycleEvent,
-  reportCRMTeamLifecycleOnce
+  reportCRMTeamConsumptionOnce,
+  reportCRMTeamEnterpriseVerificationOnce,
+  reportCRMTeamRechargeOnce
 } from '@fastgpt/service/support/marketing/interface';
 
 describe('CRM team lifecycle interface', () => {
@@ -66,10 +67,7 @@ describe('CRM team lifecycle interface', () => {
   it('checks the team marker before querying team or user', async () => {
     mocks.has.mockResolvedValueOnce(true);
 
-    await reportCRMTeamLifecycleOnce({
-      teamId: 'team-1',
-      event: CRMLifecycleEvent.Consumption
-    });
+    await reportCRMTeamConsumptionOnce({ teamId: 'team-1' });
 
     expect(mocks.has).toHaveBeenCalledWith({
       scope: 'integration-report',
@@ -81,10 +79,7 @@ describe('CRM team lifecycle interface', () => {
   });
 
   it('resolves the team owner visitor and marks the team only after CRM succeeds', async () => {
-    await reportCRMTeamLifecycleOnce({
-      teamId: 'team-1',
-      event: CRMLifecycleEvent.Recharge
-    });
+    await reportCRMTeamRechargeOnce({ teamId: 'team-1' });
 
     expect(mocks.findTeam).toHaveBeenCalledWith('team-1', 'ownerId name');
     expect(mocks.findUser).toHaveBeenCalledWith('user-1', 'fastgpt_sem');
@@ -105,10 +100,7 @@ describe('CRM team lifecycle interface', () => {
   it('does not mark a failed CRM request', async () => {
     mocks.report.mockResolvedValueOnce(false);
 
-    await reportCRMTeamLifecycleOnce({
-      teamId: 'team-1',
-      event: CRMLifecycleEvent.Consumption
-    });
+    await reportCRMTeamConsumptionOnce({ teamId: 'team-1' });
 
     expect(mocks.mark).not.toHaveBeenCalled();
   });
@@ -116,9 +108,8 @@ describe('CRM team lifecycle interface', () => {
   it('reports enterprise verification without a visitor id using the team owner', async () => {
     mocks.findUser.mockResolvedValueOnce({ fastgpt_sem: {} });
 
-    await reportCRMTeamLifecycleOnce({
+    await reportCRMTeamEnterpriseVerificationOnce({
       teamId: 'team-1',
-      event: CRMLifecycleEvent.EnterpriseVerification,
       enterprise: {
         submissionId: 'enterprise-task-1',
         company: '认证企业',
@@ -156,7 +147,7 @@ describe('CRM team lifecycle interface', () => {
     });
     expect(mocks.has).toHaveBeenCalledWith({
       scope: 'integration-report',
-      segments: ['crm', 'lifecycle', 'enterprise_verification', 'team', 'team-1', 'details-v2']
+      segments: ['crm', 'lifecycle', 'enterprise_verification_details-v2', 'team', 'team-1']
     });
     expect(mocks.mark).toHaveBeenCalled();
   });
@@ -164,10 +155,7 @@ describe('CRM team lifecycle interface', () => {
   it('fails open when Redis cannot read the team marker', async () => {
     mocks.has.mockRejectedValueOnce(new Error('redis unavailable'));
 
-    await reportCRMTeamLifecycleOnce({
-      teamId: 'team-1',
-      event: CRMLifecycleEvent.Consumption
-    });
+    await reportCRMTeamConsumptionOnce({ teamId: 'team-1' });
 
     expect(mocks.findTeam).toHaveBeenCalledTimes(1);
     expect(mocks.report).toHaveBeenCalledTimes(1);
@@ -177,10 +165,7 @@ describe('CRM team lifecycle interface', () => {
   it('does not mark when the owner has no visitor id', async () => {
     mocks.findUser.mockResolvedValueOnce({ fastgpt_sem: {} });
 
-    await reportCRMTeamLifecycleOnce({
-      teamId: 'team-1',
-      event: CRMLifecycleEvent.Consumption
-    });
+    await reportCRMTeamConsumptionOnce({ teamId: 'team-1' });
 
     expect(mocks.report).not.toHaveBeenCalled();
     expect(mocks.mark).not.toHaveBeenCalled();

--- a/packages/service/test/support/marketing/crmInterface.test.ts
+++ b/packages/service/test/support/marketing/crmInterface.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   has: vi.fn(),
   mark: vi.fn(),
   report: vi.fn(),
+  reportEnterprise: vi.fn(),
   configured: vi.fn(),
   findUser: vi.fn(),
   findTeam: vi.fn(),
@@ -40,7 +41,8 @@ vi.mock('@fastgpt/service/support/marketing/attribution', async (importOriginal)
   return {
     ...original,
     isCRMReportingConfigured: mocks.configured,
-    reportCRMVisitorLifecycle: mocks.report
+    reportCRMVisitorLifecycle: mocks.report,
+    reportCRMEnterpriseVerification: mocks.reportEnterprise
   };
 });
 
@@ -56,7 +58,8 @@ describe('CRM team lifecycle interface', () => {
     mocks.has.mockResolvedValue(false);
     mocks.mark.mockResolvedValue(undefined);
     mocks.report.mockResolvedValue(true);
-    mocks.findTeam.mockResolvedValue({ ownerId: 'user-1' });
+    mocks.reportEnterprise.mockResolvedValue(true);
+    mocks.findTeam.mockResolvedValue({ ownerId: 'user-1', name: '认证团队' });
     mocks.findUser.mockResolvedValue({ fastgpt_sem: { visitor_id: 'stored-visitor' } });
   });
 
@@ -83,7 +86,7 @@ describe('CRM team lifecycle interface', () => {
       event: CRMLifecycleEvent.Recharge
     });
 
-    expect(mocks.findTeam).toHaveBeenCalledWith('team-1', 'ownerId');
+    expect(mocks.findTeam).toHaveBeenCalledWith('team-1', 'ownerId name');
     expect(mocks.findUser).toHaveBeenCalledWith('user-1', 'fastgpt_sem');
     expect(mocks.report).toHaveBeenCalledWith({
       visitorId: 'stored-visitor',
@@ -108,6 +111,54 @@ describe('CRM team lifecycle interface', () => {
     });
 
     expect(mocks.mark).not.toHaveBeenCalled();
+  });
+
+  it('reports enterprise verification without a visitor id using the team owner', async () => {
+    mocks.findUser.mockResolvedValueOnce({ fastgpt_sem: {} });
+
+    await reportCRMTeamLifecycleOnce({
+      teamId: 'team-1',
+      event: CRMLifecycleEvent.EnterpriseVerification,
+      enterprise: {
+        submissionId: 'enterprise-task-1',
+        company: '认证企业',
+        summary: '企业认证需求',
+        name: '联系人',
+        contact: '13800138000',
+        position: 'CTO',
+        consultationTopic: 'SaaS 版',
+        details: {
+          unified_credit_code: '91310000MA1K000006',
+          legal_person_name: '法人',
+          bank_name: '开户银行',
+          bank_account: '4111111111111111'
+        }
+      }
+    });
+
+    expect(mocks.reportEnterprise).toHaveBeenCalledWith({
+      submissionId: 'enterprise-task-1',
+      company: '认证企业',
+      summary: '企业认证需求',
+      name: '联系人',
+      contact: '13800138000',
+      position: 'CTO',
+      consultationTopic: 'SaaS 版',
+      details: {
+        unified_credit_code: '91310000MA1K000006',
+        legal_person_name: '法人',
+        bank_name: '开户银行',
+        bank_account: '4111111111111111',
+        team_name: '认证团队'
+      },
+      cloudUserId: 'user-1',
+      visitorId: undefined
+    });
+    expect(mocks.has).toHaveBeenCalledWith({
+      scope: 'integration-report',
+      segments: ['crm', 'lifecycle', 'enterprise_verification', 'team', 'team-1', 'details-v2']
+    });
+    expect(mocks.mark).toHaveBeenCalled();
   });
 
   it('fails open when Redis cannot read the team marker', async () => {


### PR DESCRIPTION
## What changed

- Report enterprise verification to CRM with the authenticated `cloud_user_id` and stable enterprise-auth task ID.
- Allow the enterprise report to omit `visitor_id` until the website visitor is identified.
- Keep CRM reporting best-effort so successful enterprise verification is not affected by CRM availability.
- Update the `pro` submodule to the companion FastGPT Pro change.

## Why

Enterprise verification can happen before the website visitor ID is available. The CRM must persist the lead first and associate it with the visitor later during login.

## Validation

- FastGPT marketing tests: 15 passed
- Root TypeScript check passed
- `pro` TypeScript check passed
- CRM companion PR: https://github.com/labring/lead-crm/pull/14
- FastGPT Pro companion PR: https://github.com/labring/fastgpt-pro/pull/1066