### PR TITLE
perf(admin): optimize username-based list searches

### DIFF
--- a/packages/global/openapi/admin/routes/pays/api.ts
+++ b/packages/global/openapi/admin/routes/pays/api.ts
@@ -1,20 +1,40 @@
 import z from 'zod';
 import { PaginationResponseSchema, PaginationSchema } from '../../../api';
 import { BillTypeEnum, BillStatusEnum } from '../../../../support/wallet/bill/constants';
+import { BillSchema } from '../../../../support/wallet/bill/type';
+import { ObjectIdSchema } from '../../../../common/type/mongo';
+
+/* ============================================================================
+ * API: 获取支付记录
+ * Route: POST /admin/routes/pays/getPays
+ * Method: POST
+ * Description: 分页获取支付记录，支持按用户名、订单类型和状态筛选
+ * Tags: ['Admin', 'Pays', 'Read']
+ * ============================================================================ */
 
 export const BillItemSchema = z.object({
-  id: z.string().meta({ description: '订单ID' }),
+  _id: ObjectIdSchema.meta({ description: '订单 ID' }),
+  teamId: ObjectIdSchema.meta({ description: '团队 ID' }),
+  tmbId: ObjectIdSchema.meta({ description: '支付成员 ID' }),
   orderId: z.string().meta({ description: '订单号' }),
   type: z.enum(BillTypeEnum).meta({ description: '订单类型' }),
   status: z.enum(BillStatusEnum).meta({ description: '订单状态' }),
   price: z.number().meta({ description: '订单金额' }),
-  username: z.string().meta({ description: '关联用户名' }),
-  createTime: z.date().meta({ description: '创建时间' })
+  username: z.string().meta({ description: '支付成员用户名' }),
+  createTime: z.coerce.date().meta({ description: '创建时间' }),
+  couponId: BillSchema.shape.couponId,
+  hasInvoice: BillSchema.shape.hasInvoice,
+  metadata: BillSchema.shape.metadata.partial().passthrough(),
+  refundData: BillSchema.shape.refundData
 });
+export type BillItemType = z.infer<typeof BillItemSchema>;
 
 export const GetPaysBodySchema = PaginationSchema.extend({
-  username: z.string().meta({ description: '搜索用户名' }),
+  username: z.string().trim().max(100).optional().meta({ description: '搜索用户名' }),
   type: z.enum(BillTypeEnum).optional().meta({ description: '订单类型筛选' }),
   status: z.enum(BillStatusEnum).optional().meta({ description: '订单状态筛选' })
 });
+export type GetPaysBodyType = z.infer<typeof GetPaysBodySchema>;
+
 export const GetPaysResponseSchema = PaginationResponseSchema(BillItemSchema);
+export type GetPaysResponseType = z.infer<typeof GetPaysResponseSchema>;

--- a/packages/global/openapi/admin/routes/users/api.ts
+++ b/packages/global/openapi/admin/routes/users/api.ts
@@ -5,17 +5,32 @@ import { UserStatusEnum } from '../../../../support/user/constant';
 export const UserItemSchema = z.object({
   _id: z.string().meta({ description: '用户ID' }),
   username: z.string().meta({ description: '用户名' }),
+  contact: z.string().optional().meta({ description: '联系方式' }),
   avatar: z.string().optional().meta({ description: '用户头像' }),
   status: z.enum(UserStatusEnum).meta({ description: '用户状态' }),
   createTime: z.date().meta({ description: '创建时间' })
 });
+export type UserItemType = z.infer<typeof UserItemSchema>;
 
-// getUsers
+/* ============================================================================
+ * API: 获取用户列表
+ * Route: POST /admin/routes/users/getUsers
+ * Method: POST
+ * Description: 分页获取用户列表，支持按用户名搜索
+ * Tags: ['Admin', 'Users', 'Read']
+ * ============================================================================ */
+
 export const GetUsersBodySchema = PaginationSchema.extend({
-  username: z.string().meta({ description: '搜索用户名（支持模糊匹配）' })
+  username: z
+    .string()
+    .trim()
+    .max(100)
+    .optional()
+    .meta({ description: '搜索用户名（支持模糊匹配）' })
 });
 export type GetUsersBodyType = z.infer<typeof GetUsersBodySchema>;
 export const GetUsersResponseSchema = PaginationResponseSchema(UserItemSchema);
+export type GetUsersResponseType = z.infer<typeof GetUsersResponseSchema>;
 
 // addUser
 export const AddUserBodySchema = z.object({


### PR DESCRIPTION
## What

- update FastGPT Pro with optimized username search paths for teams, plans, pays, and users
- add validated OpenAPI contracts for pay/user pagination and responses
- preserve final-result pagination and total semantics

## Key changes

- apply username/team-name filters before relationship lookups
- deduplicate records when multiple matched users belong to the same team
- remove pay-list N+1 creator queries
- skip empty username regex queries and escape regex input

## Verification

- Pro admin route tests: 25/25 passed
- getTeams/getPlans/getPays/getUsers: 100% lines, branches, functions, statements
- Pro Admin typecheck, targeted ESLint, Prettier, and diff checks passed

## Related

- labring/fastgpt-pro#1084