### PR TITLE
fix(ai): require model type in selectors

### DIFF
--- a/projects/app/src/components/Select/AIModelSelector.tsx
+++ b/projects/app/src/components/Select/AIModelSelector.tsx
@@ -24,7 +24,7 @@ import { useUserModelStore } from '@/web/core/ai/model/useUserModelStore';
 import type { OutLinkChatAuthProps } from '@fastgpt/global/support/permission/chat';
 
 type Props = Omit<SelectProps, 'list'> & {
-  modelType?: ModelTypeEnum;
+  modelType: ModelTypeEnum;
   /** 迁移期限制模型范围；候选模型仍来自当前成员完整目录。 */
   list?: SelectProps['list'];
   disableTip?: string;
@@ -81,7 +81,7 @@ const ModelLabel = ({
 
 /** 通过统一 loader 校验完整目录，再使用 useUserModelStore 本地筛选和选择模型。 */
 const AIModelSelector = ({
-  modelType = ModelTypeEnum.llm,
+  modelType,
   list: restrictedList,
   onChange,
   disableTip,

--- a/projects/app/src/components/common/PromptEditor/OptimizerPopover/index.tsx
+++ b/projects/app/src/components/common/PromptEditor/OptimizerPopover/index.tsx
@@ -15,6 +15,7 @@ import { useUserModelStore } from '@/web/core/ai/model/useUserModelStore';
 import { useUserModelLists } from '@/web/core/ai/model/useUserModelLists';
 import { onOptimizePrompt } from '@/web/common/api/fetch';
 import MyTooltip from '@fastgpt/web/components/common/MyTooltip';
+import { ModelTypeEnum } from '@fastgpt/global/core/ai/constants';
 
 export type OptimizerPromptProps = {
   onChangeText: (text: string) => void;
@@ -218,6 +219,7 @@ const OptimizerPopover = ({
                     <Box flex={1} />
                     {modelOptions && modelOptions.length > 0 && (
                       <AIModelSelector
+                        modelType={ModelTypeEnum.llm}
                         borderColor={'transparent'}
                         _hover={{
                           border: '1px solid',

--- a/projects/app/src/components/core/ai/AISettingModal/index.tsx
+++ b/projects/app/src/components/core/ai/AISettingModal/index.tsx
@@ -33,7 +33,7 @@ import MySelect from '@fastgpt/web/components/common/MySelect';
 import MultipleSelect from '@fastgpt/web/components/common/MySelect/MultipleSelect';
 import JsonEditor from '@fastgpt/web/components/common/Textarea/JsonEditor';
 import { getLLMSupportParams } from '@fastgpt/global/core/ai/llm/utils';
-import { reasoningEffortList } from '@fastgpt/global/core/ai/constants';
+import { ModelTypeEnum, reasoningEffortList } from '@fastgpt/global/core/ai/constants';
 import type { ReasoningEffort } from '@fastgpt/global/core/ai/llm/type';
 import { findClientModelByValue } from '@/web/core/ai/model/modelReference';
 
@@ -272,6 +272,7 @@ const AIChatSettingsModal = ({
         <SectionCard title={t('app:ai_setting_basic_config')}>
           <SettingRow label={t('common:core.ai.Model')}>
             <AIModelSelector
+              modelType={ModelTypeEnum.llm}
               width={'100%'}
               h={'36px'}
               value={modelId}

--- a/projects/app/src/components/core/app/DatasetParamsModal.tsx
+++ b/projects/app/src/components/core/app/DatasetParamsModal.tsx
@@ -18,6 +18,7 @@ import { DatasetSearchModeEnum } from '@fastgpt/global/core/dataset/constants';
 import { useTranslation } from 'next-i18next';
 import { useUserModelStore } from '@/web/core/ai/model/useUserModelStore';
 import { useUserModelLists } from '@/web/core/ai/model/useUserModelLists';
+import { ModelTypeEnum } from '@fastgpt/global/core/ai/constants';
 
 import { NodeInputKeyEnum } from '@fastgpt/global/core/workflow/constants';
 import LightRowTabs from '@fastgpt/web/components/common/Tabs/LightRowTabs';
@@ -326,6 +327,7 @@ const DatasetParamsModal = ({
                     </Box>
                     <Box flex={'1 0 0'}>
                       <SelectAiModel
+                        modelType={ModelTypeEnum.rerank}
                         bg={'myGray.50'}
                         h={'36px'}
                         value={reRankModelIdWatch || rerankModel}
@@ -417,6 +419,7 @@ const DatasetParamsModal = ({
                   <FormLabel flex={['0 0 80px', '1 0 0']}>{t('common:core.ai.Model')}</FormLabel>
                   <Box flex={['1 0 0', '0 0 300px']}>
                     <SelectAiModel
+                      modelType={ModelTypeEnum.llm}
                       width={'100%'}
                       value={
                         queryExtensionModelId !== undefined

--- a/projects/app/src/pageComponents/app/detail/Edit/ChatAgent/ChatTest.tsx
+++ b/projects/app/src/pageComponents/app/detail/Edit/ChatAgent/ChatTest.tsx
@@ -34,6 +34,7 @@ import ProModal from '@/components/ProTip/ProModal';
 import ChatAIModelSelector from '@/pageComponents/chat/ChatWindow/ChatAIModelSelector';
 import { getErrText } from '@fastgpt/global/common/error/utils';
 import { findClientModelByValue } from '@/web/core/ai/model/modelReference';
+import { ModelTypeEnum } from '@fastgpt/global/core/ai/constants';
 
 type Props = {
   appForm: AppFormEditFormType;
@@ -106,6 +107,7 @@ const ChatTest = ({ appForm, setAppForm, setRenderEdit, form2WorkflowFn }: Props
     () => (
       <Box w={'fit-content'} maxW={'300px'} flex={'0 1 auto'} minW={0}>
         <ChatAIModelSelector
+          modelType={ModelTypeEnum.llm}
           h={'36px'}
           w={'fit-content'}
           maxW={'300px'}

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeCode/Copilot.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeCode/Copilot.tsx
@@ -36,6 +36,7 @@ import type {
   FlowNodeInputItemType,
   FlowNodeOutputItemType
 } from '@fastgpt/global/core/workflow/type/io';
+import { ModelTypeEnum } from '@fastgpt/global/core/ai/constants';
 
 export type OnOptimizeCodeProps = {
   optimizerInput: string;
@@ -364,6 +365,7 @@ const NodeCopilot = ({
             <Flex align="center" pb={2}>
               {modelOptions.length > 0 && (
                 <AIModelSelector
+                  modelType={ModelTypeEnum.llm}
                   borderColor="transparent"
                   _hover={{ border: '1px solid', borderColor: 'primary.400' }}
                   size="sm"

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodePluginIO/InputTypeConfig.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodePluginIO/InputTypeConfig.tsx
@@ -52,6 +52,7 @@ import InputSlider from '@fastgpt/web/components/common/MySlider/InputSlider';
 import { getUserFileAmountLimit } from '@fastgpt/global/core/workflow/fileLimit';
 import { canInputBeAgentGenerated } from '@fastgpt/global/core/app/formEdit/utils';
 import { getModelInputOptions } from './InputTypeConfig.utils';
+import { ModelTypeEnum } from '@fastgpt/global/core/ai/constants';
 
 const inputFormGridTemplateColumns = 'max-content minmax(0, 1fr)';
 
@@ -753,6 +754,7 @@ const InputTypeConfig = ({
                 inputType === FlowNodeInputTypeEnum.selectLLMModel) && (
                 <Box flex={'1'}>
                   <AIModelSelector
+                    modelType={ModelTypeEnum.llm}
                     value={defaultValue}
                     list={availableModels}
                     onChange={(model) => {

--- a/projects/app/src/pageComponents/chat/ChatWindow/HomeChatWindow.tsx
+++ b/projects/app/src/pageComponents/chat/ChatWindow/HomeChatWindow.tsx
@@ -53,6 +53,7 @@ import ChatWindowHeader from './ChatWindowHeader';
 import ToolMenu from '@/pageComponents/chat/ToolMenu';
 import MobileModelSelectorDrawer from './MobileModelSelectorDrawer';
 import { mobileChatHeaderIconButtonStyle } from './headerIconButtonStyle';
+import { ModelTypeEnum } from '@fastgpt/global/core/ai/constants';
 import { useSandboxEditor, useSandboxStatus } from '@/pageComponents/chat/SandboxEditor/hook';
 import { getDisplayHistoryTitle } from '@/web/core/chat/context/historyTitleUtils';
 import { ChatSourceTypeEnum } from '@fastgpt/global/core/chat/constants';
@@ -331,6 +332,7 @@ const HomeChatWindow = () => {
         {isPc && availableModels.length > 0 && (
           <Box w={'fit-content'} maxW={'300px'} flex={'0 1 auto'} minW={0}>
             <ChatAIModelSelector
+              modelType={ModelTypeEnum.llm}
               h={'36px'}
               w={'fit-content'}
               maxW={'300px'}

--- a/projects/app/src/pageComponents/dashboard/skill/detail/preview/SkillPreview.tsx
+++ b/projects/app/src/pageComponents/dashboard/skill/detail/preview/SkillPreview.tsx
@@ -25,6 +25,7 @@ import { defaultQGConfig, defaultWhisperConfig } from '@fastgpt/global/core/app/
 import { useRequest } from '@fastgpt/web/hooks/useRequest';
 import { getInitChatInfo } from '@/web/core/chat/api';
 import { findClientModelByValue } from '@/web/core/ai/model/modelReference';
+import { ModelTypeEnum } from '@fastgpt/global/core/ai/constants';
 
 const fileSelectConfig: AppFileSelectConfigType = {
   maxFiles: 10,
@@ -146,6 +147,7 @@ const SkillPreview = () => {
   const ModelSelectorInput = useMemo(() => {
     return (
       <ChatAIModelSelector
+        modelType={ModelTypeEnum.llm}
         h={'36px'}
         boxShadow={'none'}
         size={'sm'}

--- a/projects/app/test/components/core/app/DatasetParamsModal.test.ts
+++ b/projects/app/test/components/core/app/DatasetParamsModal.test.ts
@@ -1,0 +1,68 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DatasetSearchModeEnum } from '@fastgpt/global/core/dataset/constants';
+import { ModelTypeEnum } from '@fastgpt/global/core/ai/constants';
+
+const mocks = vi.hoisted(() => ({
+  selectAiModel: vi.fn()
+}));
+
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}));
+vi.mock('@/web/core/ai/model/useUserModelStore', () => ({
+  useUserModelStore: () => ({ defaultModels: {} })
+}));
+vi.mock('@/web/core/ai/model/useUserModelLists', () => ({
+  useUserModelLists: () => ({
+    llmModelList: [],
+    reRankModelList: [{ modelId: 'rerank-id', model: 'rerank-model', name: 'Rerank model' }]
+  })
+}));
+vi.mock('@/components/Select/AIModelSelector', () => ({
+  default: (props: unknown) => {
+    mocks.selectAiModel(props);
+    return null;
+  }
+}));
+vi.mock('@fastgpt/web/components/common/MyModal', () => ({
+  default: ({ children }: { children: React.ReactNode }) => children
+}));
+vi.mock('@chakra-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@chakra-ui/react')>();
+  return {
+    ...actual,
+    ModalBody: ({ children }: { children: React.ReactNode }) => children,
+    ModalFooter: ({ children }: { children: React.ReactNode }) => children
+  };
+});
+
+import DatasetParamsModal from '@/components/core/app/DatasetParamsModal';
+
+describe('DatasetParamsModal', () => {
+  beforeEach(() => {
+    mocks.selectAiModel.mockClear();
+  });
+
+  it('uses the rerank model type for the rerank selector', () => {
+    renderToStaticMarkup(
+      React.createElement(DatasetParamsModal, {
+        searchMode: DatasetSearchModeEnum.embedding,
+        usingReRank: true,
+        rerankModelId: 'rerank-id',
+        rerankWeight: 0.5,
+        onClose: vi.fn(),
+        onSuccess: vi.fn()
+      })
+    );
+
+    expect(mocks.selectAiModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelType: ModelTypeEnum.rerank,
+        value: 'rerank-id',
+        list: [{ value: 'rerank-id', label: 'Rerank model' }]
+      })
+    );
+  });
+});


### PR DESCRIPTION
## What

- make AIModelSelector modelType required and remove the implicit LLM default
- mark the dataset rerank selector as rerank so available rerank models are not filtered out
- complete every existing selector call site with its explicit model type
- add a regression test for the dataset rerank selector

## Why

The dataset parameter modal passed a rerank allowlist to AIModelSelector without specifying its model type. The selector then applied its implicit LLM filter, making the intersection empty even though the user model catalog contained rerank models.

Making modelType required turns future omissions into TypeScript errors instead of silent empty selector lists.

## Testing

- pnpm --dir projects/app typecheck
- pnpm test projects/app/test/components/core/app/DatasetParamsModal.test.ts projects/app/test/components/Select/AIModelSelector.utils.test.ts
- FASTGPT_TEST_SCOPE=app,global,service,web,repo pnpm test
- Prettier check and ESLint on all changed files