### PR TITLE
docs(upgrade): complete 4.16.1 upgrade guide

### DIFF
--- a/deploy/dev/docker-compose.cn.yml
+++ b/deploy/dev/docker-compose.cn.yml
@@ -248,7 +248,7 @@ services:
       <<: [*x-no-proxy-config]
       FASTGPT_ENDPOINT: http://fastgpt:3000
   fastgpt-plugin:
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.1.0
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.1.1
     container_name: fastgpt-plugin
     restart: always
     network_mode: host

--- a/deploy/dev/docker-compose.yml
+++ b/deploy/dev/docker-compose.yml
@@ -248,7 +248,7 @@ services:
       <<: [*x-no-proxy-config]
       FASTGPT_ENDPOINT: http://fastgpt:3000
   fastgpt-plugin:
-    image: ghcr.io/labring/fastgpt-plugin:v1.1.0
+    image: ghcr.io/labring/fastgpt-plugin:v1.1.1
     container_name: fastgpt-plugin
     restart: always
     network_mode: host

--- a/deploy/version/main/args.json
+++ b/deploy/version/main/args.json
@@ -1,7 +1,7 @@
 {
   "tags": {
-    "fastgpt": "v4.16.0",
-    "fastgpt-plugin": "v1.1.0",
+    "fastgpt": "v4.16.1",
+    "fastgpt-plugin": "v1.1.1",
     "fastgpt-code-sandbox": "v4.16.0",
     "fastgpt-mcp_server": "v4.14.23",
 

--- a/document/content/self-host/upgrading/4-16/4161.en.mdx
+++ b/document/content/self-host/upgrading/4-16/4161.en.mdx
@@ -9,7 +9,7 @@ upgradeTags:
 
 ## 📦 Upgrade guide
 
-### Update Agent Sandbox environment variables and runtime images
+### 1. Update Agent Sandbox environment variables and runtime images
 
 When Agent Sandbox is enabled, check the following settings in both `fastgpt-app` and `fastgpt-pro`. Version 4.16.1 uses a single full runtime image reference:
 
@@ -27,7 +27,13 @@ AGENT_SANDBOX_APT_MIRROR=https://archive.ubuntu.com/ubuntu
 
 For the complete image list for China Mainland and global registries, root/non-root image selection, and custom package registry settings, see [OpenSandbox Configuration](../../config/sandbox/opensandbox).
 
-### Migrate tool JSON Schema storage format
+### 2. Update images
+
+- Update the fastgpt-app (FastGPT core service) image tag to `v4.16.1`
+- Update the fastgpt-pro (FastGPT commercial edition) image tag to `v4.16.1`
+- Update the fastgpt-plugin image tag to `v1.1.1`
+
+### 3. Migrate tool JSON Schema storage format
 
 Run the migrations in this release order:
 
@@ -71,6 +77,7 @@ curl -X POST 'https://你的域名/api/admin/4161/initToolJsonSchemaStorage' \
 2. Fixed AgentV2 calling a child Workflow without disabling streaming output within the Workflow.
 3. Fixed an issue where a team invitation link could be used to accept the same invitation repeatedly.
 4. Fixed the date picker in Usage records showing one extra day.
+5. Fixed the client incorrectly displaying a fallback image model when no image model is configured for a Dataset.
 
 ## 🛠️ Code Improvements
 

--- a/document/content/self-host/upgrading/4-16/4161.mdx
+++ b/document/content/self-host/upgrading/4-16/4161.mdx
@@ -9,7 +9,7 @@ upgradeTags:
 
 ## 📦 升级指南
 
-### 更新 Agent Sandbox 环境变量和运行态镜像
+### 1. 更新 Agent Sandbox 环境变量和运行态镜像
 
 启用 Agent Sandbox 时，请在 `fastgpt-app` 和 `fastgpt-pro` 中同步检查以下配置。4.16.1 使用完整的运行态镜像地址：
 
@@ -27,7 +27,13 @@ AGENT_SANDBOX_APT_MIRROR=https://mirrors.tuna.tsinghua.edu.cn/ubuntu
 
 中国大陆镜像源和全球镜像源的完整镜像列表、root/non-root 镜像选择，以及自定义依赖源配置，请参考 [OpenSandbox 配置](../../config/sandbox/opensandbox)。
 
-### 迁移工具 JSON Schema 存储格式
+### 2. 镜像更新
+
+- 更新 fastgpt-app（FastGPT 主服务）镜像 tag: v4.16.1
+- 更新 fastgpt-pro（FastGPT 商业版）镜像 tag: v4.16.1
+- 更新 fastgpt-plugin 镜像 tag: v1.1.1
+
+### 3. 迁移工具 JSON Schema 存储格式
 
 请严格按以下版本顺序执行迁移：
 
@@ -71,6 +77,7 @@ curl -X POST 'https://你的域名/api/admin/4161/initToolJsonSchemaStorage' \
 2. AgentV2 调用子工作流，工作流内流输出内容未禁用。
 3. 团队邀请链接，可重复接收同一个团队邀请。
 4. 使用记录，日期选择器会多一天。
+5. 修复知识库未配置图片模型时，客户端错误回退展示的问题。
 
 ## 🛠️ 代码优化
 

--- a/document/public/deploy/docker/main/cn/docker-compose.milvus.yml
+++ b/document/public/deploy/docker/main/cn/docker-compose.milvus.yml
@@ -238,7 +238,7 @@ services:
 
   fastgpt-app:
     container_name: fastgpt-app
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.16.0
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.16.1
     ports:
       - 3000:3000
     networks:
@@ -396,7 +396,7 @@ services:
       <<: [*x-log-config, *x-no-proxy-config]
       FASTGPT_ENDPOINT: http://fastgpt-app:3000
   fastgpt-plugin:
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.1.0
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.1.1
     container_name: fastgpt-plugin
     restart: always
     networks:

--- a/document/public/deploy/docker/main/cn/docker-compose.oceanbase.yml
+++ b/document/public/deploy/docker/main/cn/docker-compose.oceanbase.yml
@@ -216,7 +216,7 @@ services:
 
   fastgpt-app:
     container_name: fastgpt-app
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.16.0
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.16.1
     ports:
       - 3000:3000
     networks:
@@ -374,7 +374,7 @@ services:
       <<: [*x-log-config, *x-no-proxy-config]
       FASTGPT_ENDPOINT: http://fastgpt-app:3000
   fastgpt-plugin:
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.1.0
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.1.1
     container_name: fastgpt-plugin
     restart: always
     networks:

--- a/document/public/deploy/docker/main/cn/docker-compose.opengauss.yml
+++ b/document/public/deploy/docker/main/cn/docker-compose.opengauss.yml
@@ -200,7 +200,7 @@ services:
 
   fastgpt-app:
     container_name: fastgpt-app
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.16.0
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.16.1
     ports:
       - 3000:3000
     networks:
@@ -358,7 +358,7 @@ services:
       <<: [*x-log-config, *x-no-proxy-config]
       FASTGPT_ENDPOINT: http://fastgpt-app:3000
   fastgpt-plugin:
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.1.0
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.1.1
     container_name: fastgpt-plugin
     restart: always
     networks:

--- a/document/public/deploy/docker/main/cn/docker-compose.pg.yml
+++ b/document/public/deploy/docker/main/cn/docker-compose.pg.yml
@@ -198,7 +198,7 @@ services:
 
   fastgpt-app:
     container_name: fastgpt-app
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.16.0
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.16.1
     ports:
       - 3000:3000
     networks:
@@ -356,7 +356,7 @@ services:
       <<: [*x-log-config, *x-no-proxy-config]
       FASTGPT_ENDPOINT: http://fastgpt-app:3000
   fastgpt-plugin:
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.1.0
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.1.1
     container_name: fastgpt-plugin
     restart: always
     networks:

--- a/document/public/deploy/docker/main/cn/docker-compose.seekdb.yml
+++ b/document/public/deploy/docker/main/cn/docker-compose.seekdb.yml
@@ -203,7 +203,7 @@ services:
 
   fastgpt-app:
     container_name: fastgpt-app
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.16.0
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.16.1
     ports:
       - 3000:3000
     networks:
@@ -361,7 +361,7 @@ services:
       <<: [*x-log-config, *x-no-proxy-config]
       FASTGPT_ENDPOINT: http://fastgpt-app:3000
   fastgpt-plugin:
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.1.0
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.1.1
     container_name: fastgpt-plugin
     restart: always
     networks:

--- a/document/public/deploy/docker/main/cn/docker-compose.zilliz.yml
+++ b/document/public/deploy/docker/main/cn/docker-compose.zilliz.yml
@@ -181,7 +181,7 @@ services:
 
   fastgpt-app:
     container_name: fastgpt-app
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.16.0
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.16.1
     ports:
       - 3000:3000
     networks:
@@ -337,7 +337,7 @@ services:
       <<: [*x-log-config, *x-no-proxy-config]
       FASTGPT_ENDPOINT: http://fastgpt-app:3000
   fastgpt-plugin:
-    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.1.0
+    image: registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.1.1
     container_name: fastgpt-plugin
     restart: always
     networks:

--- a/document/public/deploy/docker/main/global/docker-compose.milvus.yml
+++ b/document/public/deploy/docker/main/global/docker-compose.milvus.yml
@@ -238,7 +238,7 @@ services:
 
   fastgpt-app:
     container_name: fastgpt-app
-    image: ghcr.io/labring/fastgpt:v4.16.0
+    image: ghcr.io/labring/fastgpt:v4.16.1
     ports:
       - 3000:3000
     networks:
@@ -396,7 +396,7 @@ services:
       <<: [*x-log-config, *x-no-proxy-config]
       FASTGPT_ENDPOINT: http://fastgpt-app:3000
   fastgpt-plugin:
-    image: ghcr.io/labring/fastgpt-plugin:v1.1.0
+    image: ghcr.io/labring/fastgpt-plugin:v1.1.1
     container_name: fastgpt-plugin
     restart: always
     networks:

--- a/document/public/deploy/docker/main/global/docker-compose.oceanbase.yml
+++ b/document/public/deploy/docker/main/global/docker-compose.oceanbase.yml
@@ -216,7 +216,7 @@ services:
 
   fastgpt-app:
     container_name: fastgpt-app
-    image: ghcr.io/labring/fastgpt:v4.16.0
+    image: ghcr.io/labring/fastgpt:v4.16.1
     ports:
       - 3000:3000
     networks:
@@ -374,7 +374,7 @@ services:
       <<: [*x-log-config, *x-no-proxy-config]
       FASTGPT_ENDPOINT: http://fastgpt-app:3000
   fastgpt-plugin:
-    image: ghcr.io/labring/fastgpt-plugin:v1.1.0
+    image: ghcr.io/labring/fastgpt-plugin:v1.1.1
     container_name: fastgpt-plugin
     restart: always
     networks:

--- a/document/public/deploy/docker/main/global/docker-compose.opengauss.yml
+++ b/document/public/deploy/docker/main/global/docker-compose.opengauss.yml
@@ -200,7 +200,7 @@ services:
 
   fastgpt-app:
     container_name: fastgpt-app
-    image: ghcr.io/labring/fastgpt:v4.16.0
+    image: ghcr.io/labring/fastgpt:v4.16.1
     ports:
       - 3000:3000
     networks:
@@ -358,7 +358,7 @@ services:
       <<: [*x-log-config, *x-no-proxy-config]
       FASTGPT_ENDPOINT: http://fastgpt-app:3000
   fastgpt-plugin:
-    image: ghcr.io/labring/fastgpt-plugin:v1.1.0
+    image: ghcr.io/labring/fastgpt-plugin:v1.1.1
     container_name: fastgpt-plugin
     restart: always
     networks:

--- a/document/public/deploy/docker/main/global/docker-compose.pg.yml
+++ b/document/public/deploy/docker/main/global/docker-compose.pg.yml
@@ -198,7 +198,7 @@ services:
 
   fastgpt-app:
     container_name: fastgpt-app
-    image: ghcr.io/labring/fastgpt:v4.16.0
+    image: ghcr.io/labring/fastgpt:v4.16.1
     ports:
       - 3000:3000
     networks:
@@ -356,7 +356,7 @@ services:
       <<: [*x-log-config, *x-no-proxy-config]
       FASTGPT_ENDPOINT: http://fastgpt-app:3000
   fastgpt-plugin:
-    image: ghcr.io/labring/fastgpt-plugin:v1.1.0
+    image: ghcr.io/labring/fastgpt-plugin:v1.1.1
     container_name: fastgpt-plugin
     restart: always
     networks:

--- a/document/public/deploy/docker/main/global/docker-compose.seekdb.yml
+++ b/document/public/deploy/docker/main/global/docker-compose.seekdb.yml
@@ -203,7 +203,7 @@ services:
 
   fastgpt-app:
     container_name: fastgpt-app
-    image: ghcr.io/labring/fastgpt:v4.16.0
+    image: ghcr.io/labring/fastgpt:v4.16.1
     ports:
       - 3000:3000
     networks:
@@ -361,7 +361,7 @@ services:
       <<: [*x-log-config, *x-no-proxy-config]
       FASTGPT_ENDPOINT: http://fastgpt-app:3000
   fastgpt-plugin:
-    image: ghcr.io/labring/fastgpt-plugin:v1.1.0
+    image: ghcr.io/labring/fastgpt-plugin:v1.1.1
     container_name: fastgpt-plugin
     restart: always
     networks:

--- a/document/public/deploy/docker/main/global/docker-compose.zilliz.yml
+++ b/document/public/deploy/docker/main/global/docker-compose.zilliz.yml
@@ -181,7 +181,7 @@ services:
 
   fastgpt-app:
     container_name: fastgpt-app
-    image: ghcr.io/labring/fastgpt:v4.16.0
+    image: ghcr.io/labring/fastgpt:v4.16.1
     ports:
       - 3000:3000
     networks:
@@ -337,7 +337,7 @@ services:
       <<: [*x-log-config, *x-no-proxy-config]
       FASTGPT_ENDPOINT: http://fastgpt-app:3000
   fastgpt-plugin:
-    image: ghcr.io/labring/fastgpt-plugin:v1.1.0
+    image: ghcr.io/labring/fastgpt-plugin:v1.1.1
     container_name: fastgpt-plugin
     restart: always
     networks:


### PR DESCRIPTION
## What

- number the V4.16.1 upgrade steps and add app, pro, and plugin image tags
- document the Agent Sandbox runtime configuration and tool JSON Schema migration sequence
- add the Dataset image-model fallback fix
- keep the English release notes in sync
- update deploy args to FastGPT `v4.16.1` and Plugin `v1.1.1`, then regenerate the dev and public Docker Compose files

## Validation

- `prettier --check` for both changed MDX files
- `node document/script/checkDocRefs.js`
- `node deploy/init.mjs`
- generated deployment file scope and image tags verified
- `git diff --check`