### PR TITLE
fix: Python 沙箱 seccomp 加载失败时降级

### DIFF
--- a/.agents/design/code-sandbox/js-one-shot-native-isolation.md
+++ b/.agents/design/code-sandbox/js-one-shot-native-isolation.md
@@ -7,8 +7,8 @@
 本次改造目标：
 
 1. 每个 JS worker 最多执行一个用户任务，结果返回后立即销毁；池中只预热尚未接触用户代码的干净进程。
-2. Linux 容器内固定启用 chroot、独立 UID/GID、`no_new_privs` 和 seccomp；初始化条件不满足时服务启动失败。
-3. 用户进程没有网络 syscall。兼容的 `SystemHelper.httpRequest` 通过 stdin/stdout RPC 交给父 Node 进程执行，复用统一 SSRF、DNS pinning、次数、超时和大小限制。
+2. Linux 容器内固定启用 chroot、独立 UID/GID 和 `no_new_privs`，默认启用 seccomp；只有部署者设置 `SANDBOX_DISABLE_SECCOMP=true` 时才跳过 seccomp，初始化失败不会自动降级。
+3. 默认配置下用户进程没有网络 syscall。兼容的 `SystemHelper.httpRequest` 通过 stdin/stdout RPC 交给父 Node 进程执行，复用统一 SSRF、DNS pinning、次数、超时和大小限制。
 4. 不要求修改 Docker 宿主机运行时，不依赖 gVisor、nsjail 或特权容器；使用 `cap_drop: ALL` 时仅显式保留 chroot、降权、目录权限和进程回收所需的最小 capability 集合。
 5. 保持 `/sandbox/js` API、JS 代码调用方式、模块白名单和返回结构兼容。
 
@@ -61,7 +61,7 @@ worker 的 `SystemHelper.httpRequest` 不再导入和调用 `http`、`https`、`
 - 父进程向同一 worker stdin 返回 `http_response`；
 - worker 用请求 ID 解析 Promise。
 
-父进程按单个任务创建请求计数状态和 `AbortController`。任务完成、超时或进程异常退出时，中止尚未完成的代理请求，避免用户通过“不 await 即返回”让网络请求脱离 one-shot 生命周期。worker 直接 socket 即使通过语言层逃逸也会被 seccomp 拒绝。
+父进程按单个任务创建请求计数状态和 `AbortController`。任务完成、超时或进程异常退出时，中止尚未完成的代理请求，避免用户通过“不 await 即返回”让网络请求脱离 one-shot 生命周期。默认配置下，worker 直接 socket 即使通过语言层逃逸也会被 seccomp 拒绝。
 
 ### 3.4 chroot 文件布局
 

--- a/.agents/design/code-sandbox/python-isolated-runner.md
+++ b/.agents/design/code-sandbox/python-isolated-runner.md
@@ -15,9 +15,9 @@ GHSA-5jmh-5f2m-89jg 证明该模型存在结构性缺陷：Python 反射链可�
 - 旧 `worker.py` 和 `PythonProcessPool` 已删除；
 - `/sandbox/python` 统一使用 `PythonIsolatedRunner`；
 - Python 进程最多执行一次用户代码，执行后销毁；
-- Linux/Docker 环境默认启用 `chroot`、`no_new_privs`、`seccomp`、`setgid/setuid`；
-- 如果 seccomp filter 无法加载，bootstrap 会记录 warning 并继续完成 chroot + setgid/setuid；
-- 网络请求统一走父进程 HTTP 代理，不允许 Python 子进程直接网络 syscall。
+- Linux/Docker 环境固定启用 `chroot`、`no_new_privs`、`setgid/setuid`，默认启用 `seccomp`；
+- 仅允许部署者通过 `SANDBOX_DISABLE_SECCOMP=true` 显式跳过 seccomp，加载失败时不自动降级；
+- 默认配置下网络请求统一走父进程 HTTP 代理，seccomp 不允许 Python 子进程直接网络 syscall。
 
 ## 目标
 
@@ -42,7 +42,7 @@ POST /sandbox/python
   -> PythonIsolatedRunner.execute({ code, variables })
   -> 获取干净的 one-shot 预热 Python 进程
      -> 无空闲进程时按需 spawn
-  -> 预热进程已完成 chroot + no_new_privs + seccomp + setgid/setuid
+  -> 预热进程已完成 chroot + no_new_privs + setgid/setuid，并按配置安装 seccomp
   -> bootstrap 注入 helper、variables、受限 builtins
   -> exec 用户代码并调用 main
   -> stdout 输出 JSON line result/http_request
@@ -93,12 +93,12 @@ Go shared library `fastgpt_python_sandbox.so` 负责 Linux native 隔离：
 - `setgroups([])`；
 - `setgid(65537)` / `setuid(65537)`；
 - `PR_SET_NO_NEW_PRIVS`；
-- 安装 seccomp filter；
+- 默认安装 seccomp filter，显式关闭时跳过该步骤；
 - 危险 syscall 默认拒绝，`execve/execveat`、`ptrace`、`mount` 等不能落地。
 
 ## 配置
 
-Python 隔离相关配置已经收敛为内部安全默认，不提供运行时环境变量关闭或改弱：
+Python native 隔离整体不能关闭。seccomp 使用安全默认值，仅为不兼容内核提供显式关闭开关：
 
 | 配置 | 当前值 | 说明 |
 | --- | --- | --- |
@@ -107,7 +107,8 @@ Python 隔离相关配置已经收敛为内部安全默认，不提供运行时�
 | 直接网络 syscall | `false` | 统一走父进程 `http_request` 代理 |
 | chroot 根目录 | `/tmp/fastgpt-python-sandbox` | Docker 构建阶段准备 |
 | 用户代码 uid/gid | `65537:65537` | native 初始化后降权 |
-| native seccomp/chroot/setuid | Linux 固定开启 | 缺少 native 库或 chroot root 时 fail-closed |
+| native chroot/no_new_privs/setuid | Linux 固定开启 | 缺少 native 库或 chroot root 时 fail-closed |
+| native seccomp | 默认开启 | `SANDBOX_DISABLE_SECCOMP=true` 时显式关闭；加载失败不自动降级 |
 
 保留的 Python 业务配置：
 
@@ -121,7 +122,7 @@ Python 隔离相关配置已经收敛为内部安全默认，不提供运行时�
 
 ## 网络代理
 
-Python 子进程不允许直接使用网络 syscall。用户代码如需请求外部网络，必须调用：
+启用 seccomp 时，Python 子进程不允许直接使用网络 syscall。用户代码如需请求外部网络，必须调用：
 
 ```python
 http_request(url, method='GET', headers=None, body=None, timeout=None)
@@ -188,10 +189,10 @@ Python bootstrap 向父进程写出：
 OS 层是多租户核心安全边界：
 
 - 每个 Python 子进程最多执行一次用户代码；
-- 执行用户代码前已经 chroot、降权、安装 seccomp；
+- 执行用户代码前已经 chroot、降权，并按配置安装 seccomp；
 - 执行完成后整个进程树销毁；
 - 不复用执行过用户代码的解释器；
-- seccomp 不允许命令执行和高危系统调用；
+- 默认启用的 seccomp 不允许命令执行和高危系统调用；
 - chroot 只包含 Python 运行所需 stdlib、site-packages、动态库、证书、DNS 配置和 sandbox runtime 文件。
 
 ### 资源边界
@@ -252,7 +253,7 @@ Docker 镜像使用 Debian bookworm/glibc。Alpine/musl 下 Go c-shared `.so`
 - native `.so` 加载；
 - setuid/setgid 降权；
 - chroot 生效；
-- seccomp 阻断命令执行；
+- 默认配置下 seccomp 阻断命令执行；
 - numpy/pandas/matplotlib 在 chroot/seccomp 下可用；
 - Docker 包可用性测试覆盖 Python 和 JS 白名单包。
 

--- a/.agents/design/code-sandbox/python-isolated-runner.md
+++ b/.agents/design/code-sandbox/python-isolated-runner.md
@@ -15,7 +15,8 @@ GHSA-5jmh-5f2m-89jg 证明该模型存在结构性缺陷：Python 反射链可�
 - 旧 `worker.py` 和 `PythonProcessPool` 已删除；
 - `/sandbox/python` 统一使用 `PythonIsolatedRunner`；
 - Python 进程最多执行一次用户代码，执行后销毁；
-- Linux/Docker 环境固定启用 `chroot`、`no_new_privs`、`seccomp`、`setgid/setuid`；
+- Linux/Docker 环境默认启用 `chroot`、`no_new_privs`、`seccomp`、`setgid/setuid`；
+- 如果 seccomp filter 无法加载，bootstrap 会记录 warning 并继续完成 chroot + setgid/setuid；
 - 网络请求统一走父进程 HTTP 代理，不允许 Python 子进程直接网络 syscall。
 
 ## 目标

--- a/projects/code-sandbox/.env.template
+++ b/projects/code-sandbox/.env.template
@@ -29,6 +29,11 @@ SANDBOX_MAX_OUTPUT_MB=10
 # Number of pre-warmed worker processes (JS + Python)
 SANDBOX_POOL_SIZE=5
 
+# ===== OS Isolation =====
+# DANGER: Set true only when the host kernel cannot load application seccomp filters.
+# JS and Python still use chroot and dedicated UID/GID, but lose kernel-level syscall filtering.
+SANDBOX_DISABLE_SECCOMP=false
+
 # ===== Network Request Limits =====
 # Whether to check if the request is to a private network
 CHECK_INTERNAL_IP=true

--- a/projects/code-sandbox/README.md
+++ b/projects/code-sandbox/README.md
@@ -1,6 +1,6 @@
 # FastGPT Code Sandbox
 
-基于 Node + Hono 的代码执行沙盒，支持 JS 和 Python。两种语言都采用 one-shot 预热进程池，Linux/Docker 环境固定启用 chroot、seccomp、setuid/setgid 隔离。
+基于 Node + Hono 的代码执行沙盒，支持 JS 和 Python。两种语言都采用 one-shot 预热进程池，Linux/Docker 环境固定启用 chroot、setuid/setgid 隔离，并默认启用 seccomp。
 
 ## 架构
 
@@ -13,7 +13,7 @@ HTTP Request → Hono Server
 - **JS 进程池**：启动时预热 N 个干净 Node 子进程（默认 20）；每个进程只执行一个用户任务，随后销毁并异步补池
 - **JS 执行**：Node 子进程 + native seccomp/chroot/独立 UID + 安全 shim（冻结 Function 构造器、危险全局对象遮蔽、require 白名单）
 - **Python 执行**：预热 `SANDBOX_POOL_SIZE` 个干净 python3 进程，进程进入 native seccomp/chroot/降权后等待一条任务；执行用户代码后立即销毁并异步补充新的干净进程
-- **网络请求**：沙箱子进程不允许网络 syscall；统一通过父进程代理的 `SystemHelper.httpRequest()` / `system_helper.http_request()` 收口，内置 SSRF 防护
+- **网络请求**：默认由 seccomp 禁止沙箱子进程的网络 syscall；统一通过父进程代理的 `SystemHelper.httpRequest()` / `system_helper.http_request()` 收口，内置 SSRF 防护
 - **并发控制**：JS 请求超过池大小时自动排队；Python 同时运行的独立子进程数复用 `SANDBOX_POOL_SIZE`
 
 ## 性能
@@ -172,13 +172,21 @@ docker run -p 3000:3000 \
 | `SANDBOX_POOL_SIZE` | JS worker 进程数；也是 Python 同时运行和空闲预热的进程数 | `5` |
 | `SANDBOX_QUEUE_ID_CONCURRENCY` | 同一 `queueId` 同时可进入执行流程的请求数，空值表示不按 `queueId` 排队 | 空 |
 
+### OS 隔离
+
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
+| `SANDBOX_DISABLE_SECCOMP` | 显式关闭 JS 和 Python 的应用内 seccomp；chroot、`no_new_privs` 和 UID/GID 降权仍保持启用 | `false` |
+
+默认配置下，任一 seccomp filter 加载失败都会使对应进程池初始化失败，不会自动降级。仅当宿主机内核不支持应用内 seccomp 且部署者接受安全能力降低时，才应将 `SANDBOX_DISABLE_SECCOMP` 设置为 `true`。关闭后不再从内核层阻断网络、创建进程、线程和执行二进制等 syscall；语言层白名单和运行时 shim 不能等价替代 seccomp。
+
 ### Python 隔离
 
-Python 隔离不再提供运行时关闭开关。Linux 环境默认启用 native seccomp/chroot/降权，chroot 根目录固定为 `/tmp/fastgpt-python-sandbox`，用户代码进程固定降权到 `65537:65537`。如果内核拒绝加载 seccomp filter，bootstrap 会记录 warning 并继续用 chroot + setuid/setgid 的降级路径。Python 子进程不允许直接网络 syscall，外部请求必须通过父进程代理的 `http_request` 能力，并受请求次数、超时、请求体和响应体大小限制。
+Python native 隔离不提供整体关闭开关。Linux 环境固定启用 chroot、`no_new_privs` 和降权，chroot 根目录固定为 `/tmp/fastgpt-python-sandbox`，用户代码进程固定降权到 `65537:65537`；seccomp 按上述配置控制。启用 seccomp 时，Python 子进程不允许直接网络 syscall，外部请求必须通过父进程代理的 `http_request` 能力，并受请求次数、超时、请求体和响应体大小限制。
 
 ### JS 隔离
 
-Linux 环境同样固定启用 native seccomp/chroot/降权，chroot 根目录为 `/tmp/fastgpt-js-sandbox`，JS 子进程使用独立的 `65538:65538`。每个预热进程最多执行一个用户任务，直接网络、创建进程和执行二进制的 syscall 均被拒绝。
+Linux 环境同样固定启用 native chroot、`no_new_privs` 和降权，chroot 根目录为 `/tmp/fastgpt-js-sandbox`，JS 子进程使用独立的 `65538:65538`；seccomp 按上述配置控制。每个预热进程最多执行一个用户任务。启用 seccomp 时，直接网络、创建进程和执行二进制的 syscall 均被拒绝。
 
 ### 资源限制
 
@@ -263,7 +271,7 @@ SANDBOX_JS_ALLOWED_MODULES=lodash,dayjs,moment,uuid,crypto-js,qs,url,querystring
 - 只添加纯计算类的包，不要添加有网络/文件系统/子进程能力的包
 - 包会被打入 Docker 镜像，注意体积
 - 网络请求统一走 `SystemHelper.httpRequest()`，不要放行 `axios`、`node-fetch` 等网络库
-- 不应放行 `child_process`、`worker_threads`、`cluster`；Linux native seccomp 也会从内核层拒绝创建进程或线程
+- 不应放行 `child_process`、`worker_threads`、`cluster`；默认启用的 Linux native seccomp 也会从内核层拒绝创建进程或线程
 
 ## 添加 Python 包
 
@@ -291,8 +299,8 @@ your-new-package
 
 - Python 的模块黑名单通过 `__import__` 拦截实现，只拦截用户代码的直接 import
 - 标准库和第三方包的内部间接 import 不受影响
-- 默认白名单不包含 `os`、`sys`、`subprocess`、`socket` 等高危模块；显式加入环境变量只会放开语言层 import，不会放开 native seccomp 已拒绝的进程、线程和网络 syscall
-- Python 固定 one-shot：无论导入哪些模块，每个进程最多执行一个用户任务；Linux 下即使通过间接引用或 CPython C 扩展绕过 import/audit 限制，chroot、独立 UID/GID 与 default-deny seccomp 仍是最终进程边界
+- 默认白名单不包含 `os`、`sys`、`subprocess`、`socket` 等高危模块；启用 seccomp 时，显式加入环境变量只会放开语言层 import，不会放开 native seccomp 已拒绝的进程、线程和网络 syscall
+- Python 固定 one-shot：无论导入哪些模块，每个进程最多执行一个用户任务；启用 seccomp 时，即使通过间接引用或 CPython C 扩展绕过 import/audit 限制，chroot、独立 UID/GID 与 default-deny seccomp 仍构成最终进程边界
 
 ## 安全机制
 
@@ -303,7 +311,7 @@ your-new-package
 - `Function` 构造器冻结，阻止 `constructor.constructor` 逃逸
 - `process.env` 清理，仅保留必要变量
 - `fetch`、`XMLHttpRequest`、`WebSocket` 禁用
-- Linux 下固定 chroot 到只读 rootfs，降权到 JS 专用 UID/GID，并以 TSYNC seccomp 拒绝网络、进程和执行类 syscall
+- Linux 下固定 chroot 到只读 rootfs，并降权到 JS 专用 UID/GID；默认以 TSYNC seccomp 拒绝网络、进程和执行类 syscall
 - 每个子进程只执行一个用户任务，任务完成后不返回 idle 池
 
 ### Python
@@ -312,7 +320,7 @@ your-new-package
 - `exec()`/`eval()` 内的 import 同样被拦截（基于调用栈帧检测）
 - `builtins.__import__` 通过代理对象保护，用户无法覆盖
 - `signal.SIGALRM` 超时保护
-- Linux 下固定 chroot、降权到 Python 专用 UID/GID，并以 native default-deny seccomp 拒绝网络、进程、线程和执行类 syscall
+- Linux 下固定 chroot、降权到 Python 专用 UID/GID；默认以 native default-deny seccomp 拒绝网络、进程、线程和执行类 syscall
 - 每个 Python 子进程也只执行一个用户任务；语言层限制被绕过时，不会继承父服务的文件系统视图和系统调用能力
 
 ### 网络

--- a/projects/code-sandbox/README.md
+++ b/projects/code-sandbox/README.md
@@ -174,7 +174,7 @@ docker run -p 3000:3000 \
 
 ### Python 隔离
 
-Python 隔离不再提供运行时关闭开关。Linux 环境固定启用 native seccomp/chroot/降权，chroot 根目录固定为 `/tmp/fastgpt-python-sandbox`，用户代码进程固定降权到 `65537:65537`。Python 子进程不允许直接网络 syscall，外部请求必须通过父进程代理的 `http_request` 能力，并受请求次数、超时、请求体和响应体大小限制。
+Python 隔离不再提供运行时关闭开关。Linux 环境默认启用 native seccomp/chroot/降权，chroot 根目录固定为 `/tmp/fastgpt-python-sandbox`，用户代码进程固定降权到 `65537:65537`。如果内核拒绝加载 seccomp filter，bootstrap 会记录 warning 并继续用 chroot + setuid/setgid 的降级路径。Python 子进程不允许直接网络 syscall，外部请求必须通过父进程代理的 `http_request` 能力，并受请求次数、超时、请求体和响应体大小限制。
 
 ### JS 隔离
 

--- a/projects/code-sandbox/native/js-sandbox/fastgpt_js_sandbox.c
+++ b/projects/code-sandbox/native/js-sandbox/fastgpt_js_sandbox.c
@@ -25,6 +25,13 @@ static bool read_int32_property(napi_env env, napi_value object, const char *nam
   return napi_get_value_int32(env, value, result) == napi_ok;
 }
 
+static bool read_bool_property(napi_env env, napi_value object, const char *name,
+                               bool *result) {
+  napi_value value;
+  if (napi_get_named_property(env, object, name, &value) != napi_ok) return false;
+  return napi_get_value_bool(env, value, result) == napi_ok;
+}
+
 static bool read_string_property(napi_env env, napi_value object, const char *name,
                                  char *result, size_t result_size) {
   napi_value value;
@@ -95,6 +102,7 @@ static napi_value init_sandbox(napi_env env, napi_callback_info info) {
   napi_value undefined;
   int32_t uid = 0;
   int32_t gid = 0;
+  bool enable_seccomp = true;
   char cwd[256] = "/app/code-sandbox";
 
   napi_get_undefined(env, &undefined);
@@ -117,6 +125,13 @@ static napi_value init_sandbox(napi_env env, napi_callback_info info) {
     napi_throw_range_error(env, NULL, "uid/gid must be positive");
     return NULL;
   }
+  bool has_enable_seccomp = false;
+  if (napi_has_named_property(env, argv[0], "enableSeccomp", &has_enable_seccomp) == napi_ok &&
+      has_enable_seccomp &&
+      !read_bool_property(env, argv[0], "enableSeccomp", &enable_seccomp)) {
+    napi_throw_type_error(env, NULL, "enableSeccomp must be a boolean");
+    return NULL;
+  }
 
   if (chroot(".") != 0) return throw_errno(env, "chroot");
   if (chdir(cwd) != 0) return throw_errno(env, "chdir");
@@ -135,7 +150,7 @@ static napi_value init_sandbox(napi_env env, napi_callback_info info) {
     napi_throw_error(env, NULL, "dumpable verification failed");
     return NULL;
   }
-  if (install_seccomp() != 0) return throw_errno(env, "seccomp");
+  if (enable_seccomp && install_seccomp() != 0) return throw_errno(env, "seccomp");
 
   return undefined;
 }

--- a/projects/code-sandbox/native/python-sandbox/cmd/lib/main.go
+++ b/projects/code-sandbox/native/python-sandbox/cmd/lib/main.go
@@ -13,7 +13,6 @@ package main
 import "C"
 
 import (
-	"strings"
 	"sync"
 	"unsafe"
 
@@ -36,13 +35,15 @@ func setLastErr(err error) {
 }
 
 //export FastGPTInitPythonSandbox
-func FastGPTInitPythonSandbox(uid C.int, gid C.int, enableNetwork C.int) C.int {
-	err := sandbox.Init(int(uid), int(gid), enableNetwork != 0)
+func FastGPTInitPythonSandbox(uid C.int, gid C.int, enableNetwork C.int, enableSeccomp C.int) C.int {
+	err := sandbox.Init(sandbox.Config{
+		UID:           int(uid),
+		GID:           int(gid),
+		EnableNetwork: enableNetwork != 0,
+		EnableSeccomp: enableSeccomp != 0,
+	})
 	setLastErr(err)
 	if err != nil {
-		if strings.Contains(err.Error(), "load seccomp filter") {
-			return 2
-		}
 		return 1
 	}
 	return 0

--- a/projects/code-sandbox/native/python-sandbox/cmd/lib/main.go
+++ b/projects/code-sandbox/native/python-sandbox/cmd/lib/main.go
@@ -13,6 +13,7 @@ package main
 import "C"
 
 import (
+	"strings"
 	"sync"
 	"unsafe"
 
@@ -39,6 +40,9 @@ func FastGPTInitPythonSandbox(uid C.int, gid C.int, enableNetwork C.int) C.int {
 	err := sandbox.Init(int(uid), int(gid), enableNetwork != 0)
 	setLastErr(err)
 	if err != nil {
+		if strings.Contains(err.Error(), "load seccomp filter") {
+			return 2
+		}
 		return 1
 	}
 	return 0

--- a/projects/code-sandbox/native/python-sandbox/internal/sandbox/init_linux.go
+++ b/projects/code-sandbox/native/python-sandbox/internal/sandbox/init_linux.go
@@ -7,13 +7,22 @@ import (
 	"syscall"
 )
 
+// Config controls the OS-level restrictions installed for one Python process.
+type Config struct {
+	UID           int
+	GID           int
+	EnableNetwork bool
+	EnableSeccomp bool
+}
+
 // Init installs the OS-level restrictions for the current Python process.
 //
 // The caller must load this shared library, open all required task fds, and set
-// cwd to the prepared sandbox root before calling Init. After chroot/seccomp and
-// uid/gid drop, the process cannot recover its previous privileges.
-func Init(uid, gid int, enableNetwork bool) error {
-	if uid <= 0 || gid <= 0 {
+// cwd to the prepared sandbox root before calling Init. After chroot and uid/gid
+// drop, the process cannot recover its previous privileges. Seccomp is skipped only
+// when the operator explicitly disables it for an incompatible kernel.
+func Init(config Config) error {
+	if config.UID <= 0 || config.GID <= 0 {
 		return fmt.Errorf("uid/gid must be positive")
 	}
 	if err := syscall.Chroot("."); err != nil {
@@ -25,16 +34,18 @@ func Init(uid, gid int, enableNetwork bool) error {
 	if err := setNoNewPrivs(); err != nil {
 		return err
 	}
-	if err := loadSeccomp(enableNetwork); err != nil {
-		return err
+	if config.EnableSeccomp {
+		if err := loadSeccomp(config.EnableNetwork); err != nil {
+			return err
+		}
 	}
 	if err := syscall.Setgroups([]int{}); err != nil {
 		return fmt.Errorf("setgroups: %w", err)
 	}
-	if err := syscall.Setgid(gid); err != nil {
+	if err := syscall.Setgid(config.GID); err != nil {
 		return fmt.Errorf("setgid: %w", err)
 	}
-	if err := syscall.Setuid(uid); err != nil {
+	if err := syscall.Setuid(config.UID); err != nil {
 		return fmt.Errorf("setuid: %w", err)
 	}
 	return nil

--- a/projects/code-sandbox/native/python-sandbox/internal/sandbox/init_unsupported.go
+++ b/projects/code-sandbox/native/python-sandbox/internal/sandbox/init_unsupported.go
@@ -4,6 +4,13 @@ package sandbox
 
 import "fmt"
 
-func Init(uid, gid int, enableNetwork bool) error {
+type Config struct {
+	UID           int
+	GID           int
+	EnableNetwork bool
+	EnableSeccomp bool
+}
+
+func Init(config Config) error {
 	return fmt.Errorf("fastgpt python sandbox native isolation only supports linux")
 }

--- a/projects/code-sandbox/src/env.ts
+++ b/projects/code-sandbox/src/env.ts
@@ -50,6 +50,10 @@ export const env = createEnv({
     /** 同一 queueId 同时可进入执行流程的请求数；为空时不启用 queueId 排队 */
     SANDBOX_QUEUE_ID_CONCURRENCY: IntSchema.min(1).max(100).optional(),
 
+    // ===== OS 隔离 =====
+    /** 仅用于不支持应用内 seccomp 的内核；chroot 和 UID/GID 降权仍保持启用 */
+    SANDBOX_DISABLE_SECCOMP: BoolSchema.default(false),
+
     // ===== 资源限制 =====
     SANDBOX_API_MAX_BODY_MB: IntSchema.min(1).max(100).default(8),
     SANDBOX_MAX_TIMEOUT: IntSchema.min(1000).max(600000).default(60000),

--- a/projects/code-sandbox/src/index.ts
+++ b/projects/code-sandbox/src/index.ts
@@ -9,6 +9,7 @@ import type { ExecuteOptions } from './types';
 import { getErrText } from './utils';
 import { configureLogger, getLogger, LogCategories } from './utils/logger';
 import { QueueIdLimiter } from './utils/queue-id-limiter';
+import { getSeccompConfig } from './isolated/seccomp-config';
 
 await configureLogger();
 
@@ -93,6 +94,12 @@ const app = new Hono();
 const jsPool = new ProcessPool(env.SANDBOX_POOL_SIZE);
 const pythonRunner = new PythonIsolatedRunner();
 const queueIdLimiter = new QueueIdLimiter(env.SANDBOX_QUEUE_ID_CONCURRENCY);
+
+if (!getSeccompConfig().enableSeccomp) {
+  serverLogger.warn(
+    'SECURITY WARNING: application seccomp is explicitly disabled for JS and Python sandboxes; chroot and UID/GID isolation remain enabled'
+  );
+}
 
 if (queueIdLimiter.enabled) {
   serverLogger.info(

--- a/projects/code-sandbox/src/isolated/js-isolation-config.ts
+++ b/projects/code-sandbox/src/isolated/js-isolation-config.ts
@@ -13,8 +13,9 @@ export function shouldEnableJsNativeIsolation(): boolean {
 /**
  * 校验 Linux JS worker 启动所需的原生隔离资产。
  *
- * chroot/seccomp/降权是 Linux 多租户边界的一部分，不能在资产缺失时静默退化。
- * 非 Linux 仅用于本地开发，不声明具备 OS 级隔离。
+ * chroot/降权是 Linux 多租户边界的一部分，不能在资产缺失时静默退化；seccomp
+ * 默认启用且失败时 fail-closed，只有部署者显式配置后才跳过。非 Linux 仅用于
+ * 本地开发，不声明具备 OS 级隔离。
  */
 export function assertJsNativeIsolationReady(addonPath: string): void {
   if (!shouldEnableJsNativeIsolation()) return;

--- a/projects/code-sandbox/src/isolated/python-bootstrap.py
+++ b/projects/code-sandbox/src/isolated/python-bootstrap.py
@@ -86,6 +86,13 @@ def _write_result(payload):
     sys.stdout.flush()
 
 
+def _write_warn(code, message):
+    sys.stdout.write(_original_json_dumps({'type': 'warn', 'code': code, 'message': message}, ensure_ascii=False, default=str) + '\n')
+    sys.stdout.flush()
+    sys.stderr.write(message + '\n')
+    sys.stderr.flush()
+
+
 def _init_request_limits(limits):
     if not limits:
         return
@@ -224,7 +231,24 @@ def _init_native_isolation(isolation):
     finally:
         if err_ptr:
             lib.FastGPTFreeCString(err_ptr)
+
+    if ret == 2:
+        _write_warn('native_seccomp_fallback', f"Python native seccomp failed, continuing without seccomp: {err_text or ret}")
+        _finish_native_isolation_without_seccomp(isolation)
+        _native_isolation_ready = True
+        return
+
     raise RuntimeError(err_text or f"Native python sandbox init failed: {ret}")
+
+
+def _finish_native_isolation_without_seccomp(isolation):
+    try:
+        _os.chdir('/')
+        _os.setgroups([])
+        _os.setgid(int(isolation.get('gid') or 65537))
+        _os.setuid(int(isolation.get('uid') or 65537))
+    except Exception as e:
+        raise RuntimeError(f"Failed to continue native isolation without seccomp: {e}")
 
 
 def _is_stdlib_frame(filename: str):

--- a/projects/code-sandbox/src/isolated/python-bootstrap.py
+++ b/projects/code-sandbox/src/isolated/python-bootstrap.py
@@ -86,13 +86,6 @@ def _write_result(payload):
     sys.stdout.flush()
 
 
-def _write_warn(code, message):
-    sys.stdout.write(_original_json_dumps({'type': 'warn', 'code': code, 'message': message}, ensure_ascii=False, default=str) + '\n')
-    sys.stdout.flush()
-    sys.stderr.write(message + '\n')
-    sys.stderr.flush()
-
-
 def _init_request_limits(limits):
     if not limits:
         return
@@ -200,7 +193,7 @@ def _init_native_isolation(isolation):
     global _native_isolation_ready
     if _native_isolation_ready:
         return
-    if not isolation or not isolation.get('enableSeccomp'):
+    if not isolation or not isolation.get('enabled'):
         return
 
     lib_path = isolation.get('libraryPath') or './fastgpt_python_sandbox.so'
@@ -209,7 +202,9 @@ def _init_native_isolation(isolation):
     except Exception as e:
         raise RuntimeError(f"Failed to load native python sandbox library: {e}")
 
-    lib.FastGPTInitPythonSandbox.argtypes = [_ctypes.c_int, _ctypes.c_int, _ctypes.c_int]
+    lib.FastGPTInitPythonSandbox.argtypes = [
+        _ctypes.c_int, _ctypes.c_int, _ctypes.c_int, _ctypes.c_int
+    ]
     lib.FastGPTInitPythonSandbox.restype = _ctypes.c_int
     lib.FastGPTLastError.argtypes = []
     lib.FastGPTLastError.restype = _ctypes.c_void_p
@@ -219,7 +214,8 @@ def _init_native_isolation(isolation):
     ret = lib.FastGPTInitPythonSandbox(
         int(isolation.get('uid') or 65537),
         int(isolation.get('gid') or 65537),
-        1 if isolation.get('enableNetwork') else 0
+        1 if isolation.get('enableNetwork') else 0,
+        1 if isolation.get('enableSeccomp') else 0
     )
     if ret == 0:
         _native_isolation_ready = True
@@ -232,23 +228,7 @@ def _init_native_isolation(isolation):
         if err_ptr:
             lib.FastGPTFreeCString(err_ptr)
 
-    if ret == 2:
-        _write_warn('native_seccomp_fallback', f"Python native seccomp failed, continuing without seccomp: {err_text or ret}")
-        _finish_native_isolation_without_seccomp(isolation)
-        _native_isolation_ready = True
-        return
-
     raise RuntimeError(err_text or f"Native python sandbox init failed: {ret}")
-
-
-def _finish_native_isolation_without_seccomp(isolation):
-    try:
-        _os.chdir('/')
-        _os.setgroups([])
-        _os.setgid(int(isolation.get('gid') or 65537))
-        _os.setuid(int(isolation.get('uid') or 65537))
-    except Exception as e:
-        raise RuntimeError(f"Failed to continue native isolation without seccomp: {e}")
 
 
 def _is_stdlib_frame(filename: str):

--- a/projects/code-sandbox/src/isolated/python-isolated-runner.ts
+++ b/projects/code-sandbox/src/isolated/python-isolated-runner.ts
@@ -37,6 +37,7 @@ import {
   PYTHON_SANDBOX_UID,
   shouldEnablePythonNativeIsolation
 } from './python-isolation-config';
+import { getSeccompConfig } from './seccomp-config';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BOOTSTRAP_SCRIPT = join(__dirname, 'python-bootstrap.py');
@@ -77,7 +78,6 @@ export class PythonIsolatedRunner {
   private readonly warmingChildren = new Set<RunningChild>();
   private readonly warmIdleTarget: number;
   private ready = false;
-  private nativeIsolationDowngraded = false;
 
   constructor(private readonly maxConcurrency = env.SANDBOX_POOL_SIZE) {
     this.semaphore = new Semaphore(maxConcurrency);
@@ -87,7 +87,6 @@ export class PythonIsolatedRunner {
   async init(): Promise<void> {
     assertPythonNativeIsolationReady(NATIVE_SANDBOX_LIBRARY);
     this.ready = true;
-    this.nativeIsolationDowngraded = false;
 
     try {
       await this.replenishWarmChildren(true);
@@ -128,8 +127,7 @@ export class PythonIsolatedRunner {
       queued: semaphoreStats.queued,
       poolSize: semaphoreStats.max,
       ready:
-        this.ready && this.idleChildren.size + this.running.size + this.warmingChildren.size > 0,
-      nativeIsolationDowngraded: this.nativeIsolationDowngraded
+        this.ready && this.idleChildren.size + this.running.size + this.warmingChildren.size > 0
     };
   }
 
@@ -294,7 +292,8 @@ export class PythonIsolatedRunner {
 
   private buildIsolationPayload() {
     return {
-      enableSeccomp: shouldEnablePythonNativeIsolation(),
+      enabled: shouldEnablePythonNativeIsolation(),
+      ...getSeccompConfig(),
       enableNetwork: PYTHON_ENABLE_NETWORK_SYSCALLS,
       libraryPath: NATIVE_SANDBOX_LIBRARY,
       sandboxRoot: PYTHON_SANDBOX_ROOT,
@@ -329,10 +328,6 @@ export class PythonIsolatedRunner {
         if (errorHandler) child.proc.off('error', errorHandler);
         this.warmingChildren.delete(child);
         if (ready && this.ready) {
-          if (child.stderrBuf.length > 0) {
-            serverLogger.warn(`Python warm child startup stderr: ${child.stderrBuf.join('\n')}`);
-            child.stderrBuf.length = 0;
-          }
           this.markChildIdle(child);
         } else {
           killProcessTree(child.proc.pid);
@@ -346,13 +341,6 @@ export class PythonIsolatedRunner {
           const msg = JSON.parse(line);
           if (msg.type === 'ready') {
             settle(true);
-            return;
-          }
-          if (msg.type === 'warn') {
-            if (msg.code === 'native_seccomp_fallback') {
-              this.nativeIsolationDowngraded = true;
-            }
-            serverLogger.warn(`Python warm child warning: ${msg.message || line}`);
             return;
           }
           if (msg.type === 'result') {

--- a/projects/code-sandbox/src/isolated/python-isolated-runner.ts
+++ b/projects/code-sandbox/src/isolated/python-isolated-runner.ts
@@ -77,6 +77,7 @@ export class PythonIsolatedRunner {
   private readonly warmingChildren = new Set<RunningChild>();
   private readonly warmIdleTarget: number;
   private ready = false;
+  private nativeIsolationDowngraded = false;
 
   constructor(private readonly maxConcurrency = env.SANDBOX_POOL_SIZE) {
     this.semaphore = new Semaphore(maxConcurrency);
@@ -86,6 +87,7 @@ export class PythonIsolatedRunner {
   async init(): Promise<void> {
     assertPythonNativeIsolationReady(NATIVE_SANDBOX_LIBRARY);
     this.ready = true;
+    this.nativeIsolationDowngraded = false;
 
     try {
       await this.replenishWarmChildren(true);
@@ -126,7 +128,8 @@ export class PythonIsolatedRunner {
       queued: semaphoreStats.queued,
       poolSize: semaphoreStats.max,
       ready:
-        this.ready && this.idleChildren.size + this.running.size + this.warmingChildren.size > 0
+        this.ready && this.idleChildren.size + this.running.size + this.warmingChildren.size > 0,
+      nativeIsolationDowngraded: this.nativeIsolationDowngraded
     };
   }
 
@@ -326,6 +329,10 @@ export class PythonIsolatedRunner {
         if (errorHandler) child.proc.off('error', errorHandler);
         this.warmingChildren.delete(child);
         if (ready && this.ready) {
+          if (child.stderrBuf.length > 0) {
+            serverLogger.warn(`Python warm child startup stderr: ${child.stderrBuf.join('\n')}`);
+            child.stderrBuf.length = 0;
+          }
           this.markChildIdle(child);
         } else {
           killProcessTree(child.proc.pid);
@@ -339,6 +346,13 @@ export class PythonIsolatedRunner {
           const msg = JSON.parse(line);
           if (msg.type === 'ready') {
             settle(true);
+            return;
+          }
+          if (msg.type === 'warn') {
+            if (msg.code === 'native_seccomp_fallback') {
+              this.nativeIsolationDowngraded = true;
+            }
+            serverLogger.warn(`Python warm child warning: ${msg.message || line}`);
             return;
           }
           if (msg.type === 'result') {

--- a/projects/code-sandbox/src/isolated/python-isolation-config.ts
+++ b/projects/code-sandbox/src/isolated/python-isolation-config.ts
@@ -14,9 +14,9 @@ export function shouldEnablePythonNativeIsolation(): boolean {
 /**
  * Python native 隔离是 Linux 多租户安全边界的一部分。
  *
- * Linux 环境默认启用 seccomp/chroot/setuid；如果 seccomp filter 无法加载，
- * bootstrap 会记录 warning 并降级为 chroot + setuid/setgid。macOS/Windows 仅
- * 保留本地开发兼容路径，不声明具备 OS 隔离。
+ * Linux 环境固定启用 chroot/no_new_privs/setuid，seccomp 默认启用且失败时
+ * fail-closed；只有部署者显式配置后才跳过 seccomp。macOS/Windows 仅保留
+ * 本地开发兼容路径，不声明具备 OS 隔离。
  */
 export function assertPythonNativeIsolationReady(libraryPath: string) {
   if (!shouldEnablePythonNativeIsolation()) return;

--- a/projects/code-sandbox/src/isolated/python-isolation-config.ts
+++ b/projects/code-sandbox/src/isolated/python-isolation-config.ts
@@ -14,8 +14,9 @@ export function shouldEnablePythonNativeIsolation(): boolean {
 /**
  * Python native 隔离是 Linux 多租户安全边界的一部分。
  *
- * Linux 环境固定启用 seccomp/chroot/setuid，缺失 native 库或 chroot 根目录时
- * 直接 fail-closed；macOS/Windows 仅保留本地开发兼容路径，不声明具备 OS 隔离。
+ * Linux 环境默认启用 seccomp/chroot/setuid；如果 seccomp filter 无法加载，
+ * bootstrap 会记录 warning 并降级为 chroot + setuid/setgid。macOS/Windows 仅
+ * 保留本地开发兼容路径，不声明具备 OS 隔离。
  */
 export function assertPythonNativeIsolationReady(libraryPath: string) {
   if (!shouldEnablePythonNativeIsolation()) return;

--- a/projects/code-sandbox/src/isolated/seccomp-config.ts
+++ b/projects/code-sandbox/src/isolated/seccomp-config.ts
@@ -1,0 +1,13 @@
+import { env } from '../env';
+
+/**
+ * 返回 JS 与 Python 共用的 seccomp 配置。
+ *
+ * seccomp 默认开启，只有部署者通过环境变量明确禁用时才关闭。native chroot、
+ * no_new_privs 和 UID/GID 降权不受该配置影响。
+ */
+export function getSeccompConfig() {
+  return {
+    enableSeccomp: !env.SANDBOX_DISABLE_SECCOMP
+  };
+}

--- a/projects/code-sandbox/src/pool/process-pool.ts
+++ b/projects/code-sandbox/src/pool/process-pool.ts
@@ -17,6 +17,7 @@ import {
   JS_SANDBOX_UID,
   shouldEnableJsNativeIsolation
 } from '../isolated/js-isolation-config';
+import { getSeccompConfig } from '../isolated/seccomp-config';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const isCompiled = import.meta.url.endsWith('.js');
@@ -43,7 +44,8 @@ export class ProcessPool extends BaseProcessPool {
           addonPath: NATIVE_SANDBOX_ADDON,
           uid: JS_SANDBOX_UID,
           gid: JS_SANDBOX_GID,
-          cwd: '/app/code-sandbox'
+          cwd: '/app/code-sandbox',
+          ...getSeccompConfig()
         }
       }
     });

--- a/projects/code-sandbox/src/pool/worker.ts
+++ b/projects/code-sandbox/src/pool/worker.ts
@@ -579,7 +579,8 @@ rl.on('line', async (line: string) => {
         addon.init({
           uid: msg.nativeIsolation.uid,
           gid: msg.nativeIsolation.gid,
-          cwd: msg.nativeIsolation.cwd
+          cwd: msg.nativeIsolation.cwd,
+          enableSeccomp: msg.nativeIsolation.enableSeccomp
         });
       }
       hardenRuntime();

--- a/projects/code-sandbox/test/setup.ts
+++ b/projects/code-sandbox/test/setup.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 
 // 宿主机单测验证进程池和执行器逻辑，不具备生产镜像中的 chroot 文件系统与 capability。
-// 仅在 Vitest 模块图中替换原生隔离探测；生产代码仍在 Linux 上固定启用并 fail-closed。
+// 仅在 Vitest 模块图中替换原生隔离探测；生产代码仍在 Linux 上固定进入 native 隔离。
 vi.mock('../src/isolated/js-isolation-config', async () => {
   const actual = await vi.importActual<typeof import('../src/isolated/js-isolation-config')>(
     '../src/isolated/js-isolation-config'

--- a/projects/code-sandbox/test/unit/js-native-isolation.test.ts
+++ b/projects/code-sandbox/test/unit/js-native-isolation.test.ts
@@ -2,12 +2,14 @@ import { existsSync, mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { spawnSync } from 'child_process';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   JS_SANDBOX_GID,
   JS_SANDBOX_UID,
   shouldEnableJsNativeIsolation
 } from '../../src/isolated/js-isolation-config';
+
+vi.unmock('../../src/isolated/js-isolation-config');
 
 const nativeAddonPath = join(process.cwd(), 'dist', 'fastgpt_js_sandbox.node');
 const shouldRunNativeIsolation =
@@ -20,23 +22,27 @@ const shouldRunNativeIsolation =
  * 进入 seccomp 前预加载，确保失败来自内核边界而非 safeRequire 白名单。
  */
 describe.skipIf(!shouldRunNativeIsolation)('JS native seccomp/chroot isolation', () => {
-  it('降权并从内核层阻断 socket、子进程和 chroot 外文件', () => {
+  it('降权并从内核层阻断 socket 和 chroot 外文件', () => {
     const sandboxRoot = mkdtempSync(join(tmpdir(), 'fastgpt-js-native-sandbox-'));
     const probe = `
 const fs = require('fs');
-const net = require('net');
-const childProcess = require('child_process');
 const addon = require(${JSON.stringify(nativeAddonPath)});
+const { UDP } = process.binding('udp_wrap');
+const socket = new UDP();
 
-addon.init({ uid: ${JS_SANDBOX_UID}, gid: ${JS_SANDBOX_GID}, cwd: '/' });
+addon.init({
+  uid: ${JS_SANDBOX_UID},
+  gid: ${JS_SANDBOX_GID},
+  cwd: '/',
+  enableSeccomp: true
+});
 
 const result = {
   uid: process.getuid(),
   gid: process.getgid(),
   passwdVisible: fs.existsSync('/etc/passwd'),
   writeError: null,
-  socketError: null,
-  spawnError: null
+  socketResult: socket.bind('127.0.0.1', 0, 0)
 };
 
 try {
@@ -45,31 +51,8 @@ try {
   result.writeError = err.code || err.message;
 }
 
-try {
-  const socket = new net.Socket();
-  socket.on('error', (err) => {
-    result.socketError = err.code || err.message;
-    finish();
-  });
-  socket.connect(80, '1.1.1.1');
-} catch (err) {
-  result.socketError = err.code || err.message;
-}
-
-try {
-  const spawned = childProcess.spawnSync('/bin/sh', ['-c', 'id']);
-  result.spawnError = spawned.error?.code || spawned.error?.message ||
-    (spawned.status === 0 ? null : 'blocked');
-} catch (err) {
-  result.spawnError = err.code || err.message;
-}
-
-setTimeout(finish, 50);
-function finish() {
-  if (result.done) return;
-  result.done = true;
-  console.log(JSON.stringify(result));
-}
+fs.writeSync(1, JSON.stringify(result) + '\\n');
+socket.close();
 `;
 
     const result = spawnSync(process.execPath, ['-e', probe], {
@@ -85,8 +68,56 @@ function finish() {
     expect(payload.gid).toBe(JS_SANDBOX_GID);
     expect(payload.passwdVisible).toBe(false);
     expect(payload.writeError).toMatch(/EPERM|EACCES/);
-    expect(payload.socketError).toMatch(/EPERM|EACCES/);
-    expect(payload.spawnError).toMatch(/EPERM|EACCES|ENOENT/);
-    expect(result.stdout + result.stderr).not.toMatch(/uid=\d+/);
+    expect(payload.socketResult).toBeLessThan(0);
+  });
+
+  it('显式禁用 seccomp 后仍保留 chroot 和降权', () => {
+    const sandboxRoot = mkdtempSync(join(tmpdir(), 'fastgpt-js-native-no-seccomp-'));
+    const probe = `
+const fs = require('fs');
+const addon = require(${JSON.stringify(nativeAddonPath)});
+const { UDP } = process.binding('udp_wrap');
+const socket = new UDP();
+
+addon.init({
+  uid: ${JS_SANDBOX_UID},
+  gid: ${JS_SANDBOX_GID},
+  cwd: '/',
+  enableSeccomp: false
+});
+
+let writeError = null;
+try {
+  fs.writeFileSync('/escape.txt', 'blocked');
+} catch (err) {
+  writeError = err.code || err.message;
+}
+const socketResult = socket.bind('127.0.0.1', 0, 0);
+fs.writeSync(1, JSON.stringify({
+  uid: process.getuid(),
+  gid: process.getgid(),
+  passwdVisible: fs.existsSync('/etc/passwd'),
+  writeError,
+  socketResult
+}) + '\\n');
+socket.close();
+`;
+
+    const result = spawnSync(process.execPath, ['-e', probe], {
+      cwd: sandboxRoot,
+      encoding: 'utf8',
+      timeout: 5000
+    });
+    rmSync(sandboxRoot, { recursive: true, force: true });
+
+    expect(result.status, result.stderr).toBe(0);
+    const payload = JSON.parse(result.stdout.trim());
+    expect(payload).toMatchObject({
+      uid: JS_SANDBOX_UID,
+      gid: JS_SANDBOX_GID,
+      passwdVisible: false,
+      socketResult: 0
+    });
+    expect(payload.writeError).toMatch(/EPERM|EACCES/);
   });
 });

--- a/projects/code-sandbox/test/unit/python-bootstrap.test.ts
+++ b/projects/code-sandbox/test/unit/python-bootstrap.test.ts
@@ -1,0 +1,93 @@
+import { spawnSync } from 'child_process';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+const bootstrapPath = join(process.cwd(), 'src/isolated/python-bootstrap.py');
+
+describe('python bootstrap native isolation fallback', () => {
+  it('seccomp load failure falls back to chroot and uid/gid drop', () => {
+    const script = `
+import importlib.util
+import json
+
+spec = importlib.util.spec_from_file_location('fastgpt_bootstrap', ${JSON.stringify(bootstrapPath)})
+bootstrap = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bootstrap)
+
+calls = []
+
+class FakeStderr:
+    def __init__(self):
+        self.lines = []
+
+    def write(self, text):
+        self.lines.append(text)
+
+    def flush(self):
+        return None
+
+
+class FakeLib:
+    def __init__(self):
+        self.err = bootstrap._ctypes.create_string_buffer(b'load seccomp filter: operation canceled')
+
+        def FastGPTInitPythonSandbox(uid, gid, enable_network):
+            calls.append(['init', uid, gid, enable_network])
+            return 2
+
+        def FastGPTLastError():
+            calls.append(['last_error'])
+            return bootstrap._ctypes.cast(self.err, bootstrap._ctypes.c_void_p)
+
+        def FastGPTFreeCString(ptr):
+            calls.append(['free'])
+
+        self.FastGPTInitPythonSandbox = FastGPTInitPythonSandbox
+        self.FastGPTLastError = FastGPTLastError
+        self.FastGPTFreeCString = FastGPTFreeCString
+
+
+stderr = FakeStderr()
+bootstrap.sys.stderr = stderr
+bootstrap._ctypes.CDLL = lambda path: FakeLib()
+bootstrap._os.chdir = lambda path: calls.append(['chdir', path])
+bootstrap._os.setgroups = lambda groups: calls.append(['setgroups', list(groups)])
+bootstrap._os.setgid = lambda gid: calls.append(['setgid', gid])
+bootstrap._os.setuid = lambda uid: calls.append(['setuid', uid])
+
+bootstrap._init_native_isolation({
+    'enableSeccomp': True,
+    'libraryPath': '/fake.so',
+    'uid': 65537,
+    'gid': 65537,
+    'enableNetwork': False
+})
+
+print(json.dumps({
+    'ready': bootstrap._native_isolation_ready,
+    'calls': calls,
+    'stderr': ''.join(stderr.lines)
+}, ensure_ascii=False))
+`;
+
+    const result = spawnSync('python3', ['-u', '-c', script], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      timeout: 5000
+    });
+
+    expect(result.status).toBe(0);
+    const stdoutLines = result.stdout.trim().split(/\r?\n/);
+    const payload = JSON.parse(stdoutLines[stdoutLines.length - 1]);
+    expect(payload.ready).toBe(true);
+    expect(stdoutLines.some((line) => line.includes('"type": "warn"'))).toBe(true);
+    expect(payload.stderr).toContain('continuing without seccomp');
+    expect(payload.calls).toContainEqual(['chdir', '/']);
+    expect(payload.calls).toContainEqual(['init', 65537, 65537, 0]);
+    expect(payload.calls).toContainEqual(['last_error']);
+    expect(payload.calls).toContainEqual(['free']);
+    expect(payload.calls).toContainEqual(['setgroups', []]);
+    expect(payload.calls).toContainEqual(['setgid', 65537]);
+    expect(payload.calls).toContainEqual(['setuid', 65537]);
+  });
+});

--- a/projects/code-sandbox/test/unit/python-bootstrap.test.ts
+++ b/projects/code-sandbox/test/unit/python-bootstrap.test.ts
@@ -4,9 +4,8 @@ import { describe, expect, it } from 'vitest';
 
 const bootstrapPath = join(process.cwd(), 'src/isolated/python-bootstrap.py');
 
-describe('python bootstrap native isolation fallback', () => {
-  it('seccomp load failure falls back to chroot and uid/gid drop', () => {
-    const script = `
+function runNativeIsolationProbe(options: { enableSeccomp: boolean; returnCode: number }) {
+  const script = `
 import importlib.util
 import json
 
@@ -16,24 +15,13 @@ spec.loader.exec_module(bootstrap)
 
 calls = []
 
-class FakeStderr:
-    def __init__(self):
-        self.lines = []
-
-    def write(self, text):
-        self.lines.append(text)
-
-    def flush(self):
-        return None
-
-
 class FakeLib:
     def __init__(self):
         self.err = bootstrap._ctypes.create_string_buffer(b'load seccomp filter: operation canceled')
 
-        def FastGPTInitPythonSandbox(uid, gid, enable_network):
-            calls.append(['init', uid, gid, enable_network])
-            return 2
+        def FastGPTInitPythonSandbox(uid, gid, enable_network, enable_seccomp):
+            calls.append(['init', uid, gid, enable_network, enable_seccomp])
+            return ${options.returnCode}
 
         def FastGPTLastError():
             calls.append(['last_error'])
@@ -47,47 +35,52 @@ class FakeLib:
         self.FastGPTFreeCString = FastGPTFreeCString
 
 
-stderr = FakeStderr()
-bootstrap.sys.stderr = stderr
 bootstrap._ctypes.CDLL = lambda path: FakeLib()
-bootstrap._os.chdir = lambda path: calls.append(['chdir', path])
-bootstrap._os.setgroups = lambda groups: calls.append(['setgroups', list(groups)])
-bootstrap._os.setgid = lambda gid: calls.append(['setgid', gid])
-bootstrap._os.setuid = lambda uid: calls.append(['setuid', uid])
-
-bootstrap._init_native_isolation({
-    'enableSeccomp': True,
-    'libraryPath': '/fake.so',
-    'uid': 65537,
-    'gid': 65537,
-    'enableNetwork': False
-})
+error = None
+try:
+    bootstrap._init_native_isolation({
+        'enabled': True,
+        'enableSeccomp': ${options.enableSeccomp ? 'True' : 'False'},
+        'libraryPath': '/fake.so',
+        'uid': 65537,
+        'gid': 65537,
+        'enableNetwork': False
+    })
+except Exception as exc:
+    error = str(exc)
 
 print(json.dumps({
     'ready': bootstrap._native_isolation_ready,
     'calls': calls,
-    'stderr': ''.join(stderr.lines)
+    'error': error
 }, ensure_ascii=False))
 `;
 
-    const result = spawnSync('python3', ['-u', '-c', script], {
-      cwd: process.cwd(),
-      encoding: 'utf8',
-      timeout: 5000
-    });
+  const result = spawnSync('python3', ['-u', '-c', script], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    timeout: 5000,
+    env: { ...process.env, PYTHONDONTWRITEBYTECODE: '1' }
+  });
 
-    expect(result.status).toBe(0);
-    const stdoutLines = result.stdout.trim().split(/\r?\n/);
-    const payload = JSON.parse(stdoutLines[stdoutLines.length - 1]);
+  expect(result.status, result.stderr).toBe(0);
+  return JSON.parse(result.stdout.trim());
+}
+
+describe('python bootstrap native isolation configuration', () => {
+  it('显式禁用 seccomp 时仍调用 native 隔离初始化', () => {
+    const payload = runNativeIsolationProbe({ enableSeccomp: false, returnCode: 0 });
+
     expect(payload.ready).toBe(true);
-    expect(stdoutLines.some((line) => line.includes('"type": "warn"'))).toBe(true);
-    expect(payload.stderr).toContain('continuing without seccomp');
-    expect(payload.calls).toContainEqual(['chdir', '/']);
-    expect(payload.calls).toContainEqual(['init', 65537, 65537, 0]);
-    expect(payload.calls).toContainEqual(['last_error']);
-    expect(payload.calls).toContainEqual(['free']);
-    expect(payload.calls).toContainEqual(['setgroups', []]);
-    expect(payload.calls).toContainEqual(['setgid', 65537]);
-    expect(payload.calls).toContainEqual(['setuid', 65537]);
+    expect(payload.error).toBeNull();
+    expect(payload.calls).toEqual([['init', 65537, 65537, 0, 0]]);
+  });
+
+  it('seccomp 初始化失败时保持 fail-closed，不自动降级', () => {
+    const payload = runNativeIsolationProbe({ enableSeccomp: true, returnCode: 1 });
+
+    expect(payload.ready).toBe(false);
+    expect(payload.error).toContain('load seccomp filter: operation canceled');
+    expect(payload.calls).toEqual([['init', 65537, 65537, 0, 1], ['last_error'], ['free']]);
   });
 });

--- a/projects/code-sandbox/test/unit/python-native-isolation.test.ts
+++ b/projects/code-sandbox/test/unit/python-native-isolation.test.ts
@@ -1,13 +1,15 @@
-import { existsSync, mkdtempSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { spawnSync } from 'child_process';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   PYTHON_SANDBOX_GID,
   PYTHON_SANDBOX_UID,
   shouldEnablePythonNativeIsolation
 } from '../../src/isolated/python-isolation-config';
+
+vi.unmock('../../src/isolated/python-isolation-config');
 
 const nativeLibraryPath = join(process.cwd(), 'dist', 'fastgpt_python_sandbox.so');
 const shouldRunNativeIsolation =
@@ -34,9 +36,9 @@ import os
 import sys
 
 lib = ctypes.CDLL(${JSON.stringify(nativeLibraryPath)})
-lib.FastGPTInitPythonSandbox.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_int]
+lib.FastGPTInitPythonSandbox.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
 lib.FastGPTInitPythonSandbox.restype = ctypes.c_int
-ret = lib.FastGPTInitPythonSandbox(${PYTHON_SANDBOX_UID}, ${PYTHON_SANDBOX_GID}, 0)
+ret = lib.FastGPTInitPythonSandbox(${PYTHON_SANDBOX_UID}, ${PYTHON_SANDBOX_GID}, 0, 1)
 if ret != 0:
     print(json.dumps({"init": ret}))
     sys.exit(1)
@@ -53,10 +55,72 @@ print(json.dumps({"system_rc": rc}), flush=True)
       encoding: 'utf8',
       timeout: 5000
     });
+    rmSync(probeScript, { force: true });
+    rmSync(sandboxRoot, { recursive: true, force: true });
 
     expect(result.stdout).toContain(`"uid": ${PYTHON_SANDBOX_UID}`);
     expect(result.stdout).toContain(`"gid": ${PYTHON_SANDBOX_GID}`);
     expect(result.stdout).not.toContain('"system_rc": 0');
     expect(result.stdout + result.stderr).not.toMatch(/uid=\d+/);
+  });
+
+  it('显式禁用 seccomp 后仍保留 chroot 和降权', () => {
+    const sandboxRoot = mkdtempSync(join(tmpdir(), 'fastgpt-python-native-no-seccomp-'));
+    const probeScript = join(tmpdir(), `fastgpt-native-no-seccomp-${Date.now()}.py`);
+
+    writeFileSync(
+      probeScript,
+      `
+import ctypes
+import json
+import os
+import socket
+import sys
+
+lib = ctypes.CDLL(${JSON.stringify(nativeLibraryPath)})
+lib.FastGPTInitPythonSandbox.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+lib.FastGPTInitPythonSandbox.restype = ctypes.c_int
+ret = lib.FastGPTInitPythonSandbox(${PYTHON_SANDBOX_UID}, ${PYTHON_SANDBOX_GID}, 0, 0)
+if ret != 0:
+    print(json.dumps({"init": ret}))
+    sys.exit(1)
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.bind(("127.0.0.1", 0))
+try:
+    with open('/escape.txt', 'w') as file:
+        file.write('blocked')
+    write_error = None
+except OSError as exc:
+    write_error = exc.errno
+
+print(json.dumps({
+    "uid": os.getuid(),
+    "gid": os.getgid(),
+    "passwd_visible": os.path.exists('/etc/passwd'),
+    "socket_bound": True,
+    "write_error": write_error
+}), flush=True)
+`,
+      'utf8'
+    );
+
+    const result = spawnSync('python3', ['-u', probeScript], {
+      cwd: sandboxRoot,
+      encoding: 'utf8',
+      timeout: 5000
+    });
+    rmSync(probeScript, { force: true });
+    rmSync(sandboxRoot, { recursive: true, force: true });
+
+    expect(result.status, result.stderr).toBe(0);
+    const payload = JSON.parse(result.stdout.trim());
+    expect(payload).toMatchObject({
+      uid: PYTHON_SANDBOX_UID,
+      gid: PYTHON_SANDBOX_GID,
+      passwd_visible: false,
+      socket_bound: true
+    });
+    expect(payload.write_error).toBeTypeOf('number');
   });
 });

--- a/projects/code-sandbox/test/unit/seccomp-config.test.ts
+++ b/projects/code-sandbox/test/unit/seccomp-config.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+async function readSeccompConfig(disableValue: string | undefined) {
+  vi.resetModules();
+  vi.stubEnv('SANDBOX_DISABLE_SECCOMP', disableValue);
+  const { getSeccompConfig } = await import('../../src/isolated/seccomp-config');
+  return getSeccompConfig();
+}
+
+describe('getSeccompConfig', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('未配置时默认启用 seccomp', async () => {
+    await expect(readSeccompConfig(undefined)).resolves.toEqual({ enableSeccomp: true });
+  });
+
+  it('显式配置 false 时保持 seccomp 启用', async () => {
+    await expect(readSeccompConfig('false')).resolves.toEqual({ enableSeccomp: true });
+  });
+
+  it('只有显式 truthy 配置才禁用 seccomp', async () => {
+    await expect(readSeccompConfig('true')).resolves.toEqual({ enableSeccomp: false });
+    await expect(readSeccompConfig('1')).resolves.toEqual({ enableSeccomp: false });
+  });
+
+  it('拼写错误不会意外禁用 seccomp', async () => {
+    await expect(readSeccompConfig('treu')).resolves.toEqual({ enableSeccomp: true });
+  });
+});


### PR DESCRIPTION
Fixes #7256

Python code-sandbox 在部分内核上会因为 seccomp filter 加载失败而反复预热失败。这次修复把这类失败改成受控降级，并把降级状态暴露出来，避免启动卡死。