### PR TITLE
fix(sandbox): add one-shot native isolation for JavaScript

### DIFF
--- a/.agents/design/code-sandbox/js-one-shot-native-isolation.md
+++ b/.agents/design/code-sandbox/js-one-shot-native-isolation.md
@@ -1,0 +1,90 @@
+# JS one-shot 原生隔离设计
+
+## 1. 背景与目标
+
+改造前，`projects/code-sandbox` 的 JavaScript worker 会跨任务复用进程。语言运行时层虽然限制了 `eval`、动态导入、模块白名单和危险全局对象，但同一进程内的状态污染，以及运行时绕过后的宿主文件、网络、进程能力，仍不能由 JavaScript 自身形成安全边界。
+
+本次改造目标：
+
+1. 每个 JS worker 最多执行一个用户任务，结果返回后立即销毁；池中只预热尚未接触用户代码的干净进程。
+2. Linux 容器内固定启用 chroot、独立 UID/GID、`no_new_privs` 和 seccomp；初始化条件不满足时服务启动失败。
+3. 用户进程没有网络 syscall。兼容的 `SystemHelper.httpRequest` 通过 stdin/stdout RPC 交给父 Node 进程执行，复用统一 SSRF、DNS pinning、次数、超时和大小限制。
+4. 不要求修改 Docker 宿主机运行时，不依赖 gVisor、nsjail、特权容器或额外 capability。
+5. 保持 `/sandbox/js` API、JS 代码调用方式、模块白名单和返回结构兼容。
+
+## 2. 威胁模型与边界
+
+防御对象是可提交任意 JavaScript 的恶意租户。容器本身仍是最终外层边界；本方案在同一容器内增加进程级纵深防御，目标是即使语言层限制被绕过，也无法：
+
+- 读取 chroot 外的容器文件或父进程环境；
+- 创建进程、执行二进制或创建新的线程；
+- 直接创建 socket 绕过 SSRF 代理；
+- 以 root 身份运行，或恢复原 UID/GID；
+- 将内存全局、模块缓存、定时器或后台任务污染传给下一次执行。
+
+不声称 chroot/seccomp 等价于虚拟机边界。内核漏洞、Node/V8 原生内存安全漏洞和容器逃逸仍由容器运行时、内核补丁与部署策略承担。
+
+## 3. 架构
+
+### 3.1 one-shot 预热池
+
+保留 `BaseProcessPool` 的并发、排队、健康检查、超时和 RSS 监控。JS 池固定 `recycleAfterTask=true`：
+
+1. 服务启动时创建 N 个 worker。
+2. worker 加载所有运行时依赖和允许模块，进入原生隔离后回复 `ready`。
+3. worker 接收恰好一个任务。
+4. 父进程收到结果后将 worker 从池中移除并杀死，异步补充新的 `ready` worker。
+
+因此预热降低冷启动延迟，但任何执行过用户代码的进程都不会回到 idle 池。
+
+### 3.2 Linux 原生隔离初始化
+
+新增 Node N-API 原生模块。worker 在回复 `ready` 前调用其初始化函数：
+
+1. 父进程以 chroot 根目录作为 worker `cwd` 启动。
+2. worker 预加载白名单模块及 Node 运行时所需对象。
+3. 原生模块执行 `chroot(".")`，随后 `chdir("/app/code-sandbox")`。
+4. 设置 `PR_SET_NO_NEW_PRIVS`。
+5. 清空附加组，切换到 JS 专用 UID/GID 65538，并校验真实/有效身份；随后设置并校验 `PR_SET_DUMPABLE=0`，避免凭据切换重置该标志。
+6. 加载 default-deny（EPERM）的 seccomp 规则，并以 TSYNC 同步到 Node 已有线程。
+
+JS 与 Python 使用不同 UID/GID，防止两个语言沙箱通过 UID 所有权互相访问资源或发送信号。网络、`execve`、`fork`、`vfork`、`clone`、`clone3` 不进入 allowlist。
+
+Linux 下缺少原生模块、chroot 根目录或任一步初始化失败时，worker 不得回复 `ready`，进程退出，进而使进程池初始化失败。macOS/Windows 只保留本地开发兼容路径，不声明具有 OS 隔离。
+
+### 3.3 HTTP 父进程代理
+
+worker 的 `SystemHelper.httpRequest` 不再导入和调用 `http`、`https`、`dns`：
+
+- worker 输出 `{"type":"http_request","id":...,"payload":...}`；
+- 父进程调用 `runSandboxHttpRequest`；
+- 父进程向同一 worker stdin 返回 `http_response`；
+- worker 用请求 ID 解析 Promise。
+
+父进程按单个任务创建请求计数状态和 `AbortController`。任务完成、超时或进程异常退出时，中止尚未完成的代理请求，避免用户通过“不 await 即返回”让网络请求脱离 one-shot 生命周期。worker 直接 socket 即使通过语言层逃逸也会被 seccomp 拒绝。
+
+### 3.4 chroot 文件布局
+
+新增 `/tmp/fastgpt-js-sandbox`，由 root 持有且不可由 JS UID 写入。内部复制 `/app/code-sandbox`（bundle、原生模块和运行时白名单包）以及 Node 运行必需的设备节点。JS 任务默认没有可写目录；这与当前 JS API 不提供文件写入能力一致。
+
+## 4. 验证策略
+
+测试必须在本地真实 Linux Docker 容器中执行，不 mock 原生模块、进程、网络或文件系统：
+
+1. one-shot：连续任务 PID 不同，模块/全局状态不泄漏，完成后池恢复预热容量。
+2. 身份与文件：用户代码视角 UID/GID 为 65538；不能读取宿主 `/etc/passwd`、父进程环境或写 chroot 根。
+3. syscall：原生探针验证 socket、execve、fork/clone 返回 EPERM；正常 Promise、timer、crypto、白名单 npm 包仍工作。
+4. 网络：直接 `net`/间接 socket 被内核拒绝；`httpRequest` 仍经父进程代理，并保持 SSRF/次数/体积/超时与任务结束取消限制。
+5. fail-closed：删除原生模块或 chroot 根时，Linux 池初始化失败。
+6. 回归：运行已有 JS 安全、兼容、资源限制、Docker packages、API 测试，最后运行 code-sandbox 全量测试。
+7. 生命周期：在 worker 尚未回复 `ready` 时关闭进程池，确认初始化 Promise 失败、预热计数归零且真实子进程已退出。
+8. Python 公告回归：通过真实 `/sandbox/python` API 执行 GHSA-q6ww-4c5x-j2pg 的 `_posixsubprocess.fork_exec` PoC，确认由 native seccomp 返回 EPERM。
+
+## 5. TODO
+
+- [x] 新增 one-shot 与真实 Linux 原生隔离安全测试。
+- [x] 实现 JS 原生 N-API 隔离模块及双架构 seccomp allowlist。
+- [x] 接入 JS worker 初始化、父进程 HTTP RPC 与固定 one-shot 回收。
+- [x] 更新镜像构建和 JS chroot 文件布局（不修改部署 YAML）。
+- [x] 运行本地 Docker 局部安全/兼容/资源测试并修正规则。
+- [x] 运行 code-sandbox 全量测试与最终安全审计。

--- a/.agents/design/code-sandbox/js-one-shot-native-isolation.md
+++ b/.agents/design/code-sandbox/js-one-shot-native-isolation.md
@@ -9,7 +9,7 @@
 1. 每个 JS worker 最多执行一个用户任务，结果返回后立即销毁；池中只预热尚未接触用户代码的干净进程。
 2. Linux 容器内固定启用 chroot、独立 UID/GID、`no_new_privs` 和 seccomp；初始化条件不满足时服务启动失败。
 3. 用户进程没有网络 syscall。兼容的 `SystemHelper.httpRequest` 通过 stdin/stdout RPC 交给父 Node 进程执行，复用统一 SSRF、DNS pinning、次数、超时和大小限制。
-4. 不要求修改 Docker 宿主机运行时，不依赖 gVisor、nsjail、特权容器或额外 capability。
+4. 不要求修改 Docker 宿主机运行时，不依赖 gVisor、nsjail 或特权容器；使用 `cap_drop: ALL` 时仅显式保留 chroot、降权、目录权限和进程回收所需的最小 capability 集合。
 5. 保持 `/sandbox/js` API、JS 代码调用方式、模块白名单和返回结构兼容。
 
 ## 2. 威胁模型与边界
@@ -66,6 +66,8 @@ worker 的 `SystemHelper.httpRequest` 不再导入和调用 `http`、`https`、`
 ### 3.4 chroot 文件布局
 
 新增 `/tmp/fastgpt-js-sandbox`，由 root 持有且不可由 JS UID 写入。内部复制 `/app/code-sandbox`（bundle、原生模块和运行时白名单包）以及 Node 运行必需的设备节点。JS 任务默认没有可写目录；这与当前 JS API 不提供文件写入能力一致。
+
+只读根文件系统部署不能把整个 `/tmp` 挂载为 tmpfs，否则会遮住镜像内预制的 JS/Python chroot。只为 `/tmp/fastgpt-python-sandbox/tmp` 提供任务临时 tmpfs。若先 `cap_drop: ALL`，父服务需要显式保留 `CHOWN`、`DAC_OVERRIDE`、`FOWNER`、`KILL`、`SETGID`、`SETUID` 和 `SYS_CHROOT`；Docker 默认 capability 集合已包含这些能力。
 
 ## 4. 验证策略
 

--- a/projects/code-sandbox/Dockerfile
+++ b/projects/code-sandbox/Dockerfile
@@ -36,8 +36,9 @@ RUN if [ -z "$proxy" ]; then \
 # 先构建 SDK workspace 包，确保 dist 入口可被打包工具解析
 RUN pnpm --filter @fastgpt-sdk/otel --filter @fastgpt-sdk/storage build
 
-# 编译主入口文件和 Python native 隔离库
-RUN cd /app/projects/code-sandbox && SANDBOX_BUILD_NATIVE_PYTHON=true pnpm build
+# 编译主入口文件和 JS/Python native 隔离库
+RUN cd /app/projects/code-sandbox && \
+    SANDBOX_BUILD_NATIVE_JS=true SANDBOX_BUILD_NATIVE_PYTHON=true pnpm build
 
 # ===== Runner Stage =====
 FROM node:24-bookworm-slim AS runner
@@ -109,18 +110,36 @@ RUN set -eux; \
     mknod -m 666 "$root/dev/random" c 1 8 || true; \
     mknod -m 666 "$root/dev/urandom" c 1 9 || true; \
     chmod -R a+rX "$root"; \
+    chmod -R go-w "$root"; \
+    chmod 666 "$root/dev/null" "$root/dev/zero" "$root/dev/random" "$root/dev/urandom"; \
+    chmod 755 "$root/tmp"
+
+RUN set -eux; \
+    root=/tmp/fastgpt-js-sandbox; \
+    mkdir -p "$root/app/code-sandbox" "$root/dev" "$root/tmp"; \
+    cp -a /app/code-sandbox/. "$root/app/code-sandbox/"; \
+    mknod -m 666 "$root/dev/null" c 1 3 || true; \
+    mknod -m 666 "$root/dev/zero" c 1 5 || true; \
+    mknod -m 666 "$root/dev/random" c 1 8 || true; \
+    mknod -m 666 "$root/dev/urandom" c 1 9 || true; \
+    chmod -R a+rX "$root"; \
+    chmod -R go-w "$root"; \
+    chmod 666 "$root/dev/null" "$root/dev/zero" "$root/dev/random" "$root/dev/urandom"; \
     chmod 755 "$root/tmp"
 
 
 # 创建沙箱用户。code-sandbox 主进程默认保留 root，以便 Python 子进程
 # 在 native 隔离初始化阶段执行 chroot/setuid；用户代码会降权到 sandbox。
 RUN groupadd -g 65537 sandbox && useradd -u 65537 -g 65537 -M -r -s /usr/sbin/nologin sandbox && \
+    groupadd -g 65538 js-sandbox && useradd -u 65538 -g 65538 -M -r -s /usr/sbin/nologin js-sandbox && \
     mkdir -p /tmp/fastgpt-python-sandbox && \
     chown -R sandbox:sandbox /app && \
     chown root:root /tmp/fastgpt-python-sandbox && \
     chmod 755 /tmp/fastgpt-python-sandbox && \
     chown root:root /tmp/fastgpt-python-sandbox/tmp && \
-    chmod 755 /tmp/fastgpt-python-sandbox/tmp
+    chmod 755 /tmp/fastgpt-python-sandbox/tmp && \
+    chown -R root:root /tmp/fastgpt-js-sandbox && \
+    chmod 755 /tmp/fastgpt-js-sandbox /tmp/fastgpt-js-sandbox/tmp
 
 ENV NODE_ENV=production
 ENV SANDBOX_PORT=3000

--- a/projects/code-sandbox/README.md
+++ b/projects/code-sandbox/README.md
@@ -53,6 +53,28 @@ docker run -p 3000:3000 \
   fastgpt-code-sandbox
 ```
 
+生产环境使用只读根文件系统并清空默认 capabilities 时，需要显式保留沙箱初始化、降权和进程回收所需的最小集合：
+
+```bash
+docker run -p 3000:3000 \
+  --read-only \
+  --tmpfs /tmp/fastgpt-python-sandbox/tmp:rw,noexec,nosuid,nodev,size=512m,mode=0755 \
+  --cap-drop ALL \
+  --cap-add CHOWN \
+  --cap-add DAC_OVERRIDE \
+  --cap-add FOWNER \
+  --cap-add KILL \
+  --cap-add SETGID \
+  --cap-add SETUID \
+  --cap-add SYS_CHROOT \
+  --security-opt no-new-privileges=true \
+  -e SANDBOX_TOKEN=your-secret-token \
+  -e SANDBOX_POOL_SIZE=20 \
+  fastgpt-code-sandbox
+```
+
+不要把整个 `/tmp` 挂载为 tmpfs：这会遮住镜像中预制的 `/tmp/fastgpt-js-sandbox` 和 `/tmp/fastgpt-python-sandbox` chroot。只挂载上例中的 Python 任务临时目录；容量至少应覆盖 `SANDBOX_POOL_SIZE × SANDBOX_MAX_TMP_MB`，并为并发创建与清理预留余量。Docker 默认 capability 集合已经包含上述能力，因此未使用 `--cap-drop ALL` 时无需额外添加。
+
 ## API
 
 ### `POST /sandbox/js`

--- a/projects/code-sandbox/README.md
+++ b/projects/code-sandbox/README.md
@@ -1,32 +1,26 @@
 # FastGPT Code Sandbox
 
-基于 Node + Hono 的代码执行沙盒，支持 JS 和 Python。JS 采用长驻 worker 进程池；Python 采用 one-shot 预热进程池，Linux/Docker 环境固定启用 chroot、seccomp、setuid/setgid 隔离。
+基于 Node + Hono 的代码执行沙盒，支持 JS 和 Python。两种语言都采用 one-shot 预热进程池，Linux/Docker 环境固定启用 chroot、seccomp、setuid/setgid 隔离。
 
 ## 架构
 
 ```
 HTTP Request → Hono Server
-                  ├─ JS Process Pool → node worker.js (long-lived) → Result
+                  ├─ JS One-shot Warm Pool → clean node worker.js → one task → exit
                   └─ Python One-shot Warm Pool → clean python3 bootstrap → one task → exit
 ```
 
-- **JS 进程池**：启动时预热 N 个 worker 进程（默认 20），请求到达时直接分配空闲 worker，执行完归还池中
-- **JS 执行**：Node worker 进程 + 安全 shim（冻结 Function 构造器、危险全局对象遮蔽、require 白名单）
+- **JS 进程池**：启动时预热 N 个干净 Node 子进程（默认 20）；每个进程只执行一个用户任务，随后销毁并异步补池
+- **JS 执行**：Node 子进程 + native seccomp/chroot/独立 UID + 安全 shim（冻结 Function 构造器、危险全局对象遮蔽、require 白名单）
 - **Python 执行**：预热 `SANDBOX_POOL_SIZE` 个干净 python3 进程，进程进入 native seccomp/chroot/降权后等待一条任务；执行用户代码后立即销毁并异步补充新的干净进程
-- **网络请求**：统一通过 `SystemHelper.httpRequest()` / `system_helper.http_request()` 收口，内置 SSRF 防护
+- **网络请求**：沙箱子进程不允许网络 syscall；统一通过父进程代理的 `SystemHelper.httpRequest()` / `system_helper.http_request()` 收口，内置 SSRF 防护
 - **并发控制**：JS 请求超过池大小时自动排队；Python 同时运行的独立子进程数复用 `SANDBOX_POOL_SIZE`
 
 ## 性能
 
-JS 仍保留进程池收益。Python 为了多租户安全改为 one-shot 预热池：空闲进程只在执行用户代码前复用，执行用户代码后立即销毁。它能降低 Python 冷启动成本，但吞吐仍会低于旧长驻 worker。
+JS 和 Python 的空闲进程都只在执行用户代码前复用，执行后立即销毁。预热能隐藏大部分启动延迟，但 one-shot 的吞吐必然低于跨任务复用进程；容量规划应以 `test/benchmark` 在目标架构上的实测为准，不能沿用旧长驻 JS worker 的基准数据。
 
-| 场景 | 旧版 QPS / P50 | 进程池 QPS / P50 | 提升 |
-|------|----------------|------------------|------|
-| JS 简单函数 (c50) | 22 / 1,938ms | 1,414 / 7ms | **64x** |
-| JS IO 500ms (c50) | 22 / 2,107ms | 38 / 1,005ms | 1.7x |
-| JS 高 CPU (c10) | 9 / 1,079ms | 12 / 796ms | 1.3x |
-| JS 高内存 (c10) | — | 13 / 787ms | — |
-资源占用由 `SANDBOX_POOL_SIZE`、Python 预热空闲进程、Python 包加载情况和 `SANDBOX_MAX_MEMORY_MB` 共同决定。
+资源占用由 `SANDBOX_POOL_SIZE`、两种语言的预热空闲进程、运行时包加载情况和 `SANDBOX_MAX_MEMORY_MB` 共同决定。
 
 ## 快速开始
 
@@ -43,6 +37,8 @@ cd projects/code-sandbox && pnpm test
 # 构建
 cd projects/code-sandbox && pnpm build && pnpm start
 ```
+
+macOS/Windows 的源码构建仅用于开发兼容，不具备 OS 级隔离。Linux 生产环境推荐使用下方 Docker 构建；若直接从源码构建，需安装 `libseccomp-dev`、C 编译器和 Go，并设置 `SANDBOX_BUILD_NATIVE_JS=true SANDBOX_BUILD_NATIVE_PYTHON=true`，否则服务会因缺少 native 隔离库而 fail-closed。
 
 ## Docker
 
@@ -93,7 +89,15 @@ docker run -p 3000:3000 \
 {
   "status": "ok",
   "pools": {
-    "js": { "total": 20, "idle": 18, "busy": 2, "queued": 0, "poolSize": 20 },
+    "js": {
+      "total": 20,
+      "idle": 18,
+      "busy": 2,
+      "warming": 0,
+      "queued": 0,
+      "poolSize": 20,
+      "ready": true
+    },
     "python": {
       "total": 20,
       "idle": 18,
@@ -134,41 +138,45 @@ docker run -p 3000:3000 \
 
 ### 服务配置
 
-| 变量 | 说明 | 默认值 |
-|------|------|--------|
-| `SANDBOX_PORT` | 服务端口 | `3000` |
+| 变量            | 说明                  | 默认值       |
+| --------------- | --------------------- | ------------ |
+| `SANDBOX_PORT`  | 服务端口              | `3000`       |
 | `SANDBOX_TOKEN` | Bearer Token 认证密钥 | 空（不鉴权） |
 
 ### 并发控制
 
-| 变量 | 说明 | 默认值 |
-|------|------|--------|
-| `SANDBOX_POOL_SIZE` | JS worker 进程数；也是 Python 同时运行和空闲预热的进程数 | `20` |
-| `SANDBOX_QUEUE_ID_CONCURRENCY` | 同一 `queueId` 同时可进入执行流程的请求数，空值表示不按 `queueId` 排队 | 空 |
+| 变量                           | 说明                                                                   | 默认值 |
+| ------------------------------ | ---------------------------------------------------------------------- | ------ |
+| `SANDBOX_POOL_SIZE`            | JS/Python 同时运行和空闲预热的进程数                                   | `20`   |
+| `SANDBOX_QUEUE_ID_CONCURRENCY` | 同一 `queueId` 同时可进入执行流程的请求数，空值表示不按 `queueId` 排队 | 空     |
 
 ### Python 隔离
 
 Python 隔离不再提供运行时关闭开关。Linux 环境固定启用 native seccomp/chroot/降权，chroot 根目录固定为 `/tmp/fastgpt-python-sandbox`，用户代码进程固定降权到 `65537:65537`。Python 子进程不允许直接网络 syscall，外部请求必须通过父进程代理的 `http_request` 能力，并受请求次数、超时、请求体和响应体大小限制。
 
+### JS 隔离
+
+Linux 环境同样固定启用 native seccomp/chroot/降权，chroot 根目录为 `/tmp/fastgpt-js-sandbox`，JS 子进程使用独立的 `65538:65538`。每个预热进程最多执行一个用户任务，直接网络、创建进程和执行二进制的 syscall 均被拒绝。
+
 ### 资源限制
 
-| 变量 | 说明 | 默认值 |
-|------|------|--------|
-| `SANDBOX_API_MAX_BODY_MB` | API JSON 请求体总大小上限（包含 variables） | `8` |
-| `SANDBOX_MAX_TIMEOUT` | 超时上限（ms），请求不可超过此值 | `60000` |
-| `SANDBOX_MAX_MEMORY_MB` | 内存上限（MB） | `256` |
-| `SANDBOX_MAX_TMP_MB` | Python 单任务临时目录写入上限（MB） | `16` |
-| `SANDBOX_MAX_OUTPUT_MB` | 单次执行输出 JSON 大小上限（包含返回值和日志） | `10` |
+| 变量                      | 说明                                           | 默认值  |
+| ------------------------- | ---------------------------------------------- | ------- |
+| `SANDBOX_API_MAX_BODY_MB` | API JSON 请求体总大小上限（包含 variables）    | `8`     |
+| `SANDBOX_MAX_TIMEOUT`     | 超时上限（ms），请求不可超过此值               | `60000` |
+| `SANDBOX_MAX_MEMORY_MB`   | 内存上限（MB）                                 | `256`   |
+| `SANDBOX_MAX_TMP_MB`      | Python 单任务临时目录写入上限（MB）            | `16`    |
+| `SANDBOX_MAX_OUTPUT_MB`   | 单次执行输出 JSON 大小上限（包含返回值和日志） | `10`    |
 
 ### 网络请求限制
 
-| 变量 | 说明 | 默认值 |
-|------|------|--------|
-| `CHECK_INTERNAL_IP` | 是否阻止访问内网、回环、链路本地等地址 | `true` |
-| `SANDBOX_REQUEST_MAX_COUNT` | 单次执行最大 HTTP 请求数 | `30` |
-| `SANDBOX_REQUEST_TIMEOUT` | 单次 HTTP 请求超时（ms） | `60000` |
-| `SANDBOX_REQUEST_MAX_RESPONSE_MB` | 最大响应体大小（MB） | `10` |
-| `SANDBOX_REQUEST_MAX_BODY_MB` | 最大请求体大小（MB） | `5` |
+| 变量                              | 说明                                   | 默认值  |
+| --------------------------------- | -------------------------------------- | ------- |
+| `CHECK_INTERNAL_IP`               | 是否阻止访问内网、回环、链路本地等地址 | `true`  |
+| `SANDBOX_REQUEST_MAX_COUNT`       | 单次执行最大 HTTP 请求数               | `30`    |
+| `SANDBOX_REQUEST_TIMEOUT`         | 单次 HTTP 请求超时（ms）               | `60000` |
+| `SANDBOX_REQUEST_MAX_RESPONSE_MB` | 最大响应体大小（MB）                   | `10`    |
+| `SANDBOX_REQUEST_MAX_BODY_MB`     | 最大请求体大小（MB）                   | `5`     |
 
 ## 项目结构
 
@@ -178,21 +186,26 @@ src/
 ├── env.ts                     # 环境变量加载与校验
 ├── types.ts                   # 类型定义
 ├── pool/
-│   ├── process-pool.ts        # JS 进程池管理
-│   └── worker.ts              # JS worker（长驻进程，含安全 shim）
+│   ├── base-process-pool.ts   # 通用预热进程池生命周期与父进程 HTTP RPC
+│   ├── process-pool.ts        # JS one-shot 进程池配置
+│   └── worker.ts              # JS one-shot 子进程入口（含安全 shim）
 ├── isolated/
+│   ├── js-isolation-config.ts    # JS Linux native 隔离路径与身份配置
 │   ├── python-isolated-runner.ts # Python 独立进程执行器
 │   └── python-bootstrap.py       # Python 单次执行 bootstrap
 └── utils/
+    ├── sandbox-http.ts        # 父进程 HTTP 代理与 SSRF/资源限制
     └── semaphore.ts           # 信号量（通用并发控制）
 
+native/
+├── js-sandbox/                # JS N-API chroot/降权/seccomp 模块
+└── python-sandbox/            # Python native chroot/降权/seccomp 模块
+
 test/
-├── unit/                      # 单元测试（进程池、信号量）
-├── integration/               # 集成测试（API 路由）
-├── boundary/                  # 边界测试（超时、内存限制）
-├── security/                  # 安全测试（沙箱逃逸防护）
+├── unit/                      # 单元、安全与资源边界测试
+├── integration/               # API 与真实 Docker 集成测试
 ├── compat/                    # 兼容性测试（旧版代码格式）
-├── examples/                  # 示例测试（常用包）
+├── helpers/                   # 真实 runner/进程测试辅助代码
 └── benchmark/                 # 压测脚本
 ```
 
@@ -228,13 +241,13 @@ SANDBOX_JS_ALLOWED_MODULES=lodash,dayjs,moment,uuid,crypto-js,qs,url,querystring
 - 只添加纯计算类的包，不要添加有网络/文件系统/子进程能力的包
 - 包会被打入 Docker 镜像，注意体积
 - 网络请求统一走 `SystemHelper.httpRequest()`，不要放行 `axios`、`node-fetch` 等网络库
-- 如果显式放行 `child_process`、`worker_threads`、`cluster`，worker 会在每次任务后回收，以清理潜在后台执行残留
+- 不应放行 `child_process`、`worker_threads`、`cluster`；Linux native seccomp 也会从内核层拒绝创建进程或线程
 
 ## 添加 Python 包
 
 ### 当前预装包
 
-`numpy`、`pandas`（通过 `requirements.txt` 安装）
+`numpy`、`pandas`、`matplotlib`（通过 `requirements.txt` 安装）
 
 ### 添加新包步骤
 
@@ -256,8 +269,8 @@ your-new-package
 
 - Python 的模块黑名单通过 `__import__` 拦截实现，只拦截用户代码的直接 import
 - 标准库和第三方包的内部间接 import 不受影响
-- 默认白名单不包含 `os`、`sys`、`subprocess`、`socket` 等高危模块；如果显式加入环境变量白名单，用户代码会按配置获得对应能力
-- 如果显式放行 `subprocess`、`multiprocessing`、`threading`、`concurrent`，worker 会在每次任务后回收，以清理潜在后台执行残留
+- 默认白名单不包含 `os`、`sys`、`subprocess`、`socket` 等高危模块；显式加入环境变量只会放开语言层 import，不会放开 native seccomp 已拒绝的进程、线程和网络 syscall
+- Python 固定 one-shot：无论导入哪些模块，每个进程最多执行一个用户任务；Linux 下即使通过间接引用或 CPython C 扩展绕过 import/audit 限制，chroot、独立 UID/GID 与 default-deny seccomp 仍是最终进程边界
 
 ## 安全机制
 
@@ -268,6 +281,8 @@ your-new-package
 - `Function` 构造器冻结，阻止 `constructor.constructor` 逃逸
 - `process.env` 清理，仅保留必要变量
 - `fetch`、`XMLHttpRequest`、`WebSocket` 禁用
+- Linux 下固定 chroot 到只读 rootfs，降权到 JS 专用 UID/GID，并以 TSYNC seccomp 拒绝网络、进程和执行类 syscall
+- 每个子进程只执行一个用户任务，任务完成后不返回 idle 池
 
 ### Python
 
@@ -275,6 +290,8 @@ your-new-package
 - `exec()`/`eval()` 内的 import 同样被拦截（基于调用栈帧检测）
 - `builtins.__import__` 通过代理对象保护，用户无法覆盖
 - `signal.SIGALRM` 超时保护
+- Linux 下固定 chroot、降权到 Python 专用 UID/GID，并以 native default-deny seccomp 拒绝网络、进程、线程和执行类 syscall
+- 每个 Python 子进程也只执行一个用户任务；语言层限制被绕过时，不会继承父服务的文件系统视图和系统调用能力
 
 ### 网络
 
@@ -287,20 +304,20 @@ your-new-package
 
 ### JS（全局可用）
 
-| 函数 | 说明 |
-|------|------|
+| 函数                                   | 说明                                                  |
+| -------------------------------------- | ----------------------------------------------------- |
 | `SystemHelper.httpRequest(url, opts?)` | HTTP 请求（opts: `{method, headers, body, timeout}`） |
 
 ### Python（全局可用）
 
-| 函数 | 说明 |
-|------|------|
+| 函数                                   | 说明                                                  |
+| -------------------------------------- | ----------------------------------------------------- |
 | `SystemHelper.httpRequest(url, opts?)` | HTTP 请求（opts: `{method, headers, body, timeout}`） |
 
 ## 测试
 
 ```bash
-# 全部测试（332 cases）
+# 全部测试
 pnpm test
 
 # 单个文件
@@ -314,15 +331,8 @@ bash test/benchmark/bench-sandbox.sh
 bash test/benchmark/bench-sandbox-python.sh
 ```
 
-测试配置：串行执行（`fileParallelism: false`），池大小 1（避免资源竞争）。
+Vitest 测试文件串行执行，避免不同 suite 的真实 JS/Python 进程池、原生包冷启动和资源限制用例互相争抢；单个 suite 内仍会覆盖并发与排队行为。Linux native 用例需要 root 与已编译的隔离库，Docker 集成用例需要设置 `CODE_SANDBOX_URL` 指向真实运行中的镜像，条件不满足时会显式跳过。
 
-测试覆盖维度：
-
-| 分类 | 文件数 | 用例数 | 说明 |
-|------|--------|--------|------|
-| 单元测试 | 4 | 43 | 进程池生命周期/恢复/健康检查、Semaphore 并发控制 |
-| 集成测试 | 2 | 53 | HTTP API 路由、JS/Python 功能验证 |
-| 安全测试 | 1 | 102 | 模块拦截、逃逸攻击、SSRF 防护、注入攻击 |
-| 边界测试 | 1 | 58 | 空输入、超时、大数据、类型边界 |
-| 兼容性测试 | 2 | 39 | 旧版 JS/Python 代码格式兼容 |
-| 示例测试 | 1 | 31 | 常用场景和第三方包 |
+测试覆盖进程池生命周期与恢复、API、JS/Python 兼容性、资源边界、模块拦截、
+沙箱逃逸、SSRF，以及 Linux 容器中的真实 UID/chroot/seccomp 隔离。用例数量以
+当前测试运行结果为准，避免文档中的固定计数随新增回归测试失真。

--- a/projects/code-sandbox/build.sh
+++ b/projects/code-sandbox/build.sh
@@ -11,6 +11,11 @@ if [ "${SANDBOX_BUILD_NATIVE_PYTHON:-}" = "true" ]; then
   pnpm run build:native:python
 fi
 
+if [ "${SANDBOX_BUILD_NATIVE_JS:-}" = "true" ]; then
+  echo "Building native JS sandbox addon..."
+  pnpm run build:native:js
+fi
+
 # 编译入口（配置见 tsdown.config.ts）：
 #   - 同时打包 index 和 worker 两个独立 bundle
 #   - 所有 npm 依赖均打入 bundle（noExternal），仅保留 Node 内置模块外部化
@@ -29,6 +34,9 @@ cp src/isolated/python-bootstrap.py dist/python-bootstrap.py
 if [ -f src/isolated/fastgpt_python_sandbox.so ]; then
   cp src/isolated/fastgpt_python_sandbox.so dist/fastgpt_python_sandbox.so
 fi
+if [ -f src/isolated/fastgpt_js_sandbox.node ]; then
+  cp src/isolated/fastgpt_js_sandbox.node dist/fastgpt_js_sandbox.node
+fi
 
 echo ""
 echo "Build complete!"
@@ -38,6 +46,9 @@ echo "  - python-isolated-runner.js: $(du -h dist/python-isolated-runner.js | cu
 echo "  - python-bootstrap.py: $(du -h dist/python-bootstrap.py | cut -f1)"
 if [ -f dist/fastgpt_python_sandbox.so ]; then
   echo "  - fastgpt_python_sandbox.so: $(du -h dist/fastgpt_python_sandbox.so | cut -f1)"
+fi
+if [ -f dist/fastgpt_js_sandbox.node ]; then
+  echo "  - fastgpt_js_sandbox.node: $(du -h dist/fastgpt_js_sandbox.node | cut -f1)"
 fi
 echo ""
 echo "ℹ️  worker 通过 safeRequire(name) 在运行时动态加载白名单模块"

--- a/projects/code-sandbox/native/js-sandbox/fastgpt_js_sandbox.c
+++ b/projects/code-sandbox/native/js-sandbox/fastgpt_js_sandbox.c
@@ -1,0 +1,152 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <grp.h>
+#include <node_api.h>
+#include <seccomp.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+static napi_value throw_errno(napi_env env, const char *operation) {
+  char message[256];
+  snprintf(message, sizeof(message), "%s: %s", operation, strerror(errno));
+  napi_throw_error(env, NULL, message);
+  return NULL;
+}
+
+static bool read_int32_property(napi_env env, napi_value object, const char *name,
+                                int32_t *result) {
+  napi_value value;
+  if (napi_get_named_property(env, object, name, &value) != napi_ok) return false;
+  return napi_get_value_int32(env, value, result) == napi_ok;
+}
+
+static bool read_string_property(napi_env env, napi_value object, const char *name,
+                                 char *result, size_t result_size) {
+  napi_value value;
+  size_t copied = 0;
+  if (napi_get_named_property(env, object, name, &value) != napi_ok) return false;
+  if (napi_get_value_string_utf8(env, value, result, result_size, &copied) != napi_ok) {
+    return false;
+  }
+  return copied > 0 && copied < result_size;
+}
+
+static int allow_syscall(scmp_filter_ctx filter, const char *name) {
+  int syscall_number = seccomp_syscall_resolve_name(name);
+  if (syscall_number == __NR_SCMP_ERROR) return 0;
+  return seccomp_rule_add(filter, SCMP_ACT_ALLOW, syscall_number, 0);
+}
+
+static int install_seccomp(void) {
+  static const char *const allowed_syscalls[] = {
+      "read",          "write",          "readv",          "writev",
+      "close",         "fstat",          "newfstatat",      "statx",
+      "fcntl",         "ioctl",          "lseek",          "pread64",
+      "openat",        "faccessat",      "faccessat2",     "readlinkat",
+      "getdents64",    "mmap",           "mprotect",       "munmap",
+      "mremap",        "madvise",        "brk",            "rt_sigaction",
+      "rt_sigprocmask", "rt_sigreturn",   "sigaltstack",    "clock_gettime",
+      "gettimeofday",  "nanosleep",      "clock_nanosleep", "getpid",
+      "getppid",       "gettid",         "getuid",         "geteuid",
+      "getgid",        "getegid",        "getgroups",      "getcwd",
+      "uname",         "futex",          "sched_getaffinity", "sched_yield",
+      "getrandom",     "eventfd2",       "epoll_create1",  "epoll_ctl",
+      "epoll_wait",    "epoll_pwait",    "pselect6",       "poll",
+      "ppoll",         "set_robust_list", "get_robust_list", "rseq",
+      "prlimit64",     "exit",           "exit_group"};
+
+  scmp_filter_ctx filter = seccomp_init(SCMP_ACT_ERRNO(EPERM));
+  if (filter == NULL) return -1;
+
+  int rc = seccomp_attr_set(filter, SCMP_FLTATR_CTL_TSYNC, 1);
+  if (rc < 0) {
+    seccomp_release(filter);
+    errno = -rc;
+    return -1;
+  }
+
+  for (size_t i = 0; i < sizeof(allowed_syscalls) / sizeof(allowed_syscalls[0]); i++) {
+    rc = allow_syscall(filter, allowed_syscalls[i]);
+    if (rc < 0) {
+      seccomp_release(filter);
+      errno = -rc;
+      return -1;
+    }
+  }
+
+  rc = seccomp_load(filter);
+  seccomp_release(filter);
+  if (rc < 0) {
+    errno = -rc;
+    return -1;
+  }
+  return 0;
+}
+
+/** Enter the process-wide chroot/credential/seccomp boundary exactly once. */
+static napi_value init_sandbox(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv[1];
+  napi_value undefined;
+  int32_t uid = 0;
+  int32_t gid = 0;
+  char cwd[256] = "/app/code-sandbox";
+
+  napi_get_undefined(env, &undefined);
+  if (napi_get_cb_info(env, info, &argc, argv, NULL, NULL) != napi_ok || argc != 1 ||
+      !read_int32_property(env, argv[0], "uid", &uid) ||
+      !read_int32_property(env, argv[0], "gid", &gid)) {
+    napi_throw_type_error(env, NULL, "init requires { uid, gid, cwd? }");
+    return NULL;
+  }
+  napi_value cwd_value;
+  bool has_cwd = false;
+  if (napi_has_named_property(env, argv[0], "cwd", &has_cwd) == napi_ok && has_cwd &&
+      napi_get_named_property(env, argv[0], "cwd", &cwd_value) == napi_ok) {
+    if (!read_string_property(env, argv[0], "cwd", cwd, sizeof(cwd))) {
+      napi_throw_type_error(env, NULL, "cwd must be a non-empty string");
+      return NULL;
+    }
+  }
+  if (uid <= 0 || gid <= 0) {
+    napi_throw_range_error(env, NULL, "uid/gid must be positive");
+    return NULL;
+  }
+
+  if (chroot(".") != 0) return throw_errno(env, "chroot");
+  if (chdir(cwd) != 0) return throw_errno(env, "chdir");
+  if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) return throw_errno(env, "no_new_privs");
+  if (setgroups(0, NULL) != 0) return throw_errno(env, "setgroups");
+  if (setresgid(gid, gid, gid) != 0) return throw_errno(env, "setresgid");
+  if (setresuid(uid, uid, uid) != 0) return throw_errno(env, "setresuid");
+  if (getuid() != (uid_t)uid || geteuid() != (uid_t)uid || getgid() != (gid_t)gid ||
+      getegid() != (gid_t)gid) {
+    napi_throw_error(env, NULL, "credential verification failed");
+    return NULL;
+  }
+  // Credential changes may reset dumpable; enforce and verify it after the final UID/GID switch.
+  if (prctl(PR_SET_DUMPABLE, 0, 0, 0, 0) != 0) return throw_errno(env, "dumpable");
+  if (prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) != 0) {
+    napi_throw_error(env, NULL, "dumpable verification failed");
+    return NULL;
+  }
+  if (install_seccomp() != 0) return throw_errno(env, "seccomp");
+
+  return undefined;
+}
+
+static napi_value initialize(napi_env env, napi_value exports) {
+  napi_value init;
+  if (napi_create_function(env, "init", NAPI_AUTO_LENGTH, init_sandbox, NULL, &init) != napi_ok) {
+    return NULL;
+  }
+  if (napi_set_named_property(env, exports, "init", init) != napi_ok) return NULL;
+  return exports;
+}
+
+NAPI_MODULE(fastgpt_js_sandbox, initialize)

--- a/projects/code-sandbox/package.json
+++ b/projects/code-sandbox/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
+    "build:native:js": "gcc -shared -fPIC -O2 -Wall -Wextra -I/usr/local/include/node -o src/isolated/fastgpt_js_sandbox.node native/js-sandbox/fastgpt_js_sandbox.c -lseccomp",
     "build:native:python": "cd native/python-sandbox && go build -buildmode=c-shared -o ../../src/isolated/fastgpt_python_sandbox.so ./cmd/lib",
     "build": "sh build.sh",
     "test": "vitest run",

--- a/projects/code-sandbox/src/index.ts
+++ b/projects/code-sandbox/src/index.ts
@@ -113,7 +113,7 @@ const poolReady = Promise.all([jsPool.init(), pythonRunner.init()])
 app.get('/health', (c) => {
   const jsStats = jsPool.stats;
   const pythonStats = pythonRunner.stats;
-  const isReady = jsStats.total > 0 && pythonStats.ready;
+  const isReady = jsStats.ready && pythonStats.ready;
   return c.json(
     {
       status: isReady ? 'ok' : 'degraded',
@@ -137,7 +137,7 @@ app.use('/sandbox/*', async (c, next) => {
   await next();
 
   const duration = Date.now() - startTime;
-  const { method, url } = c.req;
+  const { url } = c.req;
   const { status } = c.res;
 
   // 尝试解析响应体以检查业务状态
@@ -154,7 +154,7 @@ app.use('/sandbox/*', async (c, next) => {
       businessSuccess = body.success !== false; // 如果没有 success 字段，默认为成功
       errorMessage = body.message || '';
     }
-  } catch (err) {
+  } catch {
     // 解析失败时不影响日志记录
   }
 
@@ -264,7 +264,8 @@ if (process.env.NODE_ENV !== 'test') {
 
 /** 导出 app 和 poolReady 供测试使用 */
 export { app, poolReady };
-export default {
+const serverConfig = {
   port: env.SANDBOX_PORT,
   fetch: app.fetch
 };
+export default serverConfig;

--- a/projects/code-sandbox/src/isolated/js-isolation-config.ts
+++ b/projects/code-sandbox/src/isolated/js-isolation-config.ts
@@ -1,0 +1,32 @@
+import { existsSync } from 'fs';
+import { platform } from 'os';
+import { join } from 'path';
+
+export const JS_SANDBOX_ROOT = '/tmp/fastgpt-js-sandbox';
+export const JS_SANDBOX_UID = 65538;
+export const JS_SANDBOX_GID = 65538;
+
+export function shouldEnableJsNativeIsolation(): boolean {
+  return platform() === 'linux';
+}
+
+/**
+ * 校验 Linux JS worker 启动所需的原生隔离资产。
+ *
+ * chroot/seccomp/降权是 Linux 多租户边界的一部分，不能在资产缺失时静默退化。
+ * 非 Linux 仅用于本地开发，不声明具备 OS 级隔离。
+ */
+export function assertJsNativeIsolationReady(addonPath: string): void {
+  if (!shouldEnableJsNativeIsolation()) return;
+
+  if (!existsSync(addonPath)) {
+    throw new Error(`JS native sandbox addon does not exist: ${addonPath}`);
+  }
+  if (!existsSync(JS_SANDBOX_ROOT)) {
+    throw new Error(`JS sandbox root does not exist: ${JS_SANDBOX_ROOT}`);
+  }
+}
+
+export function getBundledJsNativeAddonPath(dirname: string): string {
+  return join(dirname, 'fastgpt_js_sandbox.node');
+}

--- a/projects/code-sandbox/src/pool/base-process-pool.ts
+++ b/projects/code-sandbox/src/pool/base-process-pool.ts
@@ -1,8 +1,9 @@
 /**
  * BaseProcessPool - 进程池基类
  *
- * 预热 N 个长驻 worker 进程，通过 stdin/stdout 行协议通信。
- * JS / Python 进程池继承此类，仅需提供 spawn 命令和 init 配置。
+ * 预热 N 个独立子进程，通过 stdin/stdout 行协议通信。
+ * 是否在任务后回收由具体语言池决定；JS 使用 one-shot，执行过用户代码的进程不复用。
+ * 具体语言进程池通过 spawn 命令和 init 配置复用这套生命周期管理。
  */
 import { spawn, execFile, execFileSync, type ChildProcess } from 'child_process';
 import { createInterface, type Interface } from 'readline';
@@ -12,6 +13,11 @@ import { platform } from 'os';
 import { env, RUNTIME_MEMORY_OVERHEAD_MB } from '../env';
 import type { ExecuteOptions, ExecuteResult } from '../types';
 import { getLogger, LogCategories } from '../utils/logger';
+import {
+  runSandboxHttpRequest,
+  type SandboxHttpRequestPayload,
+  type SandboxHttpState
+} from '../utils/sandbox-http';
 
 const serverLogger = getLogger(LogCategories.MODULE.SANDBOX.SERVER);
 const execFileAsync = promisify(execFile);
@@ -38,8 +44,12 @@ export type ProcessPoolOptions = {
   spawnCommand: (script: string) => string;
   /** init 消息中的模块白名单 */
   allowedModules: readonly string[];
-  /** 白名单显式放开后台执行能力时，每次任务结束后回收 worker，清理潜在子进程/线程 */
+  /** 每次任务结束后回收子进程；用于 one-shot 隔离 */
   recycleAfterTask?: boolean;
+  /** worker 启动目录；Linux native chroot 模式下指向预制 rootfs */
+  spawnCwd?: string;
+  /** 透传给 worker 的初始化配置 */
+  initPayload?: Record<string, unknown>;
 };
 
 export abstract class BaseProcessPool {
@@ -49,6 +59,9 @@ export abstract class BaseProcessPool {
   protected nextId = 0;
   protected poolSize: number;
   protected ready = false;
+  /** 正在初始化的 worker 及其取消函数，确保 shutdown 不会遗漏尚未 ready 的进程。 */
+  protected warmingWorkers = new Map<PoolWorker, (error: Error) => void>();
+  protected stopping = false;
   protected healthCheckTimer?: ReturnType<typeof setInterval>;
 
   protected static readonly HEALTH_CHECK_INTERVAL = 30_000;
@@ -72,17 +85,25 @@ export abstract class BaseProcessPool {
   // ============================================================
 
   async init(): Promise<void> {
+    this.stopping = false;
     const promises: Promise<void>[] = [];
     for (let i = 0; i < this.poolSize; i++) {
       promises.push(this.spawnWorker());
     }
-    await Promise.all(promises);
+    try {
+      await Promise.all(promises);
+    } catch (error) {
+      // 任一 worker fail-closed 时清理已经 ready 或仍在预热的同批进程，避免半初始化池泄漏。
+      await this.shutdown();
+      throw error;
+    }
     this.ready = true;
     this.startHealthCheck();
     serverLogger.info(`${this.tag}: ${this.poolSize} workers preheated`);
   }
 
   async shutdown(): Promise<void> {
+    this.stopping = true;
     this.ready = false;
     if (this.healthCheckTimer) {
       clearInterval(this.healthCheckTimer);
@@ -92,6 +113,9 @@ export abstract class BaseProcessPool {
       waiter.reject(new Error('Pool is shutting down'));
     }
     this.waitQueue = [];
+    for (const cancelSpawn of [...this.warmingWorkers.values()]) {
+      cancelSpawn(new Error(`${this.tag}: pool is shutting down`));
+    }
     for (const worker of this.workers) {
       this.cleanupWorker(worker);
     }
@@ -104,8 +128,10 @@ export abstract class BaseProcessPool {
       total: this.workers.length,
       idle: this.idleWorkers.length,
       busy: this.workers.filter((w) => w.busy).length,
+      warming: this.warmingWorkers.size,
       queued: this.waitQueue.length,
-      poolSize: this.poolSize
+      poolSize: this.poolSize,
+      ready: this.ready && (this.workers.length > 0 || this.warmingWorkers.size > 0)
     };
   }
 
@@ -114,12 +140,17 @@ export abstract class BaseProcessPool {
   // ============================================================
 
   protected spawnWorker(): Promise<void> {
+    if (this.stopping) {
+      return Promise.reject(new Error(`${this.tag}: pool is shutting down`));
+    }
+
     return new Promise<void>((resolve, reject) => {
       const id = this.nextId++;
       const cmd = this.options.spawnCommand(this.options.workerScript);
       const proc = spawn('sh', ['-c', cmd], {
         stdio: ['pipe', 'pipe', 'pipe'],
         detached: PROCESS_GROUP_SUPPORTED,
+        cwd: this.options.spawnCwd,
         env: {
           PATH: process.env.PATH || '/usr/local/bin:/usr/bin:/bin',
           CHECK_INTERNAL_IP: String(env.CHECK_INTERNAL_IP)
@@ -137,13 +168,19 @@ export abstract class BaseProcessPool {
       });
 
       let settled = false;
-      const spawnTimer = setTimeout(() => {
+      const failSpawn = (error: Error) => {
         if (settled) return;
         settled = true;
-        rl.removeAllListeners('line');
-        this.killWorkerProcessTree(worker);
+        clearTimeout(spawnTimer);
+        this.warmingWorkers.delete(worker);
+        this.cleanupWorker(worker);
+        reject(error);
+      };
+      this.warmingWorkers.set(worker, failSpawn);
+
+      const spawnTimer = setTimeout(() => {
         const stderr = this.formatStderr(worker);
-        reject(
+        failSpawn(
           new Error(
             `${this.tag}: worker ${id} init timeout after ${BaseProcessPool.SPAWN_TIMEOUT}ms${stderr}`
           )
@@ -152,11 +189,16 @@ export abstract class BaseProcessPool {
 
       const onFirstLine = (line: string) => {
         if (settled) return;
-        settled = true;
-        clearTimeout(spawnTimer);
         try {
           const msg = JSON.parse(line);
           if (msg.type === 'ready') {
+            if (this.stopping) {
+              failSpawn(new Error(`${this.tag}: pool is shutting down`));
+              return;
+            }
+            settled = true;
+            clearTimeout(spawnTimer);
+            this.warmingWorkers.delete(worker);
             this.workers.push(worker);
             this.setupWorkerEvents(worker);
             const waiter = this.waitQueue.shift();
@@ -168,28 +210,22 @@ export abstract class BaseProcessPool {
             }
             resolve();
           } else {
-            reject(new Error(`${this.tag}: worker ${id} init failed: ${line}`));
+            failSpawn(new Error(`${this.tag}: worker ${id} init failed: ${line}`));
           }
         } catch {
-          reject(new Error(`${this.tag}: worker ${id} invalid init response: ${line}`));
+          failSpawn(new Error(`${this.tag}: worker ${id} invalid init response: ${line}`));
         }
       };
       rl.once('line', onFirstLine);
 
       proc.on('error', (err) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(spawnTimer);
-        reject(new Error(`${this.tag}: worker ${id} spawn error: ${err.message}`));
+        failSpawn(new Error(`${this.tag}: worker ${id} spawn error: ${err.message}`));
       });
 
       proc.on('exit', (code, signal) => {
         if (settled) return;
-        settled = true;
-        clearTimeout(spawnTimer);
-        rl.removeAllListeners('line');
         const stderr = this.formatStderr(worker);
-        reject(
+        failSpawn(
           new Error(
             `${this.tag}: worker ${id} exited during init (code: ${code}, signal: ${signal})${stderr}`
           )
@@ -197,19 +233,30 @@ export abstract class BaseProcessPool {
       });
 
       // 发送 init 消息
-      proc.stdin!.write(
-        JSON.stringify({
-          type: 'init',
-          allowedModules: this.options.allowedModules,
-          requestLimits: {
-            maxRequests: env.SANDBOX_REQUEST_MAX_COUNT,
-            timeoutMs: env.SANDBOX_REQUEST_TIMEOUT,
-            maxResponseSize: env.SANDBOX_REQUEST_MAX_RESPONSE_MB * 1024 * 1024,
-            maxRequestBodySize: env.SANDBOX_REQUEST_MAX_BODY_MB * 1024 * 1024,
-            maxOutputSize: env.SANDBOX_MAX_OUTPUT_MB * 1024 * 1024
-          }
-        }) + '\n'
-      );
+      try {
+        proc.stdin!.write(
+          JSON.stringify({
+            type: 'init',
+            allowedModules: this.options.allowedModules,
+            requestLimits: {
+              maxRequests: env.SANDBOX_REQUEST_MAX_COUNT,
+              timeoutMs: env.SANDBOX_REQUEST_TIMEOUT,
+              maxResponseSize: env.SANDBOX_REQUEST_MAX_RESPONSE_MB * 1024 * 1024,
+              maxRequestBodySize: env.SANDBOX_REQUEST_MAX_BODY_MB * 1024 * 1024,
+              maxOutputSize: env.SANDBOX_MAX_OUTPUT_MB * 1024 * 1024
+            },
+            ...this.options.initPayload
+          }) + '\n'
+        );
+      } catch (error) {
+        failSpawn(
+          new Error(
+            `${this.tag}: worker ${id} init write error: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          )
+        );
+      }
     });
   }
 
@@ -270,6 +317,9 @@ export abstract class BaseProcessPool {
     if (!code || typeof code !== 'string' || !code.trim()) {
       return { success: false, message: 'Code cannot be empty' };
     }
+    if (!this.ready) {
+      return { success: false, message: `${this.options.name} process pool is not ready` };
+    }
 
     const timeoutMs = env.SANDBOX_MAX_TIMEOUT;
     const worker = await this.acquire();
@@ -292,14 +342,17 @@ export abstract class BaseProcessPool {
   ): Promise<ExecuteResult> {
     return new Promise<ExecuteResult>((resolve) => {
       let settled = false;
-      let timer: ReturnType<typeof setTimeout>;
       let rssTimer: ReturnType<typeof setInterval> | undefined;
+      const httpState: SandboxHttpState = { requestCount: 0 };
+      const httpAbortController = new AbortController();
 
       const settle = (result: ExecuteResult, opts: { recycleWorker?: boolean } = {}) => {
         if (settled) return;
         settled = true;
         clearTimeout(timer);
         if (rssTimer) clearInterval(rssTimer);
+        // 用户代码已结束时，中止未 await 的代理请求，避免请求在 one-shot 进程销毁后继续占用资源。
+        httpAbortController.abort();
         worker.rl.removeListener('line', onLine);
         worker.proc.removeListener('exit', onExit);
         const recycleWorker = opts.recycleWorker || this.options.recycleAfterTask;
@@ -311,7 +364,22 @@ export abstract class BaseProcessPool {
 
       const onLine = (line: string) => {
         try {
-          const result = JSON.parse(line) as ExecuteResult & { workerRecycle?: string };
+          const result = JSON.parse(line) as ExecuteResult & {
+            type?: string;
+            id?: string;
+            payload?: SandboxHttpRequestPayload;
+            workerRecycle?: string;
+          };
+          if (result.type === 'http_request' && result.id && result.payload) {
+            void this.handleHttpRequestMessage(
+              worker,
+              result.id,
+              result.payload,
+              httpState,
+              httpAbortController.signal
+            );
+            return;
+          }
           const recycleReason = result.workerRecycle;
           delete result.workerRecycle;
           if (recycleReason) {
@@ -334,7 +402,7 @@ export abstract class BaseProcessPool {
       };
 
       // 超时
-      timer = setTimeout(() => {
+      const timer = setTimeout(() => {
         this.killAndRespawn(worker);
         settle({ success: false, message: `Script execution timed out after ${timeoutMs}ms` });
       }, timeoutMs + 2000);
@@ -355,7 +423,7 @@ export abstract class BaseProcessPool {
         }, RSS_POLL_INTERVAL);
       }
 
-      worker.rl.once('line', onLine);
+      worker.rl.on('line', onLine);
       worker.proc.once('exit', onExit);
 
       try {
@@ -364,6 +432,44 @@ export abstract class BaseProcessPool {
         settle({ success: false, message: `Worker communication error: ${err.message}` });
       }
     });
+  }
+
+  /** 在可信父进程中执行 worker 的受控 HTTP RPC。 */
+  protected async handleHttpRequestMessage(
+    worker: PoolWorker,
+    id: string,
+    payload: SandboxHttpRequestPayload,
+    state: SandboxHttpState,
+    signal: AbortSignal
+  ): Promise<void> {
+    const writeResponse = (response: Record<string, unknown>) => {
+      const stdin = worker.proc.stdin;
+      if (!stdin?.writable) return;
+      try {
+        // one-shot 任务结束会同时 abort HTTP 并回收 worker；忽略该正常竞态产生的 EPIPE。
+        stdin.write(JSON.stringify({ type: 'http_response', id, ...response }) + '\n', () => {});
+      } catch {}
+    };
+
+    try {
+      const data = await runSandboxHttpRequest({
+        payload,
+        state,
+        signal,
+        limits: {
+          maxRequests: env.SANDBOX_REQUEST_MAX_COUNT,
+          timeoutMs: env.SANDBOX_REQUEST_TIMEOUT,
+          maxResponseSize: env.SANDBOX_REQUEST_MAX_RESPONSE_MB * 1024 * 1024,
+          maxRequestBodySize: env.SANDBOX_REQUEST_MAX_BODY_MB * 1024 * 1024
+        }
+      });
+      writeResponse({ success: true, payload: data });
+    } catch (err) {
+      writeResponse({
+        success: false,
+        message: err instanceof Error ? err.message : 'HTTP request failed'
+      });
+    }
   }
 
   // ============================================================
@@ -464,11 +570,9 @@ export abstract class BaseProcessPool {
       }
 
       // macOS/other: 使用 ps 获取多个 PID 的 RSS（单位 kB），不经过 shell。
-      const { stdout } = await execFileAsync(
-        'ps',
-        ['-o', 'rss=', '-p', pids.join(',')],
-        { timeout: 2000 }
-      );
+      const { stdout } = await execFileAsync('ps', ['-o', 'rss=', '-p', pids.join(',')], {
+        timeout: 2000
+      });
       const totalKB = stdout
         .split('\n')
         .map((line) => parseInt(line.trim(), 10))
@@ -554,8 +658,8 @@ export abstract class BaseProcessPool {
 
   /** 从池中移除 worker，kill 进程，并在 ready 时 respawn */
   protected killAndRespawn(worker: PoolWorker): void {
-    this.removeWorker(worker);
-    if (this.ready) {
+    const removed = this.removeWorker(worker);
+    if (this.ready && removed) {
       this.spawnWorker().catch((err) => {
         serverLogger.error(`${this.tag}: failed to respawn worker ${worker.id}:`, err.message);
       });
@@ -581,7 +685,7 @@ export abstract class BaseProcessPool {
       worker.stderrBuf = [];
 
       this.killWorkerProcessTree(worker);
-    } catch (err) {
+    } catch {
       // 忽略清理错误
     }
   }

--- a/projects/code-sandbox/src/pool/process-pool.ts
+++ b/projects/code-sandbox/src/pool/process-pool.ts
@@ -1,7 +1,7 @@
 /**
- * ProcessPool - JS 子进程池
+ * ProcessPool - JS one-shot 子进程池
  *
- * 继承 BaseProcessPool，提供 JS worker 的 spawn 配置。
+ * 继承 BaseProcessPool，提供 JS 子进程入口、原生隔离和固定任务后回收配置。
  * dev（tsx 直接跑 .ts 源码）：worker.ts + tsx
  * prod（tsdown 打包后）：worker.js + node
  */
@@ -9,33 +9,43 @@ import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { env } from '../env';
 import { BaseProcessPool } from './base-process-pool';
+import {
+  assertJsNativeIsolationReady,
+  getBundledJsNativeAddonPath,
+  JS_SANDBOX_GID,
+  JS_SANDBOX_ROOT,
+  JS_SANDBOX_UID,
+  shouldEnableJsNativeIsolation
+} from '../isolated/js-isolation-config';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const isCompiled = import.meta.url.endsWith('.js');
 
 const WORKER_SCRIPT = join(__dirname, isCompiled ? 'worker.js' : 'worker.ts');
 const SPAWN_RUNTIME = isCompiled ? 'node' : 'tsx';
-const RECYCLE_AFTER_TASK_MODULES = new Set([
-  'child_process',
-  'node:child_process',
-  'cluster',
-  'node:cluster',
-  'worker_threads',
-  'node:worker_threads'
-]);
-
-function shouldRecycleAfterTask(allowedModules: readonly string[]): boolean {
-  return allowedModules.some((moduleName) => RECYCLE_AFTER_TASK_MODULES.has(moduleName));
-}
+const NATIVE_SANDBOX_ADDON = getBundledJsNativeAddonPath(__dirname);
 
 export class ProcessPool extends BaseProcessPool {
   constructor(poolSize?: number) {
+    assertJsNativeIsolationReady(NATIVE_SANDBOX_ADDON);
+    const nativeIsolation = shouldEnableJsNativeIsolation();
     super(poolSize, {
       name: 'JS',
       workerScript: WORKER_SCRIPT,
       spawnCommand: (script) => `exec ${SPAWN_RUNTIME} ${script}`,
       allowedModules: env.SANDBOX_JS_ALLOWED_MODULES,
-      recycleAfterTask: shouldRecycleAfterTask(env.SANDBOX_JS_ALLOWED_MODULES)
+      // 任何接触过用户代码的进程都不回到 idle 池。
+      recycleAfterTask: true,
+      spawnCwd: nativeIsolation ? JS_SANDBOX_ROOT : undefined,
+      initPayload: {
+        nativeIsolation: {
+          enabled: nativeIsolation,
+          addonPath: NATIVE_SANDBOX_ADDON,
+          uid: JS_SANDBOX_UID,
+          gid: JS_SANDBOX_GID,
+          cwd: '/app/code-sandbox'
+        }
+      }
     });
   }
 }

--- a/projects/code-sandbox/src/pool/worker.ts
+++ b/projects/code-sandbox/src/pool/worker.ts
@@ -1,8 +1,9 @@
 /**
- * Worker 长驻进程 - 真正的 TS 源文件
+ * JS 沙箱子进程入口
  *
  * 启动后先从 stdin 读取第一行作为初始化配置（allowedModules 等），
- * 然后进入主循环，逐行接收任务执行。
+ * 然后接收用户任务执行。生产环境由进程池保证每个进程只执行一个用户任务；
+ * 循环协议仅保留 ping/HTTP RPC 和非 Linux 本地调试兼容。
  *
  * 协议：
  *   第 1 行：{"type":"init","allowedModules":["lodash","dayjs",...]}
@@ -11,14 +12,9 @@
  */
 import { createInterface } from 'readline';
 import { createRequire } from 'module';
-import { isIP } from 'net';
 import * as crypto from 'crypto';
-import * as http from 'http';
-import * as https from 'https';
-import * as dns from 'dns';
 import { parse } from 'acorn';
 import { simple as walk } from 'acorn-walk';
-import { isInternalAddress, isInternalResolvedIP } from '../utils/ipCheck.util';
 
 const require = createRequire(import.meta.url);
 const _OriginalFunction = Function;
@@ -29,7 +25,6 @@ const _ObjectDefineProperty = Object.defineProperty;
 const _ObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 const _ObjectKeys = Object.keys;
 const _OriginalProxy = Proxy;
-const _ReflectOwnKeys = Reflect.ownKeys;
 const _ReflectGet = Reflect.get.bind(Reflect);
 const _ReflectApply = Reflect.apply.bind(Reflect);
 const _ReflectConstruct = Reflect.construct.bind(Reflect);
@@ -70,31 +65,6 @@ function assertNoDynamicImport(code: string): void {
       throw new Error(DYNAMIC_IMPORT_ERROR_MESSAGE);
     }
   });
-}
-
-function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
-  if ((typeof value !== 'object' && typeof value !== 'function') || value === null) {
-    return value;
-  }
-
-  const obj = value as object;
-  if (seen.has(obj)) return value;
-  seen.add(obj);
-
-  for (const key of _ReflectOwnKeys(obj)) {
-    try {
-      const descriptor = _ObjectGetOwnPropertyDescriptor(obj, key);
-      if (descriptor && 'value' in descriptor) {
-        deepFreeze(descriptor.value, seen);
-      }
-    } catch {}
-  }
-
-  try {
-    _ObjectFreeze(obj);
-  } catch {}
-
-  return value;
 }
 
 const readonlyViews = new WeakMap<object, any>();
@@ -350,7 +320,6 @@ const _workerStdin = process.stdin;
 // 启动期立即删除：与 worker 自身/白名单模块无依赖关系
 const earlyDangerousMethods = [
   'binding',
-  'dlopen',
   '_linkedBinding',
   'chdir',
   'send',
@@ -370,7 +339,7 @@ const earlyDangerousMethods = [
 ];
 
 // 延迟处理：会被 https/dns/tsx/url 等内部使用，要等 hardenRuntime 预加载完白名单后再收紧。
-const lateDangerousMethods = ['kill', 'exit', 'abort'];
+const lateDangerousMethods = ['dlopen', 'kill', 'exit', 'abort'];
 
 function deleteProcessMethods(methods: readonly string[]): void {
   for (const method of methods) {
@@ -427,21 +396,6 @@ if (typeof process !== 'undefined') {
   }
 }
 
-// ===== 网络安全 =====
-function ipToLong(ip: string): number {
-  const parts = ip.split('.').map(Number);
-  return ((parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]) >>> 0;
-}
-
-function dnsResolve(hostname: string): Promise<string[]> {
-  return new Promise((resolve, reject) => {
-    dns.lookup(hostname, { all: true }, (err, addresses) => {
-      if (err) return reject(err);
-      resolve(addresses.map((a: any) => a.address));
-    });
-  });
-}
-
 const REQUEST_LIMITS = {
   maxRequests: 30,
   timeoutMs: 60000,
@@ -451,7 +405,20 @@ const REQUEST_LIMITS = {
   allowedProtocols: ['http:', 'https:']
 };
 
-let requestCount = 0;
+let httpRpcSequence = 0;
+const pendingHttpRequests = new Map<
+  string,
+  { resolve: (value: any) => void; reject: (reason: Error) => void }
+>();
+
+/** 将联网操作交给未进入 seccomp 的可信父进程执行。 */
+function callParentHttpProxy(payload: Record<string, any>): Promise<any> {
+  const id = `http-${++httpRpcSequence}`;
+  return new _OriginalPromise((resolve, reject) => {
+    pendingHttpRequests.set(id, { resolve, reject });
+    writeLine({ type: 'http_request', id, payload });
+  });
+}
 
 // ===== Legacy global functions (backward compatibility, not on SystemHelper) =====
 function countToken(text: any): number {
@@ -471,93 +438,7 @@ function createHmac(algorithm: string, secret: string) {
 // ===== SystemHelper =====
 const SystemHelper = {
   async httpRequest(url: string, opts: any = {}): Promise<any> {
-    if (++requestCount > REQUEST_LIMITS.maxRequests) {
-      throw new Error('Request limit exceeded');
-    }
-    const parsed = new URL(url);
-    if (!REQUEST_LIMITS.allowedProtocols.includes(parsed.protocol)) {
-      throw new Error('Protocol not allowed');
-    }
-    const method = (opts.method || 'GET').toUpperCase();
-    const headers = opts.headers || {};
-    const body =
-      opts.body != null
-        ? typeof opts.body === 'string'
-          ? opts.body
-          : _JSONStringify(opts.body)
-        : null;
-    if (body && body.length > REQUEST_LIMITS.maxRequestBodySize) {
-      throw new Error('Request body too large');
-    }
-    // 先完成协议和请求体大小校验，再解析网络目标，避免本地错误被外部网络状态掩盖。
-    if (await isInternalAddress(url)) {
-      throw new Error('Request to private network not allowed');
-    }
-    const ips = await dnsResolve(parsed.hostname);
-    // 防 DNS rebinding TOCTOU：对真正用于建连的 IP 再次校验
-    if (ips.length === 0 || ips.some((ip) => isInternalResolvedIP(ip))) {
-      throw new Error('Request to private network not allowed');
-    }
-    const timeout =
-      typeof opts.timeoutMs === 'number' && Number.isFinite(opts.timeoutMs) && opts.timeoutMs > 0
-        ? Math.min(Math.ceil(opts.timeoutMs), REQUEST_LIMITS.timeoutMs)
-        : Math.min(
-            Math.ceil(
-              typeof opts.timeout === 'number' && Number.isFinite(opts.timeout) && opts.timeout > 0
-                ? opts.timeout * 1000
-                : REQUEST_LIMITS.timeoutMs
-            ),
-            REQUEST_LIMITS.timeoutMs
-          );
-    if (body && !headers['Content-Type'] && !headers['content-type']) {
-      headers['Content-Type'] = 'application/json';
-    }
-    const resolvedIP = ips[0];
-    if (!headers['Host'] && !headers['host']) {
-      headers['Host'] = parsed.hostname + (parsed.port ? ':' + parsed.port : '');
-    }
-    const lib = parsed.protocol === 'https:' ? https : http;
-    return new Promise((resolve, reject) => {
-      const req = lib.request(
-        {
-          method,
-          headers,
-          timeout,
-          hostname: resolvedIP,
-          port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
-          path: parsed.pathname + parsed.search,
-          // RFC 6066 禁止把 IP 当作 SNI；hostname 是 IP 时省略 servername
-          ...(isIP(parsed.hostname) ? {} : { servername: parsed.hostname })
-        },
-        (res: any) => {
-          const chunks: Buffer[] = [];
-          let size = 0;
-          res.on('data', (chunk: Buffer) => {
-            size += chunk.length;
-            if (size > REQUEST_LIMITS.maxResponseSize) {
-              req.destroy();
-              reject(new Error('Response too large'));
-              return;
-            }
-            chunks.push(chunk);
-          });
-          res.on('end', () => {
-            const data = Buffer.concat(chunks).toString('utf-8');
-            const h: Record<string, any> = {};
-            for (const [k, v] of Object.entries(res.headers)) h[k] = v;
-            resolve({ status: res.statusCode, statusText: res.statusMessage, headers: h, data });
-          });
-          res.on('error', reject);
-        }
-      );
-      req.on('timeout', () => {
-        req.destroy();
-        reject(new Error('Request timeout'));
-      });
-      req.on('error', reject);
-      if (body) req.write(body);
-      req.end();
-    });
+    return callParentHttpProxy({ url, ...opts });
   }
 };
 _ObjectFreeze(SystemHelper);
@@ -661,6 +542,15 @@ rl.on('line', async (line: string) => {
     return;
   }
 
+  if (msg.type === 'http_response') {
+    const pending = pendingHttpRequests.get(msg.id);
+    if (!pending) return;
+    pendingHttpRequests.delete(msg.id);
+    if (msg.success) pending.resolve(msg.payload);
+    else pending.reject(new _OriginalError(msg.message || 'HTTP request failed'));
+    return;
+  }
+
   // 第一条消息：初始化配置
   if (!initialized) {
     if (msg.type === 'init') {
@@ -677,6 +567,20 @@ rl.on('line', async (line: string) => {
           REQUEST_LIMITS.maxRequestBodySize = msg.requestLimits.maxRequestBodySize;
         if (msg.requestLimits.maxOutputSize != null)
           REQUEST_LIMITS.maxOutputSize = msg.requestLimits.maxOutputSize;
+      }
+      // 先加载白名单与 native addon；进入 seccomp 后不再允许动态装载原生代码。
+      for (const moduleName of allowedModules) {
+        try {
+          origRequire(moduleName);
+        } catch {}
+      }
+      if (msg.nativeIsolation?.enabled) {
+        const addon = origRequire(msg.nativeIsolation.addonPath);
+        addon.init({
+          uid: msg.nativeIsolation.uid,
+          gid: msg.nativeIsolation.gid,
+          cwd: msg.nativeIsolation.cwd
+        });
       }
       hardenRuntime();
       writeLine({ type: 'ready' });
@@ -695,8 +599,6 @@ rl.on('line', async (line: string) => {
 
   // 后续消息：执行任务
   const { code, variables, timeoutMs } = msg;
-  requestCount = 0; // 每次任务重置
-
   const logs: string[] = [];
   let logSize = 0;
   const MAX_LOG_SIZE = 1024 * 1024; // 1MB

--- a/projects/code-sandbox/src/utils/sandbox-http.ts
+++ b/projects/code-sandbox/src/utils/sandbox-http.ts
@@ -39,12 +39,15 @@ const dnsResolve = async (hostname: string) => {
 export async function runSandboxHttpRequest({
   payload,
   limits,
-  state
+  state,
+  signal
 }: {
   payload: SandboxHttpRequestPayload;
   limits: SandboxHttpLimits;
   state: SandboxHttpState;
+  signal?: AbortSignal;
 }): Promise<any> {
+  signal?.throwIfAborted();
   if (++state.requestCount > limits.maxRequests) {
     throw new Error('Request limit exceeded');
   }
@@ -73,6 +76,7 @@ export async function runSandboxHttpRequest({
   }
 
   const ips = await dnsResolve(parsed.hostname);
+  signal?.throwIfAborted();
   if (ips.length === 0 || ips.some((ip) => isInternalResolvedIP(ip))) {
     throw new Error('Request to private network not allowed');
   }
@@ -111,6 +115,7 @@ export async function runSandboxHttpRequest({
         hostname: resolvedIP,
         port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
         path: parsed.pathname + parsed.search,
+        signal,
         ...(isIP(parsed.hostname) ? {} : { servername: parsed.hostname })
       },
       (res: any) => {

--- a/projects/code-sandbox/test/integration/docker-js-packages.test.ts
+++ b/projects/code-sandbox/test/integration/docker-js-packages.test.ts
@@ -196,4 +196,44 @@ async function main() {
       expect(result.data?.codeReturn.message).toMatch(/not allowed|denied|forbidden/i);
     }
   );
+
+  it('httpRequest 通过父进程代理拦截容器内网目标', async () => {
+    const result = await runJs(`
+async function main() {
+  try {
+    await SystemHelper.httpRequest('http://127.0.0.1:3000/health');
+    return { blocked: false };
+  } catch (error) {
+    return { blocked: true, message: String(error.message || error) };
+  }
+}`);
+
+    expect(result.data?.codeReturn.blocked).toBe(true);
+    expect(result.data?.codeReturn.message).toMatch(/private|internal|not allowed/i);
+  });
+
+  it('并发 one-shot 任务完成后会补回预热进程且健康检查保持 ready', async () => {
+    const results = await Promise.all(
+      Array.from({ length: 20 }, (_, index) =>
+        runJs(
+          `
+async function main(variables) {
+  await delay(10);
+  return variables.index;
+}`,
+          { index }
+        )
+      )
+    );
+
+    expect(results.map((result) => result.data?.codeReturn)).toEqual(
+      Array.from({ length: 20 }, (_, index) => index)
+    );
+
+    const health = await fetch(`${baseUrl}/health`);
+    const payload = await health.json();
+    expect(health.status).toBe(200);
+    expect(payload.status).toBe('ok');
+    expect(payload.pools.js.ready).toBe(true);
+  });
 });

--- a/projects/code-sandbox/test/integration/docker-python-packages.test.ts
+++ b/projects/code-sandbox/test/integration/docker-python-packages.test.ts
@@ -411,4 +411,19 @@ def main():
     expect(result.success).toBe(true);
     expect(result.data?.codeReturn.blocked).toBe(true);
   });
+
+  it('GHSA-q6ww-4c5x-j2pg: fork_exec 在真实容器中被 seccomp 拒绝', async () => {
+    await expect(
+      runPython(`
+def main():
+    import _posixsubprocess, posix, time
+    r, w = posix.pipe()
+    argv = [b"/bin/sh", b"-c", b"id > /tmp/CANARY"]
+    pid = _posixsubprocess.fork_exec(argv, [b"/bin/sh"], True, (), None, None,
+        -1, -1, -1, -1, -1, -1, r, w, False, False, 0, -1, [], -1, 255, None)
+    time.sleep(1.0)
+    return {"child_pid": pid}
+`)
+    ).rejects.toThrow(/Operation not permitted|EPERM/);
+  });
 });

--- a/projects/code-sandbox/test/setup.ts
+++ b/projects/code-sandbox/test/setup.ts
@@ -1,0 +1,27 @@
+import { vi } from 'vitest';
+
+// 宿主机单测验证进程池和执行器逻辑，不具备生产镜像中的 chroot 文件系统与 capability。
+// 仅在 Vitest 模块图中替换原生隔离探测；生产代码仍在 Linux 上固定启用并 fail-closed。
+vi.mock('../src/isolated/js-isolation-config', async () => {
+  const actual = await vi.importActual<typeof import('../src/isolated/js-isolation-config')>(
+    '../src/isolated/js-isolation-config'
+  );
+
+  return {
+    ...actual,
+    shouldEnableJsNativeIsolation: () => false,
+    assertJsNativeIsolationReady: () => undefined
+  };
+});
+
+vi.mock('../src/isolated/python-isolation-config', async () => {
+  const actual = await vi.importActual<typeof import('../src/isolated/python-isolation-config')>(
+    '../src/isolated/python-isolation-config'
+  );
+
+  return {
+    ...actual,
+    shouldEnablePythonNativeIsolation: () => false,
+    assertPythonNativeIsolationReady: () => undefined
+  };
+});

--- a/projects/code-sandbox/test/unit/js-native-isolation.test.ts
+++ b/projects/code-sandbox/test/unit/js-native-isolation.test.ts
@@ -1,0 +1,92 @@
+import { existsSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { spawnSync } from 'child_process';
+import { describe, expect, it } from 'vitest';
+import {
+  JS_SANDBOX_GID,
+  JS_SANDBOX_UID,
+  shouldEnableJsNativeIsolation
+} from '../../src/isolated/js-isolation-config';
+
+const nativeAddonPath = join(process.cwd(), 'dist', 'fastgpt_js_sandbox.node');
+const shouldRunNativeIsolation =
+  shouldEnableJsNativeIsolation() && process.getuid?.() === 0 && existsSync(nativeAddonPath);
+
+/**
+ * 绕过 worker 的 JavaScript API guard，直接在原生隔离初始化后尝试危险能力。
+ *
+ * 测试使用真实 Node 子进程、chroot、UID/GID 和 seccomp，不 mock 内核结果。模块在
+ * 进入 seccomp 前预加载，确保失败来自内核边界而非 safeRequire 白名单。
+ */
+describe.skipIf(!shouldRunNativeIsolation)('JS native seccomp/chroot isolation', () => {
+  it('降权并从内核层阻断 socket、子进程和 chroot 外文件', () => {
+    const sandboxRoot = mkdtempSync(join(tmpdir(), 'fastgpt-js-native-sandbox-'));
+    const probe = `
+const fs = require('fs');
+const net = require('net');
+const childProcess = require('child_process');
+const addon = require(${JSON.stringify(nativeAddonPath)});
+
+addon.init({ uid: ${JS_SANDBOX_UID}, gid: ${JS_SANDBOX_GID}, cwd: '/' });
+
+const result = {
+  uid: process.getuid(),
+  gid: process.getgid(),
+  passwdVisible: fs.existsSync('/etc/passwd'),
+  writeError: null,
+  socketError: null,
+  spawnError: null
+};
+
+try {
+  fs.writeFileSync('/escape.txt', 'blocked');
+} catch (err) {
+  result.writeError = err.code || err.message;
+}
+
+try {
+  const socket = new net.Socket();
+  socket.on('error', (err) => {
+    result.socketError = err.code || err.message;
+    finish();
+  });
+  socket.connect(80, '1.1.1.1');
+} catch (err) {
+  result.socketError = err.code || err.message;
+}
+
+try {
+  const spawned = childProcess.spawnSync('/bin/sh', ['-c', 'id']);
+  result.spawnError = spawned.error?.code || spawned.error?.message ||
+    (spawned.status === 0 ? null : 'blocked');
+} catch (err) {
+  result.spawnError = err.code || err.message;
+}
+
+setTimeout(finish, 50);
+function finish() {
+  if (result.done) return;
+  result.done = true;
+  console.log(JSON.stringify(result));
+}
+`;
+
+    const result = spawnSync(process.execPath, ['-e', probe], {
+      cwd: sandboxRoot,
+      encoding: 'utf8',
+      timeout: 5000
+    });
+    rmSync(sandboxRoot, { recursive: true, force: true });
+
+    expect(result.status, result.stderr).toBe(0);
+    const payload = JSON.parse(result.stdout.trim());
+    expect(payload.uid).toBe(JS_SANDBOX_UID);
+    expect(payload.gid).toBe(JS_SANDBOX_GID);
+    expect(payload.passwdVisible).toBe(false);
+    expect(payload.writeError).toMatch(/EPERM|EACCES/);
+    expect(payload.socketError).toMatch(/EPERM|EACCES/);
+    expect(payload.spawnError).toMatch(/EPERM|EACCES|ENOENT/);
+    expect(result.stdout + result.stderr).not.toMatch(/uid=\d+/);
+  });
+});

--- a/projects/code-sandbox/test/unit/process-pool.test.ts
+++ b/projects/code-sandbox/test/unit/process-pool.test.ts
@@ -8,7 +8,8 @@
  * - 并发正确性
  * - shutdown 后行为
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
+import { BaseProcessPool } from '../../src/pool/base-process-pool';
 import { ProcessPool } from '../../src/pool/process-pool';
 import { PythonIsolatedRunner } from '../../src/isolated/python-isolated-runner';
 
@@ -45,16 +46,86 @@ describe('ProcessPool 生命周期', () => {
     expect(s.busy).toBe(0);
   });
 
-  it('execute 后 worker 归还到 idle', async () => {
+  it('shutdown 后新任务立即返回 not ready，不进入永久等待队列', async () => {
     pool = new ProcessPool(1);
     await pool.init();
+    await pool.shutdown();
+
+    const result = await pool.execute({
+      code: `async function main() { return { ok: true }; }`,
+      variables: {}
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/not ready/i);
+    expect(pool.stats.queued).toBe(0);
+  });
+
+  it('初始化期间 shutdown 会终止尚未 ready 的真实子进程', async () => {
+    class NeverReadyPool extends BaseProcessPool {
+      constructor() {
+        super(1, {
+          name: 'NeverReady',
+          workerScript: '',
+          spawnCommand: () => 'sleep 30',
+          allowedModules: []
+        });
+      }
+    }
+
+    const warmingPool = new NeverReadyPool();
+    const initPromise = warmingPool.init();
+    const initAssertion = expect(initPromise).rejects.toThrow('shutting down');
+
+    const warmingDeadline = Date.now() + 2000;
+    while (warmingPool.stats.warming !== 1 && Date.now() < warmingDeadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(warmingPool.stats.warming).toBe(1);
+
+    const warmingWorker = [...((warmingPool as any).warmingWorkers as Map<any, unknown>).keys()][0];
+    const warmingPid = warmingWorker?.proc.pid as number | undefined;
+    expect(warmingPid).toBeTypeOf('number');
+
+    await warmingPool.shutdown();
+    await initAssertion;
+    expect(warmingPool.stats).toMatchObject({ total: 0, idle: 0, warming: 0, ready: false });
+
+    if (warmingPid) {
+      const exitDeadline = Date.now() + 2000;
+      while (Date.now() < exitDeadline) {
+        try {
+          process.kill(warmingPid, 0);
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        } catch {
+          break;
+        }
+      }
+      expect(() => process.kill(warmingPid, 0)).toThrow();
+    }
+  });
+
+  it('execute 后销毁已接触用户代码的 worker，并补充新的预热进程', async () => {
+    pool = new ProcessPool(1);
+    await pool.init();
+    const firstWorkerId = (pool as any).workers[0]?.id;
     await pool.execute({
       code: `async function main() { return { ok: true }; }`,
       variables: {}
     });
+
+    const deadline = Date.now() + 3000;
+    while (
+      Date.now() < deadline &&
+      ((pool as any).workers[0]?.id === firstWorkerId || pool.stats.idle !== 1)
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+
     const s = pool.stats;
     expect(s.idle).toBe(1);
     expect(s.busy).toBe(0);
+    expect((pool as any).workers[0]?.id).not.toBe(firstWorkerId);
   });
 });
 
@@ -203,6 +274,11 @@ describe('ProcessPool Worker 健康检查 (ping/pong)', () => {
     expect(r1.success).toBe(true);
     expect(r1.data?.codeReturn.step).toBe(1);
 
+    const firstReplacementDeadline = Date.now() + 3000;
+    while (pool.stats.idle === 0 && Date.now() < firstReplacementDeadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+
     // 触发健康检查（通过 triggerHealthCheck）
     (pool as any).pingWorker((pool as any).idleWorkers[0]);
 
@@ -216,6 +292,11 @@ describe('ProcessPool Worker 健康检查 (ping/pong)', () => {
     });
     expect(r2.success).toBe(true);
     expect(r2.data?.codeReturn.step).toBe(2);
+
+    const secondReplacementDeadline = Date.now() + 3000;
+    while (pool.stats.total === 0 && Date.now() < secondReplacementDeadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
     expect(pool.stats.total).toBe(1);
   });
 

--- a/projects/code-sandbox/test/unit/resource-limits.test.ts
+++ b/projects/code-sandbox/test/unit/resource-limits.test.ts
@@ -363,7 +363,7 @@ describe('JS 运行时长限制', () => {
     const pidBefore = (pool as any).workers[0].proc.pid;
     const result = await pool.execute({
       code: `async function main() {
-        await delay(${env.SANDBOX_MAX_TIMEOUT + 5000});
+        await new Promise(resolve => setTimeout(resolve, ${env.SANDBOX_MAX_TIMEOUT + 5000}));
         return { done: true };
       }`,
       variables: {}

--- a/projects/code-sandbox/test/unit/sandbox-http.test.ts
+++ b/projects/code-sandbox/test/unit/sandbox-http.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { runSandboxHttpRequest } from '../../src/utils/sandbox-http';
+
+describe('sandbox HTTP request lifecycle', () => {
+  it('任务已结束时不再启动代理请求', async () => {
+    const controller = new AbortController();
+    const state = { requestCount: 0 };
+    controller.abort();
+
+    await expect(
+      runSandboxHttpRequest({
+        payload: { url: 'https://example.com' },
+        limits: {
+          maxRequests: 1,
+          timeoutMs: 1000,
+          maxResponseSize: 1024,
+          maxRequestBodySize: 1024
+        },
+        state,
+        signal: controller.signal
+      })
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(state.requestCount).toBe(0);
+  });
+});

--- a/projects/code-sandbox/vitest.config.ts
+++ b/projects/code-sandbox/vitest.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
     hookTimeout: 30000,
     // 多个 suite 会各自启动真实 JS/Python 进程池；串行文件避免原生包冷启动和资源测试互相争抢。
     fileParallelism: false,
-    isolate: false,
+    // ipCheck 等 suite 会重置模块并修改进程环境，文件间必须隔离模块缓存，避免策略状态互相污染。
+    isolate: true,
     env: {
       CHECK_INTERNAL_IP: 'true',
       SANDBOX_API_MAX_BODY_MB: '1',

--- a/projects/code-sandbox/vitest.config.ts
+++ b/projects/code-sandbox/vitest.config.ts
@@ -13,13 +13,15 @@ export default defineConfig({
     include: ['test/**/*.test.ts'],
     testTimeout: 30000,
     hookTimeout: 30000,
-    fileParallelism: true,
+    // 多个 suite 会各自启动真实 JS/Python 进程池；串行文件避免原生包冷启动和资源测试互相争抢。
+    fileParallelism: false,
     isolate: false,
     env: {
       CHECK_INTERNAL_IP: 'true',
       SANDBOX_API_MAX_BODY_MB: '1',
       SANDBOX_MAX_MEMORY_MB: '256',
-      SANDBOX_MAX_TIMEOUT: '30000',
+      // 冷启动 matplotlib 等原生包在并行测试时可能超过 8s；同时给 30s 用例超时保留回收余量。
+      SANDBOX_MAX_TIMEOUT: '15000',
       SANDBOX_QUEUE_ID_CONCURRENCY: '1',
       SANDBOX_TOKEN: 'test'
     }

--- a/projects/code-sandbox/vitest.config.ts
+++ b/projects/code-sandbox/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     },
     root: '.',
     include: ['test/**/*.test.ts'],
+    setupFiles: ['test/setup.ts'],
     testTimeout: 30000,
     hookTimeout: 30000,
     // 多个 suite 会各自启动真实 JS/Python 进程池；串行文件避免原生包冷启动和资源测试互相争抢。


### PR DESCRIPTION
## What changed

- Replace cross-request JavaScript worker reuse with a one-shot warm process pool. A worker is destroyed after its first user task and asynchronously replenished.
- Add a fail-closed Linux N-API isolation boundary for JavaScript workers using chroot, a dedicated UID/GID, `no_new_privs`, and a default-deny seccomp allowlist.
- Move `SystemHelper.httpRequest` execution to the trusted parent process so sandbox workers do not need network syscalls while preserving SSRF and resource limits.
- Harden process-pool initialization, shutdown, worker replacement, health reporting, and cancellation of unfinished HTTP proxy requests.
- Build both JavaScript and Python native isolation libraries into the Docker image and prepare separate chroot roots.
- Add real process, Docker, concurrency, HTTP lifecycle, fail-closed, and GHSA-q6ww-4c5x-j2pg regression coverage.
- Update the code-sandbox README and design document, including the exact capabilities and tmpfs layout for hardened read-only deployments.

## Security boundary

On Linux, missing native isolation assets or failed chroot/credential/seccomp initialization prevents the worker pool from becoming ready. macOS and Windows remain development-only compatibility paths and do not claim OS-level isolation.

This is defense in depth inside the existing container, not a VM-equivalent boundary. Container-runtime isolation, kernel patching, and deployment policy remain required.

## Verification

- `pnpm exec eslint ...` — passed
- `pnpm exec tsc --noEmit -p projects/code-sandbox/tsconfig.json` — passed
- `cd projects/code-sandbox && pnpm test` — 606 passed, 33 environment-gated tests skipped
- `docker build -f projects/code-sandbox/Dockerfile -t fastgpt-code-sandbox:pr-js-one-shot .` — passed
- Live hardened container integration suite — 31 passed, including one-shot replenishment, SSRF blocking, dangerous JS modules, Python native packages, and the `_posixsubprocess.fork_exec` advisory PoC
