### PR TITLE
refactor(app): extract AppConfigItem to unify app config row layouts

### DIFF
--- a/projects/app/src/components/core/app/AppConfigItem.tsx
+++ b/projects/app/src/components/core/app/AppConfigItem.tsx
@@ -1,0 +1,63 @@
+import {
+  Box,
+  Button,
+  Flex,
+  type BoxProps,
+  type ButtonProps,
+  type FlexProps
+} from '@chakra-ui/react';
+import MyIcon from '@fastgpt/web/components/common/Icon';
+import type { IconNameType } from '@fastgpt/web/components/common/Icon/type';
+import MyTooltip from '@fastgpt/web/components/common/MyTooltip';
+import FormLabel from '@fastgpt/web/components/common/MyBox/FormLabel';
+import React from 'react';
+
+type AppConfigItemProps = Omit<FlexProps, 'children'> & {
+  icon: IconNameType;
+  label: React.ReactNode;
+  tip?: React.ReactNode;
+  action?: React.ReactNode;
+  labelProps?: BoxProps;
+};
+
+/**
+ * Render the shared row layout for an application chat configuration item.
+ * The row owns spacing and typography so individual configuration components only provide content.
+ */
+const AppConfigItem = ({ icon, label, tip, action, labelProps, ...props }: AppConfigItemProps) => {
+  return (
+    <Flex alignItems={'center'} w={'100%'} minW={0} {...props}>
+      <MyIcon name={icon} mr={2} w={'20px'} flexShrink={0} />
+      <FormLabel {...labelProps}>{label}</FormLabel>
+      {tip}
+      <Box flex={1} />
+      {action}
+    </Flex>
+  );
+};
+
+export const AppConfigItemAction = ({
+  tooltip,
+  children,
+  ...props
+}: Omit<ButtonProps, 'children'> & {
+  tooltip: React.ReactNode;
+  children: React.ReactNode;
+}) => {
+  return (
+    <MyTooltip label={tooltip}>
+      <Button
+        variant={'transparentBase'}
+        iconSpacing={1}
+        size={'sm'}
+        mr={'-5px'}
+        color={'myGray.600'}
+        {...props}
+      >
+        {children}
+      </Button>
+    </MyTooltip>
+  );
+};
+
+export default React.memo(AppConfigItem);

--- a/projects/app/src/components/core/app/AutoExecConfig.tsx
+++ b/projects/app/src/components/core/app/AutoExecConfig.tsx
@@ -1,12 +1,11 @@
-import { Box, Button, Flex, ModalBody, Switch, Textarea, useDisclosure } from '@chakra-ui/react';
+import { Box, Flex, ModalBody, Switch, Textarea, useDisclosure } from '@chakra-ui/react';
 import { defaultAutoExecuteConfig } from '@fastgpt/global/core/app/constants';
 import { type AppAutoExecuteConfigType } from '@fastgpt/global/core/app/type';
-import MyIcon from '@fastgpt/web/components/common/Icon';
 import FormLabel from '@fastgpt/web/components/common/MyBox/FormLabel';
 import { useTranslation } from 'next-i18next';
 import ChatFunctionTip from './Tip';
-import MyTooltip from '@fastgpt/web/components/common/MyTooltip';
 import MyModal from '@fastgpt/web/components/common/MyModal';
+import AppConfigItem, { AppConfigItemAction } from './AppConfigItem';
 
 const AutoExecConfig = ({
   value = defaultAutoExecuteConfig,
@@ -25,23 +24,17 @@ const AutoExecConfig = ({
     : t('common:core.app.whisper.Close');
 
   return (
-    <Flex alignItems={'center'}>
-      <MyIcon name={'core/app/simpleMode/autoExec'} mr={2} w={'20px'} />
-      <FormLabel color={'myGray.600'}>{t('app:auto_execute')}</FormLabel>
-      <ChatFunctionTip type={'autoExec'} />
-      <Box flex={1} />
-      <MyTooltip label={t('common:core.app.Config_auto_execute')}>
-        <Button
-          variant={'transparentBase'}
-          iconSpacing={1}
-          size={'sm'}
-          mr={'-5px'}
-          onClick={onOpen}
-          color={'myGray.600'}
-        >
-          {formLabel}
-        </Button>
-      </MyTooltip>
+    <>
+      <AppConfigItem
+        icon={'core/app/simpleMode/autoExec'}
+        label={t('app:auto_execute')}
+        tip={<ChatFunctionTip type={'autoExec'} />}
+        action={
+          <AppConfigItemAction tooltip={t('common:core.app.Config_auto_execute')} onClick={onOpen}>
+            {formLabel}
+          </AppConfigItemAction>
+        }
+      />
       <MyModal
         title={t('common:core.app.Auto execute')}
         iconSrc="core/app/simpleMode/autoExec"
@@ -80,7 +73,7 @@ const AutoExecConfig = ({
           )}
         </ModalBody>
       </MyModal>
-    </Flex>
+    </>
   );
 };
 

--- a/projects/app/src/components/core/app/FileSelect.tsx
+++ b/projects/app/src/components/core/app/FileSelect.tsx
@@ -1,9 +1,6 @@
-import MyIcon from '@fastgpt/web/components/common/Icon';
-import MyTooltip from '@fastgpt/web/components/common/MyTooltip';
 import {
   Box,
   Button,
-  Flex,
   useDisclosure,
   HStack,
   type BoxProps,
@@ -24,6 +21,7 @@ import { defaultAppSelectFileConfig } from '@fastgpt/global/core/app/constants';
 import InputSlider from '@fastgpt/web/components/common/MySlider/InputSlider';
 import { FileTypeSelectorPanel } from '@fastgpt/web/components/core/app/FileTypeSelector';
 import { getUserFileAmountLimit } from '@fastgpt/global/core/workflow/fileLimit';
+import AppConfigItem, { AppConfigItemAction } from './AppConfigItem';
 
 const FileSelect = ({
   value = defaultAppSelectFileConfig,
@@ -57,26 +55,24 @@ const FileSelect = ({
     : t('common:core.app.whisper.Close');
 
   return (
-    <Flex alignItems={'center'}>
-      <MyIcon name={'core/app/simpleMode/file'} mr={2} w={'20px'} />
-      <FormLabel {...labelStyle}>{t('app:file_upload')}</FormLabel>
-      <ChatFunctionTip type={'file'} />
-      <Box flex={1} />
-      <MyTooltip label={t('app:config_file_upload')}>
-        <Button
-          variant={'transparentBase'}
-          iconSpacing={1}
-          size={'sm'}
-          mr={'-5px'}
-          color={'myGray.600'}
-          onClick={() => {
-            setLocalValue(value);
-            onOpen();
-          }}
-        >
-          {formLabel}
-        </Button>
-      </MyTooltip>
+    <>
+      <AppConfigItem
+        icon={'core/app/simpleMode/file'}
+        label={t('app:file_upload')}
+        labelProps={labelStyle}
+        tip={<ChatFunctionTip type={'file'} />}
+        action={
+          <AppConfigItemAction
+            tooltip={t('app:config_file_upload')}
+            onClick={() => {
+              setLocalValue(value);
+              onOpen();
+            }}
+          >
+            {formLabel}
+          </AppConfigItemAction>
+        }
+      />
       <MyModal
         title={t('app:file_upload')}
         isOpen={isOpen}
@@ -171,7 +167,7 @@ const FileSelect = ({
           </HStack>
         )}
       </MyModal>
-    </Flex>
+    </>
   );
 };
 

--- a/projects/app/src/components/core/app/InputGuideConfig/index.tsx
+++ b/projects/app/src/components/core/app/InputGuideConfig/index.tsx
@@ -1,6 +1,4 @@
-import MyIcon from '@fastgpt/web/components/common/Icon';
-import MyTooltip from '@fastgpt/web/components/common/MyTooltip';
-import { Box, Button, Flex, useDisclosure } from '@chakra-ui/react';
+import { useDisclosure } from '@chakra-ui/react';
 import React from 'react';
 import { useTranslation } from 'next-i18next';
 import type { ChatInputGuideConfigType } from '@fastgpt/global/core/app/type';
@@ -8,9 +6,9 @@ import { getCountChatInputGuideTotal } from '@/web/core/chat/inputGuide/api';
 import { useQuery } from '@tanstack/react-query';
 import { defaultChatInputGuideConfig } from '@fastgpt/global/core/app/constants';
 import ChatFunctionTip from '../Tip';
-import FormLabel from '@fastgpt/web/components/common/MyBox/FormLabel';
 import InputGuideConfigModal from './InputGuideConfigModal';
 import dynamic from 'next/dynamic';
+import AppConfigItem, { AppConfigItemAction } from '../AppConfigItem';
 
 const LexiconConfigModal = dynamic(() => import('./LexiconConfigModal'), {
   ssr: false
@@ -48,25 +46,17 @@ const InputGuideConfig = ({
     : t('common:core.app.whisper.Close');
 
   return (
-    <Flex alignItems={'center'}>
-      <MyIcon name={'core/app/inputGuides'} mr={2} w={'20px'} />
-      <Flex alignItems={'center'}>
-        <FormLabel>{t('app:input_guide')}</FormLabel>
-        <ChatFunctionTip type={'inputGuide'} />
-      </Flex>
-      <Box flex={1} />
-      <MyTooltip label={t('app:config_input_guide')}>
-        <Button
-          variant={'transparentBase'}
-          iconSpacing={1}
-          size={'sm'}
-          mr={'-5px'}
-          color={'myGray.600'}
-          onClick={onOpen}
-        >
-          {statusText}
-        </Button>
-      </MyTooltip>
+    <>
+      <AppConfigItem
+        icon={'core/app/inputGuides'}
+        label={t('app:input_guide')}
+        tip={<ChatFunctionTip type={'inputGuide'} />}
+        action={
+          <AppConfigItemAction tooltip={t('app:config_input_guide')} onClick={onOpen}>
+            {statusText}
+          </AppConfigItemAction>
+        }
+      />
 
       <InputGuideConfigModal
         isOpen={isOpen}
@@ -78,7 +68,7 @@ const InputGuideConfig = ({
       />
 
       {isOpenLexiconConfig && <LexiconConfigModal appId={appId} onClose={onCloseLexiconConfig} />}
-    </Flex>
+    </>
   );
 };
 

--- a/projects/app/src/components/core/app/QGConfig.tsx
+++ b/projects/app/src/components/core/app/QGConfig.tsx
@@ -1,5 +1,4 @@
 import MyIcon from '@fastgpt/web/components/common/Icon';
-import MyTooltip from '@fastgpt/web/components/common/MyTooltip';
 import { Box, Button, Flex, useDisclosure, Switch, type BoxProps } from '@chakra-ui/react';
 
 import React from 'react';
@@ -10,6 +9,7 @@ import QuestionTip from '@fastgpt/web/components/common/MyTooltip/QuestionTip';
 import { defaultQGConfig } from '@fastgpt/global/core/app/constants';
 import ChatFunctionTip from './Tip';
 import FormLabel from '@fastgpt/web/components/common/MyBox/FormLabel';
+import AppConfigItem, { AppConfigItemAction } from './AppConfigItem';
 import { useSystemStore } from '@/web/common/system/useSystemStore';
 import AIModelSelector from '@/components/Select/AIModelSelector';
 import CustomPromptEditor from '@fastgpt/web/components/common/Textarea/CustomPromptEditor';
@@ -36,25 +36,20 @@ const QGConfig = ({
     : t('common:core.app.whisper.Close');
 
   return (
-    <Flex alignItems={'center'}>
-      <MyIcon name={'core/chat/QGFill'} mr={2} w={'20px'} />
-      <FormLabel>{t('common:core.app.Question Guide')}</FormLabel>
-      <ChatFunctionTip type={'nextQuestion'} />
-      <Box flex={1} />
-      <MyTooltip label={t('app:config_question_guide')}>
-        <Button
-          variant={'transparentBase'}
-          size={'sm'}
-          mr={'-5px'}
-          color={'myGray.600'}
-          onClick={onOpen}
-        >
-          {formLabel}
-        </Button>
-      </MyTooltip>
+    <>
+      <AppConfigItem
+        icon={'core/chat/QGFill'}
+        label={t('common:core.app.Question Guide')}
+        tip={<ChatFunctionTip type={'nextQuestion'} />}
+        action={
+          <AppConfigItemAction tooltip={t('app:config_question_guide')} onClick={onOpen}>
+            {formLabel}
+          </AppConfigItemAction>
+        }
+      />
 
       {isOpen && <QGConfigModal value={value} onChange={onChange} onClose={onClose} />}
-    </Flex>
+    </>
   );
 };
 

--- a/projects/app/src/components/core/app/ScheduledTriggerConfig.tsx
+++ b/projects/app/src/components/core/app/ScheduledTriggerConfig.tsx
@@ -1,18 +1,7 @@
-import {
-  Box,
-  Button,
-  Flex,
-  ModalBody,
-  useDisclosure,
-  Switch,
-  Textarea,
-  HStack
-} from '@chakra-ui/react';
+import { Box, Flex, ModalBody, useDisclosure, Switch, Textarea } from '@chakra-ui/react';
 import React, { useCallback, useEffect } from 'react';
-import MyIcon from '@fastgpt/web/components/common/Icon';
 import { useTranslation } from 'next-i18next';
 import QuestionTip from '@fastgpt/web/components/common/MyTooltip/QuestionTip';
-import MyTooltip from '@fastgpt/web/components/common/MyTooltip';
 import { type AppScheduledTriggerConfigType } from '@fastgpt/global/core/app/type';
 import MyModal from '@fastgpt/web/components/common/MyModal';
 import TimezoneSelect from '@fastgpt/web/components/common/MySelect/TimezoneSelect';
@@ -21,6 +10,7 @@ import ScheduleTimeSelect, {
   defaultCronString
 } from '@fastgpt/web/components/common/MySelect/CronSelector';
 import FormLabel from '@fastgpt/web/components/common/MyBox/FormLabel';
+import AppConfigItem, { AppConfigItemAction } from './AppConfigItem';
 
 const ScheduledTriggerConfig = ({
   value,
@@ -63,25 +53,16 @@ const ScheduledTriggerConfig = ({
 
   return (
     <>
-      <Flex alignItems={'center'}>
-        <MyIcon name={'core/app/schedulePlan'} w={'20px'} />
-        <HStack ml={2} flex={1} spacing={1}>
-          <FormLabel color={'myGray.600'}>{t('common:core.app.Interval timer run')}</FormLabel>
-          <QuestionTip label={t('common:core.app.Interval timer tip')} />
-        </HStack>
-        <MyTooltip label={t('common:core.app.Config schedule plan')}>
-          <Button
-            variant={'transparentBase'}
-            iconSpacing={1}
-            size={'sm'}
-            mr={'-5px'}
-            color={'myGray.600'}
-            onClick={onOpen}
-          >
+      <AppConfigItem
+        icon={'core/app/schedulePlan'}
+        label={t('common:core.app.Interval timer run')}
+        tip={<QuestionTip ml={1} label={t('common:core.app.Interval timer tip')} />}
+        action={
+          <AppConfigItemAction tooltip={t('common:core.app.Config schedule plan')} onClick={onOpen}>
             {cronString2Label(value?.cronString ?? '', t)}
-          </Button>
-        </MyTooltip>
-      </Flex>
+          </AppConfigItemAction>
+        }
+      />
 
       <MyModal
         isOpen={isOpen}

--- a/projects/app/src/components/core/app/TTSSelect.tsx
+++ b/projects/app/src/components/core/app/TTSSelect.tsx
@@ -1,5 +1,4 @@
 import MyIcon from '@fastgpt/web/components/common/Icon';
-import MyTooltip from '@fastgpt/web/components/common/MyTooltip';
 import { Box, Button, Flex, useDisclosure, HStack } from '@chakra-ui/react';
 import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'next-i18next';
@@ -17,6 +16,7 @@ import { useContextSelector } from 'use-context-selector';
 import { AppContext } from '@/pageComponents/app/detail/context';
 import Avatar from '@fastgpt/web/components/common/Avatar';
 import MultipleRowSelect from '@fastgpt/web/components/common/MySelect/MultipleRowSelect';
+import AppConfigItem, { AppConfigItemAction } from './AppConfigItem';
 
 type TTSSelectorItemType = {
   alias: string;
@@ -145,25 +145,22 @@ const TTSSelect = ({
   }, [cancelAudio, onClose]);
 
   return (
-    <Flex alignItems={'center'} w={'100%'} minW={0}>
-      <MyIcon name={'core/app/simpleMode/tts'} mr={2} w={'20px'} />
-      <FormLabel>{t('common:core.app.TTS')}</FormLabel>
-      <ChatFunctionTip type={'tts'} />
-      <Box flex={'1 1 0'} minW={3} />
-      <MyTooltip label={t('common:core.app.Select TTS')}>
-        <Button
-          variant={'transparentBase'}
-          iconSpacing={1}
-          size={'sm'}
-          mr={'-5px'}
-          minW={0}
-          maxW={['180px', '260px']}
-          onClick={onOpen}
-          color={'myGray.600'}
-        >
-          {formLabel}
-        </Button>
-      </MyTooltip>
+    <>
+      <AppConfigItem
+        icon={'core/app/simpleMode/tts'}
+        label={t('common:core.app.TTS')}
+        tip={<ChatFunctionTip type={'tts'} />}
+        action={
+          <AppConfigItemAction
+            tooltip={t('common:core.app.Select TTS')}
+            minW={0}
+            maxW={['180px', '260px']}
+            onClick={onOpen}
+          >
+            {formLabel}
+          </AppConfigItemAction>
+        }
+      />
       <MyModal
         title={t('common:core.app.TTS')}
         isOpen={isOpen}
@@ -236,7 +233,7 @@ const TTSSelect = ({
           />
         </Flex>
       </MyModal>
-    </Flex>
+    </>
   );
 };
 

--- a/projects/app/src/components/core/app/VariableEdit.tsx
+++ b/projects/app/src/components/core/app/VariableEdit.tsx
@@ -1,16 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import {
-  Box,
-  Button,
-  Flex,
-  Table,
-  Thead,
-  Tr,
-  Th,
-  Td,
-  TableContainer,
-  Tbody
-} from '@chakra-ui/react';
+import { Box, Flex, Table, Thead, Tr, Th, Td, TableContainer, Tbody } from '@chakra-ui/react';
 import { SmallAddIcon } from '@chakra-ui/icons';
 import {
   VariableInputEnum,
@@ -22,7 +11,6 @@ import MyTooltip from '@fastgpt/web/components/common/MyTooltip';
 import { useTranslation } from 'next-i18next';
 import { formatEditorVariablePickerIcon } from '@fastgpt/global/core/workflow/utils';
 import ChatFunctionTip from './Tip';
-import FormLabel from '@fastgpt/web/components/common/MyBox/FormLabel';
 import MyIconButton from '@fastgpt/web/components/common/Icon/button';
 import DndDrag, {
   Draggable,
@@ -31,6 +19,7 @@ import DndDrag, {
   type DraggableStateSnapshot
 } from '@fastgpt/web/components/common/DndDrag';
 import VariableEditModal from './VariableEditModal';
+import AppConfigItem, { AppConfigItemAction } from './AppConfigItem';
 
 export const defaultVariable: VariableItemType = {
   key: '',
@@ -90,25 +79,22 @@ const VariableEdit = ({
   return (
     <Box className="nodrag">
       {/* Row box */}
-      <Flex alignItems={'center'}>
-        <MyIcon name={'core/app/simpleMode/variable'} w={'20px'} />
-        <FormLabel ml={2}>{t('common:core.module.Variable')}</FormLabel>
-        <ChatFunctionTip type={'variable'} />
-        <Box flex={1} />
-        <Button
-          variant={'transparentBase'}
-          leftIcon={<SmallAddIcon />}
-          iconSpacing={1}
-          size={'sm'}
-          color={'myGray.600'}
-          mr={'-5px'}
-          onClick={() => {
-            setEditingVariable(addVariable());
-          }}
-        >
-          {t('common:add_new')}
-        </Button>
-      </Flex>
+      <AppConfigItem
+        icon={'core/app/simpleMode/variable'}
+        label={t('common:core.module.Variable')}
+        tip={<ChatFunctionTip type={'variable'} />}
+        action={
+          <AppConfigItemAction
+            tooltip={t('common:add_new')}
+            leftIcon={<SmallAddIcon />}
+            onClick={() => {
+              setEditingVariable(addVariable());
+            }}
+          >
+            {t('common:add_new')}
+          </AppConfigItemAction>
+        }
+      />
       {/* Form render */}
       {formatVariables.length > 0 && (
         <TableContainer mt={2} borderRadius={'md'} overflow={'hidden'} borderWidth={'1px'}>

--- a/projects/app/src/components/core/app/WelcomeTextConfig.tsx
+++ b/projects/app/src/components/core/app/WelcomeTextConfig.tsx
@@ -1,11 +1,11 @@
-import { Box, Button, Flex, type TextareaProps } from '@chakra-ui/react';
+import { Button, type TextareaProps } from '@chakra-ui/react';
 import React from 'react';
 import MyIcon from '@fastgpt/web/components/common/Icon';
 import MyTooltip from '@fastgpt/web/components/common/MyTooltip';
 import ChatFunctionTip from './Tip';
 import MyTextarea from '@/components/common/Textarea/MyTextarea';
 import { useTranslation } from 'next-i18next';
-import FormLabel from '@fastgpt/web/components/common/MyBox/FormLabel';
+import AppConfigItem from './AppConfigItem';
 
 type WelcomeTextConfigProps = TextareaProps & {
   drawerMode?: boolean;
@@ -53,21 +53,14 @@ const WelcomeTextConfig = ({
   if (drawerMode) {
     return (
       <>
-        <Flex
-          alignItems={'center'}
-          justifyContent={'space-between'}
-          w={'100%'}
+        <AppConfigItem
+          icon={'core/app/simpleMode/chat'}
+          label={t('common:core.app.Welcome Text')}
+          tip={<ChatFunctionTip type={'welcome'} />}
+          action={<FoldIconButton isFolded={isFolded} tip={foldButtonTip} onClick={onToggleFold} />}
           h={7}
           mb={isFolded ? 0 : 2}
-        >
-          <MyIcon name={'core/app/simpleMode/chat'} w={5} flexShrink={0} />
-          <FormLabel ml={2} flexShrink={0}>
-            {t('common:core.app.Welcome Text')}
-          </FormLabel>
-          <ChatFunctionTip type={'welcome'} />
-          <Box flex={1} />
-          <FoldIconButton isFolded={isFolded} tip={foldButtonTip} onClick={onToggleFold} />
-        </Flex>
+        />
         {!isFolded && (
           <MyTextarea
             iconSrc={'core/app/simpleMode/chat'}
@@ -99,17 +92,16 @@ const WelcomeTextConfig = ({
 
   return (
     <>
-      <Flex alignItems={'center'}>
-        <MyIcon name={'core/app/simpleMode/chat'} w={5} />
-        <FormLabel ml={2}>{t('common:core.app.Welcome Text')}</FormLabel>
-        <ChatFunctionTip type={'welcome'} />
-        {onToggleFold && (
-          <>
-            <Box flex={1} />
+      <AppConfigItem
+        icon={'core/app/simpleMode/chat'}
+        label={t('common:core.app.Welcome Text')}
+        tip={<ChatFunctionTip type={'welcome'} />}
+        action={
+          onToggleFold ? (
             <FoldIconButton isFolded={isFolded} tip={foldButtonTip} onClick={onToggleFold} />
-          </>
-        )}
-      </Flex>
+          ) : undefined
+        }
+      />
       {!isFolded && (
         <MyTextarea
           className="nowheel"

--- a/projects/app/src/components/core/app/WhisperConfig.tsx
+++ b/projects/app/src/components/core/app/WhisperConfig.tsx
@@ -1,5 +1,3 @@
-import MyIcon from '@fastgpt/web/components/common/Icon';
-import MyTooltip from '@fastgpt/web/components/common/MyTooltip';
 import { Box, Button, Flex, useDisclosure, Switch } from '@chakra-ui/react';
 import React from 'react';
 import { useTranslation } from 'next-i18next';
@@ -8,6 +6,7 @@ import MyModal from '@fastgpt/web/components/v2/common/MyModal';
 import QuestionTip from '@fastgpt/web/components/common/MyTooltip/QuestionTip';
 import { defaultWhisperConfig } from '@fastgpt/global/core/app/constants';
 import FormLabel from '@fastgpt/web/components/common/MyBox/FormLabel';
+import AppConfigItem, { AppConfigItemAction } from './AppConfigItem';
 
 const WhisperConfig = ({
   isOpenAudio,
@@ -29,23 +28,17 @@ const WhisperConfig = ({
     : t('common:core.app.whisper.Close');
 
   return (
-    <Flex alignItems={'center'}>
-      <MyIcon name={'core/app/simpleMode/whisper'} mr={2} w={'20px'} />
-      <FormLabel>{t('common:core.app.Whisper')}</FormLabel>
-      <QuestionTip label={t('common:core.app.Config whisper')} ml={1} />
-      <Box flex={1} />
-      <MyTooltip label={t('common:core.app.Config whisper')}>
-        <Button
-          variant={'transparentBase'}
-          iconSpacing={1}
-          size={'sm'}
-          mr={'-5px'}
-          color={'myGray.600'}
-          onClick={onOpen}
-        >
-          {formLabel}
-        </Button>
-      </MyTooltip>
+    <>
+      <AppConfigItem
+        icon={'core/app/simpleMode/whisper'}
+        label={t('common:core.app.Whisper')}
+        tip={<QuestionTip label={t('common:core.app.Config whisper')} ml={1} />}
+        action={
+          <AppConfigItemAction tooltip={t('common:core.app.Config whisper')} onClick={onOpen}>
+            {formLabel}
+          </AppConfigItemAction>
+        }
+      />
       <MyModal
         title={t('common:core.app.Whisper config')}
         isOpen={isOpen}
@@ -105,7 +98,7 @@ const WhisperConfig = ({
           </>
         )}
       </MyModal>
-    </Flex>
+    </>
   );
 };
 


### PR DESCRIPTION
<!-- Describe your PR here -->
### Summary

- Extract reusable `AppConfigItem` and `AppConfigItemAction` components to standardize layout, icon spacing, and action buttons across app configuration items.
- Refactor `AutoExecConfig`, `FileSelect`, `InputGuideConfig`, `QGConfig`, `ScheduledTriggerConfig`, `TTSSelect`, `VariableEdit`, `WelcomeTextConfig`, and `WhisperConfig` to use `AppConfigItem`.
