### PR TITLE
fix(api): normalize admin plan ObjectIds

### DIFF
--- a/packages/global/openapi/admin/routes/plans/api.ts
+++ b/packages/global/openapi/admin/routes/plans/api.ts
@@ -1,11 +1,12 @@
 import z from 'zod';
+import { ObjectIdSchema } from '../../../../common/type/mongo';
 import { NumSchema } from '../../../../common/zod';
 import { PaginationResponseSchema } from '../../../api';
 import { SubTypeEnum, StandardSubLevelEnum } from '../../../../support/wallet/sub/constants';
 
 export const PlanItemSchema = z.object({
-  id: z.string().meta({ description: '订阅ID' }),
-  teamId: z.string().meta({ description: '团队ID' }),
+  id: ObjectIdSchema.meta({ description: '订阅ID' }),
+  teamId: ObjectIdSchema.meta({ description: '团队ID' }),
   type: z.enum(SubTypeEnum).meta({ description: '套餐类型' }),
   level: z.enum(StandardSubLevelEnum).optional().meta({ description: '套餐等级' }),
   totalPoints: z.number().optional().meta({ description: '总积分' }),

--- a/packages/global/test/openapi/common/team.test.ts
+++ b/packages/global/test/openapi/common/team.test.ts
@@ -218,23 +218,30 @@ describe('common and team OpenAPI contracts', () => {
   });
 
   it('parses admin plan responses from the shared contract', () => {
-    expect(
-      GetAdminPlansResponseSchema.parse({
-        list: [
-          {
-            id: normalizedStandardPlan._id,
-            teamId: normalizedStandardPlan.teamId,
-            type: SubTypeEnum.extraDatasetSize,
-            extraDatasetSize: 1024,
-            startTime: new Date('2026-01-01T00:00:00.000Z'),
-            expiredTime: new Date('2027-01-01T00:00:00.000Z'),
-            maxTeamMember: null
-          }
-        ],
-        total: 1
-      })
-    ).toMatchObject({
-      list: [{ type: SubTypeEnum.extraDatasetSize, maxTeamMember: null }],
+    const response = GetAdminPlansResponseSchema.parse({
+      list: [
+        {
+          id: { toString: () => normalizedStandardPlan._id },
+          teamId: { toString: () => normalizedStandardPlan.teamId },
+          type: SubTypeEnum.extraDatasetSize,
+          extraDatasetSize: 1024,
+          startTime: new Date('2026-01-01T00:00:00.000Z'),
+          expiredTime: new Date('2027-01-01T00:00:00.000Z'),
+          maxTeamMember: null
+        }
+      ],
+      total: 1
+    });
+
+    expect(response).toMatchObject({
+      list: [
+        {
+          id: normalizedStandardPlan._id,
+          teamId: normalizedStandardPlan.teamId,
+          type: SubTypeEnum.extraDatasetSize,
+          maxTeamMember: null
+        }
+      ],
       total: 1
     });
   });


### PR DESCRIPTION
## Summary

- use the shared `ObjectIdSchema` for admin plan response IDs
- normalize Mongoose `ObjectId` values to strings during response parsing
- add a regression assertion covering ObjectId-like `id` and `teamId` values

## Root cause

`getPlans` returns Mongoose ObjectId values while the shared response contract previously required strict strings. The route now parses its response through that contract, so every plan failed validation for `id` and `teamId`.

## Tests

- `pnpm test:global` (106 files, 2038 tests passed)
- ESLint on changed files
- Prettier check on changed files
- `git diff --check`