### PR TITLE
fix(wallet): preserve invoice bill IDs and normalize months

### DIFF
--- a/packages/global/openapi/admin/routes/pays/api.ts
+++ b/packages/global/openapi/admin/routes/pays/api.ts
@@ -24,6 +24,7 @@ export const BillItemSchema = z.object({
   createTime: z.coerce.date().meta({ description: '创建时间' }),
   couponId: BillSchema.shape.couponId,
   hasInvoice: BillSchema.shape.hasInvoice,
+  paidAmount: BillSchema.shape.paidAmount,
   metadata: BillSchema.shape.metadata.partial().passthrough(),
   refundData: BillSchema.shape.refundData
 });

--- a/packages/global/openapi/support/user/team/api.ts
+++ b/packages/global/openapi/support/user/team/api.ts
@@ -7,7 +7,7 @@ import {
   ShortAuthStringSchema
 } from '../../../../support/user/account/verification/type';
 import { TeamMemberRoleEnum, TeamMemberStatusEnum } from '../../../../support/user/team/constant';
-import { OpenaiAccountSchema } from '../../../../support/user/team/type';
+import { OpenaiAccountSchema, TeamTmbItemSchema } from '../../../../support/user/team/type';
 import { ClientTeamPlanStatusSchema, TeamSubSchema } from '../../../../support/wallet/sub/type';
 
 /* ============================================================================
@@ -283,6 +283,9 @@ export const TeamListItemSchema = z
     isWecomTeam: z.boolean().optional().meta({
       example: false,
       description: '是否为企业微信团队'
+    }),
+    accountCancellation: TeamTmbItemSchema.shape.accountCancellation.meta({
+      description: '团队账号注销状态；仅在团队处于注销流程中时返回'
     }),
     openaiAccount: OpenaiAccountSchema.optional().meta({
       description: '团队 OpenAI 账号配置'

--- a/packages/global/openapi/support/wallet/bill/invoice/api.ts
+++ b/packages/global/openapi/support/wallet/bill/invoice/api.ts
@@ -103,6 +103,10 @@ export type InvoiceRecordsResponseType = z.infer<typeof InvoiceRecordsResponseSc
 
 export const UnInvoiceListItemSchema = z
   .object({
+    _id: ObjectIdSchema.meta({
+      example: '68ee0bd23d17260b7829b137',
+      description: '待开票订单 ID'
+    }),
     price: NumSchema.meta({ example: 9900, description: '订单金额' }),
     type: z
       .enum(BillTypeEnum)

--- a/packages/global/support/wallet/bill/type.ts
+++ b/packages/global/support/wallet/bill/type.ts
@@ -8,7 +8,6 @@ import { NumSchema } from '../../../common/zod';
 
 export const BillSchema = z.object({
   _id: ObjectIdSchema.meta({ description: '订单 ID' }),
-  userId: ObjectIdSchema.meta({ description: '用户 ID' }),
   teamId: ObjectIdSchema.meta({ description: '团队 ID' }),
   tmbId: ObjectIdSchema.meta({ description: '团队成员 ID' }),
   createTime: z.coerce.date().meta({ description: '创建时间' }),
@@ -19,7 +18,8 @@ export const BillSchema = z.object({
   couponId: ObjectIdSchema.optional().meta({
     description: '优惠券 ID'
   }),
-  hasInvoice: z.boolean().meta({ description: '是否已开发票' }),
+  hasInvoice: z.boolean().optional().meta({ description: '是否已开发票' }),
+  paidAmount: NumSchema.optional().meta({ description: '实际支付金额' }),
   metadata: z
     .object({
       payWay: z.enum(BillPayWayEnum).meta({ description: '支付方式' }),

--- a/packages/global/support/wallet/bill/type.ts
+++ b/packages/global/support/wallet/bill/type.ts
@@ -4,6 +4,7 @@ import { BillPayWayEnum, BillStatusEnum, BillTypeEnum } from './constants';
 import type { TeamInvoiceHeaderType } from '../../user/team/type';
 import z from 'zod';
 import { ObjectIdSchema } from '../../../common/type/mongo';
+import { NumSchema } from '../../../common/zod';
 
 export const BillSchema = z.object({
   _id: ObjectIdSchema.meta({ description: '订单 ID' }),
@@ -24,7 +25,7 @@ export const BillSchema = z.object({
       payWay: z.enum(BillPayWayEnum).meta({ description: '支付方式' }),
       subMode: z.enum(SubModeEnum).optional().meta({ description: '订阅周期' }),
       standSubLevel: z.enum(StandardSubLevelEnum).optional().meta({ description: '订阅等级' }),
-      month: z.number().optional().meta({ description: '月数' }),
+      month: NumSchema.nonnegative().optional().meta({ description: '月数' }),
       datasetSize: z.number().optional().meta({ description: '数据集大小' }),
       extraPoints: z.number().optional().meta({ description: '额外积分' }),
       activitySource: z.literal('enterpriseAuth').optional().meta({ description: '活动赠送来源' }),

--- a/packages/global/test/openapi/support/user/api.test.ts
+++ b/packages/global/test/openapi/support/user/api.test.ts
@@ -363,6 +363,10 @@ describe('support user OpenAPI contracts', () => {
           tmbId: objectId,
           role: 'owner',
           status: 'active',
+          accountCancellation: {
+            status: 'pending',
+            scheduledCancelAt: '2026-09-01T00:00:00.000Z'
+          },
           notificationAccount: null,
           permission: {
             role: 1,
@@ -376,7 +380,15 @@ describe('support user OpenAPI contracts', () => {
           }
         }
       ])
-    ).toMatchObject([{ notificationAccount: null }]);
+    ).toMatchObject([
+      {
+        notificationAccount: null,
+        accountCancellation: {
+          status: 'pending',
+          scheduledCancelAt: '2026-09-01T00:00:00.000Z'
+        }
+      }
+    ]);
   });
 
   it('rejects missing team write parameters at the schema boundary', () => {

--- a/packages/global/test/openapi/support/wallet/api.test.ts
+++ b/packages/global/test/openapi/support/wallet/api.test.ts
@@ -3,6 +3,7 @@ import { openAPIDocument } from '../../../../openapi/provider/devapi';
 import { openAPIPaths, openAPITagGroups } from '../../../../openapi/path';
 import { DevApiTagsMap } from '../../../../openapi/tag';
 import { BillItemSchema } from '../../../../openapi/support/wallet/bill/api';
+import { GetPaysResponseSchema } from '../../../../openapi/admin/routes/pays/api';
 import {
   InvoiceSubmitBodySchema,
   UnInvoiceListResponseSchema
@@ -12,6 +13,7 @@ import {
   BillStatusEnum,
   BillTypeEnum
 } from '../../../../support/wallet/bill/constants';
+import { BillSchema } from '../../../../support/wallet/bill/type';
 
 describe('wallet OpenAPI contracts', () => {
   const routes = {
@@ -94,6 +96,31 @@ describe('wallet OpenAPI contracts', () => {
     });
 
     expect(bill.metadata.month).toBe(12.17);
+  });
+
+  it('preserves paid amount across the database and admin response contracts', () => {
+    const bill = {
+      _id: '68ee0bd23d17260b7829b137',
+      teamId: '68ee0bd23d17260b7829b138',
+      tmbId: '68ee0bd23d17260b7829b139',
+      createTime: '2026-01-01T00:00:00.000Z',
+      orderId: 'bank-coupon-order',
+      status: BillStatusEnum.SUCCESS,
+      type: BillTypeEnum.extraPoints,
+      price: 100,
+      paidAmount: 80,
+      metadata: {
+        payWay: BillPayWayEnum.bank
+      }
+    };
+
+    expect(BillSchema.parse(bill)).toMatchObject({ paidAmount: 80 });
+    expect(
+      GetPaysResponseSchema.parse({
+        list: [{ ...bill, username: 'billing@example.com' }],
+        total: 1
+      }).list[0]
+    ).toMatchObject({ paidAmount: 80 });
   });
 
   it('keeps Mongo bill IDs when preparing an invoice submission', () => {

--- a/packages/global/test/openapi/support/wallet/api.test.ts
+++ b/packages/global/test/openapi/support/wallet/api.test.ts
@@ -4,6 +4,10 @@ import { openAPIPaths, openAPITagGroups } from '../../../../openapi/path';
 import { DevApiTagsMap } from '../../../../openapi/tag';
 import { BillItemSchema } from '../../../../openapi/support/wallet/bill/api';
 import {
+  InvoiceSubmitBodySchema,
+  UnInvoiceListResponseSchema
+} from '../../../../openapi/support/wallet/bill/invoice/api';
+import {
   BillPayWayEnum,
   BillStatusEnum,
   BillTypeEnum
@@ -90,6 +94,24 @@ describe('wallet OpenAPI contracts', () => {
     });
 
     expect(bill.metadata.month).toBe(12.17);
+  });
+
+  it('keeps Mongo bill IDs when preparing an invoice submission', () => {
+    const billId = '68ee0bd23d17260b7829b137';
+    const bills = UnInvoiceListResponseSchema.parse([
+      {
+        _id: billId,
+        price: 9900,
+        type: BillTypeEnum.standSubPlan,
+        createTime: '2026-01-01T00:00:00.000Z',
+        orderId: 'invoice-order'
+      }
+    ]);
+
+    expect(bills[0]._id).toBe(billId);
+    expect(InvoiceSubmitBodySchema.shape.billIdList.parse(bills.map((bill) => bill._id))).toEqual([
+      billId
+    ]);
   });
 
   it('omits empty request and response placeholders', () => {

--- a/packages/web/i18n/en/account_bill.json
+++ b/packages/web/i18n/en/account_bill.json
@@ -28,7 +28,7 @@
   "save_failed": "Save exception",
   "save_success": "Saved successfully",
   "submit_failed": "Submission failed",
-  "submit_success": "Submission successful",
+  "submit_success": "Invoice request submitted successfully",
   "submitted": "Submitted",
   "support_wallet_apply_invoice": "Billable bills",
   "support_wallet_bill_tag_invoice": "bill invoice",

--- a/packages/web/i18n/ko-KR/account_bill.json
+++ b/packages/web/i18n/ko-KR/account_bill.json
@@ -28,7 +28,7 @@
   "save_failed": "저장 중 오류가 발생했습니다",
   "save_success": "저장되었습니다",
   "submit_failed": "제출 실패",
-  "submit_success": "제출 성공",
+  "submit_success": "세금계산서 신청이 성공적으로 제출되었습니다",
   "submitted": "제출됨",
   "support_wallet_apply_invoice": "청구 가능한 내역",
   "support_wallet_bill_tag_invoice": "세금계산서",

--- a/packages/web/i18n/zh-CN/account_bill.json
+++ b/packages/web/i18n/zh-CN/account_bill.json
@@ -28,7 +28,7 @@
   "save_failed": "保存异常",
   "save_success": "保存成功",
   "submit_failed": "提交失败",
-  "submit_success": "提交成功",
+  "submit_success": "开票申请成功",
   "submitted": "已提交",
   "support_wallet_apply_invoice": "可开票账单",
   "support_wallet_bill_tag_invoice": "账单发票",

--- a/packages/web/i18n/zh-Hant/account_bill.json
+++ b/packages/web/i18n/zh-Hant/account_bill.json
@@ -28,7 +28,7 @@
   "save_failed": "儲存異常",
   "save_success": "儲存成功",
   "submit_failed": "提交失敗",
-  "submit_success": "提交成功",
+  "submit_success": "開票申請成功",
   "submitted": "已提交",
   "support_wallet_apply_invoice": "可開立帳單",
   "support_wallet_bill_tag_invoice": "帳單發票",

--- a/projects/app/src/pageComponents/account/bill/ApplyInvoiceModal.tsx
+++ b/projects/app/src/pageComponents/account/bill/ApplyInvoiceModal.tsx
@@ -30,7 +30,6 @@ import { type TeamInvoiceHeaderType } from '@fastgpt/global/support/user/team/ty
 import { InvoiceHeaderSingleForm } from './InvoiceHeaderForm';
 import MyBox from '@fastgpt/web/components/common/MyBox';
 import { getTeamInvoiceHeader } from '@/web/support/user/team/api';
-import { useRouter } from 'next/router';
 import { useForm } from 'react-hook-form';
 
 type chosenBillDataType = {
@@ -38,9 +37,14 @@ type chosenBillDataType = {
   price: number;
 };
 
-const ApplyInvoiceModal = ({ onClose }: { onClose: () => void }) => {
+const ApplyInvoiceModal = ({
+  onClose,
+  onSuccess
+}: {
+  onClose: () => void;
+  onSuccess: () => void;
+}) => {
   const { t } = useClientTranslation('account_bill');
-  const router = useRouter();
 
   const [chosenBillDataList, setChosenBillDataList] = useState<chosenBillDataType[]>([]);
   const [totalPrice, setTotalPrice] = useState(0);
@@ -80,10 +84,7 @@ const ApplyInvoiceModal = ({ onClose }: { onClose: () => void }) => {
       manual: true,
       successToast: t('account_bill:submit_success'),
       errorToast: t('account_bill:submit_failed'),
-      onSuccess: () => {
-        onClose();
-        router.reload();
-      }
+      onSuccess
     }
   );
 

--- a/projects/app/src/pages/account/bill/index.tsx
+++ b/projects/app/src/pages/account/bill/index.tsx
@@ -24,6 +24,7 @@ const BillAndInvoice = () => {
   const { invoiceTab = InvoiceTabEnum.bill } = router.query as { invoiceTab: `${InvoiceTabEnum}` };
 
   const [isOpenInvoiceModal, setIsOpenInvoiceModal] = useState(false);
+  const [recordsRefreshKey, setRecordsRefreshKey] = useState(0);
 
   return (
     <AccountContainer>
@@ -99,8 +100,8 @@ const BillAndInvoice = () => {
             minH={0}
             overflow={['visible', 'hidden']}
           >
-            {invoiceTab === InvoiceTabEnum.bill && <BillTable />}
-            {invoiceTab === InvoiceTabEnum.invoice && <InvoiceTable />}
+            {invoiceTab === InvoiceTabEnum.bill && <BillTable key={recordsRefreshKey} />}
+            {invoiceTab === InvoiceTabEnum.invoice && <InvoiceTable key={recordsRefreshKey} />}
             {invoiceTab === InvoiceTabEnum.invoiceHeader && <InvoiceHeaderForm />}
           </Box>
         </Flex>
@@ -108,6 +109,10 @@ const BillAndInvoice = () => {
           <ApplyInvoiceModal
             onClose={() => {
               setIsOpenInvoiceModal(false);
+            }}
+            onSuccess={() => {
+              setIsOpenInvoiceModal(false);
+              setRecordsRefreshKey((key) => key + 1);
             }}
           />
         )}

--- a/projects/app/src/web/support/wallet/bill/invoice/api.ts
+++ b/projects/app/src/web/support/wallet/bill/invoice/api.ts
@@ -1,19 +1,17 @@
 import { GET, POST } from '@/web/common/api/request';
-import type { BillTypeEnum } from '@fastgpt/global/support/wallet/bill/constants';
 import type { InvoiceFileInfo } from '@fastgpt/global/support/wallet/bill/invoice/type';
 import type { InvoiceType } from '@fastgpt/global/support/wallet/bill/type';
 import type { InvoiceSchemaType } from '@fastgpt/global/support/wallet/bill/type';
 import type { PaginationProps, PaginationResponse } from '@fastgpt/global/openapi/api';
+import type {
+  UnInvoiceListItemType,
+  UnInvoiceListResponseType
+} from '@fastgpt/global/openapi/support/wallet/bill/invoice/api';
 
-export type invoiceBillDataType = {
-  type: BillTypeEnum;
-  price: number;
-  createTime: Date;
-  _id: string;
-};
+export type invoiceBillDataType = UnInvoiceListItemType;
 
 export const getInvoiceBillsList = () =>
-  GET<invoiceBillDataType[]>(`/proApi/support/wallet/bill/invoice/unInvoiceList`);
+  GET<UnInvoiceListResponseType>(`/proApi/support/wallet/bill/invoice/unInvoiceList`);
 
 export const submitInvoice = (data: InvoiceType) =>
   POST(`/proApi/support/wallet/bill/invoice/submit`, data);


### PR DESCRIPTION
## What
- retain Mongo bill `_id` in the pending-invoice response so invoice submission receives valid `billIdList` values
- derive the frontend pending-bill type from the OpenAPI response contract
- normalize historical numeric-string `metadata.month` values when payment records are parsed
- add regression coverage for pending invoice IDs and submission IDs

## Root causes
- the pending-invoice response schema omitted `_id`, so Zod stripped it before the frontend submitted an invoice
- coupon redemption stored `(durationDay / 30).toFixed(2)` directly, producing historical string months

## Verification
- focused Global wallet tests passed (7/7)
- Global full suite passed (113 files, 2088 tests)
- focused Admin wallet tests passed (18/18)
- Admin full suite passed (125 files, 689 tests)
- App and Admin typechecks passed

## Dependency
- Pro write-path and Admin regression fixes: https://github.com/labring/fastgpt-pro/pull/1093