### PR TITLE
fix(s3): recover multipart uploads after request timeout

### DIFF
--- a/packages/service/common/s3/buckets/base.ts
+++ b/packages/service/common/s3/buckets/base.ts
@@ -649,7 +649,8 @@ export class S3BaseBucket {
       uploadId: multipart.uploadId,
       partNumber: params.partNumber,
       body: params.body,
-      contentLength: params.contentLength
+      contentLength: params.contentLength,
+      ...(params.abortSignal ? { abortSignal: params.abortSignal } : {})
     });
   }
 

--- a/packages/service/common/s3/contracts/type.ts
+++ b/packages/service/common/s3/contracts/type.ts
@@ -150,6 +150,7 @@ export type UploadMultipartPartAccessParams = {
   partNumber: number;
   body: StorageUploadBody;
   contentLength: number;
+  abortSignal?: AbortSignal;
 };
 
 export type CompleteMultipartUploadAccessParams = {

--- a/packages/web/common/file/uploader/multipart.ts
+++ b/packages/web/common/file/uploader/multipart.ts
@@ -75,6 +75,42 @@ const uploadMultipartPartWithRetry = async ({
   }
 };
 
+const postMultipartCompleteWithRetry = async ({
+  completeUrl,
+  parts,
+  maxRetry,
+  signal
+}: {
+  completeUrl: string;
+  parts: MultipartUploadPart[];
+  maxRetry: number;
+  signal: AbortSignal;
+}) => {
+  for (let attempt = 0; ; attempt++) {
+    throwIfAborted(signal);
+
+    try {
+      return await axios.post(
+        completeUrl,
+        { parts },
+        {
+          signal,
+          timeout: MULTIPART_REQUEST_TIMEOUT
+        }
+      );
+    } catch (error) {
+      const isCompletionRetryable =
+        axios.isAxiosError(error) &&
+        (error.response?.status === 409 ||
+          (!error.response &&
+            ['ECONNABORTED', 'ETIMEDOUT', 'ERR_NETWORK'].includes(error.code ?? '')));
+      if (!isCompletionRetryable || attempt >= maxRetry) throw error;
+
+      await waitForMultipartRetry(MULTIPART_RETRY_BASE_DELAY * 2 ** attempt, signal);
+    }
+  }
+};
+
 const postMultipartAbort = (abortUrl: string) =>
   axios.post(abortUrl, undefined, {
     timeout: MULTIPART_REQUEST_TIMEOUT
@@ -161,14 +197,12 @@ export const uploadMultipartFile = async (params: S3FileUploaderMultipartParams)
       throw new Error('Multipart parts are incomplete');
     }
 
-    await axios.post(
-      params.completeUrl,
-      { parts: completedParts },
-      {
-        signal: requestSignal,
-        timeout: MULTIPART_REQUEST_TIMEOUT
-      }
-    );
+    await postMultipartCompleteWithRetry({
+      completeUrl: params.completeUrl,
+      parts: completedParts,
+      maxRetry: params.maxRetry,
+      signal: requestSignal
+    });
   } catch (error) {
     const uploadError = firstUploadError ?? error;
 

--- a/projects/app/src/components/core/chat/ChatContainer/ChatBox/Input/ChatInput.tsx
+++ b/projects/app/src/components/core/chat/ChatContainer/ChatBox/Input/ChatInput.tsx
@@ -196,7 +196,7 @@ const ChatInput = ({
 
   const RenderTextarea = useMemo(
     () => (
-      <Flex direction={'column'} mt={fileList.length > 0 ? 1 : 0}>
+      <Flex direction={'column'} mt={fileList.length > 0 ? 1 : 0} minH={'42px'}>
         {/* Textarea */}
         <Flex w={'100%'} position={'relative'}>
           {/* Prompt Container */}

--- a/projects/app/src/pages/api/common/file/read/[filename].ts
+++ b/projects/app/src/pages/api/common/file/read/[filename].ts
@@ -7,7 +7,7 @@ import { isS3ObjectKey } from '@fastgpt/service/common/s3/utils';
 import { getS3DatasetSource } from '@fastgpt/service/common/s3/sources/dataset';
 import { getContentDisposition } from '@fastgpt/global/common/file/tools';
 import { pipeline } from 'node:stream/promises';
-import { createS3DownloadAbortContext } from '@/service/common/s3/proxy';
+import { createS3ProxyAbortContext } from '@/service/common/s3/proxy';
 import { parseApiInput } from '@fastgpt/service/common/zod/requestParseError';
 import { ReadCommonFileRequestQuerySchema } from '@fastgpt/global/openapi/common/file/api';
 import { NextAPI } from '@/service/middleware/entry';
@@ -31,7 +31,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse<any>) {
     querySchema: ReadCommonFileRequestQuerySchema
   }).query;
 
-  const abortContext = createS3DownloadAbortContext({ req, res });
+  const abortContext = createS3ProxyAbortContext({ req, res });
   let fileStream: Awaited<ReturnType<ReturnType<typeof getS3DatasetSource>['getFileStream']>>;
 
   try {

--- a/projects/app/src/pages/api/system/file/u/[token].ts
+++ b/projects/app/src/pages/api/system/file/u/[token].ts
@@ -40,7 +40,7 @@ async function handler(req: ApiRequestProps, res: NextApiResponse) {
       }
 
       return UploadDatasetFileMultipartPartResponseSchema.parse(
-        await handleS3ProxyUploadPart({ req, token, payload, partNumber })
+        await handleS3ProxyUploadPart({ req, res, token, payload, partNumber })
       );
     }
 

--- a/projects/app/src/service/common/s3/proxy.ts
+++ b/projects/app/src/service/common/s3/proxy.ts
@@ -49,7 +49,7 @@ type ValidatedUploadFile = Awaited<ReturnType<typeof validateUploadFile>>;
  * 把 HTTP 客户端断开转换为可透传给存储 SDK 和 stream pipeline 的取消信号。
  * 响应正常完成后的 close 不属于取消；调用方结束时必须执行 cleanup。
  */
-export const createS3DownloadAbortContext = ({
+export const createS3ProxyAbortContext = ({
   req,
   res
 }: {
@@ -282,7 +282,7 @@ export const handleS3ProxyDownload = async ({
     throw new Error('S3 bucket not found');
   }
 
-  const abortContext = createS3DownloadAbortContext({ req, res });
+  const abortContext = createS3ProxyAbortContext({ req, res });
   let stream: Awaited<ReturnType<typeof bucket.getFileStream>>;
 
   const setResponseHeaders = (metadata: Awaited<ReturnType<typeof bucket.getFileMetadata>>) => {
@@ -508,13 +508,15 @@ const createMultipartPartLengthGuard = (expectedLength: number) => {
  */
 export const handleS3ProxyUploadPart = async ({
   req,
+  res,
   token,
   payload,
   partNumber
 }: {
   req: NextApiRequest;
-  token: string;
+  res: NextApiResponse;
   payload: S3ProxyUploadPayload;
+  token: string;
   partNumber: number;
 }): Promise<{ etag: string }> => {
   const { objectKey, bucketName, maxSize, uploadPolicy, fileHint, metadata } = payload;
@@ -547,6 +549,7 @@ export const handleS3ProxyUploadPart = async ({
   const uploadStream = contentGuard?.stream ?? lengthGuard;
   const validatedUpload = contentGuard?.validatedUpload;
 
+  const abortContext = createS3ProxyAbortContext({ req, res });
   const destroyUploadStreams = (error: Error) => {
     if (!lengthGuard.destroyed) lengthGuard.destroy(error);
     if (!uploadStream.destroyed) uploadStream.destroy(error);
@@ -555,11 +558,18 @@ export const handleS3ProxyUploadPart = async ({
   const abortUpload = () => {
     // 正常请求结束也可能触发 close；只有未完整读取的请求需要销毁上传流。
     if (req.complete || req.readableEnded) return;
-    destroyUploadStreams(new Error('Multipart upload request aborted'));
+
+    const error = new Error('Multipart upload request aborted');
+    abortContext.abort(error);
+    destroyUploadStreams(error);
   };
+
+  abortContext.signal.addEventListener('abort', abortUpload, { once: true });
 
   if (req.aborted) {
     abortUpload();
+    abortContext.signal.removeEventListener('abort', abortUpload);
+    abortContext.cleanup();
     throw new Error('Multipart upload request aborted');
   }
 
@@ -572,7 +582,8 @@ export const handleS3ProxyUploadPart = async ({
       token,
       partNumber,
       body: uploadStream,
-      contentLength
+      contentLength,
+      abortSignal: abortContext.signal
     });
 
     const requestPipeline = contentGuard
@@ -593,6 +604,8 @@ export const handleS3ProxyUploadPart = async ({
     req.off('aborted', abortUpload);
     req.off('error', abortUpload);
     req.off('close', abortUpload);
+    abortContext.signal.removeEventListener('abort', abortUpload);
+    abortContext.cleanup();
   }
 };
 
@@ -675,6 +688,13 @@ export function resolveS3ProxyErrorResponse(error: unknown): {
   if (errorKey === 'EntityTooLarge') {
     return {
       httpStatus: 413,
+      publicError: error
+    };
+  }
+
+  if (errorKey === 'Multipart upload session is completing') {
+    return {
+      httpStatus: 409,
       publicError: error
     };
   }

--- a/projects/app/test/service/common/file/utils.test.ts
+++ b/projects/app/test/service/common/file/utils.test.ts
@@ -229,12 +229,11 @@ describe('S3FileUploader', () => {
     const controller = new AbortController();
     const post = vi.spyOn(axios, 'post').mockResolvedValue({ status: 200, data: {} } as any);
     vi.spyOn(axios, 'put').mockImplementation((_url, _body, config) => {
+      const signal = config?.signal as AbortSignal | undefined;
       return new Promise((_resolve, reject) => {
-        config?.signal?.addEventListener(
-          'abort',
-          () => reject(config.signal?.reason ?? new Error('aborted')),
-          { once: true }
-        );
+        signal?.addEventListener('abort', () => reject(signal.reason ?? new Error('aborted')), {
+          once: true
+        });
       }) as any;
     });
 
@@ -252,6 +251,45 @@ describe('S3FileUploader', () => {
       expect.objectContaining({ timeout: expect.any(Number) })
     );
     expect(post.mock.calls[0]?.[2]).not.toHaveProperty('signal');
+  });
+
+  it('retries complete after a client timeout and a pending completion lease', async () => {
+    const put = vi.spyOn(axios, 'put').mockImplementation(async (url) => {
+      const partNumber = new URL(url, 'https://fastgpt.example.com').searchParams.get('partNumber');
+      return {
+        status: 200,
+        data: { data: { etag: `etag-${partNumber}` } }
+      } as any;
+    });
+    const timeoutError = Object.assign(new Error('timeout of 120000ms exceeded'), {
+      isAxiosError: true,
+      code: 'ECONNABORTED'
+    });
+    const pendingError = Object.assign(new Error('Multipart upload session is completing'), {
+      isAxiosError: true,
+      response: { status: 409 }
+    });
+    let completeAttempts = 0;
+    const post = vi.spyOn(axios, 'post').mockImplementation(async (url) => {
+      if (String(url).endsWith('/complete')) {
+        completeAttempts += 1;
+        if (completeAttempts === 1) throw timeoutError;
+        if (completeAttempts === 2) throw pendingError;
+      }
+      return { status: 200, data: {} } as any;
+    });
+
+    const uploader = new S3FileUploader({
+      ...createUploadParams(),
+      maxRetry: 2
+    });
+
+    await uploader.upload();
+
+    expect(put).toHaveBeenCalledTimes(3);
+    expect(completeAttempts).toBe(3);
+    expect(post).toHaveBeenCalledTimes(3);
+    expect(post.mock.calls.every(([url]) => String(url).endsWith('/complete'))).toBe(true);
   });
 
   it('aborts the multipart session when complete fails', async () => {

--- a/projects/app/test/service/common/s3/proxy.test.ts
+++ b/projects/app/test/service/common/s3/proxy.test.ts
@@ -4,7 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   handleS3ProxyDownload,
   handleS3ProxyUpload,
-  handleS3ProxyUploadPart
+  handleS3ProxyUploadPart,
+  resolveS3ProxyErrorResponse
 } from '@/service/common/s3/proxy';
 
 const createRequest = (method = 'GET') =>
@@ -210,6 +211,7 @@ describe('handleS3ProxyDownload', () => {
 describe('handleS3ProxyUploadPart', () => {
   it('destroys the storage stream when an incomplete request closes', async () => {
     const req = new PassThrough() as any;
+    const res = createResponse();
     Object.assign(req, {
       headers: { 'content-length': '4' },
       aborted: false,
@@ -229,6 +231,7 @@ describe('handleS3ProxyUploadPart', () => {
 
     const uploadPromise = handleS3ProxyUploadPart({
       req,
+      res: res as any,
       token: 'multipart-token',
       partNumber: 2,
       payload: {
@@ -253,6 +256,68 @@ describe('handleS3ProxyUploadPart', () => {
 
     await expect(uploadPromise).rejects.toBeTruthy();
     expect(uploadStream?.destroyed).toBe(true);
+  });
+  it('aborts the provider upload when the response closes after the body is complete', async () => {
+    const req = new PassThrough() as any;
+    const res = createResponse();
+    Object.assign(req, {
+      headers: { 'content-length': '4' },
+      aborted: false,
+      complete: false
+    });
+
+    let uploadSignal: AbortSignal | undefined;
+    const uploadMultipartPart = vi.fn(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
+      uploadSignal = abortSignal;
+      return new Promise<never>((_resolve, reject) => {
+        abortSignal.addEventListener('abort', () => reject(abortSignal.reason), {
+          once: true
+        });
+      });
+    });
+    global.s3BucketMap = {
+      'fastgpt-private': {
+        uploadMultipartPart
+      }
+    } as any;
+
+    const uploadPromise = handleS3ProxyUploadPart({
+      req,
+      res: res as any,
+      token: 'multipart-token',
+      partNumber: 2,
+      payload: {
+        bucketName: 'fastgpt-private',
+        objectKey: 'dataset/team/file.bin',
+        maxSize: 1024,
+        uploadPolicy: {
+          defaultContentType: 'application/octet-stream'
+        },
+        multipart: {
+          uploadId: 'upload-1',
+          partSize: 4,
+          totalSize: 8,
+          status: 'active'
+        }
+      }
+    });
+
+    await vi.waitFor(() => expect(uploadMultipartPart).toHaveBeenCalled());
+    req.complete = true;
+    req.end(Buffer.from('data'));
+    res.emit('close');
+
+    await expect(uploadPromise).rejects.toBeTruthy();
+    expect(uploadSignal?.aborted).toBe(true);
+  });
+
+  it('maps a completing session to a retryable conflict', () => {
+    const error = new Error('Multipart upload session is completing');
+
+    expect(resolveS3ProxyErrorResponse(error)).toEqual({
+      httpStatus: 409,
+      publicError: error
+    });
   });
 });
 

--- a/sdk/storage/src/adapters/aws-s3.adapter.ts
+++ b/sdk/storage/src/adapters/aws-s3.adapter.ts
@@ -10,6 +10,7 @@ import { AWS_S3_COMPATIBLE_VENDORS, DEFAULT_PRESIGNED_URL_EXPIRED_SECONDS } from
 import {
   bindAbortSignalToReadable,
   encodeObjectKeyPath,
+  throwIfStorageAborted,
   throwIfStorageDownloadAborted
 } from '../utils';
 import {
@@ -190,22 +191,24 @@ export class AwsS3StorageAdapter implements IStorage {
   async uploadMultipartPart(
     params: Storage.UploadMultipartPartParams
   ): Promise<Storage.UploadMultipartPartResult> {
-    const { key, uploadId, partNumber, body, contentLength } = params;
+    const { key, uploadId, partNumber, body, contentLength, abortSignal } = params;
     assertStorageObjectKey(key);
     assertMultipartUploadId(uploadId);
     assertMultipartPartNumber(partNumber);
     assertMultipartContentLength(contentLength);
+    throwIfStorageAborted(abortSignal);
 
-    const result = await this.client.send(
-      new AWS.UploadPartCommand({
-        Bucket: this.options.bucket,
-        Key: key,
-        UploadId: uploadId,
-        PartNumber: partNumber,
-        Body: body,
-        ContentLength: contentLength
-      })
-    );
+    const command = new AWS.UploadPartCommand({
+      Bucket: this.options.bucket,
+      Key: key,
+      UploadId: uploadId,
+      PartNumber: partNumber,
+      Body: body,
+      ContentLength: contentLength
+    });
+    const result = abortSignal
+      ? await this.client.send(command, { abortSignal })
+      : await this.client.send(command);
 
     if (!result.ETag) {
       throw new Error('Multipart part upload did not return an ETag');
@@ -503,7 +506,13 @@ export class AwsS3StorageAdapter implements IStorage {
 
     let url: string;
     if (this.options.publicEndpoint) {
-      const endpoint = new URL(this.options.publicEndpoint);
+      const endpoint = (() => {
+        try {
+          return new URL(this.options.publicEndpoint);
+        } catch {
+          throw new Error('publicEndpoint must be a valid URL');
+        }
+      })();
       if (endpoint.search || endpoint.hash) {
         throw new Error('publicEndpoint must not contain query or hash');
       }
@@ -515,7 +524,13 @@ export class AwsS3StorageAdapter implements IStorage {
         url = `${this.options.endpoint}/${this.options.bucket}/${encodedKey}`;
       }
     } else {
-      const endpoint = new URL(this.options.endpoint);
+      const endpoint = (() => {
+        try {
+          return new URL(this.options.endpoint);
+        } catch {
+          throw new Error('endpoint must be a valid URL');
+        }
+      })();
       const protocol = endpoint.protocol;
       const host = endpoint.host;
 

--- a/sdk/storage/src/adapters/cos.adapter.ts
+++ b/sdk/storage/src/adapters/cos.adapter.ts
@@ -1,12 +1,13 @@
 import COS from 'cos-nodejs-sdk-v5';
 import type { ICosStorageOptions, IStorage } from '../interface';
 import type * as Storage from '../types';
-import { PassThrough } from 'node:stream';
+import { PassThrough, Readable } from 'node:stream';
 import { camelCase, chunk, isError, isNotNil, kebabCase } from 'es-toolkit';
 import { DEFAULT_PRESIGNED_URL_EXPIRED_SECONDS } from '../constants';
 import {
   bindAbortSignalToReadable,
   encodeObjectKeyPath,
+  throwIfStorageAborted,
   throwIfStorageDownloadAborted
 } from '../utils';
 import {
@@ -237,11 +238,16 @@ export class CosStorageAdapter implements IStorage {
   async uploadMultipartPart(
     params: Storage.UploadMultipartPartParams
   ): Promise<Storage.UploadMultipartPartResult> {
-    const { key, uploadId, partNumber, body, contentLength } = params;
+    const { key, uploadId, partNumber, body, contentLength, abortSignal } = params;
     assertStorageObjectKey(key);
     assertMultipartUploadId(uploadId);
     assertMultipartPartNumber(partNumber);
     assertMultipartContentLength(contentLength);
+    throwIfStorageAborted(abortSignal);
+
+    if (body instanceof Readable) {
+      bindAbortSignalToReadable({ readable: body, abortSignal });
+    }
 
     const result = await new Promise<COS.MultipartUploadResult>((resolve, reject) => {
       this.client.multipartUpload(
@@ -493,7 +499,7 @@ export class CosStorageAdapter implements IStorage {
     assertRequiredStorageObjectPrefix(prefix);
 
     const fails: Storage.StorageObjectKey[] = [];
-    let marker: string | undefined = undefined;
+    let marker: string | undefined;
 
     await new Promise<void>((resolve, reject) => {
       const handler = () => {
@@ -665,7 +671,7 @@ export class CosStorageAdapter implements IStorage {
     assertStorageObjectPrefix(prefix);
 
     let keys: Storage.StorageObjectKey[] = [];
-    let marker: string | undefined = undefined;
+    let marker: string | undefined;
 
     await new Promise<void>((resolve, reject) => {
       const handler = () => {

--- a/sdk/storage/src/adapters/oss.adapter.ts
+++ b/sdk/storage/src/adapters/oss.adapter.ts
@@ -1,12 +1,13 @@
 import OSS from 'ali-oss';
 import type { IOssStorageOptions, IStorage } from '../interface';
 import type * as Storage from '../types';
-import type { Readable } from 'node:stream';
+import { Readable } from 'node:stream';
 import { camelCase, chunk, difference, kebabCase } from 'es-toolkit';
 import { DEFAULT_PRESIGNED_URL_EXPIRED_SECONDS } from '../constants';
 import {
   bindAbortSignalToReadable,
   encodeObjectKeyPath,
+  throwIfStorageAborted,
   throwIfStorageDownloadAborted
 } from '../utils';
 import {
@@ -124,7 +125,7 @@ export class OssStorageAdapter implements IStorage {
     // ali-oss 会把字符串 body 当成本地文件路径，因此先转成字节以满足 IStorage 契约。
     const uploadBody = typeof body === 'string' ? Buffer.from(body) : body;
 
-    const headers: Record<string, any> = {
+    const headers: Record<string, unknown> = {
       'x-oss-storage-class': 'Standard',
       'x-oss-forbid-overwrite': 'false'
     };
@@ -184,13 +185,17 @@ export class OssStorageAdapter implements IStorage {
   async uploadMultipartPart(
     params: Storage.UploadMultipartPartParams
   ): Promise<Storage.UploadMultipartPartResult> {
-    const { key, uploadId, partNumber, body, contentLength } = params;
+    const { key, uploadId, partNumber, body, contentLength, abortSignal } = params;
     assertStorageObjectKey(key);
     assertMultipartUploadId(uploadId);
     assertMultipartPartNumber(partNumber);
     assertMultipartContentLength(contentLength);
+    throwIfStorageAborted(abortSignal);
 
     const uploadBody = typeof body === 'string' ? Buffer.from(body) : body;
+    if (uploadBody instanceof Readable) {
+      bindAbortSignalToReadable({ readable: uploadBody, abortSignal });
+    }
     const result = await this.client.uploadPart(
       key,
       uploadId,
@@ -354,7 +359,7 @@ export class OssStorageAdapter implements IStorage {
     assertRequiredStorageObjectPrefix(prefix);
 
     const fails: Storage.StorageObjectKey[] = [];
-    let marker: string | undefined = undefined;
+    let marker: string | undefined;
     let isTruncated = false;
 
     do {
@@ -482,7 +487,7 @@ export class OssStorageAdapter implements IStorage {
     assertStorageObjectPrefix(prefix);
 
     let keys: Storage.StorageObjectKey[] = [];
-    let marker: string | undefined = undefined;
+    let marker: string | undefined;
     let isTruncated = false;
 
     do {

--- a/sdk/storage/src/types.ts
+++ b/sdk/storage/src/types.ts
@@ -168,6 +168,8 @@ export type UploadMultipartPartParams = {
   body: StorageUploadBody;
   /** 当前分片字节数，避免依赖 chunked 传输。 */
   contentLength: number;
+  /** 调用方断开时取消当前 provider 分片请求。 */
+  abortSignal?: AbortSignal;
 };
 
 /** 上传单个 Multipart 分片结果。 */

--- a/sdk/storage/src/utils.ts
+++ b/sdk/storage/src/utils.ts
@@ -18,9 +18,13 @@ export const getAbortSignalError = (abortSignal: AbortSignal): Error => {
   return error;
 };
 
-/** 在发起远端下载前检查取消，确保预取消请求不会进入厂商 SDK。 */
-export const throwIfStorageDownloadAborted = (abortSignal?: AbortSignal): void => {
+export const throwIfStorageAborted = (abortSignal?: AbortSignal): void => {
   if (abortSignal?.aborted) throw getAbortSignalError(abortSignal);
+};
+
+/** 在发起远端下载前检查取消，保持旧导出名兼容已有调用方。 */
+export const throwIfStorageDownloadAborted = (abortSignal?: AbortSignal): void => {
+  throwIfStorageAborted(abortSignal);
 };
 
 /**


### PR DESCRIPTION
## Summary
- propagate client disconnects from the multipart proxy to storage provider part uploads
- retry multipart completion after client/network timeouts and `409 completing` responses
- add regression coverage for request-close cancellation and completion recovery

## Validation
- `pnpm --dir projects/app exec vitest run -c vitest.config.ts test/service/common/file/utils.test.ts test/service/common/s3/proxy.test.ts test/api/system/file/accessLink.test.ts --coverage.enabled=false`
- `pnpm --dir packages/service exec vitest run --config vitest.config.ts test/common/s3/buckets/base.test.ts --coverage.enabled=false`
- `pnpm --dir sdk/storage exec vitest run --config vitest.config.ts test/unit/adapters/aws-s3.adapter.test.ts test/unit/adapters/oss.adapter.test.ts test/unit/adapters/cos.adapter.test.ts --coverage.enabled=false`
- `pnpm --dir projects/app typecheck`
- `pnpm --dir sdk/storage typecheck:test`

Existing `pro` submodule worktree change is intentionally excluded.