### PR TITLE
fix: harden dataset and invoice zod compatibility

### DIFF
--- a/packages/global/core/dataset/type.ts
+++ b/packages/global/core/dataset/type.ts
@@ -25,6 +25,7 @@ import { ParentIdSchema } from '../../common/parentFolder/type';
 import z from 'zod';
 import { ObjectIdSchema } from '../../common/type/mongo';
 import { PermissionSchema } from '../../support/permission/controller';
+import { NumSchema } from '../../common/zod';
 
 /* ===== Chunk ===== */
 export const ChunkSettingsSchema = z.object({
@@ -37,7 +38,7 @@ export const ChunkSettingsSchema = z.object({
     .enum(ChunkTriggerConfigTypeEnum)
     .optional()
     .meta({ description: '分块触发时机' }),
-  chunkTriggerMinSize: z.number().optional().meta({ description: '分块触发最小大小' }),
+  chunkTriggerMinSize: NumSchema.optional().meta({ description: '分块触发最小大小' }),
 
   dataEnhanceCollectionName: z.boolean().optional().meta({ description: '增加集合名到分块里' }),
   imageIndex: z.boolean().optional().meta({ description: '图片索引' }),
@@ -53,11 +54,11 @@ export const ChunkSettingsSchema = z.object({
     .enum(ParagraphChunkAIModeEnum)
     .optional()
     .meta({ description: '段落分块 AI 模式' }),
-  paragraphChunkDeep: z.number().optional().meta({ description: '段落分块深度' }),
-  paragraphChunkMinSize: z.number().optional().meta({ description: '段落分块最小大小' }),
-  chunkSize: z.number().optional().meta({ description: '分块大小' }),
+  paragraphChunkDeep: NumSchema.optional().meta({ description: '段落分块深度' }),
+  paragraphChunkMinSize: NumSchema.optional().meta({ description: '段落分块最小大小' }),
+  chunkSize: NumSchema.optional().meta({ description: '分块大小' }),
   chunkSplitter: z.string().optional().meta({ description: '自定义最高优先分割符号' }),
-  indexSize: z.number().optional().meta({ description: '索引大小' }),
+  indexSize: NumSchema.optional().meta({ description: '索引大小' }),
   qaPrompt: z.string().optional().meta({ description: 'QA 拆分提示词' })
 });
 export type ChunkSettingsType = z.infer<typeof ChunkSettingsSchema>;

--- a/packages/global/openapi/support/wallet/bill/invoice/api.ts
+++ b/packages/global/openapi/support/wallet/bill/invoice/api.ts
@@ -90,7 +90,11 @@ export const InvoiceRecordSchema = z
     bankName: z.string().optional().meta({ description: '开户银行' }),
     bankAccount: z.string().optional().meta({ description: '银行账号' }),
     needSpecialInvoice: z.boolean().meta({ example: false, description: '是否为增值税专用发票' }),
-    contactPhone: z.string().meta({ example: '13800138000', description: '联系人电话' }),
+    contactPhone: z
+      .string()
+      .nullish()
+      .transform((value) => value ?? '-')
+      .meta({ example: '13800138000', description: '联系人电话；历史记录缺失时返回 -' }),
     emailAddress: z.string().meta({ example: 'billing@example.com', description: '发票接收邮箱' })
   })
   .meta({ description: '发票记录；文件内容不在列表接口中返回' });

--- a/packages/global/test/openapi/core/dataset.test.ts
+++ b/packages/global/test/openapi/core/dataset.test.ts
@@ -11,6 +11,7 @@ import {
   UpdateDatasetCollaboratorResponseSchema,
   PostDatasetSyncBodySchema
 } from '../../../openapi/core/dataset/api';
+import { CreateCollectionByFileIdBodySchema } from '../../../openapi/core/dataset/collection/createApi';
 
 const objectId = '68ad85a7463006c963799a05';
 
@@ -82,6 +83,26 @@ describe('Dataset OpenAPI contracts', () => {
     expect(
       openAPIDocument.paths?.['/proApi/core/dataset/datasetSync']?.post?.responses?.[200]?.content
     ).toBeUndefined();
+  });
+
+  it('coerces collection chunk settings sent as numeric strings', () => {
+    const params = CreateCollectionByFileIdBodySchema.parse({
+      datasetId: objectId,
+      fileId: 'dataset/example.pdf',
+      chunkTriggerMinSize: '100',
+      paragraphChunkDeep: '5',
+      paragraphChunkMinSize: '100',
+      chunkSize: '512',
+      indexSize: '768'
+    });
+
+    expect(params).toMatchObject({
+      chunkTriggerMinSize: 100,
+      paragraphChunkDeep: 5,
+      paragraphChunkMinSize: 100,
+      chunkSize: 512,
+      indexSize: 768
+    });
   });
 
   it('documents that Dataset collaborator updates require at least one collaborator', () => {

--- a/packages/global/test/openapi/support/wallet/api.test.ts
+++ b/packages/global/test/openapi/support/wallet/api.test.ts
@@ -5,6 +5,7 @@ import { DevApiTagsMap } from '../../../../openapi/tag';
 import { BillItemSchema } from '../../../../openapi/support/wallet/bill/api';
 import { GetPaysResponseSchema } from '../../../../openapi/admin/routes/pays/api';
 import {
+  InvoiceRecordsResponseSchema,
   InvoiceSubmitBodySchema,
   UnInvoiceListResponseSchema
 } from '../../../../openapi/support/wallet/bill/invoice/api';
@@ -14,6 +15,7 @@ import {
   BillTypeEnum
 } from '../../../../support/wallet/bill/constants';
 import { BillSchema } from '../../../../support/wallet/bill/type';
+import { InvoiceStatusEnum } from '../../../../support/wallet/bill/invoice/constants';
 
 describe('wallet OpenAPI contracts', () => {
   const routes = {
@@ -139,6 +141,28 @@ describe('wallet OpenAPI contracts', () => {
     expect(InvoiceSubmitBodySchema.shape.billIdList.parse(bills.map((bill) => bill._id))).toEqual([
       billId
     ]);
+  });
+
+  it('fills the legacy missing invoice contact phone with a placeholder', () => {
+    const response = InvoiceRecordsResponseSchema.parse({
+      list: [
+        {
+          _id: '68ad85a7463006c963799a01',
+          teamId: '68ad85a7463006c963799a02',
+          amount: 9900,
+          status: InvoiceStatusEnum.submitted,
+          createTime: '2026-01-01T00:00:00.000Z',
+          billIdList: ['68ad85a7463006c963799a03'],
+          teamName: 'Example Team',
+          unifiedCreditCode: '91110000MA1234567X',
+          needSpecialInvoice: false,
+          emailAddress: 'billing@example.com'
+        }
+      ],
+      total: 1
+    });
+
+    expect(response.list[0].contactPhone).toBe('-');
   });
 
   it('omits empty request and response placeholders', () => {

--- a/projects/app/src/pageComponents/dataset/detail/CollectionCard/Context.tsx
+++ b/projects/app/src/pageComponents/dataset/detail/CollectionCard/Context.tsx
@@ -20,6 +20,7 @@ import { postDatasetSync } from '@/web/core/dataset/api';
 import dynamic from 'next/dynamic';
 import { usePagination } from '@fastgpt/web/hooks/usePagination';
 import { type DatasetCollectionsListItemType } from '@fastgpt/global/openapi/core/dataset/collection/api';
+import { CommonErrEnum } from '@fastgpt/global/common/error/code/common';
 import { useRouter } from 'next/router';
 import { DatasetPageContext } from '@/web/core/dataset/context/datasetPageContext';
 import { type WebsiteConfigFormType } from './WebsiteConfig';
@@ -109,6 +110,11 @@ const CollectionPageContextProvider = ({ children }: { children: ReactNode }) =>
   });
 
   const syncDataset = useCallback(async () => {
+    // 页面详情尚未加载或 query 缺失时，不发起一个必然失败的同步请求。
+    if (!datasetId || !datasetDetail._id || datasetId !== datasetDetail._id) {
+      return Promise.reject(CommonErrEnum.invalidParams);
+    }
+
     if (datasetDetail.type === DatasetTypeEnum.websiteDataset) {
       await checkTeamWebSyncLimit();
     }
@@ -117,7 +123,7 @@ const CollectionPageContextProvider = ({ children }: { children: ReactNode }) =>
     loadDatasetDetail(datasetId);
 
     getData(pageNum);
-  }, [datasetDetail.type, datasetId, getData, loadDatasetDetail, pageNum]);
+  }, [datasetDetail._id, datasetDetail.type, datasetId, getData, loadDatasetDetail, pageNum]);
   const { runAsync: onSyncDataset } = useRequest(syncDataset, {
     successToast: t('dataset:collection.sync.submit')
   });


### PR DESCRIPTION
## Summary

- Coerce dataset chunk settings sent as numeric strings with NumSchema.
- Return `-` for legacy invoice records without `contactPhone`.
- Validate `datasetId` before starting dataset sync.

## Tests

- Vitest: 17 passed.
- App TypeScript typecheck passed.
- ESLint and Prettier checks passed.