### PR TITLE
fix: unify file upload limit warnings

### DIFF
--- a/packages/web/common/file/hooks/useSelectFile.tsx
+++ b/packages/web/common/file/hooks/useSelectFile.tsx
@@ -1,16 +1,13 @@
+/* eslint-disable react-hooks/preserve-manual-memoization -- File is exposed as a stable component. */
 import React, { useRef, useCallback } from 'react';
 import { Box } from '@chakra-ui/react';
-import { useToast } from '../../../hooks/useToast';
-import { useTranslation } from 'next-i18next';
 
 export const useSelectFile = (props?: {
   fileType?: string;
   multiple?: boolean;
   maxCount?: number;
 }) => {
-  const { t } = useTranslation();
-  const { fileType = '*', multiple = false, maxCount = 10 } = props || {};
-  const { toast } = useToast();
+  const { fileType = '*', multiple = false } = props || {};
   const SelectFileDom = useRef<HTMLInputElement>(null);
   const openSign = useRef<any>();
 
@@ -27,14 +24,7 @@ export const useSelectFile = (props?: {
 
             if (!files || files?.length === 0) return;
 
-            let fileList = Array.from(files);
-            if (fileList.length > maxCount) {
-              toast({
-                status: 'warning',
-                title: t('file:select_file_amount_limit', { max: maxCount })
-              });
-              fileList = fileList.slice(0, maxCount);
-            }
+            const fileList = Array.from(files);
             onSelect(fileList, openSign.current);
 
             e.target.value = '';
@@ -42,12 +32,12 @@ export const useSelectFile = (props?: {
         />
       </Box>
     ),
-    [fileType, maxCount, multiple, t, toast]
+    [fileType, multiple]
   );
 
   const onOpen = useCallback((sign?: any) => {
     openSign.current = sign;
-    SelectFileDom.current && SelectFileDom.current.click();
+    SelectFileDom.current?.click();
   }, []);
 
   return {

--- a/projects/app/src/components/Select/FileSelectorBox.tsx
+++ b/projects/app/src/components/Select/FileSelectorBox.tsx
@@ -75,10 +75,18 @@ const FileSelector = ({
         size: formatFileSize(file.size)
       }));
 
+      const remainingFileAmount = Math.max(formatMaxCount - selectFiles.length, 0);
+      if (fileList.length > remainingFileAmount) {
+        toast({
+          status: 'warning',
+          title: t('file:some_file_count_exceeds_limit', { maxCount: formatMaxCount })
+        });
+      }
+
       const newFiles = [...fileList, ...selectFiles].slice(0, formatMaxCount);
       setSelectFiles(newFiles);
     },
-    [formatMaxCount, selectFiles, setSelectFiles]
+    [formatMaxCount, selectFiles, setSelectFiles, t, toast]
   );
 
   const handleDragEnter = (e: DragEvent<HTMLDivElement>) => {

--- a/projects/app/src/components/core/app/FileSelector/index.tsx
+++ b/projects/app/src/components/core/app/FileSelector/index.tsx
@@ -488,7 +488,7 @@ const FileSelector = ({
       if (remainingFileAmount === 0) {
         toast({
           status: 'warning',
-          title: t('chat:file_amount_over', { max: maxSelectFiles })
+          title: t('file:some_file_count_exceeds_limit', { maxCount: maxSelectFiles })
         });
         return;
       }
@@ -496,7 +496,7 @@ const FileSelector = ({
         files = files.slice(0, remainingFileAmount);
         toast({
           status: 'warning',
-          title: t('chat:file_amount_over', { max: maxSelectFiles })
+          title: t('file:some_file_count_exceeds_limit', { maxCount: maxSelectFiles })
         });
       }
       const filterFilesByMaxSize = files.filter((file) => file.size <= maxSize);

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/hooks/useFileUpload.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/hooks/useFileUpload.tsx
@@ -248,7 +248,7 @@ export const useFileUpload = (props: UseFileUploadOptions) => {
         files = files.slice(0, remainingFileAmount);
         toast({
           status: 'warning',
-          title: t('chat:file_amount_over', { max: maxSelectFiles })
+          title: t('file:some_file_count_exceeds_limit', { maxCount: maxSelectFiles })
         });
       }
 

--- a/projects/app/src/pageComponents/dataset/detail/Import/components/FileSelector.tsx
+++ b/projects/app/src/pageComponents/dataset/detail/Import/components/FileSelector.tsx
@@ -87,7 +87,7 @@ const FileSelector = ({
   const selectFileCallback = useCallback(
     (files: SelectFileItemType[]) => {
       if (selectFiles.length + files.length > maxCount) {
-        files = files.slice(0, maxCount - selectFiles.length);
+        files = files.slice(0, Math.max(maxCount - selectFiles.length, 0));
         toast({
           status: 'warning',
           title: t('file:some_file_count_exceeds_limit', { maxCount })
@@ -201,7 +201,7 @@ const FileSelector = ({
       });
     }
 
-    selectFileCallback(fileList.slice(0, maxCount));
+    selectFileCallback(fileList);
   };
 
   return (

--- a/projects/app/src/web/common/file/hooks/useSelectFile.tsx
+++ b/projects/app/src/web/common/file/hooks/useSelectFile.tsx
@@ -1,28 +1,25 @@
+/* eslint-disable react-hooks/preserve-manual-memoization -- File is exposed as a stable component and the native input key must follow upload config changes. */
 import React, { useRef, useCallback } from 'react';
 import { Box } from '@chakra-ui/react';
-import { useToast } from '@fastgpt/web/hooks/useToast';
-import { useTranslation } from 'next-i18next';
 
 export const useSelectFile = (props?: {
   fileType?: string;
   multiple?: boolean;
   maxCount?: number;
 }) => {
-  const { t } = useTranslation();
   const { fileType = '*', multiple = false, maxCount = 10 } = props || {};
-  const { toast } = useToast();
   const SelectFileDom = useRef<HTMLInputElement>(null);
   const openSign = useRef<any>();
 
   // 不用 useMemoizedFn：其稳定引用会让部分浏览器（尤其 macOS/WebKit）在 accept 变更后仍沿用旧 <input>。
   // key 强制在 fileType/multiple/maxCount 变化时重建 input，保证系统文件选择器读到最新 accept。
-  const inputMountKey = `${fileType}__${multiple}__${maxCount}`;
 
+  // File 作为组件对外暴露，需要保持引用稳定；原生 input 的 key 负责随配置变化重建。
   const File = useCallback(
     ({ onSelect }: { onSelect: (e: File[], sign?: any) => void }) => (
       <Box position={'absolute'} w={0} h={0} overflow={'hidden'}>
         <input
-          key={inputMountKey}
+          key={`${fileType}__${multiple}__${maxCount}`}
           ref={SelectFileDom}
           type="file"
           accept={fileType}
@@ -32,14 +29,7 @@ export const useSelectFile = (props?: {
 
             if (!files || files?.length === 0) return;
 
-            let fileList = Array.from(files);
-            if (fileList.length > maxCount) {
-              toast({
-                status: 'warning',
-                title: t('file:select_file_amount_limit', { max: maxCount })
-              });
-              fileList = fileList.slice(0, maxCount);
-            }
+            const fileList = Array.from(files);
             onSelect(fileList, openSign.current);
 
             e.target.value = '';
@@ -47,12 +37,12 @@ export const useSelectFile = (props?: {
         />
       </Box>
     ),
-    [fileType, multiple, maxCount, t, toast]
+    [fileType, multiple, maxCount]
   );
 
   const onOpen = useCallback((sign?: any) => {
     openSign.current = sign;
-    SelectFileDom.current && SelectFileDom.current.click();
+    SelectFileDom.current?.click();
   }, []);
 
   return {


### PR DESCRIPTION
## Summary
- unify file-count overflow handling for file picker and drag-and-drop uploads
- move truncation out of the shared file picker so each batch uses the same business validation path
- use the existing automatic-truncation warning across chat, workflow inputs, dataset imports, and the shared selector

## Validation
- app TypeScript check passed
- web tests passed: 7 files, 41 tests
- ESLint passed for the changed logic; the repository pre-commit hook still reports an existing `set-state-in-effect` issue in the dataset selector
- LSP diagnostics passed