### PR TITLE
fix: preserve chat input height with file preview

### DIFF
--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/Input/ChatInput.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/Input/ChatInput.tsx
@@ -196,7 +196,7 @@ const ChatInput = ({
 
   const RenderTextarea = useMemo(
     () => (
-      <Flex direction={'column'} mt={fileList.length > 0 ? 1 : 0}>
+      <Flex direction={'column'} mt={fileList.length > 0 ? 1 : 0} minH={'42px'}>
         {/* Textarea */}
         <Flex w={'100%'} position={'relative'}>
           {/* Prompt Container */}


### PR DESCRIPTION
## Summary
- preserve the 42px input area above the chat action buttons when file previews are present
- prevent the text input area from collapsing to the textarea height
- keep the existing file preview UI and upload behavior unchanged

## Verification
- `pnpm --dir projects/app exec eslint src/components/core/chat/ChatContainer/ChatBox/Input/ChatInput.tsx`
- `pnpm --dir projects/app typecheck`
- LSP diagnostics passed
- `git diff --check`