### PR TITLE
fix(workflow): normalize legacy app templates

### DIFF
--- a/packages/global/core/app/tool/systemTool/type/base.ts
+++ b/packages/global/core/app/tool/systemTool/type/base.ts
@@ -30,7 +30,6 @@ export const SystemToolRuntimeSchema = z
     podTimeout: z.number().int().positive(),
     maxConcurrentRequestsPerPod: z.number().int().positive()
   })
-  .strict()
   .refine((config) => config.minPods <= config.maxPods, {
     message: 'minPods cannot be greater than maxPods',
     path: ['minPods']

--- a/packages/global/core/workflow/migration/legacy/structure.ts
+++ b/packages/global/core/workflow/migration/legacy/structure.ts
@@ -102,7 +102,7 @@ const normalizeOutputType = (value: unknown) =>
     prefix: 'FlowNodeOutputTypeEnum.'
   });
 
-/** Repair deterministic storage defects before the strict V2 boundary schema runs. */
+/** Repair deterministic storage defects before the V2 boundary schema runs. */
 export const migrateLegacyWorkflowStructureData = ({
   nodes,
   edges,
@@ -231,6 +231,8 @@ export const migrateLegacyWorkflowStructureData = ({
     node.inputs = (Array.isArray(node.inputs) ? node.inputs : []).map((value, inputIndex) => {
       const input = isRecord(value) ? { ...value } : {};
       // 非对象输入降级为空对象，后续规则补齐 key、label 和类型字段。
+      // llmModelType 是旧版模型选择器的展示字段，当前输入协议不再持久化该字段。
+      delete input.llmModelType;
       optionalInputFields.forEach((key) => {
         if (input[key] === null) delete input[key];
       });
@@ -283,6 +285,8 @@ export const migrateLegacyWorkflowStructureData = ({
   });
   const normalizedChatConfig = isRecord(chatConfig) ? { ...chatConfig } : {};
   // chatConfig 缺失、非对象或包含 null 字段时，先归一为可继续迁移的对象。
+  // Mongo 子文档遗留的 _id 不属于应用对话配置，不能进入 canonical workflow。
+  delete normalizedChatConfig._id;
   Object.keys(normalizedChatConfig).forEach((key) => {
     if (normalizedChatConfig[key] === null) delete normalizedChatConfig[key];
   });

--- a/packages/global/openapi/admin/core/app/templates/api.ts
+++ b/packages/global/openapi/admin/core/app/templates/api.ts
@@ -1,48 +1,123 @@
+import { AppTypeEnum } from '../../../../../core/app/constants';
+import { AppFormEditFormV1TypeSchema } from '../../../../../core/app/formEdit/type';
+import { AppTemplateSchema } from '../../../../../core/app/type';
+import { StoreEdgeItemTypeSchema } from '../../../../../core/workflow/type/edge';
+import { OpenAPIAppChatConfigSchema } from '../../../../core/app/common/api';
+import {
+  OpenAPIFlowNodeInputItemTypeSchema,
+  OpenAPIFlowNodeOutputItemTypeSchema,
+  OpenAPIStoreNodeItemTypeSchema
+} from '../../../../core/workflow/node';
 import z from 'zod';
 
-export const CreateTemplateBodySchema = z.object({
-  name: z.string().meta({ description: '模板名称' }),
-  intro: z.string().meta({ description: '模板简介' }),
-  avatar: z.string().meta({ description: '模板头像URL' }),
-  tags: z.array(z.string()).meta({ description: '模板标签列表' }),
-  type: z.string().meta({ description: '模板类型' }),
-  isActive: z.boolean().optional().meta({ description: '是否启用' }),
-  isPromoted: z.boolean().optional().meta({ description: '是否推荐' }),
-  promoteTags: z.array(z.string()).optional().meta({ description: '推荐标签' }),
-  hideTags: z.array(z.string()).optional().meta({ description: '隐藏标签' }),
-  recommendText: z.string().optional().meta({ description: '推荐文案' }),
-  userGuide: z
-    .object({
-      type: z.enum(['markdown', 'link']).meta({ description: '用户引导类型' }),
-      content: z.string().meta({ description: '用户引导内容' })
-    })
-    .optional()
-    .meta({ description: '用户引导配置' }),
-  workflow: z.any().meta({ description: '工作流模板配置' })
+const adminTemplateTypes = new Set<string>([
+  AppTypeEnum.simple,
+  AppTypeEnum.workflow,
+  AppTypeEnum.workflowTool
+]);
+const AdminTemplateTypeSchema = z
+  .string()
+  .refine((type) => adminTemplateTypes.has(type), '不支持的模板类型');
+
+const AdminTemplateBaseSchema = AppTemplateSchema.omit({
+  templateId: true,
+  type: true,
+  workflow: true,
+  isQuickTemplate: true,
+  order: true
 });
 
-export const UpdateTemplateBodySchema = z.object({
-  templateId: z.string().meta({ description: '模板ID' }),
-  name: z.string().optional().meta({ description: '模板名称' }),
-  intro: z.string().optional().meta({ description: '模板简介' }),
-  avatar: z.string().optional().meta({ description: '模板头像URL' }),
-  tags: z.array(z.string()).optional().meta({ description: '模板标签列表' }),
-  type: z.string().optional().meta({ description: '模板类型' }),
-  isActive: z.boolean().optional().meta({ description: '是否启用' }),
-  isPromoted: z.boolean().optional().meta({ description: '是否推荐' }),
-  promoteTags: z.array(z.string()).optional().meta({ description: '推荐标签' }),
-  hideTags: z.array(z.string()).optional().meta({ description: '隐藏标签' }),
-  recommendText: z.string().optional().meta({ description: '推荐文案' }),
-  userGuide: z
-    .object({
-      type: z.enum(['markdown', 'link']).meta({ description: '用户引导类型' }),
-      content: z.string().meta({ description: '用户引导内容' })
-    })
-    .optional()
-    .meta({ description: '用户引导配置' }),
-  workflow: z.any().optional().meta({ description: '工作流模板配置' }),
-  author: z.string().optional().meta({ description: '作者' })
+const AdminWorkflowNodeSchema = OpenAPIStoreNodeItemTypeSchema.extend({
+  inputs: z.array(OpenAPIFlowNodeInputItemTypeSchema),
+  outputs: z.array(OpenAPIFlowNodeOutputItemTypeSchema)
 });
+
+const AdminWorkflowTemplateSchema = z.object({
+  nodes: z.array(AdminWorkflowNodeSchema),
+  edges: z.array(StoreEdgeItemTypeSchema),
+  chatConfig: OpenAPIAppChatConfigSchema.optional()
+});
+
+const AdminSimpleTemplateSchema = AppFormEditFormV1TypeSchema.extend({
+  chatConfig: OpenAPIAppChatConfigSchema
+});
+const AdminTemplateWorkflowSchema = z.union([
+  AdminSimpleTemplateSchema,
+  AdminWorkflowTemplateSchema
+]);
+
+/** 校验模板类型与配置结构一致，避免表单配置和节点工作流被交叉存储。 */
+const isTemplateWorkflowMatched = ({ type, workflow }: { type: string; workflow: unknown }) => {
+  const workflowSchema =
+    type === AppTypeEnum.simple ? AdminSimpleTemplateSchema : AdminWorkflowTemplateSchema;
+  return workflowSchema.safeParse(workflow).success;
+};
+
+/* ============================================================================
+ * API: 创建应用模板
+ * Route: POST /api/admin/core/app/templates/create
+ * Method: POST
+ * Description: 管理员创建应用模板，并按应用类型校验模板配置。
+ * Tags: ['Admin', 'Template', 'Write']
+ * ============================================================================ */
+
+export const CreateTemplateBodySchema = AdminTemplateBaseSchema.extend({
+  type: AdminTemplateTypeSchema.meta({ description: '模板类型' }),
+  workflow: AdminTemplateWorkflowSchema.meta({ description: '模板配置' })
+}).superRefine((data, ctx) => {
+  if (isTemplateWorkflowMatched(data)) return;
+
+  ctx.addIssue({
+    code: 'custom',
+    path: ['workflow'],
+    message: 'workflow 与模板 type 不匹配'
+  });
+});
+export type CreateTemplateBodyType = z.infer<typeof CreateTemplateBodySchema>;
+
+/* ============================================================================
+ * API: 更新应用模板
+ * Route: PUT /api/admin/core/app/templates/update
+ * Method: PUT
+ * Description: 管理员更新应用模板；更新模板配置时必须同时提交模板类型。
+ * Tags: ['Admin', 'Template', 'Write']
+ * ============================================================================ */
+
+export const UpdateTemplateBodySchema = AdminTemplateBaseSchema.partial()
+  .extend({
+    templateId: AppTemplateSchema.shape.templateId,
+    type: AdminTemplateTypeSchema.optional().meta({ description: '模板类型' }),
+    workflow: AdminTemplateWorkflowSchema.optional().meta({ description: '模板配置' })
+  })
+  .superRefine((data, ctx) => {
+    if ((data.type === undefined) !== (data.workflow === undefined)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: data.type === undefined ? ['type'] : ['workflow'],
+        message: '更新模板类型或配置时，type 和 workflow 必须同时提交'
+      });
+      return;
+    }
+
+    if (data.type === undefined || data.workflow === undefined) return;
+
+    if (isTemplateWorkflowMatched({ type: data.type, workflow: data.workflow })) return;
+
+    ctx.addIssue({
+      code: 'custom',
+      path: ['workflow'],
+      message: 'workflow 与模板 type 不匹配'
+    });
+  });
+export type UpdateTemplateBodyType = z.infer<typeof UpdateTemplateBodySchema>;
+
+/* ============================================================================
+ * API: 更新应用模板排序
+ * Route: PUT /api/admin/core/app/templates/updateOrder
+ * Method: PUT
+ * Description: 管理员批量更新应用模板排序。
+ * Tags: ['Admin', 'Template', 'Write']
+ * ============================================================================ */
 
 export const UpdateTemplateOrderBodySchema = z.object({
   templates: z
@@ -54,7 +129,17 @@ export const UpdateTemplateOrderBodySchema = z.object({
     )
     .meta({ description: '模板排序列表' })
 });
+export type UpdateTemplateOrderBodyType = z.infer<typeof UpdateTemplateOrderBodySchema>;
+
+/* ============================================================================
+ * API: 设置快捷应用模板
+ * Route: PUT /api/admin/core/app/templates/updateQuickTemplate
+ * Method: PUT
+ * Description: 管理员设置快捷应用模板。
+ * Tags: ['Admin', 'Template', 'Write']
+ * ============================================================================ */
 
 export const UpdateQuickTemplateBodySchema = z.object({
   templateIds: z.array(z.string()).meta({ description: '设置为快捷模板的模板ID列表' })
 });
+export type UpdateQuickTemplateBodyType = z.infer<typeof UpdateQuickTemplateBodySchema>;

--- a/packages/global/openapi/core/app/common/api.ts
+++ b/packages/global/openapi/core/app/common/api.ts
@@ -18,9 +18,9 @@ import {
   OpenAPIFlowNodeOutputItemTypeSchema,
   OpenAPIStoreNodeItemTypeSchema
 } from '../../workflow/node';
-import { FlowNodeInputTypeEnum } from '../../../../core/workflow/node/constant';
 import { StoreEdgeItemTypeSchema } from '../../../../core/workflow/type/edge';
-import { BoolSchema, IntSchema, NumSchema } from '../../../../common/zod';
+import { BoolSchema, NumSchema } from '../../../../common/zod';
+import { migrateWorkflowToCurrent } from '../../../../core/workflow/migration';
 import z from 'zod';
 
 const AppIdSchema = ObjectIdSchema.meta({
@@ -139,33 +139,42 @@ export const OpenAPIAppChatConfigSchema = AppChatConfigTypeSchema.extend({
   description: '应用对话运行配置，例如欢迎语、变量、语音和定时触发配置'
 });
 
-/* Create app */
 /**
- * Create API 接受当前 workflow 以及 migration 所需的已知 legacy NodeIO 字段。
- * onCreateApp 会在写入前统一迁移，避免客户端 schema 先剥离历史输入语义。
+ * 在校验前迁移创建请求中的工作流。
+ *
+ * 模板市场和 JSON 新建都可能提交历史结构，因此创建 API 是 canonical 写入边界；
+ * 迁移失败时保留原始值，让后续 Schema 返回标准请求校验错误。
  */
-const CreateAppInputSchema = OpenAPIFlowNodeInputItemTypeSchema.omit({
-  renderTypeList: true
-}).extend({
-  renderTypeList: z.array(z.enum(FlowNodeInputTypeEnum)).optional().meta({
-    description: '输入允许的渲染组件类型；历史导入数据可暂缺，由 migration 补齐'
-  }),
-  isToolParam: BoolSchema.optional().meta({
-    description: '历史工具输入默认由 Agent 生成标记',
-    deprecated: true
-  }),
-  selectedTypeIndex: IntSchema.optional().meta({
-    description: '历史工作流输入类型索引',
-    deprecated: true
-  })
+const migrateCreateAppBodyWorkflow = (value: unknown) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
+
+  const body = value as Record<string, unknown>;
+  if (!Array.isArray(body.modules)) return value;
+
+  try {
+    const workflow = migrateWorkflowToCurrent({
+      nodes: body.modules,
+      edges: body.edges,
+      chatConfig: body.chatConfig
+    });
+
+    return {
+      ...body,
+      modules: workflow.nodes,
+      edges: workflow.edges,
+      chatConfig: workflow.chatConfig
+    };
+  } catch {
+    return value;
+  }
+};
+
+const CreateAppNodeSchema = OpenAPIStoreNodeItemTypeSchema.extend({
+  inputs: z.array(OpenAPIFlowNodeInputItemTypeSchema),
+  outputs: z.array(OpenAPIFlowNodeOutputItemTypeSchema)
 });
 
-const CreateAppNodeSchema = OpenAPIStoreNodeItemTypeSchema.strict().extend({
-  inputs: z.array(CreateAppInputSchema.strict()),
-  outputs: z.array(OpenAPIFlowNodeOutputItemTypeSchema.strict())
-});
-
-const CreateAppEdgesSchema = z.array(StoreEdgeItemTypeSchema.strict());
+const CreateAppEdgesSchema = z.array(StoreEdgeItemTypeSchema);
 
 export const CreateAppBodySchema = z
   .object({
@@ -197,7 +206,7 @@ export const CreateAppBodySchema = z
       example: [],
       description: '应用连线'
     }),
-    chatConfig: OpenAPIAppChatConfigSchema.strict().optional().meta({
+    chatConfig: OpenAPIAppChatConfigSchema.optional().meta({
       description: '聊天配置'
     }),
     templateId: z.string().optional().meta({
@@ -208,7 +217,6 @@ export const CreateAppBodySchema = z
       description: 'UTM 参数'
     })
   })
-  .strict()
   .meta({
     example: {
       name: '新应用',
@@ -218,6 +226,11 @@ export const CreateAppBodySchema = z
       parentId: '68ad85a7463006c963799a05'
     }
   });
+
+export const CreateAppRequestBodySchema = z.preprocess(
+  migrateCreateAppBodyWorkflow,
+  CreateAppBodySchema
+);
 export type CreateAppBodyType = z.infer<typeof CreateAppBodySchema>;
 
 export const CreateAppResponseSchema = ObjectIdSchema.meta({
@@ -395,9 +408,12 @@ export const UpdateAppBodySchema = z
       .optional()
       .meta({ example: AppTypeEnum.workflow, description: '应用类型' }),
     avatar: z.string().optional().meta({ description: '应用头像' }),
-    intro: z.string().optional().meta({ description: '应用介绍' })
+    intro: z.string().optional().meta({ description: '应用介绍' }),
+    nodes: z.never().optional(),
+    modules: z.never().optional(),
+    edges: z.never().optional(),
+    chatConfig: z.never().optional()
   })
-  .strict()
   .meta({
     example: {
       name: '客服应用',

--- a/packages/global/openapi/core/app/version/api.ts
+++ b/packages/global/openapi/core/app/version/api.ts
@@ -2,11 +2,7 @@ import z from 'zod';
 import { VersionListItemSchema } from '../../../../core/app/version/type';
 import { ObjectIdSchema } from '../../../../common/type/mongo';
 import { PaginationSchema } from '../../../api';
-import {
-  OpenAPIFlowNodeInputItemTypeSchema,
-  OpenAPIFlowNodeOutputItemTypeSchema,
-  OpenAPIStoreNodeItemTypeSchema
-} from '../../workflow/node';
+import { OpenAPIStoreNodeItemTypeSchema } from '../../workflow/node';
 import { AppResourceRefsSchema, AppSchemaTypeSchema } from '../../../../core/app/type';
 import { OpenAPIAppChatConfigSchema } from '../common/api';
 import { BoolSchema, NumSchema } from '../../../../common/zod';
@@ -23,17 +19,9 @@ const AppVersionNodesSchema = z.array(OpenAPIStoreNodeItemTypeSchema).meta({
   description: '版本内保存的应用节点配置'
 });
 
-// Publish 请求在迁移前拒绝 legacy NodeIO；版本详情响应保留既有兼容 schema。
-const PublishAppNodesSchema = z
-  .array(
-    OpenAPIStoreNodeItemTypeSchema.strict().extend({
-      inputs: z.array(OpenAPIFlowNodeInputItemTypeSchema.strict()),
-      outputs: z.array(OpenAPIFlowNodeOutputItemTypeSchema.strict())
-    })
-  )
-  .meta({
-    description: '本次保存的应用节点配置'
-  });
+const PublishAppNodesSchema = z.array(OpenAPIStoreNodeItemTypeSchema).meta({
+  description: '本次保存的应用节点配置'
+});
 
 const AppVersionEdgesSchema = AppSchemaTypeSchema.shape.edges.default([]).meta({
   description: '版本内保存的应用连线配置'

--- a/packages/global/openapi/core/chat/completion/api.ts
+++ b/packages/global/openapi/core/chat/completion/api.ts
@@ -84,7 +84,6 @@ export const ChatCompletionAuthProxySchema = z
       description: 'API Key 代理调用的团队成员 ID'
     })
   })
-  .strict()
   .refine(({ username, tmbId }) => !!username || !!tmbId, {
     message: 'authProxy.username or authProxy.tmbId is required'
   })

--- a/packages/global/openapi/core/dataset/collection/api.ts
+++ b/packages/global/openapi/core/dataset/collection/api.ts
@@ -56,7 +56,29 @@ const BasicExportSchema = z
   .object({
     collectionId: ObjectIdSchema.describe('集合ID')
   })
-  .strict()
+  .passthrough()
+  .superRefine((data, ctx) => {
+    // 先检查原始键再清洗，避免无效聊天鉴权参数被 union 降级为普通登录态导出。
+    const chatExportKeys = [
+      'appId',
+      'skillId',
+      'sourceType',
+      'outLinkAuthData',
+      'chatId',
+      'chatItemDataId',
+      'chatTime'
+    ] as const;
+    const invalidKey = chatExportKeys.find((key) => data[key] !== undefined);
+
+    if (invalidKey) {
+      ctx.addIssue({
+        code: 'custom',
+        path: [invalidKey],
+        message: '聊天态导出字段不能用于普通导出'
+      });
+    }
+  })
+  .transform(({ collectionId }) => ({ collectionId }))
   .meta({
     description: '通过身份鉴权导出集合',
     example: {

--- a/packages/global/openapi/support/mcpServer/api.ts
+++ b/packages/global/openapi/support/mcpServer/api.ts
@@ -197,7 +197,6 @@ export const McpAuthProxySchema = z
       description: '代理调用的团队成员 ID'
     })
   })
-  .strict()
   .refine(({ username, tmbId }) => !!username || !!tmbId, {
     message: 'authProxy.username or authProxy.tmbId is required'
   });

--- a/packages/global/openapi/support/user/account/cancellation/api.ts
+++ b/packages/global/openapi/support/user/account/cancellation/api.ts
@@ -16,78 +16,60 @@ const DateTimeSchema = z.iso.datetime({ offset: true });
 
 export const AccountCancellationStatusResponseSchema = z
   .discriminatedUnion('status', [
-    z
-      .object({
-        status: z.literal('none').meta({ description: '当前没有注销申请', example: 'none' }),
-        canRequestCancellation: z.boolean().meta({
-          description: '是否允许发起注销申请',
-          example: true
-        }),
-        maskedAccount: z
-          .string()
-          .meta({ description: '当前账号脱敏值', example: 'us***@example.com' }),
-        unavailableReason: AccountCancellationUnavailableReasonSchema.optional().meta({
-          description: '不可申请原因',
-          example: 'password_verification_not_allowed'
-        })
+    z.object({
+      status: z.literal('none').meta({ description: '当前没有注销申请', example: 'none' }),
+      canRequestCancellation: z.boolean().meta({
+        description: '是否允许发起注销申请',
+        example: true
+      }),
+      maskedAccount: z
+        .string()
+        .meta({ description: '当前账号脱敏值', example: 'us***@example.com' }),
+      unavailableReason: AccountCancellationUnavailableReasonSchema.optional().meta({
+        description: '不可申请原因',
+        example: 'password_verification_not_allowed'
       })
-      .strict(),
-    z
-      .object({
-        status: z
-          .literal('pending')
-          .meta({ description: '等待期或最终清理中', example: 'pending' }),
-        maskedAccount: z
-          .string()
-          .meta({ description: '当前账号脱敏值', example: 'us***@example.com' }),
-        requestedAt: DateTimeSchema.meta({
-          description: '注销申请时间（UTC）',
-          example: '2026-07-01T10:00:00.000Z'
-        }),
-        scheduledCancelAt: DateTimeSchema.optional().meta({
-          description: '派生的计划清理时间（UTC）',
-          example: '2026-07-16T16:00:00.000Z'
-        }),
-        canCancelCancellation: z.boolean().meta({ description: '当前是否允许取消', example: true })
-      })
-      .strict()
+    }),
+    z.object({
+      status: z.literal('pending').meta({ description: '等待期或最终清理中', example: 'pending' }),
+      maskedAccount: z
+        .string()
+        .meta({ description: '当前账号脱敏值', example: 'us***@example.com' }),
+      requestedAt: DateTimeSchema.meta({
+        description: '注销申请时间（UTC）',
+        example: '2026-07-01T10:00:00.000Z'
+      }),
+      scheduledCancelAt: DateTimeSchema.optional().meta({
+        description: '派生的计划清理时间（UTC）',
+        example: '2026-07-16T16:00:00.000Z'
+      }),
+      canCancelCancellation: z.boolean().meta({ description: '当前是否允许取消', example: true })
+    })
   ])
   .meta({ description: '账号注销公开状态' });
 export type AccountCancellationStatusResponse = z.infer<
   typeof AccountCancellationStatusResponseSchema
 >;
 
-const CodeVerificationCreateSchema = z
-  .object({
-    method: z.literal('code').meta({ description: '邮箱或手机验证码', example: 'code' }),
-    payload: z
-      .object({
-        captcha: z
-          .string()
-          .min(1)
-          .max(64)
-          .meta({ description: '图片验证码答案', example: 'A1B2C3' })
-      })
-      .strict()
+const CodeVerificationCreateSchema = z.object({
+  method: z.literal('code').meta({ description: '邮箱或手机验证码', example: 'code' }),
+  payload: z.object({
+    captcha: z.string().min(1).max(64).meta({ description: '图片验证码答案', example: 'A1B2C3' })
   })
-  .strict();
+});
 
-const WechatVerificationCreateSchema = z
-  .object({
-    method: z.literal('wechat').meta({ description: '微信扫码验证', example: 'wechat' }),
-    payload: z.object({}).strict()
-  })
-  .strict();
+const WechatVerificationCreateSchema = z.object({
+  method: z.literal('wechat').meta({ description: '微信扫码验证', example: 'wechat' }),
+  payload: z.object({})
+});
 
-const OAuthCreatePayloadSchema = z
-  .object({
-    callbackUrl: z
-      .url()
-      .max(2048)
-      .meta({ description: 'OAuth 回调地址', example: 'https://example.com/login/provider' }),
-    isWecomWorkTerminal: z.boolean().optional().meta({ description: '是否来自企业微信工作台' })
-  })
-  .strict();
+const OAuthCreatePayloadSchema = z.object({
+  callbackUrl: z
+    .url()
+    .max(2048)
+    .meta({ description: 'OAuth 回调地址', example: 'https://example.com/login/provider' }),
+  isWecomWorkTerminal: z.boolean().optional().meta({ description: '是否来自企业微信工作台' })
+});
 
 const OAuthCreateMethodSchemas = [
   'oauth/github',
@@ -101,12 +83,10 @@ export const CreateAccountCancellationVerificationBodySchema = z.discriminatedUn
   CodeVerificationCreateSchema,
   WechatVerificationCreateSchema,
   ...OAuthCreateMethodSchemas.map((method) =>
-    z
-      .object({
-        method: z.literal(method).meta({ description: 'OAuth 验证方式', example: method }),
-        payload: OAuthCreatePayloadSchema
-      })
-      .strict()
+    z.object({
+      method: z.literal(method).meta({ description: 'OAuth 验证方式', example: method }),
+      payload: OAuthCreatePayloadSchema
+    })
   )
 ] as [typeof CodeVerificationCreateSchema, typeof WechatVerificationCreateSchema, ...any[]]);
 export type CreateAccountCancellationVerificationBody = z.infer<
@@ -114,65 +94,47 @@ export type CreateAccountCancellationVerificationBody = z.infer<
 >;
 
 export const CreateAccountCancellationVerificationResponseSchema = z.discriminatedUnion('method', [
-  z
-    .object({
-      method: z.literal('code'),
-      sent: z.literal(true),
-      maskedTarget: z
-        .string()
-        .meta({ description: '验证码接收目标脱敏值', example: 'us***@example.com' })
-    })
-    .strict(),
-  z
-    .object({
-      method: z.literal('wechat'),
-      code: z.string().min(16).meta({ description: '微信扫码 scene', example: 'scene-code' }),
-      codeUrl: z
-        .url()
-        .meta({ description: '微信二维码地址', example: 'https://mp.weixin.qq.com/...' }),
-      expiredAt: DateTimeSchema.optional().meta({ description: '二维码过期时间' })
-    })
-    .strict(),
+  z.object({
+    method: z.literal('code'),
+    sent: z.literal(true),
+    maskedTarget: z
+      .string()
+      .meta({ description: '验证码接收目标脱敏值', example: 'us***@example.com' })
+  }),
+  z.object({
+    method: z.literal('wechat'),
+    code: z.string().min(16).meta({ description: '微信扫码 scene', example: 'scene-code' }),
+    codeUrl: z
+      .url()
+      .meta({ description: '微信二维码地址', example: 'https://mp.weixin.qq.com/...' }),
+    expiredAt: DateTimeSchema.optional().meta({ description: '二维码过期时间' })
+  }),
   ...OAuthCreateMethodSchemas.map((method) =>
-    z
-      .object({
-        method: z.literal(method),
-        state: z.string().min(16).meta({ description: '一次性 OAuth state', example: 'state' }),
-        url: z
-          .url()
-          .meta({ description: 'Provider 授权地址', example: 'https://provider.example/authorize' })
-      })
-      .strict()
+    z.object({
+      method: z.literal(method),
+      state: z.string().min(16).meta({ description: '一次性 OAuth state', example: 'state' }),
+      url: z
+        .url()
+        .meta({ description: 'Provider 授权地址', example: 'https://provider.example/authorize' })
+    })
   )
 ] as [any, any, ...any[]]);
 export type CreateAccountCancellationVerificationResponse = z.infer<
   typeof CreateAccountCancellationVerificationResponseSchema
 >;
 
-const CodeSubmitSchema = z
-  .object({
-    method: z.literal('code'),
-    payload: z
-      .object({
-        code: z.string().min(1).max(32).meta({ description: '验证码', example: '123456' })
-      })
-      .strict()
+const CodeSubmitSchema = z.object({
+  method: z.literal('code'),
+  payload: z.object({
+    code: z.string().min(1).max(32).meta({ description: '验证码', example: '123456' })
   })
-  .strict();
-const WechatSubmitSchema = z
-  .object({
-    method: z.literal('wechat'),
-    payload: z
-      .object({
-        code: z
-          .string()
-          .min(1)
-          .max(128)
-          .meta({ description: '微信扫码 scene', example: 'scene-code' })
-      })
-      .strict()
+});
+const WechatSubmitSchema = z.object({
+  method: z.literal('wechat'),
+  payload: z.object({
+    code: z.string().min(1).max(128).meta({ description: '微信扫码 scene', example: 'scene-code' })
   })
-  .strict();
+});
 const OAuthPropsSchema = z
   .record(
     z
@@ -207,22 +169,20 @@ export const SubmitAccountCancellationBodySchema = z.discriminatedUnion('method'
   CodeSubmitSchema,
   WechatSubmitSchema,
   ...OAuthCreateMethodSchemas.map((method) =>
-    z.object({ method: z.literal(method), payload: OAuthSubmitPayloadSchema }).strict()
+    z.object({ method: z.literal(method), payload: OAuthSubmitPayloadSchema })
   )
 ] as [typeof CodeSubmitSchema, typeof WechatSubmitSchema, ...any[]]);
 export type SubmitAccountCancellationBody = z.infer<typeof SubmitAccountCancellationBodySchema>;
 
 export const SubmitAccountCancellationResponseSchema = z.discriminatedUnion('status', [
-  z.object({ status: z.literal('verificationPending') }).strict(),
-  z.object({ status: z.literal('verificationExpired') }).strict(),
-  z
-    .object({
-      status: z.literal('pending'),
-      requestedAt: DateTimeSchema,
-      scheduledCancelAt: DateTimeSchema,
-      canCancelCancellation: z.literal(true)
-    })
-    .strict()
+  z.object({ status: z.literal('verificationPending') }),
+  z.object({ status: z.literal('verificationExpired') }),
+  z.object({
+    status: z.literal('pending'),
+    requestedAt: DateTimeSchema,
+    scheduledCancelAt: DateTimeSchema,
+    canCancelCancellation: z.literal(true)
+  })
 ]);
 export type SubmitAccountCancellationResponse = z.infer<
   typeof SubmitAccountCancellationResponseSchema

--- a/packages/global/openapi/support/user/inform/api.ts
+++ b/packages/global/openapi/support/user/inform/api.ts
@@ -10,22 +10,20 @@ import {
 import { ObjectIdSchema } from '../../../../common/type/mongo';
 import { PaginationSchema } from '../../../api';
 
-const SendAuthCodeCommonSchema = z
-  .object({
-    username: AccountContactUsernameSchema.meta({
-      description: '接收验证码的邮箱或手机号',
-      example: 'user@example.com'
-    }),
-    captcha: ShortAuthStringSchema.max(64).meta({
-      description: '图片验证码答案',
-      example: 'A1B2C3'
-    }),
-    lang: LanguageSchema.meta({
-      description: '验证码消息语言',
-      example: 'zh-CN'
-    })
+const SendAuthCodeCommonSchema = z.object({
+  username: AccountContactUsernameSchema.meta({
+    description: '接收验证码的邮箱或手机号',
+    example: 'user@example.com'
+  }),
+  captcha: ShortAuthStringSchema.max(64).meta({
+    description: '图片验证码答案',
+    example: 'A1B2C3'
+  }),
+  lang: LanguageSchema.meta({
+    description: '验证码消息语言',
+    example: 'zh-CN'
   })
-  .strict();
+});
 
 export const SendAuthCodeBodySchema = z.discriminatedUnion('type', [
   SendAuthCodeCommonSchema.extend({
@@ -37,7 +35,7 @@ export const SendAuthCodeBodySchema = z.discriminatedUnion('type', [
       description: '验证码业务场景',
       example: 'register'
     })
-  }).strict(),
+  }),
   SendAuthCodeCommonSchema.extend({
     type: z.literal(VerificationCodeTypeEnum.findPassword).meta({
       description: '验证码类型',
@@ -49,7 +47,7 @@ export const SendAuthCodeBodySchema = z.discriminatedUnion('type', [
         description: '验证码业务场景',
         example: 'forgetPassword'
       })
-  }).strict(),
+  }),
   SendAuthCodeCommonSchema.extend({
     type: z.literal(VerificationCodeTypeEnum.bindNotification).meta({
       description: '验证码类型',
@@ -61,15 +59,13 @@ export const SendAuthCodeBodySchema = z.discriminatedUnion('type', [
         description: '验证码业务场景',
         example: 'bindNotification'
       })
-  }).strict()
+  })
 ]);
 export type SendAuthCodeBodyType = z.infer<typeof SendAuthCodeBodySchema>;
 
-export const SendAuthCodeResponseSchema = z
-  .object({
-    message: z.string().meta({ description: '发送结果说明', example: '发送验证码成功' })
-  })
-  .strict();
+export const SendAuthCodeResponseSchema = z.object({
+  message: z.string().meta({ description: '发送结果说明', example: '发送验证码成功' })
+});
 export type SendAuthCodeResponseType = z.infer<typeof SendAuthCodeResponseSchema>;
 
 /* ============================================================================

--- a/packages/global/support/user/team/type.ts
+++ b/packages/global/support/user/team/type.ts
@@ -70,7 +70,6 @@ export const TeamTmbItemSchema = ThidPartyAccountSchema.extend({
       status: TeamAccountCancellationStatusSchema,
       scheduledCancelAt: z.union([z.date(), z.iso.datetime({ offset: true })]).optional()
     })
-    .strict()
     .optional()
 });
 export type TeamTmbItemType = z.infer<typeof TeamTmbItemSchema>;

--- a/packages/global/test/core/workflow/migration/schema.test.ts
+++ b/packages/global/test/core/workflow/migration/schema.test.ts
@@ -78,7 +78,7 @@ describe('workflow migration boundary', () => {
     expect(result.nodes[0].inputs[1]).not.toHaveProperty('isToolParam');
   });
 
-  it('rejects V1 nodes before strict V2 parsing', async () => {
+  it('rejects V1 nodes before V2 schema parsing', async () => {
     expect(() =>
       migrateWorkflowToCurrent({
         nodes: [
@@ -107,7 +107,7 @@ describe('workflow migration boundary', () => {
     ).toThrow();
   });
 
-  it('repairs deterministic V2 structural defects before strict parsing', async () => {
+  it('repairs deterministic V2 structural defects before schema parsing', async () => {
     const result = await migrateWorkflowToCurrent({
       nodes: [
         {
@@ -206,6 +206,34 @@ describe('workflow migration boundary', () => {
 
     expect(result.nodes[0]).not.toHaveProperty('id');
     expect(result.nodes[0].nodeId).toBe('node-1');
+  });
+
+  it('removes deprecated model input metadata and Mongo chat config ids', () => {
+    const result = migrateWorkflowToCurrent({
+      nodes: [
+        {
+          nodeId: 'legacy-node',
+          flowNodeType: 'removedNodeType',
+          name: 'Legacy node',
+          inputs: [
+            {
+              key: 'model',
+              label: 'Model',
+              renderTypeList: [FlowNodeInputTypeEnum.input],
+              llmModelType: 'chat'
+            }
+          ],
+          outputs: []
+        }
+      ],
+      chatConfig: {
+        _id: 'legacy-mongo-subdocument-id'
+      }
+    });
+
+    expect(result.nodes[0].flowNodeType).toBe('emptyNode');
+    expect(result.nodes[0].inputs[0]).not.toHaveProperty('llmModelType');
+    expect(result.chatConfig).not.toHaveProperty('_id');
   });
 
   it('adds an empty config to available Agent tools missing config', async () => {
@@ -562,7 +590,7 @@ describe('workflow migration boundary', () => {
     expect(input.valueDesc).toBe('');
   });
 
-  it('drops historical null input fields before strict parsing', async () => {
+  it('drops historical null input fields before schema parsing', async () => {
     const result = await migrateWorkflowToCurrent({
       nodes: [
         {

--- a/packages/global/test/openapi/admin/core/app/templates.test.ts
+++ b/packages/global/test/openapi/admin/core/app/templates.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import { AppTypeEnum } from '@fastgpt/global/core/app/constants';
+import {
+  CreateTemplateBodySchema,
+  UpdateTemplateBodySchema
+} from '@fastgpt/global/openapi/admin/core/app/templates/api';
+
+const templateBase = {
+  name: 'Template',
+  intro: 'Template intro',
+  avatar: 'template-avatar',
+  tags: []
+};
+
+const workflow = {
+  nodes: [
+    {
+      nodeId: 'start',
+      flowNodeType: 'workflowStart',
+      name: 'Start',
+      inputs: [],
+      outputs: []
+    }
+  ],
+  edges: [],
+  chatConfig: {}
+};
+
+const simpleWorkflow = {
+  aiSettings: {
+    model: 'gpt-4o-mini',
+    isResponseAnswerText: true,
+    maxHistories: 6
+  },
+  dataset: {
+    datasets: [],
+    searchMode: 'embedding'
+  },
+  selectedTools: [],
+  chatConfig: {}
+};
+
+describe('admin app template schemas', () => {
+  it('accepts a canonical workflow template', () => {
+    expect(
+      CreateTemplateBodySchema.parse({
+        ...templateBase,
+        type: AppTypeEnum.workflow,
+        workflow
+      }).workflow
+    ).toEqual(workflow);
+  });
+
+  it('rejects an unsupported workflow node type', () => {
+    expect(
+      CreateTemplateBodySchema.safeParse({
+        ...templateBase,
+        type: AppTypeEnum.workflow,
+        workflow: {
+          ...workflow,
+          nodes: [{ ...workflow.nodes[0], flowNodeType: 'removedNodeType' }]
+        }
+      }).success
+    ).toBe(false);
+  });
+
+  it('strips unknown fields from workflow templates', () => {
+    const result = CreateTemplateBodySchema.parse({
+      ...templateBase,
+      type: AppTypeEnum.workflow,
+      workflow: {
+        ...workflow,
+        nodes: [
+          {
+            ...workflow.nodes[0],
+            inputs: [
+              {
+                key: 'model',
+                label: 'Model',
+                renderTypeList: ['input'],
+                llmModelType: 'chat'
+              }
+            ]
+          }
+        ],
+        chatConfig: { _id: 'legacy-id' }
+      }
+    });
+
+    expect(result.workflow).not.toHaveProperty('chatConfig._id');
+    expect(result.workflow).not.toHaveProperty('nodes.0.inputs.0.llmModelType');
+  });
+
+  it('strips unknown chat config fields from simple templates', () => {
+    const result = CreateTemplateBodySchema.parse({
+      ...templateBase,
+      type: AppTypeEnum.simple,
+      workflow: {
+        ...simpleWorkflow,
+        chatConfig: { _id: 'legacy-id' }
+      }
+    });
+
+    expect(result.workflow).not.toHaveProperty('chatConfig._id');
+  });
+
+  it('requires type and workflow to be updated together', () => {
+    expect(
+      UpdateTemplateBodySchema.safeParse({
+        templateId: 'commercial-template',
+        workflow
+      }).success
+    ).toBe(false);
+    expect(
+      UpdateTemplateBodySchema.safeParse({
+        templateId: 'commercial-template',
+        isActive: true
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects a workflow that does not match the updated template type', () => {
+    expect(
+      UpdateTemplateBodySchema.safeParse({
+        templateId: 'commercial-template',
+        type: AppTypeEnum.simple,
+        workflow
+      }).success
+    ).toBe(false);
+  });
+});

--- a/packages/global/test/openapi/core/app/common/api.test.ts
+++ b/packages/global/test/openapi/core/app/common/api.test.ts
@@ -1,5 +1,6 @@
 import {
   CreateAppBodySchema,
+  CreateAppRequestBodySchema,
   UpdateAppBodySchema
 } from '@fastgpt/global/openapi/core/app/common/api';
 import { PublishAppBodySchema } from '@fastgpt/global/openapi/core/app/version/api';
@@ -39,8 +40,8 @@ describe('CreateAppBodySchema', () => {
     ).toBe(true);
   });
 
-  it('accepts known legacy workflow fields for server migration', () => {
-    const result = CreateAppBodySchema.safeParse({
+  it('migrates legacy workflow before validation', () => {
+    const result = CreateAppRequestBodySchema.parse({
       name: 'legacy app',
       type: 'simple',
       modules: [
@@ -49,67 +50,60 @@ describe('CreateAppBodySchema', () => {
           inputs: [
             {
               ...currentNode.inputs[0],
-              selectedTypeIndex: 0,
-              isToolParam: true
+              llmModelType: 'chat'
             }
           ]
+        },
+        {
+          nodeId: 'legacy-system-config',
+          flowNodeType: 'userGuide',
+          name: 'Legacy system config',
+          inputs: [],
+          outputs: []
+        }
+      ],
+      edges: [],
+      chatConfig: { _id: 'legacy-chat-config' }
+    });
+
+    expect(result.modules).toHaveLength(1);
+    expect(result.modules?.[0].inputs[0]).not.toHaveProperty('llmModelType');
+    expect(result.chatConfig).not.toHaveProperty('_id');
+  });
+
+  it('strips unsupported request fields after migration', () => {
+    const result = CreateAppRequestBodySchema.parse({
+      name: 'app with extra field',
+      type: 'simple',
+      modules: [currentNode],
+      edges: [],
+      chatConfig: {},
+      unsupported: true
+    });
+
+    expect(result).not.toHaveProperty('unsupported');
+  });
+});
+
+describe('PublishAppBodySchema', () => {
+  it('accepts current NodeIO and strips unknown workflow fields', () => {
+    expect(
+      PublishAppBodySchema.safeParse({ nodes: [currentNode], edges: [], chatConfig: {} }).success
+    ).toBe(true);
+
+    const result = PublishAppBodySchema.parse({
+      nodes: [
+        {
+          ...currentNode,
+          unsupportedNodeField: true,
+          inputs: [{ ...currentNode.inputs[0], unsupportedInputField: true }]
         }
       ],
       edges: [],
       chatConfig: {}
     });
 
-    expect(result.success).toBe(true);
-    if (!result.success) return;
-    expect(result.data.modules?.[0].inputs[0]).toMatchObject({
-      selectedTypeIndex: 0,
-      isToolParam: true
-    });
-  });
-
-  it('rejects unsupported workflow fields at the API boundary', () => {
-    expect(
-      CreateAppBodySchema.safeParse({
-        name: 'legacy app',
-        type: 'simple',
-        modules: [
-          {
-            ...currentNode,
-            userGuide: 'legacy guide',
-            inputs: [{ ...currentNode.inputs[0], isToolParam: true }]
-          }
-        ],
-        edges: [
-          {
-            source: 'start-1',
-            sourceHandle: 'output',
-            target: 'end-1',
-            targetHandle: 'input',
-            legacy: true
-          }
-        ],
-        chatConfig: { pluginConfig: {} }
-      }).success
-    ).toBe(false);
-  });
-});
-
-describe('PublishAppBodySchema', () => {
-  it('accepts current NodeIO and rejects the old default field', () => {
-    expect(
-      PublishAppBodySchema.safeParse({ nodes: [currentNode], edges: [], chatConfig: {} }).success
-    ).toBe(true);
-    expect(
-      PublishAppBodySchema.safeParse({
-        nodes: [
-          {
-            ...currentNode,
-            inputs: [{ ...currentNode.inputs[0], isToolParam: true }]
-          }
-        ],
-        edges: [],
-        chatConfig: {}
-      }).success
-    ).toBe(false);
+    expect(result).not.toHaveProperty('nodes.0.unsupportedNodeField');
+    expect(result).not.toHaveProperty('nodes.0.inputs.0.unsupportedInputField');
   });
 });

--- a/packages/global/test/openapi/support/user/account/cancellation/api.test.ts
+++ b/packages/global/test/openapi/support/user/account/cancellation/api.test.ts
@@ -21,14 +21,14 @@ describe('account cancellation API contracts', () => {
     ).toThrow();
   });
 
-  it('does not accept username, scene, or extra submit fields', () => {
-    expect(() =>
+  it('strips unknown submit fields while rejecting unsupported methods', () => {
+    expect(
       SubmitAccountCancellationBodySchema.parse({
         method: 'code',
-        payload: { code: '123456' },
+        payload: { code: '123456', legacyScene: 'account-cancellation' },
         username: 'user@example.com'
       })
-    ).toThrow();
+    ).toEqual({ method: 'code', payload: { code: '123456' } });
     expect(() =>
       SubmitAccountCancellationBodySchema.parse({
         method: 'oldPassword',

--- a/packages/service/common/s3/accessLink/type.ts
+++ b/packages/service/common/s3/accessLink/type.ts
@@ -104,7 +104,6 @@ const CreateS3MultipartUploadSessionSchema = z
     completedAt: z.never().optional(),
     abortedAt: z.never().optional()
   })
-  .strict()
   .superRefine(({ totalSize, partSize }, context) => {
     if (Math.ceil(totalSize / partSize) > MAX_MULTIPART_PART_COUNT) {
       context.addIssue({

--- a/packages/service/core/ai/sandbox/type.ts
+++ b/packages/service/core/ai/sandbox/type.ts
@@ -93,18 +93,16 @@ export const SandboxImageSchema = z.object({
   tag: z.string().optional()
 });
 
-export const SandboxOperationSchema = z
-  .object({
-    id: z.string().min(1),
-    type: SandboxOperationTypeSchema,
-    phase: z.string().min(1),
-    previousStatus: SandboxStableStatusSchema.optional(),
-    startedAt: z.coerce.date(),
-    heartbeatAt: z.coerce.date(),
-    failedAt: z.coerce.date().optional(),
-    error: z.string().optional()
-  })
-  .strict();
+export const SandboxOperationSchema = z.object({
+  id: z.string().min(1),
+  type: SandboxOperationTypeSchema,
+  phase: z.string().min(1),
+  previousStatus: SandboxStableStatusSchema.optional(),
+  startedAt: z.coerce.date(),
+  heartbeatAt: z.coerce.date(),
+  failedAt: z.coerce.date().optional(),
+  error: z.string().optional()
+});
 export type SandboxOperationTypeSchemaType = z.infer<typeof SandboxOperationSchema>;
 
 const expectedOperationByStatus: Partial<Record<SandboxInstanceStatusType, SandboxOperationType>> =

--- a/packages/service/core/app/templates/register.ts
+++ b/packages/service/core/app/templates/register.ts
@@ -5,6 +5,7 @@ import { type AppTemplateSchemaType } from '@fastgpt/global/core/app/type';
 import { MongoAppTemplate } from './templateSchema';
 import { pluginClient } from '../../../thirdProvider/fastgptPlugin';
 import { addMinutes } from 'date-fns';
+import { migrateAppTemplateWorkflowToCurrent } from './utils';
 
 type PluginSystemTemplateDbConfig = Pick<AppTemplateSchemaType, 'templateId'> &
   Partial<
@@ -118,7 +119,9 @@ const getAppTemplates = async () => {
   const res = [
     ...communityTemplateConfig,
     ...dbTemplates.filter((t) => isCommercialTemaplte(t.templateId))
-  ].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+  ]
+    .map(migrateAppTemplateWorkflowToCurrent)
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
 
   return res;
 };

--- a/packages/service/core/app/templates/utils.ts
+++ b/packages/service/core/app/templates/utils.ts
@@ -1,0 +1,48 @@
+import { AppTypeEnum } from '@fastgpt/global/core/app/constants';
+import type { AppTemplateSchemaType } from '@fastgpt/global/core/app/type';
+import { migrateWorkflowToCurrent } from '@fastgpt/global/core/workflow/migration';
+
+/**
+ * 将模板内的历史工作流迁移为当前结构。
+ *
+ * 高级应用和工作流工具会迁移完整节点、连线与聊天配置；简易应用没有节点工作流，
+ * 仅复用同一迁移器清理 chatConfig。未知模板类型保持原样，避免模板市场被单条外部数据拖垮。
+ */
+export const migrateAppTemplateWorkflowToCurrent = (
+  template: AppTemplateSchemaType
+): AppTemplateSchemaType => {
+  if (!template.workflow || typeof template.workflow !== 'object') return template;
+
+  if (template.type === AppTypeEnum.simple) {
+    const workflow = template.workflow as unknown as Record<string, unknown>;
+    const migrated = migrateWorkflowToCurrent({
+      nodes: [],
+      edges: [],
+      chatConfig: workflow.chatConfig
+    });
+
+    return {
+      ...template,
+      workflow: {
+        ...workflow,
+        chatConfig: migrated.chatConfig
+      } as AppTemplateSchemaType['workflow']
+    };
+  }
+
+  if (template.type !== AppTypeEnum.workflow && template.type !== AppTypeEnum.workflowTool) {
+    return template;
+  }
+
+  const workflow = template.workflow as unknown as Record<string, unknown>;
+  const migrated = migrateWorkflowToCurrent({
+    nodes: Array.isArray(workflow.nodes) ? workflow.nodes : [],
+    edges: workflow.edges,
+    chatConfig: workflow.chatConfig
+  });
+
+  return {
+    ...template,
+    workflow: migrated
+  };
+};

--- a/packages/service/test/core/app/templates/register.test.ts
+++ b/packages/service/test/core/app/templates/register.test.ts
@@ -149,10 +149,89 @@ describe('getAppTemplatesAndLoadThem', () => {
       recommendText: 'DB recommend',
       order: 1
     });
-    expect(template?.workflow).toEqual(pluginWorkflow);
+    expect(template?.workflow).toMatchObject({
+      nodes: pluginWorkflow.nodes,
+      edges: pluginWorkflow.edges,
+      chatConfig: {
+        welcomeText: 'plugin welcome'
+      }
+    });
+    expect(template?.workflow.nodes[0].nodeId).not.toBe('stale-db-node');
     expect(template?.userGuide).toEqual({
       type: 'link',
       content: 'https://plugin.example.com'
     });
+  });
+
+  it('migrates legacy workflow fields before returning templates', async () => {
+    mocks.listWorkflows.mockResolvedValue([]);
+    mocks.findTemplates.mockReturnValue({
+      lean: vi.fn().mockResolvedValue([
+        {
+          templateId: `${AppToolSourceEnum.commercial}-legacy-workflow`,
+          name: 'Legacy workflow',
+          intro: 'intro',
+          avatar: 'avatar',
+          tags: [],
+          type: AppTypeEnum.workflow,
+          workflow: {
+            nodes: [
+              {
+                nodeId: 'start',
+                flowNodeType: FlowNodeTypeEnum.workflowStart,
+                name: 'Start',
+                inputs: [
+                  {
+                    key: 'model',
+                    label: 'Model',
+                    renderTypeList: ['input'],
+                    llmModelType: 'chat'
+                  }
+                ],
+                outputs: []
+              },
+              {
+                nodeId: 'legacy-system-config',
+                flowNodeType: 'userGuide',
+                name: 'Legacy system config',
+                inputs: [],
+                outputs: []
+              }
+            ],
+            edges: [],
+            chatConfig: { _id: 'legacy-chat-config' }
+          }
+        }
+      ])
+    });
+
+    const [template] = await getAppTemplatesAndLoadThem(true);
+
+    expect(template?.workflow.nodes).toHaveLength(1);
+    expect(template?.workflow.nodes[0].inputs[0]).not.toHaveProperty('llmModelType');
+    expect(template?.workflow.chatConfig).not.toHaveProperty('_id');
+  });
+
+  it('cleans legacy chat config fields in simple templates', async () => {
+    mocks.listWorkflows.mockResolvedValue([]);
+    mocks.findTemplates.mockReturnValue({
+      lean: vi.fn().mockResolvedValue([
+        {
+          templateId: `${AppToolSourceEnum.commercial}-legacy-simple`,
+          name: 'Legacy simple app',
+          intro: 'intro',
+          avatar: 'avatar',
+          tags: [],
+          type: AppTypeEnum.simple,
+          workflow: {
+            chatConfig: { _id: 'legacy-chat-config' }
+          }
+        }
+      ])
+    });
+
+    const [template] = await getAppTemplatesAndLoadThem(true);
+
+    expect(template?.workflow.chatConfig).not.toHaveProperty('_id');
   });
 });

--- a/projects/app/src/pageComponents/dashboard/agent/utils/appTemplateParse.ts
+++ b/projects/app/src/pageComponents/dashboard/agent/utils/appTemplateParse.ts
@@ -28,6 +28,7 @@ type ParseAppImportConfigOptions = {
   resolveScene?: JsonImportModalScene;
   allowedAppTypes?: readonly SupportedImportAppType[];
   expectedAppType?: SupportedImportAppType;
+  migrateWorkflow?: boolean;
 };
 
 const supportedImportAppTypes = [
@@ -196,10 +197,12 @@ const parseSimpleImportWorkflow = ({
 const parseWorkflowLikeImportConfig = async ({
   config,
   appType,
+  migrateWorkflow,
   t
 }: {
   config: Record<string, unknown>;
   appType: Exclude<SupportedImportAppType, AppTypeEnum.simple>;
+  migrateWorkflow: boolean;
   t: any;
 }): Promise<ImportWorkflowConfig> => {
   if (!Array.isArray(config.nodes)) {
@@ -218,11 +221,13 @@ const parseWorkflowLikeImportConfig = async ({
     throw new Error(t('app:type_not_recognized'));
   }
 
-  return migrateWorkflowToCurrent({
+  const workflow = {
     nodes: config.nodes as StoreNodeItemType[],
     edges: Array.isArray(config.edges) ? (config.edges as StoreEdgeItemType[]) : [],
     chatConfig: (config.chatConfig ?? {}) as AppChatConfigType
-  });
+  };
+
+  return migrateWorkflow ? migrateWorkflowToCurrent(workflow) : workflow;
 };
 
 /**
@@ -237,7 +242,8 @@ export const parseAppImportConfig = async ({
   t,
   resolveScene,
   allowedAppTypes,
-  expectedAppType
+  expectedAppType,
+  migrateWorkflow = false
 }: ParseAppImportConfigOptions): Promise<ParsedImportConfig> => {
   const importConfig = assertImportConfigObject(config, t);
   const appType = resolveImportAppType(importConfig, resolveScene);
@@ -251,7 +257,12 @@ export const parseAppImportConfig = async ({
   const workflow =
     appType === AppTypeEnum.simple
       ? parseSimpleImportWorkflow({ config: importConfig, t })
-      : await parseWorkflowLikeImportConfig({ config: importConfig, appType, t });
+      : await parseWorkflowLikeImportConfig({
+          config: importConfig,
+          appType,
+          migrateWorkflow,
+          t
+        });
 
   return {
     workflow,
@@ -263,7 +274,8 @@ export const parseAppImportConfig = async ({
  * 解析工作台 JSON 导入配置。
  *
  * 顶层 `type` 存在时按导出元信息校验业务结构；无 `type` 时回退
- * 现有 `getAppType` 结构识别逻辑，以兼容老版本导出 JSON。
+ * 现有 `getAppType` 结构识别逻辑，以兼容老版本导出 JSON。新建应用由服务端
+ * 创建接口统一迁移，这里保留原始工作流，避免客户端和服务端重复维护写入规则。
  */
 export const parseDashboardImportConfig = async ({
   config,
@@ -278,7 +290,8 @@ export const parseDashboardImportConfig = async ({
     config,
     t,
     resolveScene: scene,
-    allowedAppTypes: dashboardImportAppTypesByScene[scene]
+    allowedAppTypes: dashboardImportAppTypesByScene[scene],
+    migrateWorkflow: false
   });
 };
 
@@ -304,7 +317,8 @@ export const parseWorkflowImportConfig = async ({
     config,
     t,
     resolveScene: scene,
-    expectedAppType
+    expectedAppType,
+    migrateWorkflow: true
   });
 
   return workflow;

--- a/projects/app/src/pages/api/core/app/create.ts
+++ b/projects/app/src/pages/api/core/app/create.ts
@@ -5,7 +5,7 @@ import { AppTypeEnum } from '@fastgpt/global/core/app/constants';
 import { AppFolderTypeList, ToolTypeList, AppTypeList } from '@fastgpt/global/core/app/constants';
 import type { AppSchemaType } from '@fastgpt/global/core/app/type';
 import {
-  CreateAppBodySchema,
+  CreateAppRequestBodySchema,
   CreateAppResponseSchema,
   type CreateAppBodyType
 } from '@fastgpt/global/openapi/core/app/common/api';
@@ -49,7 +49,7 @@ import { parseApiInput } from '@fastgpt/service/common/zod/requestParseError';
 async function handler(req: ApiRequestProps<CreateAppBodyType>) {
   const { body } = parseApiInput({
     req,
-    bodySchema: CreateAppBodySchema
+    bodySchema: CreateAppRequestBodySchema
   });
   const { parentId, name, avatar, intro, type, modules, edges, chatConfig, templateId, utmParams } =
     body;

--- a/projects/app/test/pageComponents/dashboard/agent/utils/appTemplateParse.test.ts
+++ b/projects/app/test/pageComponents/dashboard/agent/utils/appTemplateParse.test.ts
@@ -212,9 +212,31 @@ describe('parseDashboardImportConfig', () => {
       workflow: {
         nodes: [createWorkflowNode('workflowStart')],
         edges: [{ source: 'a', sourceHandle: 'a-out', target: 'b', targetHandle: 'b-in' }],
-        chatConfig: { welcomeText: 'hello', welcomeConfig: { welcomeText: 'hello' } }
+        chatConfig: { welcomeText: 'hello' }
       }
     });
+  });
+
+  it('should preserve legacy workflow fields for create API migration', async () => {
+    const legacyStartNode = {
+      ...createWorkflowNode('workflowStart'),
+      inputs: [{ key: 'query', llmModelType: 'chat' }]
+    };
+    const legacySystemNode = createWorkflowNode('userGuide');
+
+    const result = await parseDashboardImportConfig({
+      config: {
+        type: AppTypeEnum.workflow,
+        nodes: [legacyStartNode, legacySystemNode],
+        edges: [],
+        chatConfig: { _id: 'legacy-chat-config' }
+      },
+      scene: 'agent',
+      t
+    });
+
+    expect(result.workflow.nodes).toEqual([legacyStartNode, legacySystemNode]);
+    expect(result.workflow.chatConfig).toEqual({ _id: 'legacy-chat-config' });
   });
 
   it('should parse workflow tool JSON in tool dashboard', async () => {


### PR DESCRIPTION
## What
- migrate legacy template workflows when templates are loaded and when imported JSON creates an app
- validate Admin template create/update payloads with shared Zod schemas
- remove explicit Zod strict-object behavior across the repository so unknown legacy fields are stripped
- preserve sensitive field restrictions with explicit field validation instead of whole-object strictness
- add regression coverage for legacy node/input/chatConfig cleanup and template validation

## Why
Old marketplace templates can contain removed node types and historical fields such as `llmModelType` or Mongo `_id`. Direct JSON import already followed the migration path, while marketplace creation did not.

## Verification
- App and Admin typechecks passed
- Global focused schema tests passed (54 tests)
- S3 focused tests passed (12 tests)
- App timeout cases passed in isolation (3/3)
- Admin timeout cases passed in isolation (37/37)
- Global full suite passed (2087 tests)
- Web suite passed (41 tests)
- repository scan reports zero `.strict()`, `strictObject()`, or `catchall(z.never())` Zod schemas

## Dependency
- Admin submodule changes: https://github.com/labring/fastgpt-pro/pull/1090