### PR TITLE
fix: clamp database connection pool size

### DIFF
--- a/document/content/self-host/config/env.en.mdx
+++ b/document/content/self-host/config/env.en.mdx
@@ -22,7 +22,7 @@ These variables are mainly validated by `packages/service/env.ts` and apply to `
 
 | Variable              | Default            | Description                                                                                                                                             |
 | --------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DB_MAX_LINK`         | `5`                | Maximum connection pool size for MongoDB, PG, OceanBase, openGauss, and other databases.                                                                |
+| `DB_MAX_LINK`         | `10`               | Maximum connection pool size for MongoDB, PG, OceanBase, openGauss, and other databases. Values are clamped to 10–1000.                                 |
 | `SYNC_INDEX`          | `true`             | Whether to create missing MongoDB indexes and remove explicitly declared deprecated indexes at startup. Maintain indexes manually when disabled.        |
 | `FILE_TOKEN_KEY`      | None, **required** | Secret for file read and file authorization flows. Must be at least 6 characters.                                                                       |
 | `AES256_SECRET_KEY`   | None, **required** | Secret used by AES encryption and decryption. Must be at least 6 characters.                                                                            |

--- a/document/content/self-host/config/env.mdx
+++ b/document/content/self-host/config/env.mdx
@@ -22,7 +22,7 @@ description: projects/app、projects/code-sandbox 与 pro/admin 环境变量说�
 
 | 变量                  | 默认值             | 说明                                                                                                  |
 | --------------------- | ------------------ | ----------------------------------------------------------------------------------------------------- |
-| `DB_MAX_LINK`         | `5`                | MongoDB、PG、OceanBase、openGauss 等数据库连接池最大连接数。                                          |
+| `DB_MAX_LINK`         | `10`               | MongoDB、PG、OceanBase、openGauss 等数据库连接池最大连接数，自动限制在 10～1000。                     |
 | `SYNC_INDEX`          | `true`             | 是否在启动时创建缺失的 MongoDB 索引并清理显式声明的废弃索引；关闭后需自行维护索引。                   |
 | `FILE_TOKEN_KEY`      | 无，**必填**       | 文件读取、文件鉴权相关密钥，长度至少 6 位。                                                           |
 | `AES256_SECRET_KEY`   | 无，**必填**       | AES 加解密密钥，长度至少 6 位。                                                                       |

--- a/packages/service/common/mongo/init.ts
+++ b/packages/service/common/mongo/init.ts
@@ -5,8 +5,6 @@ import { serviceEnv } from '../../env';
 
 const logger = getLogger(LogCategories.INFRA.MONGO);
 
-const maxConnecting = Math.max(5, serviceEnv.DB_MAX_LINK);
-
 /**
  * connect MongoDB and init data
  */
@@ -48,8 +46,8 @@ export async function connectMongo(props: {
 
     await db.connect(url, {
       bufferCommands: true,
-      maxConnecting: maxConnecting, // 最大连接数: 防止连接数过多时无法满足需求
-      maxPoolSize: maxConnecting, // 最大连接池大小: 防止连接池过大时无法满足需求
+      maxConnecting: serviceEnv.DB_MAX_LINK, // 最大连接数: 防止连接数过多时无法满足需求
+      maxPoolSize: serviceEnv.DB_MAX_LINK, // 最大连接池大小: 防止连接池过大时无法满足需求
       minPoolSize: 1,
       connectTimeoutMS: 60000, // 连接超时: 60秒,防止连接失败时长时间阻塞
       waitQueueTimeoutMS: 60000, // 等待队列超时: 60秒,防止等待队列长时间阻塞

--- a/packages/service/env.ts
+++ b/packages/service/env.ts
@@ -30,7 +30,9 @@ export const serviceEnv = createEnv({
   skipValidation: isPhaseProductionBuild,
   server: {
     // ==================== 基础配置 ====================
-    DB_MAX_LINK: IntSchema.min(1).default(5),
+    DB_MAX_LINK: NumSchema.int()
+      .default(10)
+      .transform((value) => Math.min(1000, Math.max(10, value))),
 
     // ==================== 密钥 ====================
     ROOT_KEY: z

--- a/packages/service/test/env.test.ts
+++ b/packages/service/test/env.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 const validInvokeTokenSecret = 'fastgpt_test_invoke_token_secret_32';
 
 const originalEnv = {
+  DB_MAX_LINK: process.env.DB_MAX_LINK,
   SYSTEM_MAX_STRING_LENGTH_M: process.env.SYSTEM_MAX_STRING_LENGTH_M,
   XLSX_PARSE_MAX_ROWS: process.env.XLSX_PARSE_MAX_ROWS,
   XLSX_PARSE_MAX_COLUMNS: process.env.XLSX_PARSE_MAX_COLUMNS,
@@ -47,6 +48,7 @@ const importServiceEnv = async () => {
 
 describe('serviceEnv', () => {
   afterEach(() => {
+    vi.stubEnv('DB_MAX_LINK', originalEnv.DB_MAX_LINK);
     vi.stubEnv('SYSTEM_MAX_STRING_LENGTH_M', originalEnv.SYSTEM_MAX_STRING_LENGTH_M);
     vi.stubEnv('XLSX_PARSE_MAX_ROWS', originalEnv.XLSX_PARSE_MAX_ROWS);
     vi.stubEnv('XLSX_PARSE_MAX_COLUMNS', originalEnv.XLSX_PARSE_MAX_COLUMNS);
@@ -86,6 +88,37 @@ describe('serviceEnv', () => {
     vi.stubEnv('AGENT_SANDBOX_APT_MIRROR', originalEnv.AGENT_SANDBOX_APT_MIRROR);
     vi.stubEnv('MILVUS_LANGUAGE_IDENTIFIER', originalEnv.MILVUS_LANGUAGE_IDENTIFIER);
     vi.stubEnv('MILVUS_ADDRESS', originalEnv.MILVUS_ADDRESS);
+  });
+
+  it('clamps DB_MAX_LINK to the supported connection pool range', async () => {
+    vi.stubEnv('FILE_TOKEN_KEY', 'filetokenkey');
+    vi.stubEnv('AES256_SECRET_KEY', 'fastgptsecret');
+    vi.stubEnv('INVOKE_TOKEN_SECRET', validInvokeTokenSecret);
+
+    vi.stubEnv('DB_MAX_LINK', undefined);
+    await expect(importServiceEnv()).resolves.toMatchObject({
+      serviceEnv: { DB_MAX_LINK: 10 }
+    });
+
+    vi.stubEnv('DB_MAX_LINK', '-1');
+    await expect(importServiceEnv()).resolves.toMatchObject({
+      serviceEnv: { DB_MAX_LINK: 10 }
+    });
+
+    vi.stubEnv('DB_MAX_LINK', '5');
+    await expect(importServiceEnv()).resolves.toMatchObject({
+      serviceEnv: { DB_MAX_LINK: 10 }
+    });
+
+    vi.stubEnv('DB_MAX_LINK', '20');
+    await expect(importServiceEnv()).resolves.toMatchObject({
+      serviceEnv: { DB_MAX_LINK: 20 }
+    });
+
+    vi.stubEnv('DB_MAX_LINK', '1001');
+    await expect(importServiceEnv()).resolves.toMatchObject({
+      serviceEnv: { DB_MAX_LINK: 1000 }
+    });
   });
 
   it('enables MongoDB index synchronization by default and supports disabling it', async () => {


### PR DESCRIPTION
## 背景

主 Mongo 连接同时承载多个 change stream。当 `DB_MAX_LINK=5` 时，长轮询可能占满连接池，使正常业务查询在连接池中等待并被记录为慢查询。

## 变更

- 在环境变量解析阶段将 `DB_MAX_LINK` 自动限制到 10–1000，默认值调整为 10
- Mongo 初始化直接使用解析后的 `serviceEnv.DB_MAX_LINK`
- 补充默认值、下限、正常值和上限转换测试
- 同步中英文环境变量文档

## 验证

- `pnpm test packages/service/test/env.test.ts`（22 tests passed）
- Prettier、ESLint、textlint、文档引用检查和 `git diff --check` 通过