### PR TITLE
fix: use VLM fallback for image caption retrieval

### DIFF
--- a/packages/service/core/dataset/search/defaultRecall/imageCaption.ts
+++ b/packages/service/core/dataset/search/defaultRecall/imageCaption.ts
@@ -1,4 +1,4 @@
-import { getLLMModel } from '../../../ai/model';
+import { getVlmModel } from '../../../ai/model';
 import { createLLMResponse } from '../../../ai/llm/request';
 import { getLogger, LogCategories } from '../../../../common/logger';
 import { normalizeImageToBase64 } from '../utils';
@@ -27,7 +27,8 @@ const emptyImageCaptionQueries = (): ImageCaptionQueries => ({
 
 /**
  * 将图片 query 转成可参与文本召回的图片描述 query。
- * VLM 未配置、模型不支持 vision 或单张图片生成失败时都只降级图片描述召回；
+ * VLM 未配置、没有可用 VLM 或单张图片生成失败时都只降级图片描述召回；
+ * 已配置的 VLM 下架后会沿用模型配置层的回退规则，切换到第一个可用 VLM。
  * 原始图片仍可能继续走图片向量召回，所以这里不会抛出错误中断搜索。
  */
 export const getImageCaptionQueries = async ({
@@ -45,8 +46,8 @@ export const getImageCaptionQueries = async ({
     return emptyImageCaptionQueries();
   }
 
-  const vlmModelData = getLLMModel(vlmModel);
-  if (!vlmModelData?.vision) {
+  const vlmModelData = getVlmModel(vlmModel);
+  if (!vlmModelData) {
     return emptyImageCaptionQueries();
   }
 

--- a/packages/service/test/core/dataset/search/defaultRecall.test.ts
+++ b/packages/service/test/core/dataset/search/defaultRecall.test.ts
@@ -5,7 +5,7 @@ import { serviceEnv } from '@fastgpt/service/env';
 const mockGetVectors = vi.hoisted(() => vi.fn());
 const mockGetEmbeddingModel = vi.hoisted(() => vi.fn());
 const mockGetDefaultRerankModel = vi.hoisted(() => vi.fn());
-const mockGetLLMModel = vi.hoisted(() => vi.fn());
+const mockGetVlmModel = vi.hoisted(() => vi.fn());
 const mockIsImageEmbeddingModel = vi.hoisted(() => vi.fn());
 const mockRecallFromVectorStore = vi.hoisted(() => vi.fn());
 const mockCreateLLMResponse = vi.hoisted(() => vi.fn());
@@ -32,7 +32,7 @@ vi.mock('@fastgpt/service/core/ai/embedding', () => ({
 vi.mock('@fastgpt/service/core/ai/model', () => ({
   getEmbeddingModel: mockGetEmbeddingModel,
   getDefaultRerankModel: mockGetDefaultRerankModel,
-  getLLMModel: mockGetLLMModel,
+  getVlmModel: mockGetVlmModel,
   isImageEmbeddingModel: mockIsImageEmbeddingModel
 }));
 
@@ -101,7 +101,7 @@ describe('default recall dataset search', () => {
       maxToken: 100
     });
     mockGetDefaultRerankModel.mockReturnValue(undefined);
-    mockGetLLMModel.mockReturnValue({
+    mockGetVlmModel.mockReturnValue({
       model: 'mock-vlm-model',
       name: 'Mock VLM Model',
       vision: true
@@ -166,6 +166,7 @@ describe('default recall dataset search', () => {
       usedUserOpenAIKey: true,
       queries: ['red handbag on a white table']
     });
+    expect(mockGetVlmModel).toHaveBeenCalledWith('mock-vlm-model');
     expect(mockGetVectors).toHaveBeenCalledWith(
       expect.objectContaining({
         inputs: [
@@ -188,7 +189,7 @@ describe('default recall dataset search', () => {
   });
 
   it('should request text and image embeddings in one getVectors call', async () => {
-    mockGetLLMModel.mockReturnValue(undefined);
+    mockGetVlmModel.mockReturnValue(undefined);
     mockIsImageEmbeddingModel.mockReturnValue(true);
     mockGetVectors.mockResolvedValueOnce({
       tokens: 12,
@@ -231,7 +232,7 @@ describe('default recall dataset search', () => {
   });
 
   it('should skip blank embedding recall inputs while preserving valid task order', async () => {
-    mockGetLLMModel.mockReturnValue(undefined);
+    mockGetVlmModel.mockReturnValue(undefined);
     mockIsImageEmbeddingModel.mockReturnValue(true);
     mockGetVectors.mockResolvedValueOnce({
       tokens: 12,
@@ -272,7 +273,7 @@ describe('default recall dataset search', () => {
   });
 
   it('should pass overlong text queries to centralized embedding fallback without creating extra queries', async () => {
-    mockGetLLMModel.mockReturnValue(undefined);
+    mockGetVlmModel.mockReturnValue(undefined);
     mockIsImageEmbeddingModel.mockReturnValue(false);
     mockGetEmbeddingModel.mockReturnValueOnce({
       model: 'mock-embedding-model',
@@ -311,7 +312,7 @@ describe('default recall dataset search', () => {
   });
 
   it('should ignore failed image embedding normalization and keep text recall', async () => {
-    mockGetLLMModel.mockReturnValue(undefined);
+    mockGetVlmModel.mockReturnValue(undefined);
     mockIsImageEmbeddingModel.mockReturnValue(true);
     serviceEnv.MULTIPLE_DATA_TO_BASE64 = true;
     mockGetImageBase64.mockRejectedValueOnce(new Error('expired image'));
@@ -357,7 +358,7 @@ describe('default recall dataset search', () => {
   });
 
   it('should skip blank full-text queries before Mongo text search', async () => {
-    mockGetLLMModel.mockReturnValue(undefined);
+    mockGetVlmModel.mockReturnValue(undefined);
     mockIsImageEmbeddingModel.mockReturnValue(false);
 
     const result = await searchDatasetData({
@@ -380,7 +381,7 @@ describe('default recall dataset search', () => {
   });
 
   it('should only batch-sign S3 keys from results that survive score filtering', async () => {
-    mockGetLLMModel.mockReturnValue(undefined);
+    mockGetVlmModel.mockReturnValue(undefined);
     mockIsImageEmbeddingModel.mockReturnValue(false);
     mockGetVectors.mockResolvedValueOnce({
       tokens: 5,


### PR DESCRIPTION
## Summary
- Resolve the configured image-caption model through the VLM model list instead of the general LLM list.
- When a configured VLM has been removed, fall back to the first available VLM.
- Keep an empty VLM configuration disabled without selecting a model.
- Update the default-recall test mock and verify the configured VLM name is passed to the VLM resolver.

## Validation
- `pnpm exec prettier --check packages/service/core/dataset/search/defaultRecall/imageCaption.ts packages/service/test/core/dataset/search/defaultRecall.test.ts`
- `node ./scripts/test/withMongo.mjs pnpm --dir packages/service exec vitest run -c vitest.config.ts test/core/dataset/search/defaultRecall.test.ts` (7 tests passed)