### PR TITLE
fix: restore template marketplace avatars

### DIFF
--- a/packages/service/core/app/templates/register.ts
+++ b/packages/service/core/app/templates/register.ts
@@ -1,4 +1,5 @@
 import { isProduction } from '@fastgpt/global/common/system/constants';
+import { imageBaseUrl } from '@fastgpt/global/common/file/image/constants';
 import { AppToolSourceEnum } from '@fastgpt/global/core/app/tool/constants';
 import { type AppTemplateSchemaType } from '@fastgpt/global/core/app/type';
 import { MongoAppTemplate } from './templateSchema';
@@ -28,7 +29,24 @@ const formatTemplateAvatar = (avatar?: string | null) => {
     return '';
   }
 
-  if (avatar.startsWith('/') || avatar.startsWith('http://') || avatar.startsWith('https://')) {
+  if (avatar.startsWith('http://') || avatar.startsWith('https://')) {
+    try {
+      const pathname = new URL(avatar).pathname;
+      const pluginTemplatePath = '/system/plugin/workflow/templates/';
+      const pathStart = pathname.indexOf(pluginTemplatePath);
+
+      // 插件返回的对象存储地址可能是 localhost 或内网地址，浏览器无法直接访问。
+      if (pathStart >= 0) {
+        return `${imageBaseUrl}${pathname.slice(pathStart + 1)}`;
+      }
+    } catch {
+      // URL 解析失败时保留原值，由图片组件的 fallback 处理。
+    }
+
+    return avatar;
+  }
+
+  if (avatar.startsWith('/')) {
     return avatar;
   }
 

--- a/packages/service/test/core/app/templates/register.test.ts
+++ b/packages/service/test/core/app/templates/register.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { imageBaseUrl } from '@fastgpt/global/common/file/image/constants';
 import { AppTypeEnum } from '@fastgpt/global/core/app/constants';
 import { AppToolSourceEnum } from '@fastgpt/global/core/app/tool/constants';
 import { FlowNodeTypeEnum } from '@fastgpt/global/core/workflow/node/constant';
@@ -29,6 +30,33 @@ beforeEach(() => {
 });
 
 describe('getAppTemplatesAndLoadThem', () => {
+  it('uses the local image proxy for plugin object storage avatars', async () => {
+    mocks.listWorkflows.mockResolvedValue([
+      {
+        templateId: 'question-classify',
+        name: 'Question classify',
+        intro: 'intro',
+        avatar:
+          'http://localhost:9000/fastgpt-public/system/plugin/workflow/templates/question-classify/logo',
+        tags: [],
+        type: AppTypeEnum.workflow,
+        workflow: {
+          nodes: [],
+          edges: []
+        }
+      }
+    ]);
+    mocks.findTemplates.mockReturnValue({
+      lean: vi.fn().mockResolvedValue([])
+    });
+
+    const [template] = await getAppTemplatesAndLoadThem(true);
+
+    expect(template?.avatar).toBe(
+      `${imageBaseUrl}system/plugin/workflow/templates/question-classify/logo`
+    );
+  });
+
   it('keeps plugin workflow fields authoritative while applying editable database config', async () => {
     const pluginWorkflow = {
       nodes: [

--- a/packages/web/components/common/Avatar/index.tsx
+++ b/packages/web/components/common/Avatar/index.tsx
@@ -12,13 +12,15 @@ const Avatar = ({
   fill,
   ...props
 }: Omit<ImageProps, 'src'> & { src?: string | null }) => {
+  // 模板服务可能会为内置图标补充根路径，兼容带前导 `/` 的图标 key。
+  const iconName = src?.startsWith('/') ? src.slice(1) : src;
   // @ts-ignore
-  const isIcon = !!iconPaths[src as any];
+  const isIcon = !!iconPaths[iconName as any];
 
   return isIcon ? (
     <Box display={'inline-flex'} {...props}>
       <MyIcon
-        name={src as any}
+        name={iconName as any}
         w={w}
         borderRadius={props.borderRadius}
         {...(fill ? { fill } : {})}

--- a/packages/web/test/components/common/Avatar.test.ts
+++ b/packages/web/test/components/common/Avatar.test.ts
@@ -1,0 +1,29 @@
+import type { ReactElement } from 'react';
+import { Box } from '@chakra-ui/react';
+import Avatar from '../../../components/common/Avatar';
+import MyIcon from '../../../components/common/Icon';
+import MyImage from '../../../components/common/Image/MyImage';
+import { describe, expect, it } from 'vitest';
+
+type AvatarView = ReactElement<Record<string, unknown>>;
+
+const renderAvatar = (props: Record<string, unknown>) =>
+  (Avatar as unknown as { type: (props: Record<string, unknown>) => AvatarView }).type(props);
+
+describe('Avatar', () => {
+  it('recognizes built-in icons with a leading slash', () => {
+    const view = renderAvatar({ src: '/core/app/type/simpleFill', w: '20px' });
+    const icon = view.props.children as ReactElement<Record<string, unknown>>;
+
+    expect(view.type).toBe(Box);
+    expect(icon.type).toBe(MyIcon);
+    expect(icon.props.name).toBe('core/app/type/simpleFill');
+  });
+
+  it('keeps regular avatar paths as images', () => {
+    const view = renderAvatar({ src: '/imgs/avatar.png', w: '20px' });
+
+    expect(view.type).toBe(MyImage);
+    expect(view.props.src).toBe('/imgs/avatar.png');
+  });
+});


### PR DESCRIPTION
修复 admin 模板市场头像全部 fallback 的问题。

原因：插件接口返回的模板头像可能是 localhost 或内网对象存储地址，浏览器无法直接访问。

改动：
- 将插件模板对象存储头像转换为应用图片代理地址。
- 让 Avatar 兼容带 `/` 前缀的内置图标 key。
- admin 图片接口直接代理 S3/MinIO 文件流，避免重定向到浏览器不可达的存储地址。
- 增加 service 和 web 回归测试。

关联 PR：labring/fastgpt-pro#1077