### PR TITLE
docs: add OrcaRouter integration example

### DIFF
--- a/document/content/self-host/config/model/meta.en.json
+++ b/document/content/self-host/config/model/meta.en.json
@@ -1,4 +1,4 @@
 {
   "title": "Model Configuration",
-  "pages": ["intro", "siliconCloud", "minimax"]
+  "pages": ["intro", "siliconCloud", "minimax", "orcaRouter"]
 }

--- a/document/content/self-host/config/model/meta.json
+++ b/document/content/self-host/config/model/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "模型配置方案",
-  "pages": ["intro", "siliconCloud", "minimax"]
+  "pages": ["intro", "siliconCloud", "minimax", "orcaRouter"]
 }

--- a/document/content/self-host/config/model/orcaRouter.en.mdx
+++ b/document/content/self-host/config/model/orcaRouter.en.mdx
@@ -1,0 +1,44 @@
+---
+title: OrcaRouter Integration Example
+description: OrcaRouter integration example for FastGPT
+---
+
+[OrcaRouter](https://www.orcarouter.ai) is an AI model routing gateway that exposes models from OpenAI, Anthropic, Google, DeepSeek, Qwen and xAI behind a single API key and endpoint. Its API is compatible with the OpenAI format, making it easy to integrate with FastGPT.
+
+Before reading this guide, make sure you've read the [Model Configuration Guide](./intro.en.mdx).
+
+## 1. Get an API Key
+
+1. Visit [OrcaRouter](https://www.orcarouter.ai), register and log in.
+2. Go to the console and create an API Key (keys start with `sk-orca-`).
+
+## 2. Add Models
+
+OrcaRouter models are not part of the built-in preset list, so add them through the [Add a Custom Model](./intro.en.mdx#add-a-custom-model) flow on the `Model Configuration` page — one model per OrcaRouter model ID. Because OrcaRouter's API is OpenAI-compatible, choose `OpenAI` as the model provider, or select `Other`.
+
+### Recommended Model List
+
+| Model ID                       | Description                                          |
+| ------------------------------ | ---------------------------------------------------- |
+| `orcarouter/auto`              | Automatically routes each request to the best model (**default**) |
+| `openai/gpt-5.5`               | OpenAI flagship model                                |
+| `openai/gpt-4o`                | OpenAI multimodal model                              |
+| `anthropic/claude-sonnet-4.6`  | Anthropic balanced model                             |
+| `anthropic/claude-opus-4.8`    | Anthropic flagship model                             |
+| `google/gemini-3.1-flash-lite` | Google fast, low-cost model                          |
+| `deepseek/deepseek-v4-flash-0731` | DeepSeek fast reasoning model                     |
+| `grok/grok-4.3`                | xAI model                                            |
+| `qwen/qwen3.7-max`             | Qwen flagship model                                  |
+
+## 3. Add a Model Provider
+
+On the Model providers page, add a new OrcaRouter channel:
+
+- Protocol type: Select **OpenAI** (OrcaRouter is OpenAI-compatible)
+- Proxy URL: `https://api.orcarouter.ai/v1`
+- Enter your OrcaRouter API Key
+- Select the models you just added
+
+## 4. Test Models
+
+After configuration, click the test button in the channel list to verify the models are working properly.

--- a/document/content/self-host/config/model/orcaRouter.mdx
+++ b/document/content/self-host/config/model/orcaRouter.mdx
@@ -1,0 +1,44 @@
+---
+title: OrcaRouter 接入示例
+description: OrcaRouter 接入示例
+---
+
+[OrcaRouter](https://www.orcarouter.ai) 是一个 AI 模型路由网关，通过单个 API Key 和端点提供 OpenAI、Anthropic、Google、DeepSeek、Qwen、xAI 等多家厂商的模型。其 API 兼容 OpenAI 格式，可以方便地接入 FastGPT。
+
+在阅读该章之前，请先确保你阅读了[模型配置说明](./intro.mdx)。
+
+## 1. 获取 API Key
+
+1. 访问 [OrcaRouter](https://www.orcarouter.ai)，注册并登录账号。
+2. 进入控制台，创建 API Key（Key 以 `sk-orca-` 开头）。
+
+## 2. 新增模型
+
+OrcaRouter 的模型不在系统内置的模型列表中，需要在`模型配置`页面通过[新增自定义模型](./intro.mdx#新增自定义模型)添加——每个 OrcaRouter 模型 ID 添加一个模型。由于 OrcaRouter 的 API 兼容 OpenAI 格式，模型提供商（provider）选择 **OpenAI**，或选择 `Other`。
+
+### 推荐模型列表
+
+| 模型 ID | 说明 |
+|---------|------|
+| `orcarouter/auto` | 自动将每个请求路由到最优模型（**默认**） |
+| `openai/gpt-5.5` | OpenAI 旗舰模型 |
+| `openai/gpt-4o` | OpenAI 多模态模型 |
+| `anthropic/claude-sonnet-4.6` | Anthropic 均衡模型 |
+| `anthropic/claude-opus-4.8` | Anthropic 旗舰模型 |
+| `google/gemini-3.1-flash-lite` | Google 快速低成本模型 |
+| `deepseek/deepseek-v4-flash-0731` | DeepSeek 快速推理模型 |
+| `grok/grok-4.3` | xAI 模型 |
+| `qwen/qwen3.7-max` | Qwen 旗舰模型 |
+
+## 3. 新增模型渠道
+
+在模型渠道页，新增一个 OrcaRouter 的渠道：
+
+- 协议类型选择 **OpenAI**（OrcaRouter 兼容 OpenAI 协议）
+- 代理地址填写：`https://api.orcarouter.ai/v1`
+- 填写 OrcaRouter 的 API Key
+- 选择刚刚添加的模型
+
+## 4. 测试模型
+
+配置完成后，可以在渠道列表中点击测试按钮，验证模型是否正常工作。


### PR DESCRIPTION
## Add OrcaRouter integration guide

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway that brings 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint and API key. Beyond routing, it runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. This PR adds a FastGPT integration guide so users can wire it up directly.

I'm an engineer on the OrcaRouter team.

### What changed

Adds an OrcaRouter integration example to the self-host model configuration docs, mirroring the existing `siliconCloud` and `minimax` pages:

- `document/content/self-host/config/model/orcaRouter.en.mdx` / `orcaRouter.mdx` — new guide: get an API key, add the models via the existing [Add a Custom Model](./intro.en.mdx#add-a-custom-model) flow, create an OpenAI-protocol channel with proxy URL `https://api.orcarouter.ai/v1`, and test.
- `document/content/self-host/config/model/meta.en.json` / `meta.json` — register the new page in the docs navigation.

### Verification

- `checkDocRefs` (the docs link/pages checker) passes: 496 mdx files + all `meta.json` validated.
- Live against the real gateway using the exact config the guide documents: `POST https://api.orcarouter.ai/v1/chat/completions` with `orcarouter/auto` returned 200 with a valid reply; an invalid key was rejected with 401; `GET /v1/models` returned 200 (207 models), and all 9 model IDs listed in the guide exist in the live catalog.
