### PR TITLE
fix: preserve apostrophes in content-disposition filenames

### DIFF
--- a/packages/global/common/file/tools.ts
+++ b/packages/global/common/file/tools.ts
@@ -232,7 +232,12 @@ export const parseContentDispositionFilename = (contentDisposition?: string) => 
   const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i;
   const matches = filenameRegex.exec(contentDisposition);
   if (matches?.[1]) {
-    return matches[1].replace(/['"]/g, '');
+    const filename = matches[1];
+    const quote = filename[0];
+    if ((quote === '"' || quote === "'") && filename.endsWith(quote)) {
+      return filename.slice(1, -1);
+    }
+    return filename;
   }
 
   return '';

--- a/packages/global/test/common/file/tool.test.ts
+++ b/packages/global/test/common/file/tool.test.ts
@@ -434,6 +434,12 @@ describe('文件工具函数测试', () => {
   });
 
   describe('getContentDisposition', () => {
+    it('preserves apostrophes in quoted fallback filenames', () => {
+      const header = `attachment; filename="O'Reilly report.txt"`;
+
+      expect(parseContentDispositionFilename(header)).toBe("O'Reilly report.txt");
+    });
+
     it('sanitizes / and \\ in download filenames to keep cross-platform names consistent', () => {
       const result = getContentDisposition({ filename: 'a//b\\c.pdf', type: 'attachment' });
       expect(result).toBe('attachment; filename="a__b_c.pdf"; filename*=UTF-8\'\'a__b_c.pdf');


### PR DESCRIPTION
## Summary

- strip only matching outer quotes from fallback `filename=` values
- preserve valid apostrophes inside quoted download filenames
- add a regression test for `O'Reilly report.txt`

## Tests

- focused regression: 1 passed
- related file utility tests: 81 passed
- complete `packages/global` tests: 98 files, 1979 tests passed
- changed-file Prettier and ESLint checks
- targeted strict TypeScript check for the production file
- `git diff --check`
