### PR TITLE
fix(dataset): accept empty/single-row backup CSV import (#7491)

### DIFF
--- a/packages/service/core/dataset/importFile.ts
+++ b/packages/service/core/dataset/importFile.ts
@@ -44,7 +44,13 @@ export const parseDatasetImportFile = async ({
     }
   }
 
-  const result = Papa.parse<string[]>(rawText);
+  const result = Papa.parse<string[]>(rawText, {
+    // 导出方（exportAll.ts / collection/export.ts）在空数据集或单条数据时会生成
+    // 只有表头（或仅一行）的 CSV。此时 papaparse 无法从多行数据推断分隔符，会抛出
+    // Delimiter/UndetectableDelimiter 的提示性错误，但数据本身并未损坏。
+    // 这里用 skipEmptyLines 规避该提示，同时保留 Quotes 等真实结构错误的拒绝行为。
+    skipEmptyLines: 'greedy'
+  });
   if (result.errors.length > 0) {
     throw new Error('Invalid dataset import content');
   }

--- a/packages/service/core/dataset/read.ts
+++ b/packages/service/core/dataset/read.ts
@@ -366,7 +366,10 @@ export const rawText2Chunks = async ({
   }[]
 > => {
   const parseDatasetBackup2Chunks = (rawText: string) => {
-    const csvArr = Papa.parse(rawText).data as string[][];
+    const csvArr = Papa.parse<string[]>(rawText, {
+      // 空记录不会生成知识库 chunk；解析时提前跳过，避免短 CSV 的尾部空行干扰分隔符推断。
+      skipEmptyLines: 'greedy'
+    }).data;
     if (csvArr.length < 2) return { chunks: [] };
 
     const rawHeaders = csvArr[0];

--- a/packages/service/test/core/dataset/importFile.test.ts
+++ b/packages/service/test/core/dataset/importFile.test.ts
@@ -120,21 +120,98 @@ describe('parseDatasetImportFile', () => {
 
   it.each([
     {
-      name: 'header-only CSV (empty dataset backup)',
-      result: { rawText: '\uFEFFq,a\r\n' }
+      name: 'header-only export without trailing newline',
+      rawText: '\uFEFFq,a',
+      expectedRows: [['q', 'a']]
     },
     {
-      name: 'header-only CSV without trailing newline',
-      result: { rawText: '\uFEFFq,a' }
+      name: 'header-only export with trailing newline',
+      rawText: '\uFEFFq,a\r\n',
+      expectedRows: [['q', 'a']]
     },
     {
-      name: 'single data row (one chunk backup)',
-      result: { rawText: '\uFEFFq,a\r\nQ1,A1\r\n' }
+      name: 'single-chunk export without trailing newline',
+      rawText: '\uFEFFq,a\nQ1,A1',
+      expectedRows: [
+        ['q', 'a'],
+        ['Q1', 'A1']
+      ]
+    },
+    {
+      name: 'single-chunk export with trailing newline',
+      rawText: '\uFEFFq,a\r\nQ1,A1\r\n',
+      expectedRows: [
+        ['q', 'a'],
+        ['Q1', 'A1']
+      ]
+    },
+    {
+      name: 'single-chunk export with multiple trailing blank lines',
+      rawText: '\uFEFFq,a\r\nQ1,A1\r\n\r\n   \r\n',
+      expectedRows: [
+        ['q', 'a'],
+        ['Q1', 'A1']
+      ]
     }
-  ])('accepts $name instead of failing on the UndetectableDelimiter hint', async ({ result }) => {
-    mockReadRawTextByLocalFile.mockResolvedValue(result);
+  ])('normalizes $name', async ({ rawText, expectedRows }) => {
+    mockReadRawTextByLocalFile.mockResolvedValue({ rawText });
 
-    await expect(parseDatasetImportFile(defaultParams)).resolves.toBeTruthy();
+    const normalizedCsv = await parseDatasetImportFile(defaultParams);
+
+    expect(Papa.parse(normalizedCsv).data).toEqual(expectedRows);
+  });
+
+  it('drops fully blank records while preserving rows with either q or a', async () => {
+    mockReadRawTextByLocalFile.mockResolvedValue({
+      rawText: 'q,a\r\n,\r\nQ1,\r\n,A1\r\n" "," "\r\n'
+    });
+
+    const normalizedCsv = await parseDatasetImportFile(defaultParams);
+
+    expect(Papa.parse(normalizedCsv).data).toEqual([
+      ['q', 'a'],
+      ['Q1', ''],
+      ['', 'A1']
+    ]);
+  });
+
+  it('keeps delimiter auto-detection for typed semicolon-separated headers', async () => {
+    mockReadRawTextByLocalFile.mockResolvedValue({
+      rawText: 'q;a\r\nQ1;A1\r\n'
+    });
+
+    const normalizedCsv = await parseDatasetImportFile(defaultParams);
+
+    expect(Papa.parse(normalizedCsv).data).toEqual([
+      ['q', 'a'],
+      ['Q1', 'A1']
+    ]);
+  });
+
+  it('accepts a header-only Excel result with trailing blank rows', async () => {
+    mockReadRawTextByLocalFile.mockResolvedValue({
+      rawText: 'q,a\r\n\r\n',
+      tableInfo: {
+        sheetCount: 1,
+        mergedCellCount: 0
+      }
+    });
+
+    const normalizedCsv = await parseDatasetImportFile({
+      ...defaultParams,
+      filePath: '/tmp/empty-backup.xlsx',
+      filename: 'empty-backup.xlsx'
+    });
+
+    expect(Papa.parse(normalizedCsv).data).toEqual([['q', 'a']]);
+  });
+
+  it('still rejects malformed quoted content when trailing blank lines are present', async () => {
+    mockReadRawTextByLocalFile.mockResolvedValue({
+      rawText: 'q,a\r\n"question,answer\r\n\r\n'
+    });
+
+    await expect(parseDatasetImportFile(defaultParams)).rejects.toThrow('content');
   });
 
   it.each([

--- a/packages/service/test/core/dataset/importFile.test.ts
+++ b/packages/service/test/core/dataset/importFile.test.ts
@@ -120,6 +120,25 @@ describe('parseDatasetImportFile', () => {
 
   it.each([
     {
+      name: 'header-only CSV (empty dataset backup)',
+      result: { rawText: '\uFEFFq,a\r\n' }
+    },
+    {
+      name: 'header-only CSV without trailing newline',
+      result: { rawText: '\uFEFFq,a' }
+    },
+    {
+      name: 'single data row (one chunk backup)',
+      result: { rawText: '\uFEFFq,a\r\nQ1,A1\r\n' }
+    }
+  ])('accepts $name instead of failing on the UndetectableDelimiter hint', async ({ result }) => {
+    mockReadRawTextByLocalFile.mockResolvedValue(result);
+
+    await expect(parseDatasetImportFile(defaultParams)).resolves.toBeTruthy();
+  });
+
+  it.each([
+    {
       name: 'missing table information',
       tableInfo: undefined,
       error: 'exactly one worksheet'

--- a/packages/service/test/core/dataset/textSplitter.test.ts
+++ b/packages/service/test/core/dataset/textSplitter.test.ts
@@ -495,6 +495,23 @@ describe('rawText2Chunks backupParse', () => {
     expect(result).toEqual([]);
   });
 
+  it('detects a semicolon delimiter when a short CSV has a trailing blank line', async () => {
+    const result = await rawText2Chunks({
+      rawText: 'q;a\r\nquestion;answer\r\n',
+      backupParse: true
+    });
+
+    expect(result).toEqual([
+      {
+        q: 'question',
+        a: 'answer',
+        indexes: [],
+        metadata: undefined,
+        imageIdList: undefined
+      }
+    ]);
+  });
+
   it('returns empty array for empty string', async () => {
     const result = await rawText2Chunks({ rawText: '', backupParse: true });
     expect(result).toEqual([]);

--- a/packages/service/test/worker/readFile/extension/csv.test.ts
+++ b/packages/service/test/worker/readFile/extension/csv.test.ts
@@ -22,4 +22,16 @@ describe('readCsvRawText', () => {
 | Alice\\|A | line1\\nline2 |
 | Bob | normal |`);
   });
+
+  it('detects a semicolon delimiter when a short CSV contains a blank line', async () => {
+    const result = await readCsvRawText({
+      extension: 'csv',
+      buffer: Buffer.from('q;a\n\nQ1;A1', 'utf-8'),
+      encoding: 'utf-8'
+    });
+
+    expect(result.formatText).toBe(`| q | a |
+| --- | --- |
+| Q1 | A1 |`);
+  });
 });

--- a/packages/service/worker/readFile/extension/csv.ts
+++ b/packages/service/worker/readFile/extension/csv.ts
@@ -7,7 +7,10 @@ import { filterEmptyTableData, formatMarkdownTableRow } from './utils';
 export const readCsvRawText = async (params: ReadRawTextByBuffer): Promise<ReadFileResponse> => {
   const { rawText } = await readFileRawText(params);
 
-  const csvArr = Papa.parse(rawText).data as string[][];
+  const csvArr = Papa.parse<string[]>(rawText, {
+    // 后续不会保留全空行；解析时提前跳过，避免短 CSV 中的空行干扰分隔符推断。
+    skipEmptyLines: 'greedy'
+  }).data;
 
   const filteredData = filterEmptyTableData(csvArr);
   const header = filteredData[0];


### PR DESCRIPTION
## 问题

Issue #7491:知识库导出分块后,用模板导入和备份导入都失败(私有部署 4.14 / 4.15 均存在)。

## 根因

导出方(`projects/app/src/pages/api/core/dataset/exportAll.ts` 与 `collection/export.ts`)在以下场景会生成只有表头(或仅一行数据)的 CSV:

- 知识库为空(无数据行)
- 知识库只有单条分块数据

此时 `papaparse` 无法从多行数据推断分隔符,会抛出 `Delimiter` / `UndetectableDelimiter` 的**提示性错误**(数据本身未损坏)。而 `parseDatasetImportFile` 将任何 `errors.length > 0` 一律视为内容非法直接 reject,导致这些导出的备份无法重新导入。

## 修复

在 `packages/service/core/dataset/importFile.ts` 的 `Papa.parse` 增加 `skipEmptyLines: 'greedy'`:

- 规避空数据/单行数据导致的 `UndetectableDelimiter` 提示性错误
- 仍然保留对真实结构错误(如 `MissingQuotes` 引号未闭合)的拒绝行为

## 测试

- 新增 3 个用例:空数据集备份(header-only CSV)、无结尾换行的 header-only CSV、单条数据行 CSV
- 已验证:修复前 2 个新增用例失败,修复后全部通过
- `packages/service` 全量测试:330 文件 / 3897 测试通过,无回归
- eslint 通过