### PR TITLE
fix: update startup cache and deployment defaults

### DIFF
--- a/deploy/version/main/docker-compose.template.yml
+++ b/deploy/version/main/docker-compose.template.yml
@@ -213,7 +213,7 @@ services:
       # root 密码，用户名为: root。如果需要修改 root 密码，直接修改这个环境变量，并重启即可。
       DEFAULT_ROOT_PSW: *x-default-root-psw
       # 数据库最大连接数
-      DB_MAX_LINK: 5
+      DB_MAX_LINK: 20
       # 自动同步索引
       SYNC_INDEX: true
       # 系统变量替换等同步字符串处理的最大字符数，单位 M，范围 1~100

--- a/document/public/deploy/docker/main/cn/docker-compose.milvus.yml
+++ b/document/public/deploy/docker/main/cn/docker-compose.milvus.yml
@@ -271,7 +271,7 @@ services:
       # root 密码，用户名为: root。如果需要修改 root 密码，直接修改这个环境变量，并重启即可。
       DEFAULT_ROOT_PSW: *x-default-root-psw
       # 数据库最大连接数
-      DB_MAX_LINK: 5
+      DB_MAX_LINK: 20
       # 自动同步索引
       SYNC_INDEX: true
       # 系统变量替换等同步字符串处理的最大字符数，单位 M，范围 1~100

--- a/document/public/deploy/docker/main/cn/docker-compose.oceanbase.yml
+++ b/document/public/deploy/docker/main/cn/docker-compose.oceanbase.yml
@@ -249,7 +249,7 @@ services:
       # root 密码，用户名为: root。如果需要修改 root 密码，直接修改这个环境变量，并重启即可。
       DEFAULT_ROOT_PSW: *x-default-root-psw
       # 数据库最大连接数
-      DB_MAX_LINK: 5
+      DB_MAX_LINK: 20
       # 自动同步索引
       SYNC_INDEX: true
       # 系统变量替换等同步字符串处理的最大字符数，单位 M，范围 1~100

--- a/document/public/deploy/docker/main/cn/docker-compose.opengauss.yml
+++ b/document/public/deploy/docker/main/cn/docker-compose.opengauss.yml
@@ -233,7 +233,7 @@ services:
       # root 密码，用户名为: root。如果需要修改 root 密码，直接修改这个环境变量，并重启即可。
       DEFAULT_ROOT_PSW: *x-default-root-psw
       # 数据库最大连接数
-      DB_MAX_LINK: 5
+      DB_MAX_LINK: 20
       # 自动同步索引
       SYNC_INDEX: true
       # 系统变量替换等同步字符串处理的最大字符数，单位 M，范围 1~100

--- a/document/public/deploy/docker/main/cn/docker-compose.pg.yml
+++ b/document/public/deploy/docker/main/cn/docker-compose.pg.yml
@@ -231,7 +231,7 @@ services:
       # root 密码，用户名为: root。如果需要修改 root 密码，直接修改这个环境变量，并重启即可。
       DEFAULT_ROOT_PSW: *x-default-root-psw
       # 数据库最大连接数
-      DB_MAX_LINK: 5
+      DB_MAX_LINK: 20
       # 自动同步索引
       SYNC_INDEX: true
       # 系统变量替换等同步字符串处理的最大字符数，单位 M，范围 1~100

--- a/document/public/deploy/docker/main/cn/docker-compose.seekdb.yml
+++ b/document/public/deploy/docker/main/cn/docker-compose.seekdb.yml
@@ -236,7 +236,7 @@ services:
       # root 密码，用户名为: root。如果需要修改 root 密码，直接修改这个环境变量，并重启即可。
       DEFAULT_ROOT_PSW: *x-default-root-psw
       # 数据库最大连接数
-      DB_MAX_LINK: 5
+      DB_MAX_LINK: 20
       # 自动同步索引
       SYNC_INDEX: true
       # 系统变量替换等同步字符串处理的最大字符数，单位 M，范围 1~100

--- a/document/public/deploy/docker/main/cn/docker-compose.zilliz.yml
+++ b/document/public/deploy/docker/main/cn/docker-compose.zilliz.yml
@@ -212,7 +212,7 @@ services:
       # root 密码，用户名为: root。如果需要修改 root 密码，直接修改这个环境变量，并重启即可。
       DEFAULT_ROOT_PSW: *x-default-root-psw
       # 数据库最大连接数
-      DB_MAX_LINK: 5
+      DB_MAX_LINK: 20
       # 自动同步索引
       SYNC_INDEX: true
       # 系统变量替换等同步字符串处理的最大字符数，单位 M，范围 1~100

--- a/document/public/deploy/docker/main/global/docker-compose.milvus.yml
+++ b/document/public/deploy/docker/main/global/docker-compose.milvus.yml
@@ -271,7 +271,7 @@ services:
       # root 密码，用户名为: root。如果需要修改 root 密码，直接修改这个环境变量，并重启即可。
       DEFAULT_ROOT_PSW: *x-default-root-psw
       # 数据库最大连接数
-      DB_MAX_LINK: 5
+      DB_MAX_LINK: 20
       # 自动同步索引
       SYNC_INDEX: true
       # 系统变量替换等同步字符串处理的最大字符数，单位 M，范围 1~100

--- a/document/public/deploy/docker/main/global/docker-compose.oceanbase.yml
+++ b/document/public/deploy/docker/main/global/docker-compose.oceanbase.yml
@@ -249,7 +249,7 @@ services:
       # root 密码，用户名为: root。如果需要修改 root 密码，直接修改这个环境变量，并重启即可。
       DEFAULT_ROOT_PSW: *x-default-root-psw
       # 数据库最大连接数
-      DB_MAX_LINK: 5
+      DB_MAX_LINK: 20
       # 自动同步索引
       SYNC_INDEX: true
       # 系统变量替换等同步字符串处理的最大字符数，单位 M，范围 1~100

--- a/document/public/deploy/docker/main/global/docker-compose.opengauss.yml
+++ b/document/public/deploy/docker/main/global/docker-compose.opengauss.yml
@@ -233,7 +233,7 @@ services:
       # root 密码，用户名为: root。如果需要修改 root 密码，直接修改这个环境变量，并重启即可。
       DEFAULT_ROOT_PSW: *x-default-root-psw
       # 数据库最大连接数
-      DB_MAX_LINK: 5
+      DB_MAX_LINK: 20
       # 自动同步索引
       SYNC_INDEX: true
       # 系统变量替换等同步字符串处理的最大字符数，单位 M，范围 1~100

--- a/document/public/deploy/docker/main/global/docker-compose.pg.yml
+++ b/document/public/deploy/docker/main/global/docker-compose.pg.yml
@@ -231,7 +231,7 @@ services:
       # root 密码，用户名为: root。如果需要修改 root 密码，直接修改这个环境变量，并重启即可。
       DEFAULT_ROOT_PSW: *x-default-root-psw
       # 数据库最大连接数
-      DB_MAX_LINK: 5
+      DB_MAX_LINK: 20
       # 自动同步索引
       SYNC_INDEX: true
       # 系统变量替换等同步字符串处理的最大字符数，单位 M，范围 1~100

--- a/document/public/deploy/docker/main/global/docker-compose.seekdb.yml
+++ b/document/public/deploy/docker/main/global/docker-compose.seekdb.yml
@@ -236,7 +236,7 @@ services:
       # root 密码，用户名为: root。如果需要修改 root 密码，直接修改这个环境变量，并重启即可。
       DEFAULT_ROOT_PSW: *x-default-root-psw
       # 数据库最大连接数
-      DB_MAX_LINK: 5
+      DB_MAX_LINK: 20
       # 自动同步索引
       SYNC_INDEX: true
       # 系统变量替换等同步字符串处理的最大字符数，单位 M，范围 1~100

--- a/document/public/deploy/docker/main/global/docker-compose.zilliz.yml
+++ b/document/public/deploy/docker/main/global/docker-compose.zilliz.yml
@@ -212,7 +212,7 @@ services:
       # root 密码，用户名为: root。如果需要修改 root 密码，直接修改这个环境变量，并重启即可。
       DEFAULT_ROOT_PSW: *x-default-root-psw
       # 数据库最大连接数
-      DB_MAX_LINK: 5
+      DB_MAX_LINK: 20
       # 自动同步索引
       SYNC_INDEX: true
       # 系统变量替换等同步字符串处理的最大字符数，单位 M，范围 1~100

--- a/packages/service/core/ai/config/utils.ts
+++ b/packages/service/core/ai/config/utils.ts
@@ -133,10 +133,13 @@ export const syncPreinstalledSystemModels = async ({
  */
 export const loadInstalledModels = async ({
   pluginDocuments = modelTemplateSnapshot,
-  language = 'en'
+  language = 'en',
+  skipPermissionCacheInvalidation = false
 }: {
   pluginDocuments?: SystemModelDocumentDataType[];
   language?: string;
+  /** 启动阶段只发布初始快照，避免重启时删除仍然有效的成员目录缓存。 */
+  skipPermissionCacheInvalidation?: boolean;
 } = {}) => {
   if (!pluginDocuments) {
     return Promise.reject(new Error('Model template snapshot is not initialized'));
@@ -292,10 +295,11 @@ export const loadInstalledModels = async ({
 
     const nextPermissionCacheSignature = getPermissionCacheSignature(_systemActiveModelList);
     if (
-      previousPermissionCacheSignature === undefined ||
+      !skipPermissionCacheInvalidation &&
+      previousPermissionCacheSignature !== undefined &&
       previousPermissionCacheSignature !== nextPermissionCacheSignature
     ) {
-      // 只有会改变成员可用模型 ID 的变更才失效缓存，避免五分钟定时刷新退化成固定清缓存。
+      // 只有已发布快照中的模型身份发生变化才失效缓存；首次启动没有可比较的旧快照。
       await clearAllMyModelsCache();
     }
 
@@ -333,19 +337,29 @@ export const loadInstalledModels = async ({
 
 /**
  * 编排模型启动或模板热刷新。插件刷新仍是启动前置条件；首次启动会先发布 ai_models 当前快照，
- * 再同步执行旧表迁移、自动预装和最终缓存刷新。任一步失败都会向启动链路抛错并终止进程。
+ * 再同步执行旧表迁移、自动预装和最终快照刷新，但不会清理成员模型目录缓存。
+ * 任一步失败都会向启动链路抛错并终止进程。
  */
 export const loadSystemModels = async (refresh = false, language = 'en') => {
   if (!refresh && global.systemModelList) return;
 
   try {
+    const isInitialLoad = !global.systemModelList;
     await preloadModelProviders();
     const pluginDocuments = await refreshModelTemplates();
-    if (!global.systemModelList) {
-      await loadInstalledModels({ pluginDocuments, language });
+    if (isInitialLoad) {
+      await loadInstalledModels({
+        pluginDocuments,
+        language,
+        skipPermissionCacheInvalidation: isInitialLoad
+      });
       const result = await bootstrapAIModelsFromLegacy({ pluginDocuments });
       await syncPreinstalledSystemModels({ pluginDocuments });
-      await loadInstalledModels({ pluginDocuments, language });
+      await loadInstalledModels({
+        pluginDocuments,
+        language,
+        skipPermissionCacheInvalidation: isInitialLoad
+      });
       getLogger(LogCategories.MODULE.AI.CONFIG).info('AI model bootstrap completed', result);
       return;
     }

--- a/packages/service/test/core/ai/config/load.test.ts
+++ b/packages/service/test/core/ai/config/load.test.ts
@@ -179,6 +179,14 @@ describe('loadSystemModels', () => {
     expect(global.systemModelList).toMatchObject([{ model: 'plugin-llm' }]);
   });
 
+  it('does not invalidate member model caches during initial startup', async () => {
+    pluginMocks.listModels.mockResolvedValue([pluginLlm]);
+
+    await loadSystemModels();
+
+    expect(reloadMocks.clearAllMyModelsCache).not.toHaveBeenCalled();
+  });
+
   it('retries after another instance wins a preinstall duplicate-key race', async () => {
     await MongoAIModel.create(pluginLlmDocument);
     const bulkWrite = vi.spyOn(MongoAIModel, 'bulkWrite').mockRejectedValueOnce({ code: 11000 });
@@ -254,6 +262,25 @@ describe('loadSystemModels', () => {
     await loadSystemModels(true);
 
     expect(reloadMocks.clearAllMyModelsCache).not.toHaveBeenCalled();
+  });
+
+  it('invalidates member caches when a hot refresh adds an active model', async () => {
+    pluginMocks.listModels.mockResolvedValue([pluginLlm]);
+    await loadSystemModels();
+    reloadMocks.clearAllMyModelsCache.mockClear();
+
+    pluginMocks.listModels.mockResolvedValue([
+      pluginLlm,
+      {
+        ...pluginLlm,
+        model: 'plugin-llm-2',
+        name: 'Plugin LLM 2'
+      }
+    ]);
+
+    await loadSystemModels(true);
+
+    expect(reloadMocks.clearAllMyModelsCache).toHaveBeenCalledOnce();
   });
 
   it('loads installed models without requesting plugin templates', async () => {

--- a/packages/web/i18n/zh-CN/publish.json
+++ b/packages/web/i18n/zh-CN/publish.json
@@ -23,7 +23,7 @@
   "official_account.create_modal_title": "创建微信公众号接入",
   "official_account.desc": "通过 API 直接接入微信公众号",
   "official_account.edit_modal_title": "编辑微信公众号接入",
-  "official_account.name": "微信公众号接入",
+  "official_account.name": "微信公众号",
   "official_account.params": "微信公众号参数",
   "official_account.title": "微信公众号",
   "private_config": "可见度配置",

--- a/projects/app/.env.template
+++ b/projects/app/.env.template
@@ -3,7 +3,7 @@ LOG_DEPTH=3
 # 默认用户密码（用户名为 root），每次重启会自动更新。
 DEFAULT_ROOT_PSW=123456
 # 数据库最大连接数
-DB_MAX_LINK=5
+DB_MAX_LINK=20
 # 自动同步索引
 SYNC_INDEX=true
 


### PR DESCRIPTION
## Summary
- Avoid invalidating member model caches during initial model startup while preserving invalidation for hot-refresh model identity changes.
- Rename the Chinese publish channel label to `微信公众号`.
- Increase `DB_MAX_LINK` defaults to 20 in app templates and the `main` deployment templates.
- Update the `pro` submodule pointer to include the matching admin template change.

## Test plan
- `pnpm test packages/service/test/core/ai/config/load.test.ts`
- `git diff --check`

## Dependency
- Depends on [fastgpt-pro#1106](https://github.com/labring/fastgpt-pro/pull/1106) for the updated submodule commit.