### PR TITLE
ci: allow read collaborators to publish previews

### DIFF
--- a/.github/workflows/preview-docs-push.yml
+++ b/.github/workflows/preview-docs-push.yml
@@ -49,7 +49,7 @@ jobs:
                   repo: context.repo.repo,
                   username
                 });
-                return ['admin', 'maintain', 'write'].includes(data.permission);
+                return ['admin', 'maintain', 'write', 'read'].includes(data.permission);
               } catch (error) {
                 core.warning(`Unable to resolve repository permission for ${username}: ${error.message}`);
                 return false;

--- a/.github/workflows/preview-fastgpt-push.yml
+++ b/.github/workflows/preview-fastgpt-push.yml
@@ -57,7 +57,7 @@ jobs:
                   repo: context.repo.repo,
                   username
                 });
-                return ['admin', 'maintain', 'write'].includes(data.permission);
+                return ['admin', 'maintain', 'write', 'read'].includes(data.permission);
               } catch (error) {
                 core.warning(`Unable to resolve repository permission for ${username}: ${error.message}`);
                 return false;


### PR DESCRIPTION
## What

Allow repository collaborators with `read` permission to automatically publish FastGPT and docs preview images after a successful build.

## Security boundary

The workflows still resolve permission through GitHub's `getCollaboratorPermissionLevel` API. Users without repository access return `none` and remain ineligible for automatic or manual preview publishing.

## Forgejo

No Forgejo workflow update is needed because these preview publishing workflows depend on GitHub Actions artifacts, PR comments, and the GitHub repository permission API.

## Validation

- `git diff --check`
- Prettier check for both modified workflow files