### PR TITLE
fix: handle missing chat settings and member names

### DIFF
--- a/packages/global/core/chat/setting/type.ts
+++ b/packages/global/core/chat/setting/type.ts
@@ -52,13 +52,16 @@ export const ChatSettingModelSchema = z.object({
       example: [{ pluginId: '68ad85a7463006c963799a05', source: 'system', inputs: {} }],
       description: '已选工具列表'
     }),
-  favouriteTags: z.array(ChatFavouriteTagSchema).meta({
-    example: [
-      { id: 'ptqn6v4I', name: '效率' },
-      { id: 'jHLWiqff', name: '学习' }
-    ],
-    description: '精选应用标签列表'
-  })
+  favouriteTags: z
+    .array(ChatFavouriteTagSchema)
+    .default([])
+    .meta({
+      example: [
+        { id: 'ptqn6v4I', name: '效率' },
+        { id: 'jHLWiqff', name: '学习' }
+      ],
+      description: '精选应用标签列表，历史配置缺失时返回空数组'
+    })
 });
 export type ChatSettingModelType = z.infer<typeof ChatSettingModelSchema>;
 

--- a/packages/global/test/core/chat/setting/type.test.ts
+++ b/packages/global/test/core/chat/setting/type.test.ts
@@ -124,6 +124,18 @@ describe('ChatSettingModelSchema', () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it('should default missing favouriteTags to an empty array', () => {
+    const result = ChatSettingModelSchema.parse({
+      _id: '507f1f77bcf86cd799439011',
+      appId: '507f1f77bcf86cd799439012',
+      teamId: '507f1f77bcf86cd799439013',
+      quickAppIds: [],
+      selectedTools: []
+    });
+
+    expect(result.favouriteTags).toEqual([]);
+  });
 });
 
 describe('ChatSettingSchema', () => {
@@ -181,5 +193,17 @@ describe('ChatSettingSchema', () => {
       favouriteTags: []
     });
     expect(result.success).toBe(true);
+  });
+
+  it('should default missing favouriteTags in the response to an empty array', () => {
+    const result = ChatSettingSchema.parse({
+      _id: '507f1f77bcf86cd799439011',
+      appId: '507f1f77bcf86cd799439012',
+      teamId: '507f1f77bcf86cd799439013',
+      quickAppList: [],
+      selectedTools: []
+    });
+
+    expect(result.favouriteTags).toEqual([]);
   });
 });

--- a/packages/service/support/user/team/teamMemberSchema.ts
+++ b/packages/service/support/user/team/teamMemberSchema.ts
@@ -26,6 +26,8 @@ const TeamMemberSchema = new Schema({
   },
   name: {
     type: String,
+    required: true,
+    trim: true,
     default: 'Member'
   },
   status: {

--- a/packages/service/support/user/utils.ts
+++ b/packages/service/support/user/utils.ts
@@ -128,7 +128,7 @@ export async function addSourceMember<T extends { tmbId: string }>({
       return {
         ...formatItem,
         sourceMember: {
-          name: tmb.name,
+          name: tmb.name?.trim() ? tmb.name : 'unknow',
           avatar: tmb.avatar,
           status: tmb.status ?? TeamMemberStatusEnum.active
         }

--- a/packages/service/test/support/user/utils.test.ts
+++ b/packages/service/test/support/user/utils.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { clearWebSyncLimit } from '../../../support/user/utils';
+import { addSourceMember, clearWebSyncLimit } from '../../../support/user/utils';
 import { MongoTeam } from '../../../support/user/team/teamSchema';
+import { MongoTeamMember } from '../../../support/user/team/teamMemberSchema';
 
 vi.mock('../../../support/user/team/teamSchema', () => ({
   MongoTeam: {
@@ -29,5 +30,46 @@ describe('support user utils', () => {
         'limit.lastWebsiteSyncTime': 1
       }
     });
+  });
+
+  it.each([null, undefined, '', '   '])(
+    'falls back to unknow when source member name is %j',
+    async (name) => {
+      vi.mocked(MongoTeamMember.find).mockReturnValue({
+        lean: vi.fn().mockResolvedValue([
+          {
+            _id: 'member-id',
+            name,
+            avatar: '',
+            status: 'active'
+          }
+        ])
+      } as any);
+
+      const [result] = await addSourceMember({
+        list: [{ tmbId: 'member-id' }]
+      });
+
+      expect(result.sourceMember.name).toBe('unknow');
+    }
+  );
+
+  it('preserves a non-empty source member name', async () => {
+    vi.mocked(MongoTeamMember.find).mockReturnValue({
+      lean: vi.fn().mockResolvedValue([
+        {
+          _id: 'member-id',
+          name: 'Member name',
+          avatar: '',
+          status: 'active'
+        }
+      ])
+    } as any);
+
+    const [result] = await addSourceMember({
+      list: [{ tmbId: 'member-id' }]
+    });
+
+    expect(result.sourceMember.name).toBe('Member name');
   });
 });


### PR DESCRIPTION
## What

- default missing historical `favouriteTags` values to an empty array
- require and trim `team_members.name` for new writes
- fall back to `unknow` when historical source member names are null or blank
- add regression coverage for both fallback paths

## Tests

- `packages/global: pnpm test test/core/chat/setting/type.test.ts`
- `packages/service: pnpm test test/support/user/utils.test.ts`
- targeted Prettier and ESLint checks
