### PR TITLE
fix(app): allow nullish avatar and intro in storage

### DIFF
--- a/packages/global/core/app/type.ts
+++ b/packages/global/core/app/type.ts
@@ -150,7 +150,7 @@ export const AppResourceRefsSchema = z.object({
 export type AppResourceRefsType = z.infer<typeof AppResourceRefsSchema>;
 
 // Mongo Collection
-export const AppSchemaTypeSchema = z.object({
+export const AppStorageSchemaTypeSchema = z.object({
   _id: ObjectIdSchema,
   parentId: ParentIdSchema.optional(),
   teamId: z.string(),
@@ -159,8 +159,8 @@ export const AppSchemaTypeSchema = z.object({
   version: z.enum(['v1', 'v2']).optional().meta({ description: '内容版本，folder 类型不会有' }),
 
   name: z.string(),
-  avatar: z.string(),
-  intro: z.string(),
+  avatar: z.string().nullish(),
+  intro: z.string().nullish(),
   templateId: z.string().optional(),
 
   updateTime: z.coerce.date(),
@@ -207,6 +207,17 @@ export const AppSchemaTypeSchema = z.object({
   inited: BoolSchema.optional().meta({
     deprecated: true
   })
+});
+export type AppStorageSchemaType = z.infer<typeof AppStorageSchemaTypeSchema>;
+
+/**
+ * 应用在服务端归一化后返回给客户端的结构。
+ *
+ * 历史存量数据可能缺少 avatar/intro，但客户端始终接收字符串，避免可空类型向 UI 扩散。
+ */
+export const AppSchemaTypeSchema = AppStorageSchemaTypeSchema.extend({
+  avatar: z.string(),
+  intro: z.string()
 });
 export type AppSchemaType = z.infer<typeof AppSchemaTypeSchema>;
 
@@ -268,7 +279,7 @@ export type SettingAIDataType = {
   [NodeInputKeyEnum.aiChatJsonSchema]?: string;
 };
 
-export const AppTemplateSchema = z.object({
+export const AppTemplateStorageSchema = z.object({
   templateId: z.string().meta({
     example: 'template-simple-chat',
     description: '模板 ID'
@@ -277,10 +288,10 @@ export const AppTemplateSchema = z.object({
     example: '客服助手',
     description: '模板名称'
   }),
-  intro: z.string().meta({
+  intro: z.string().nullish().meta({
     description: '模板介绍'
   }),
-  avatar: z.string().meta({
+  avatar: z.string().nullish().meta({
     description: '模板头像'
   }),
   tags: z.array(z.string()).meta({
@@ -337,6 +348,13 @@ export const AppTemplateSchema = z.object({
     .meta({
       description: '模板对应的应用编排配置；不同应用类型可能使用不同结构'
     })
+});
+export type AppTemplateStorageSchemaType = z.infer<typeof AppTemplateStorageSchema>;
+
+/** 模板返回客户端前的归一化结构。 */
+export const AppTemplateSchema = AppTemplateStorageSchema.extend({
+  avatar: z.string(),
+  intro: z.string()
 });
 export type AppTemplateSchemaType = z.infer<typeof AppTemplateSchema>;
 

--- a/packages/global/openapi/admin/core/app/templates/api.ts
+++ b/packages/global/openapi/admin/core/app/templates/api.ts
@@ -1,6 +1,6 @@
 import { AppTypeEnum } from '../../../../../core/app/constants';
 import { AppFormEditFormV1TypeSchema } from '../../../../../core/app/formEdit/type';
-import { AppTemplateSchema } from '../../../../../core/app/type';
+import { AppTemplateSchema, AppTemplateStorageSchema } from '../../../../../core/app/type';
 import { StoreEdgeItemTypeSchema } from '../../../../../core/workflow/type/edge';
 import { OpenAPIAppChatConfigSchema } from '../../../../core/app/common/api';
 import {
@@ -19,7 +19,7 @@ const AdminTemplateTypeSchema = z
   .string()
   .refine((type) => adminTemplateTypes.has(type), '不支持的模板类型');
 
-const AdminTemplateBaseSchema = AppTemplateSchema.omit({
+const AdminTemplateBaseSchema = AppTemplateStorageSchema.omit({
   templateId: true,
   type: true,
   workflow: true,

--- a/packages/global/openapi/core/app/common/api.ts
+++ b/packages/global/openapi/core/app/common/api.ts
@@ -186,11 +186,11 @@ export const CreateAppBodySchema = z
       example: '新应用',
       description: '应用名称'
     }),
-    avatar: z.string().optional().meta({
+    avatar: z.string().nullish().meta({
       example: 'https://example.com/avatar.png',
       description: '应用头像'
     }),
-    intro: z.string().optional().meta({
+    intro: z.string().nullish().meta({
       example: '应用介绍',
       description: '应用介绍'
     }),
@@ -407,8 +407,8 @@ export const UpdateAppBodySchema = z
       .enum(AppTypeEnum)
       .optional()
       .meta({ example: AppTypeEnum.workflow, description: '应用类型' }),
-    avatar: z.string().optional().meta({ description: '应用头像' }),
-    intro: z.string().optional().meta({ description: '应用介绍' }),
+    avatar: z.string().nullish().meta({ description: '应用头像' }),
+    intro: z.string().nullish().meta({ description: '应用介绍' }),
     nodes: z.never().optional(),
     modules: z.never().optional(),
     edges: z.never().optional(),

--- a/packages/global/openapi/core/app/folder/api.ts
+++ b/packages/global/openapi/core/app/folder/api.ts
@@ -20,7 +20,7 @@ export const CreateAppFolderBodySchema = z
       example: '默认文件夹',
       description: '文件夹名称'
     }),
-    intro: z.string().optional().meta({
+    intro: z.string().nullish().meta({
       example: '文件夹介绍',
       description: '文件夹介绍'
     }),

--- a/packages/service/core/app/controller.ts
+++ b/packages/service/core/app/controller.ts
@@ -251,7 +251,7 @@ export const getAppBasicInfoByIds = async ({ teamId, ids }: { teamId: string; id
   return apps.map((item) => ({
     id: item._id,
     name: item.name,
-    avatar: item.avatar
+    avatar: item.avatar ?? ''
   }));
 };
 

--- a/packages/service/core/app/templates/register.ts
+++ b/packages/service/core/app/templates/register.ts
@@ -22,7 +22,11 @@ type PluginSystemTemplateDbConfig = Pick<AppTemplateSchemaType, 'templateId'> &
   >;
 
 const getFileTemplates = async (): Promise<AppTemplateSchemaType[]> => {
-  return (await pluginClient.listWorkflows()) as AppTemplateSchemaType[];
+  return (await pluginClient.listWorkflows()).map((template) => ({
+    ...template,
+    avatar: template.avatar ?? '',
+    intro: template.intro ?? ''
+  })) as AppTemplateSchemaType[];
 };
 
 const formatTemplateAvatar = (avatar?: string | null) => {
@@ -120,6 +124,11 @@ const getAppTemplates = async () => {
     ...communityTemplateConfig,
     ...dbTemplates.filter((t) => isCommercialTemaplte(t.templateId))
   ]
+    .map((template) => ({
+      ...template,
+      avatar: template.avatar ?? '',
+      intro: template.intro ?? ''
+    }))
     .map(migrateAppTemplateWorkflowToCurrent)
     .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
 

--- a/packages/service/core/app/templates/templateSchema.ts
+++ b/packages/service/core/app/templates/templateSchema.ts
@@ -1,4 +1,4 @@
-import { type AppTemplateSchemaType } from '@fastgpt/global/core/app/type';
+import { type AppTemplateStorageSchemaType } from '@fastgpt/global/core/app/type';
 import { defineIndex, connectionMongo, getMongoModel } from '../../../common/mongo/index';
 import { UserTagsSchema } from '@fastgpt/global/support/user/type';
 const { Schema } = connectionMongo;
@@ -41,7 +41,7 @@ const AppTemplateSchema = new Schema({
 
 defineIndex(AppTemplateSchema, { key: { templateId: 1 } });
 
-export const MongoAppTemplate = getMongoModel<AppTemplateSchemaType>(
+export const MongoAppTemplate = getMongoModel<AppTemplateStorageSchemaType>(
   collectionName,
   AppTemplateSchema
 );

--- a/projects/app/src/pageComponents/app/detail/context.tsx
+++ b/projects/app/src/pageComponents/app/detail/context.tsx
@@ -146,9 +146,12 @@ const AppContextProvider = ({ children }: { children: ReactNode }) => {
 
   const { runAsync: updateAppDetail } = useRequest(async (data: UpdateAppBodyType) => {
     await putAppById(appId, data);
+    const { avatar, intro, ...rest } = data;
     setAppDetail((state) => ({
       ...state,
-      ...data
+      ...rest,
+      ...(avatar !== undefined && { avatar: avatar ?? '' }),
+      ...(intro !== undefined && { intro: intro ?? '' })
     }));
   });
 

--- a/projects/app/src/pages/api/core/app/create.ts
+++ b/projects/app/src/pages/api/core/app/create.ts
@@ -85,8 +85,8 @@ async function handler(req: ApiRequestProps<CreateAppBodyType>) {
   const appId = await onCreateApp({
     parentId,
     name,
-    avatar,
-    intro,
+    avatar: avatar ?? undefined,
+    intro: intro ?? undefined,
     type,
     modules,
     allowedModels: await (async () => {

--- a/projects/app/src/pages/api/core/app/detail.ts
+++ b/projects/app/src/pages/api/core/app/detail.ts
@@ -48,6 +48,8 @@ async function handler(req: NextApiRequest): Promise<GetAppDetailResponseType> {
   if (!app.permission.hasWritePer) {
     return GetAppDetailResponseSchema.parse({
       ...app,
+      avatar: app.avatar ?? '',
+      intro: app.intro ?? '',
       modules: [],
       edges: []
     });
@@ -55,6 +57,8 @@ async function handler(req: NextApiRequest): Promise<GetAppDetailResponseType> {
 
   return GetAppDetailResponseSchema.parse({
     ...app,
+    avatar: app.avatar ?? '',
+    intro: app.intro ?? '',
     modules: workflow.nodes,
     edges: workflow.edges,
     chatConfig: workflow.chatConfig

--- a/projects/app/src/pages/api/core/app/httpTools/create.ts
+++ b/projects/app/src/pages/api/core/app/httpTools/create.ts
@@ -41,7 +41,7 @@ async function handler(
   const httpToolsetId = await mongoSessionRun(async (session) => {
     const toolSetRuntimeNode = getHTTPToolSetRuntimeNode({
       name,
-      avatar,
+      avatar: avatar ?? undefined,
       toolList: [],
       ...(createType === HttpToolTypeEnum.batch && {
         baseUrl: '',
@@ -53,8 +53,8 @@ async function handler(
     const httpToolsetId = await onCreateApp({
       parentId,
       name,
-      avatar,
-      intro,
+      avatar: avatar ?? undefined,
+      intro: intro ?? undefined,
       teamId,
       tmbId,
       type: AppTypeEnum.httpToolSet,

--- a/projects/app/src/pages/api/core/app/httpTools/update.ts
+++ b/projects/app/src/pages/api/core/app/httpTools/update.ts
@@ -37,7 +37,7 @@ async function handler(
 
   const toolSetRuntimeNode = getHTTPToolSetRuntimeNode({
     name: app.name,
-    avatar: app.avatar,
+    avatar: app.avatar ?? undefined,
     baseUrl,
     apiSchemaStr,
     toolList: formattedToolList,

--- a/projects/app/src/pages/api/core/app/list.ts
+++ b/projects/app/src/pages/api/core/app/list.ts
@@ -197,6 +197,8 @@ async function handler(req: ApiRequestProps<ListAppBodyType>): Promise<ListAppRe
 
       return {
         ...rest,
+        avatar: app.avatar ?? '',
+        intro: app.intro ?? '',
         parentId: app.parentId,
         permission: Per,
         private: privateApp,

--- a/projects/app/src/pages/api/core/app/mcpTools/create.ts
+++ b/projects/app/src/pages/api/core/app/mcpTools/create.ts
@@ -53,12 +53,12 @@ async function handler(
       url,
       toolList,
       name,
-      avatar,
+      avatar: avatar ?? undefined,
       headerSecret: formatedHeaderAuth
     });
     const mcpToolsId = await onCreateApp({
       name,
-      avatar,
+      avatar: avatar ?? undefined,
       parentId,
       teamId,
       tmbId,

--- a/projects/app/src/pages/api/core/app/mcpTools/update.ts
+++ b/projects/app/src/pages/api/core/app/mcpTools/update.ts
@@ -41,7 +41,7 @@ async function handler(
     toolList,
     headerSecret: formatedHeaderAuth,
     name: app.name,
-    avatar: app.avatar
+    avatar: app.avatar ?? undefined
   });
   const storageNodes = encodeMcpToolSetNodesForStorage([toolSetRuntimeNode]);
 

--- a/projects/app/src/pages/api/core/app/update.ts
+++ b/projects/app/src/pages/api/core/app/update.ts
@@ -215,7 +215,7 @@ async function handler(req: ApiRequestProps<UpdateAppBodyType, UpdateAppQueryTyp
       return UpdateAppResponseSchema.parse(await onUpdate(session));
     });
   } else {
-    logAppUpdate({ tmbId, teamId, app, name, intro });
+    logAppUpdate({ tmbId, teamId, app, name, intro: intro ?? undefined });
 
     return UpdateAppResponseSchema.parse(await onUpdate());
   }

--- a/projects/app/src/pages/api/core/chat/init.ts
+++ b/projects/app/src/pages/api/core/chat/init.ts
@@ -199,8 +199,8 @@ async function handler(req: NextApiRequest): Promise<InitChatResponseType> {
         chatConfig: appChatConfig,
         chatModels: getChatModelNameListByModules(nodes),
         name: app.name,
-        avatar: app.avatar,
-        intro: app.intro,
+        avatar: app.avatar ?? '',
+        intro: app.intro ?? '',
         type: app.type,
         pluginInputs
       }

--- a/projects/app/src/pages/api/core/chat/outLink/init.ts
+++ b/projects/app/src/pages/api/core/chat/outLink/init.ts
@@ -91,8 +91,8 @@ async function handler(req: NextApiRequest): Promise<InitOutLinkChatResponseType
     app: {
       chatConfig: appChatConfig,
       name: app.name,
-      avatar: app.avatar,
-      intro: app.intro,
+      avatar: app.avatar ?? '',
+      intro: app.intro ?? '',
       type: app.type,
       pluginInputs
     }

--- a/projects/app/src/pages/api/core/chat/recentlyUsed.ts
+++ b/projects/app/src/pages/api/core/chat/recentlyUsed.ts
@@ -36,7 +36,7 @@ async function handler(
     .map((app) => ({
       appId: String(app._id),
       name: app.name,
-      avatar: app.avatar
+      avatar: app.avatar ?? ''
     }));
 }
 

--- a/projects/app/src/pages/api/core/plugin/admin/tool/app/systemApps.ts
+++ b/projects/app/src/pages/api/core/plugin/admin/tool/app/systemApps.ts
@@ -49,7 +49,7 @@ async function handler(
 
   return plugins.map((plugin) => ({
     _id: plugin._id,
-    avatar: plugin.avatar,
+    avatar: plugin.avatar ?? '',
     name: plugin.name
   }));
 }


### PR DESCRIPTION
## 变更说明

- 拆分 App / AppTemplate 的存储 Schema 与客户端 Schema：存储层 `avatar`、`intro` 接受 `undefined`/`null`，客户端契约保持 `string`
- Create/Update/Folder/Template 管理入参接受 nullish 字段
- 在应用列表、详情、基础信息、聊天初始化、最近使用、系统工具列表及模板加载出口将空值归一化为 `''`
- 创建 HTTP/MCP 工具时兼容 nullish 入参，前端本地状态保持字符串类型

## 验证

- `pnpm --filter @fastgpt/app typecheck`
- `pnpm test:global`（113 files / 2104 tests passed）
- 变更文件 ESLint 通过
- `git diff --check` 通过