### PR TITLE
feat(migration): backfill resource owner ACLs

### DIFF
--- a/packages/global/openapi/support/user/team/api.ts
+++ b/packages/global/openapi/support/user/team/api.ts
@@ -265,7 +265,7 @@ export const TeamListItemSchema = z
       example: '68ad85a7463006c963799a07',
       description: '团队成员 ID'
     }),
-    role: z.enum(TeamMemberRoleEnum).optional().meta({
+    role: z.enum(TeamMemberRoleEnum).nullish().meta({
       example: TeamMemberRoleEnum.owner,
       description: '团队成员角色；历史数据可能未设置该废弃字段'
     }),

--- a/packages/global/test/openapi/support/user/api.test.ts
+++ b/packages/global/test/openapi/support/user/api.test.ts
@@ -378,6 +378,27 @@ describe('support user OpenAPI contracts', () => {
             hasWriteRole: true,
             hasReadRole: true
           }
+        },
+        {
+          userId: objectId,
+          teamId: objectId,
+          teamAvatar: null,
+          teamName: 'FastGPT 团队',
+          memberName: '普通成员',
+          avatar: null,
+          tmbId: objectId,
+          role: null,
+          status: 'active',
+          permission: {
+            role: 1,
+            isOwner: false,
+            hasManagePer: false,
+            hasWritePer: false,
+            hasReadPer: true,
+            hasManageRole: false,
+            hasWriteRole: false,
+            hasReadRole: true
+          }
         }
       ])
     ).toMatchObject([
@@ -387,6 +408,10 @@ describe('support user OpenAPI contracts', () => {
           status: 'pending',
           scheduledCancelAt: '2026-09-01T00:00:00.000Z'
         }
+      },
+      {
+        role: null,
+        memberName: '普通成员'
       }
     ]);
   });

--- a/packages/service/core/ai/skill/manage/import.ts
+++ b/packages/service/core/ai/skill/manage/import.ts
@@ -1,4 +1,5 @@
 import { AgentSkillSourceEnum, AgentSkillTypeEnum } from '@fastgpt/global/core/ai/skill/constants';
+import { PerResourceTypeEnum } from '@fastgpt/global/support/permission/constant';
 import type {
   RuntimeSkillMetadataType,
   SkillPackageType
@@ -10,6 +11,7 @@ import { MongoAgentSkills } from '../model/schema';
 import { createVersion } from '../version';
 import { updateCurrentVersion } from './update';
 import type { Readable } from 'node:stream';
+import { createResourcePermissions } from '../../../../support/permission/resourcePermissionService';
 
 type ImportSkillParams = {
   skill: SkillPackageType['skill'];
@@ -24,9 +26,9 @@ type ImportSkillParams = {
  * Import an opaque package stream as the initial Skill version.
  *
  * Import intentionally does not parse or validate package contents. This function uploads the
- * package before opening the Mongo transaction, then binds currentVersionId and removes the
- * temporary S3 TTL inside the transaction. If Mongo fails, the uploaded package keeps its TTL and
- * is cleaned by the shared S3 cleanup flow.
+ * package before opening the Mongo transaction, then creates the default ACL, binds currentVersionId,
+ * and removes the temporary S3 TTL inside the transaction. If Mongo fails, the uploaded package
+ * keeps its TTL and is cleaned by the shared S3 cleanup flow.
  * Runtime metadata remains empty until the workspace is saved and deployed from the edit sandbox.
  */
 export async function importSkill({
@@ -66,6 +68,18 @@ export async function importSkill({
 
   return mongoSessionRun(async (session) => {
     await newSkill.save({ session });
+
+    await createResourcePermissions({
+      resource: {
+        _id: newSkillId,
+        type: AgentSkillTypeEnum.skill,
+        teamId,
+        ...(parentId ? { parentId } : {})
+      },
+      tmbId,
+      resourceType: PerResourceTypeEnum.agentSkill,
+      session
+    });
 
     await updateCurrentVersion({
       skillId: newSkillId,

--- a/packages/service/test/core/ai/skill/controller.test.ts
+++ b/packages/service/test/core/ai/skill/controller.test.ts
@@ -15,6 +15,12 @@ import {
   AgentSkillSourceEnum,
   AgentSkillCategoryEnum
 } from '@fastgpt/global/core/ai/skill/constants';
+import {
+  OwnerRoleVal,
+  PerResourceTypeEnum,
+  ReadRoleVal
+} from '@fastgpt/global/support/permission/constant';
+import { MongoResourcePermission } from '@fastgpt/service/support/permission/schema';
 import { Readable } from 'node:stream';
 
 describe('AgentSkill Controller', () => {
@@ -31,7 +37,11 @@ describe('AgentSkill Controller', () => {
     const skillIds = await MongoAgentSkills.find({ teamId: testTeamId }, { _id: 1 }).lean();
     await Promise.all([
       MongoAgentSkills.deleteMany({ teamId: testTeamId }),
-      MongoAgentSkillsVersion.deleteMany({ skillId: { $in: skillIds.map((skill) => skill._id) } })
+      MongoAgentSkillsVersion.deleteMany({ skillId: { $in: skillIds.map((skill) => skill._id) } }),
+      MongoResourcePermission.deleteMany({
+        teamId: testTeamId,
+        resourceType: PerResourceTypeEnum.agentSkill
+      })
     ]);
   });
 
@@ -40,7 +50,11 @@ describe('AgentSkill Controller', () => {
     const skillIds = await MongoAgentSkills.find({ teamId: testTeamId }, { _id: 1 }).lean();
     await Promise.all([
       MongoAgentSkills.deleteMany({ teamId: testTeamId }),
-      MongoAgentSkillsVersion.deleteMany({ skillId: { $in: skillIds.map((skill) => skill._id) } })
+      MongoAgentSkillsVersion.deleteMany({ skillId: { $in: skillIds.map((skill) => skill._id) } }),
+      MongoResourcePermission.deleteMany({
+        teamId: testTeamId,
+        resourceType: PerResourceTypeEnum.agentSkill
+      })
     ]);
   });
 
@@ -364,6 +378,14 @@ describe('AgentSkill Controller', () => {
       expect(skill?.description).toBe(skillData.description);
       expect(skill?.source).toBe(AgentSkillSourceEnum.personal);
       expect(skill?.currentRuntimeSkills).toHaveLength(0);
+      await expect(
+        MongoResourcePermission.findOne({
+          teamId: testTeamId,
+          resourceType: PerResourceTypeEnum.agentSkill,
+          resourceId: skillId,
+          tmbId: testTmbId
+        }).lean()
+      ).resolves.toMatchObject({ permission: OwnerRoleVal });
     });
 
     it('should allow importing duplicate name without error', async () => {
@@ -394,6 +416,49 @@ describe('AgentSkill Controller', () => {
       expect(firstSkillId).toBeDefined();
       expect(secondSkillId).toBeDefined();
       expect(firstSkillId).not.toBe(secondSkillId);
+    });
+
+    it('should create owner permission and inherit parent collaborators', async () => {
+      const folder = await createSkillFolder({
+        name: 'Import Parent',
+        teamId: testTeamId,
+        tmbId: testTmbId
+      });
+      const collaboratorTmbId = new Types.ObjectId();
+      await MongoResourcePermission.create({
+        teamId: testTeamId,
+        resourceType: PerResourceTypeEnum.agentSkill,
+        resourceId: folder._id,
+        tmbId: collaboratorTmbId,
+        permission: ReadRoleVal
+      });
+
+      const skillId = await importSkill({
+        skill: {
+          name: 'Imported Child',
+          description: 'A child imported into a folder',
+          category: []
+        },
+        teamId: testTeamId,
+        tmbId: testTmbId,
+        parentId: folder._id.toString(),
+        packageStream: Readable.from(packageContent),
+        contentLength: packageContent.length
+      });
+
+      const permissions = await MongoResourcePermission.find({
+        teamId: testTeamId,
+        resourceType: PerResourceTypeEnum.agentSkill,
+        resourceId: skillId
+      }).lean();
+      expect(
+        new Map(permissions.map((permission) => [String(permission.tmbId), permission.permission]))
+      ).toEqual(
+        new Map([
+          [testTmbId, OwnerRoleVal],
+          [String(collaboratorTmbId), ReadRoleVal]
+        ])
+      );
     });
   });
 });

--- a/packages/web/i18n/en/system_migration.json
+++ b/packages/web/i18n/en/system_migration.json
@@ -70,5 +70,5 @@
   "migrations.20260905_backfill_resource_owner_acl.datasets": "Checking dataset owner permissions",
   "migrations.20260905_backfill_resource_owner_acl.agent_skills": "Checking agent skill owner permissions",
   "migrations.20260905_backfill_resource_owner_acl.validation": "Validating resource owner permissions",
-  "migrations.20260905_backfill_resource_owner_acl.result": "Checked owner permissions for {{appsProcessedCount}} apps, {{datasetsProcessedCount}} datasets, and {{agentSkillsProcessedCount}} agent skills."
+  "migrations.20260905_backfill_resource_owner_acl.result": "Checked {{appsProcessedCount}} apps, {{datasetsProcessedCount}} datasets, and {{agentSkillsProcessedCount}} skills. Backfilled owner permissions for {{appsUpdatedCount}} apps, {{datasetsUpdatedCount}} datasets, and {{agentSkillsUpdatedCount}} skills."
 }

--- a/packages/web/i18n/en/system_migration.json
+++ b/packages/web/i18n/en/system_migration.json
@@ -63,5 +63,12 @@
   "migrations.20260905_backfill_bill_metadata.name": "Backfill missing historical bill fields",
   "migrations.20260905_backfill_bill_metadata.description": "Backfills missing payment metadata on historical WeChat balance recharge bills.",
   "migrations.20260905_backfill_bill_metadata.bills": "Backfilling bill payment metadata",
-  "migrations.20260905_backfill_bill_metadata.result": "Backfilled payment metadata for {{migratedCount}} historical bills."
+  "migrations.20260905_backfill_bill_metadata.result": "Backfilled payment metadata for {{migratedCount}} historical bills.",
+  "migrations.20260905_backfill_resource_owner_acl.name": "Backfill resource owner permissions",
+  "migrations.20260905_backfill_resource_owner_acl.description": "Checks all apps, datasets, and agent skills and grants the current team owner ownership only when a resource has no valid member owner.",
+  "migrations.20260905_backfill_resource_owner_acl.apps": "Checking app owner permissions",
+  "migrations.20260905_backfill_resource_owner_acl.datasets": "Checking dataset owner permissions",
+  "migrations.20260905_backfill_resource_owner_acl.agent_skills": "Checking agent skill owner permissions",
+  "migrations.20260905_backfill_resource_owner_acl.validation": "Validating resource owner permissions",
+  "migrations.20260905_backfill_resource_owner_acl.result": "Checked owner permissions for {{appsProcessedCount}} apps, {{datasetsProcessedCount}} datasets, and {{agentSkillsProcessedCount}} agent skills."
 }

--- a/packages/web/i18n/en/system_migration.json
+++ b/packages/web/i18n/en/system_migration.json
@@ -65,7 +65,7 @@
   "migrations.20260905_backfill_bill_metadata.bills": "Backfilling bill payment metadata",
   "migrations.20260905_backfill_bill_metadata.result": "Backfilled payment metadata for {{migratedCount}} historical bills.",
   "migrations.20260905_backfill_resource_owner_acl.name": "Backfill resource owner permissions",
-  "migrations.20260905_backfill_resource_owner_acl.description": "Checks all apps, datasets, and agent skills and grants the current team owner ownership only when a resource has no valid member owner.",
+  "migrations.20260905_backfill_resource_owner_acl.description": "Checks all apps, datasets, and personal agent skills and grants the current team owner ownership only when a resource has no valid member owner.",
   "migrations.20260905_backfill_resource_owner_acl.apps": "Checking app owner permissions",
   "migrations.20260905_backfill_resource_owner_acl.datasets": "Checking dataset owner permissions",
   "migrations.20260905_backfill_resource_owner_acl.agent_skills": "Checking agent skill owner permissions",

--- a/packages/web/i18n/ko-KR/system_migration.json
+++ b/packages/web/i18n/ko-KR/system_migration.json
@@ -65,7 +65,7 @@
   "migrations.20260905_backfill_bill_metadata.bills": "결제 메타데이터 보완 중",
   "migrations.20260905_backfill_bill_metadata.result": "기존 결제 {{migratedCount}}건의 결제 메타데이터를 보완했습니다.",
   "migrations.20260905_backfill_resource_owner_acl.name": "리소스 소유자 권한 백필",
-  "migrations.20260905_backfill_resource_owner_acl.description": "모든 앱, 지식 베이스 및 Agent Skill을 확인하고 유효한 멤버 소유자가 없는 리소스에만 현재 팀 소유자 권한을 부여합니다.",
+  "migrations.20260905_backfill_resource_owner_acl.description": "모든 앱, 지식 베이스 및 개인 Agent Skill을 확인하고 유효한 멤버 소유자가 없는 리소스에만 현재 팀 소유자 권한을 부여합니다.",
   "migrations.20260905_backfill_resource_owner_acl.apps": "앱 소유자 권한 확인 중",
   "migrations.20260905_backfill_resource_owner_acl.datasets": "지식 베이스 소유자 권한 확인 중",
   "migrations.20260905_backfill_resource_owner_acl.agent_skills": "Agent Skill 소유자 권한 확인 중",

--- a/packages/web/i18n/ko-KR/system_migration.json
+++ b/packages/web/i18n/ko-KR/system_migration.json
@@ -70,5 +70,5 @@
   "migrations.20260905_backfill_resource_owner_acl.datasets": "지식 베이스 소유자 권한 확인 중",
   "migrations.20260905_backfill_resource_owner_acl.agent_skills": "Agent Skill 소유자 권한 확인 중",
   "migrations.20260905_backfill_resource_owner_acl.validation": "리소스 소유자 권한 검증 중",
-  "migrations.20260905_backfill_resource_owner_acl.result": "앱 {{appsProcessedCount}}개, 지식 베이스 {{datasetsProcessedCount}}개, Agent Skill {{agentSkillsProcessedCount}}개의 소유자 권한을 확인했습니다."
+  "migrations.20260905_backfill_resource_owner_acl.result": "앱 {{appsProcessedCount}}개, 지식 베이스 {{datasetsProcessedCount}}개, 스킬 {{agentSkillsProcessedCount}}개를 확인했습니다. 소유자 권한 보완: 앱 {{appsUpdatedCount}}개, 지식 베이스 {{datasetsUpdatedCount}}개, 스킬 {{agentSkillsUpdatedCount}}개."
 }

--- a/packages/web/i18n/ko-KR/system_migration.json
+++ b/packages/web/i18n/ko-KR/system_migration.json
@@ -63,5 +63,12 @@
   "migrations.20260905_backfill_bill_metadata.name": "기존 주문의 누락 필드 보완",
   "migrations.20260905_backfill_bill_metadata.description": "기존 WeChat 잔액 충전 결제의 누락된 결제 메타데이터를 보완합니다.",
   "migrations.20260905_backfill_bill_metadata.bills": "결제 메타데이터 보완 중",
-  "migrations.20260905_backfill_bill_metadata.result": "기존 결제 {{migratedCount}}건의 결제 메타데이터를 보완했습니다."
+  "migrations.20260905_backfill_bill_metadata.result": "기존 결제 {{migratedCount}}건의 결제 메타데이터를 보완했습니다.",
+  "migrations.20260905_backfill_resource_owner_acl.name": "리소스 소유자 권한 백필",
+  "migrations.20260905_backfill_resource_owner_acl.description": "모든 앱, 지식 베이스 및 Agent Skill을 확인하고 유효한 멤버 소유자가 없는 리소스에만 현재 팀 소유자 권한을 부여합니다.",
+  "migrations.20260905_backfill_resource_owner_acl.apps": "앱 소유자 권한 확인 중",
+  "migrations.20260905_backfill_resource_owner_acl.datasets": "지식 베이스 소유자 권한 확인 중",
+  "migrations.20260905_backfill_resource_owner_acl.agent_skills": "Agent Skill 소유자 권한 확인 중",
+  "migrations.20260905_backfill_resource_owner_acl.validation": "리소스 소유자 권한 검증 중",
+  "migrations.20260905_backfill_resource_owner_acl.result": "앱 {{appsProcessedCount}}개, 지식 베이스 {{datasetsProcessedCount}}개, Agent Skill {{agentSkillsProcessedCount}}개의 소유자 권한을 확인했습니다."
 }

--- a/packages/web/i18n/zh-CN/system_migration.json
+++ b/packages/web/i18n/zh-CN/system_migration.json
@@ -65,7 +65,7 @@
   "migrations.20260905_backfill_bill_metadata.bills": "回填账单支付元数据",
   "migrations.20260905_backfill_bill_metadata.result": "已为 {{migratedCount}} 条历史账单回填支付元数据。",
   "migrations.20260905_backfill_resource_owner_acl.name": "补齐资源所有者权限",
-  "migrations.20260905_backfill_resource_owner_acl.description": "检查全部应用、知识库和 Agent Skill，仅在资源缺少有效成员所有者时为当前团队所有者补齐权限。",
+  "migrations.20260905_backfill_resource_owner_acl.description": "检查全部应用、知识库和个人 Agent Skill，仅在资源缺少有效成员所有者时为当前团队所有者补齐权限。",
   "migrations.20260905_backfill_resource_owner_acl.apps": "检查应用所有者权限",
   "migrations.20260905_backfill_resource_owner_acl.datasets": "检查知识库所有者权限",
   "migrations.20260905_backfill_resource_owner_acl.agent_skills": "检查 Agent Skill 所有者权限",

--- a/packages/web/i18n/zh-CN/system_migration.json
+++ b/packages/web/i18n/zh-CN/system_migration.json
@@ -63,5 +63,12 @@
   "migrations.20260905_backfill_bill_metadata.name": "回填历史订单缺失字段",
   "migrations.20260905_backfill_bill_metadata.description": "为历史微信余额充值账单回填缺失的支付元数据。",
   "migrations.20260905_backfill_bill_metadata.bills": "回填账单支付元数据",
-  "migrations.20260905_backfill_bill_metadata.result": "已为 {{migratedCount}} 条历史账单回填支付元数据。"
+  "migrations.20260905_backfill_bill_metadata.result": "已为 {{migratedCount}} 条历史账单回填支付元数据。",
+  "migrations.20260905_backfill_resource_owner_acl.name": "补齐资源所有者权限",
+  "migrations.20260905_backfill_resource_owner_acl.description": "检查全部应用、知识库和 Agent Skill，仅在资源缺少有效成员所有者时为当前团队所有者补齐权限。",
+  "migrations.20260905_backfill_resource_owner_acl.apps": "检查应用所有者权限",
+  "migrations.20260905_backfill_resource_owner_acl.datasets": "检查知识库所有者权限",
+  "migrations.20260905_backfill_resource_owner_acl.agent_skills": "检查 Agent Skill 所有者权限",
+  "migrations.20260905_backfill_resource_owner_acl.validation": "校验资源所有者权限",
+  "migrations.20260905_backfill_resource_owner_acl.result": "已检查 {{appsProcessedCount}} 个应用、{{datasetsProcessedCount}} 个知识库和 {{agentSkillsProcessedCount}} 个 Agent Skill 的所有者权限。"
 }

--- a/packages/web/i18n/zh-CN/system_migration.json
+++ b/packages/web/i18n/zh-CN/system_migration.json
@@ -70,5 +70,5 @@
   "migrations.20260905_backfill_resource_owner_acl.datasets": "检查知识库所有者权限",
   "migrations.20260905_backfill_resource_owner_acl.agent_skills": "检查 Agent Skill 所有者权限",
   "migrations.20260905_backfill_resource_owner_acl.validation": "校验资源所有者权限",
-  "migrations.20260905_backfill_resource_owner_acl.result": "已检查 {{appsProcessedCount}} 个应用、{{datasetsProcessedCount}} 个知识库和 {{agentSkillsProcessedCount}} 个 Agent Skill 的所有者权限。"
+  "migrations.20260905_backfill_resource_owner_acl.result": "已检查 {{appsProcessedCount}} 个应用、{{datasetsProcessedCount}} 个知识库和 {{agentSkillsProcessedCount}} 个技能。补齐所有者权限：{{appsUpdatedCount}} 个应用、{{datasetsUpdatedCount}} 个知识库和 {{agentSkillsUpdatedCount}} 个技能。"
 }

--- a/packages/web/i18n/zh-Hant/system_migration.json
+++ b/packages/web/i18n/zh-Hant/system_migration.json
@@ -63,5 +63,12 @@
   "migrations.20260905_backfill_bill_metadata.name": "回填歷史訂單缺失欄位",
   "migrations.20260905_backfill_bill_metadata.description": "為歷史微信餘額儲值帳單回填缺失的支付後設資料。",
   "migrations.20260905_backfill_bill_metadata.bills": "回填帳單支付後設資料",
-  "migrations.20260905_backfill_bill_metadata.result": "已為 {{migratedCount}} 筆歷史帳單回填支付後設資料。"
+  "migrations.20260905_backfill_bill_metadata.result": "已為 {{migratedCount}} 筆歷史帳單回填支付後設資料。",
+  "migrations.20260905_backfill_resource_owner_acl.name": "補齊資源擁有者權限",
+  "migrations.20260905_backfill_resource_owner_acl.description": "檢查全部應用、知識庫和 Agent Skill，僅在資源缺少有效成員擁有者時為目前團隊擁有者補齊權限。",
+  "migrations.20260905_backfill_resource_owner_acl.apps": "檢查應用擁有者權限",
+  "migrations.20260905_backfill_resource_owner_acl.datasets": "檢查知識庫擁有者權限",
+  "migrations.20260905_backfill_resource_owner_acl.agent_skills": "檢查 Agent Skill 擁有者權限",
+  "migrations.20260905_backfill_resource_owner_acl.validation": "驗證資源擁有者權限",
+  "migrations.20260905_backfill_resource_owner_acl.result": "已檢查 {{appsProcessedCount}} 個應用、{{datasetsProcessedCount}} 個知識庫和 {{agentSkillsProcessedCount}} 個 Agent Skill 的擁有者權限。"
 }

--- a/packages/web/i18n/zh-Hant/system_migration.json
+++ b/packages/web/i18n/zh-Hant/system_migration.json
@@ -65,7 +65,7 @@
   "migrations.20260905_backfill_bill_metadata.bills": "回填帳單支付後設資料",
   "migrations.20260905_backfill_bill_metadata.result": "已為 {{migratedCount}} 筆歷史帳單回填支付後設資料。",
   "migrations.20260905_backfill_resource_owner_acl.name": "補齊資源擁有者權限",
-  "migrations.20260905_backfill_resource_owner_acl.description": "檢查全部應用、知識庫和 Agent Skill，僅在資源缺少有效成員擁有者時為目前團隊擁有者補齊權限。",
+  "migrations.20260905_backfill_resource_owner_acl.description": "檢查全部應用、知識庫和個人 Agent Skill，僅在資源缺少有效成員擁有者時為目前團隊擁有者補齊權限。",
   "migrations.20260905_backfill_resource_owner_acl.apps": "檢查應用擁有者權限",
   "migrations.20260905_backfill_resource_owner_acl.datasets": "檢查知識庫擁有者權限",
   "migrations.20260905_backfill_resource_owner_acl.agent_skills": "檢查 Agent Skill 擁有者權限",

--- a/packages/web/i18n/zh-Hant/system_migration.json
+++ b/packages/web/i18n/zh-Hant/system_migration.json
@@ -70,5 +70,5 @@
   "migrations.20260905_backfill_resource_owner_acl.datasets": "檢查知識庫擁有者權限",
   "migrations.20260905_backfill_resource_owner_acl.agent_skills": "檢查 Agent Skill 擁有者權限",
   "migrations.20260905_backfill_resource_owner_acl.validation": "驗證資源擁有者權限",
-  "migrations.20260905_backfill_resource_owner_acl.result": "已檢查 {{appsProcessedCount}} 個應用、{{datasetsProcessedCount}} 個知識庫和 {{agentSkillsProcessedCount}} 個 Agent Skill 的擁有者權限。"
+  "migrations.20260905_backfill_resource_owner_acl.result": "已檢查 {{appsProcessedCount}} 個應用、{{datasetsProcessedCount}} 個知識庫和 {{agentSkillsProcessedCount}} 個技能。補齊擁有者權限：{{appsUpdatedCount}} 個應用、{{datasetsUpdatedCount}} 個知識庫和 {{agentSkillsUpdatedCount}} 個技能。"
 }

--- a/projects/app/src/migration/registry.ts
+++ b/projects/app/src/migration/registry.ts
@@ -14,6 +14,7 @@ import { backfillEvaluationModelReferences } from './tasks/20260903_backfill_eva
 import { backfillAppModelReferences } from './tasks/20260903_backfill_app_model_references';
 import { backfillAppCreateTime } from './tasks/4170/20260903_backfill_app_create_time';
 import { backfillBillMetadata } from './tasks/4170/20260905_backfill_bill_metadata';
+import { backfillResourceOwnerAcl } from './tasks/4170/20260905_backfill_resource_owner_acl';
 
 export type SystemMigrationLogger = {
   info: (message: string, metadata?: Record<string, unknown>) => void;
@@ -245,6 +246,40 @@ export const systemMigrations = [
     blockStartup: false,
     onFailure: SystemMigrationFailurePolicyEnum.continue,
     run: backfillBillMetadata
+  },
+  {
+    id: '20260905_backfill_resource_owner_acl',
+    version: '4.17.0',
+    nameKey: i18nT('system_migration:migrations.20260905_backfill_resource_owner_acl.name'),
+    descriptionKey: i18nT(
+      'system_migration:migrations.20260905_backfill_resource_owner_acl.description'
+    ),
+    resultKey: i18nT('system_migration:migrations.20260905_backfill_resource_owner_acl.result'),
+    progressSteps: [
+      {
+        key: 'apps',
+        labelKey: i18nT('system_migration:migrations.20260905_backfill_resource_owner_acl.apps')
+      },
+      {
+        key: 'datasets',
+        labelKey: i18nT('system_migration:migrations.20260905_backfill_resource_owner_acl.datasets')
+      },
+      {
+        key: 'agent_skills',
+        labelKey: i18nT(
+          'system_migration:migrations.20260905_backfill_resource_owner_acl.agent_skills'
+        )
+      },
+      {
+        key: 'validation',
+        labelKey: i18nT(
+          'system_migration:migrations.20260905_backfill_resource_owner_acl.validation'
+        )
+      }
+    ],
+    blockStartup: false,
+    onFailure: SystemMigrationFailurePolicyEnum.continue,
+    run: backfillResourceOwnerAcl
   }
 ] as const satisfies readonly SystemMigration[];
 

--- a/projects/app/src/migration/tasks/4170/20260905_backfill_resource_owner_acl/index.ts
+++ b/projects/app/src/migration/tasks/4170/20260905_backfill_resource_owner_acl/index.ts
@@ -1,0 +1,349 @@
+import {
+  systemMigrationLimits,
+  SystemMigrationStatusEnum
+} from '@fastgpt/global/migration/constants';
+import type { SystemMigrationFailedRecord } from '@fastgpt/global/migration/schema';
+import { Types } from '@fastgpt/service/common/mongo';
+import { systemMigrationBatchSize } from '@/migration/constants';
+import type { SystemMigrationContext } from '@/migration/registry';
+import { z } from 'zod';
+import {
+  backfillResourceOwnerAclRecords,
+  findValidOwnerResourceIds,
+  initializeResourceOwnerAclSnapshot,
+  readInvalidResourceOwnerAclRecords,
+  readResourceOwnerAclBatch,
+  resourceOwnerAclConfigs,
+  type ResourceOwnerAclConfig,
+  type ResourceOwnerAclFailure,
+  type ResourceOwnerAclRecord
+} from './service';
+
+const VALIDATION_STAGE_KEY = 'validation';
+const READ_CONCURRENCY = 20;
+
+const StageCheckpointSchema = z.object({
+  endId: z.string().nullable(),
+  lastId: z.string().nullable(),
+  processedCount: z.number().int().nonnegative(),
+  total: z.number().int().nonnegative()
+});
+
+const ResourceOwnerAclCheckpointSchema = z.object({
+  version: z.literal(1),
+  initialized: z.boolean(),
+  stages: z.object({
+    apps: StageCheckpointSchema,
+    datasets: StageCheckpointSchema,
+    agent_skills: StageCheckpointSchema
+  })
+});
+
+type ResourceOwnerAclCheckpoint = z.infer<typeof ResourceOwnerAclCheckpointSchema>;
+
+const emptyStageCheckpoint = () => ({
+  endId: null,
+  lastId: null,
+  processedCount: 0,
+  total: 0
+});
+
+const getFailedRecordKey = (record: SystemMigrationFailedRecord) =>
+  `${record.stageKey}:${String(record.data.resourceId)}`;
+
+const createFailedRecord = ({
+  config,
+  failure
+}: {
+  config: ResourceOwnerAclConfig;
+  failure: ResourceOwnerAclFailure;
+}): SystemMigrationFailedRecord => ({
+  stageKey: config.stageKey,
+  data: {
+    collection: config.model.collection.name,
+    resourceType: config.resourceType,
+    resourceId: String(failure.record._id),
+    teamId: failure.record.teamId == null ? null : String(failure.record.teamId)
+  },
+  reason: {
+    message: failure.message.slice(0, systemMigrationLimits.maxErrorMessageLength)
+  }
+});
+
+/**
+ * 分批扫描全部 App、Dataset 和 Agent Skill，仅为没有有效成员 owner 的资源补 team owner。
+ * 固定快照负责断点恢复，尾扫与最终校验覆盖滚动升级期间的新增数据。
+ */
+export const backfillResourceOwnerAcl = async (context: SystemMigrationContext) => {
+  let checkpoint: ResourceOwnerAclCheckpoint = (await context.getCheckpoint(
+    ResourceOwnerAclCheckpointSchema
+  )) ?? {
+    version: 1,
+    initialized: false,
+    stages: {
+      apps: emptyStageCheckpoint(),
+      datasets: emptyStageCheckpoint(),
+      agent_skills: emptyStageCheckpoint()
+    }
+  };
+
+  if (!checkpoint.initialized) {
+    const snapshots = await Promise.all(
+      resourceOwnerAclConfigs.map(initializeResourceOwnerAclSnapshot)
+    );
+    checkpoint = {
+      version: 1,
+      initialized: true,
+      stages: {
+        apps: { ...emptyStageCheckpoint(), ...snapshots[0] },
+        datasets: { ...emptyStageCheckpoint(), ...snapshots[1] },
+        agent_skills: { ...emptyStageCheckpoint(), ...snapshots[2] }
+      }
+    };
+    await context.saveCheckpoint(checkpoint);
+  }
+
+  const failedRecordMap = new Map(
+    (await context.getFailedRecords()).map((record) => [getFailedRecordKey(record), record])
+  );
+  const replaceStageFailures = ({
+    config,
+    records,
+    failures
+  }: {
+    config: ResourceOwnerAclConfig;
+    records: ResourceOwnerAclRecord[];
+    failures: ResourceOwnerAclFailure[];
+  }) => {
+    for (const record of records) {
+      failedRecordMap.delete(`${config.stageKey}:${String(record._id)}`);
+    }
+    for (const failure of failures) {
+      const failedRecord = createFailedRecord({ config, failure });
+      failedRecordMap.set(getFailedRecordKey(failedRecord), failedRecord);
+    }
+  };
+  const processRecords = async ({
+    config,
+    records
+  }: {
+    config: ResourceOwnerAclConfig;
+    records: ResourceOwnerAclRecord[];
+  }) => {
+    const result = await backfillResourceOwnerAclRecords({ config, records });
+    replaceStageFailures({ config, records, failures: result.failures });
+  };
+  const readFailedRecord = async ({
+    config,
+    failedRecord
+  }: {
+    config: ResourceOwnerAclConfig;
+    failedRecord: SystemMigrationFailedRecord;
+  }) => {
+    const resourceId = String(failedRecord.data.resourceId);
+    const id = Types.ObjectId.isValid(resourceId) ? new Types.ObjectId(resourceId) : resourceId;
+    return config.model.collection.findOne(
+      { _id: id as never },
+      { projection: { _id: 1, teamId: 1 } }
+    );
+  };
+  const readFailedRecords = async ({
+    config,
+    failedRecords
+  }: {
+    config: ResourceOwnerAclConfig;
+    failedRecords: SystemMigrationFailedRecord[];
+  }) => {
+    const records: Array<Awaited<ReturnType<typeof readFailedRecord>>> = [];
+    for (let index = 0; index < failedRecords.length; index += READ_CONCURRENCY) {
+      records.push(
+        ...(await Promise.all(
+          failedRecords
+            .slice(index, index + READ_CONCURRENCY)
+            .map((failedRecord) => readFailedRecord({ config, failedRecord }))
+        ))
+      );
+    }
+    return records;
+  };
+
+  for (const config of resourceOwnerAclConfigs) {
+    const stageCheckpoint = checkpoint.stages[config.stageKey];
+    await context.reportProgress({
+      key: config.stageKey,
+      status: SystemMigrationStatusEnum.running,
+      current: stageCheckpoint.processedCount,
+      total: stageCheckpoint.total
+    });
+
+    const stageFailedRecords = [...failedRecordMap.values()].filter(
+      (record) => record.stageKey === config.stageKey
+    );
+    for (let index = 0; index < stageFailedRecords.length; index += systemMigrationBatchSize) {
+      await context.assertActive();
+      const retryFailedRecords = stageFailedRecords.slice(index, index + systemMigrationBatchSize);
+      const retryRecords = (
+        await readFailedRecords({ config, failedRecords: retryFailedRecords })
+      ).flatMap<ResourceOwnerAclRecord>((record) =>
+        record ? [{ _id: record._id, teamId: record.teamId }] : []
+      );
+      for (const failedRecord of retryFailedRecords) {
+        failedRecordMap.delete(getFailedRecordKey(failedRecord));
+      }
+      await processRecords({ config, records: retryRecords });
+      await context.reportFailedRecords([...failedRecordMap.values()]);
+    }
+
+    while (stageCheckpoint.endId && stageCheckpoint.lastId !== stageCheckpoint.endId) {
+      await context.assertActive();
+      const records = await readResourceOwnerAclBatch({
+        config,
+        endId: stageCheckpoint.endId,
+        lastId: stageCheckpoint.lastId,
+        limit: systemMigrationBatchSize
+      });
+      if (records.length === 0) break;
+
+      await processRecords({ config, records });
+      stageCheckpoint.lastId = String(records.at(-1)!._id);
+      stageCheckpoint.processedCount += records.length;
+      checkpoint.stages[config.stageKey] = stageCheckpoint;
+      await context.reportFailedRecords([...failedRecordMap.values()]);
+      await context.saveCheckpoint(checkpoint);
+      await context.reportProgress({
+        key: config.stageKey,
+        status: SystemMigrationStatusEnum.running,
+        current: stageCheckpoint.processedCount,
+        total: stageCheckpoint.total
+      });
+    }
+
+    let tailLastId: string | null = null;
+    while (true) {
+      await context.assertActive();
+      const records = await readResourceOwnerAclBatch({
+        config,
+        lastId: tailLastId,
+        limit: systemMigrationBatchSize
+      });
+      if (records.length === 0) break;
+      await processRecords({ config, records });
+      await context.reportFailedRecords([...failedRecordMap.values()]);
+      tailLastId = String(records.at(-1)!._id);
+    }
+
+    let invalidLastId: unknown;
+    while (true) {
+      await context.assertActive();
+      const invalidRecords = await readInvalidResourceOwnerAclRecords({
+        config,
+        lastId: invalidLastId,
+        limit: systemMigrationBatchSize
+      });
+      if (invalidRecords.length === 0) break;
+      replaceStageFailures({
+        config,
+        records: invalidRecords,
+        failures: invalidRecords.map((record) => ({
+          record,
+          message: 'Resource _id is not an ObjectId'
+        }))
+      });
+      await context.reportFailedRecords([...failedRecordMap.values()]);
+      invalidLastId = invalidRecords.at(-1)!._id;
+    }
+    checkpoint.stages[config.stageKey] = stageCheckpoint;
+    await context.saveCheckpoint(checkpoint);
+    await context.reportProgress({
+      key: config.stageKey,
+      status: SystemMigrationStatusEnum.succeeded,
+      current: stageCheckpoint.total,
+      total: stageCheckpoint.total
+    });
+  }
+
+  await context.reportProgress({
+    key: VALIDATION_STAGE_KEY,
+    status: SystemMigrationStatusEnum.running
+  });
+  for (const config of resourceOwnerAclConfigs) {
+    let validationLastId: string | null = null;
+    while (true) {
+      await context.assertActive();
+      const records = await readResourceOwnerAclBatch({
+        config,
+        lastId: validationLastId,
+        limit: systemMigrationBatchSize
+      });
+      if (records.length === 0) break;
+
+      const validOwnerResourceIds = await findValidOwnerResourceIds({ config, records });
+      for (const record of records) {
+        const failureKey = `${config.stageKey}:${String(record._id)}`;
+        if (validOwnerResourceIds.has(String(record._id))) {
+          failedRecordMap.delete(failureKey);
+        } else if (!failedRecordMap.has(failureKey)) {
+          const failedRecord = createFailedRecord({
+            config,
+            failure: { record, message: 'Resource still has no valid member Owner ACL' }
+          });
+          failedRecordMap.set(failureKey, failedRecord);
+        }
+      }
+      await context.reportFailedRecords([...failedRecordMap.values()]);
+      validationLastId = String(records.at(-1)!._id);
+    }
+
+    let invalidLastId: unknown;
+    while (true) {
+      await context.assertActive();
+      const invalidRecords = await readInvalidResourceOwnerAclRecords({
+        config,
+        lastId: invalidLastId,
+        limit: systemMigrationBatchSize
+      });
+      if (invalidRecords.length === 0) break;
+      replaceStageFailures({
+        config,
+        records: invalidRecords,
+        failures: invalidRecords.map((record) => ({
+          record,
+          message: 'Resource _id is not an ObjectId'
+        }))
+      });
+      await context.reportFailedRecords([...failedRecordMap.values()]);
+      invalidLastId = invalidRecords.at(-1)!._id;
+    }
+
+    const stageFailedRecords = [...failedRecordMap.values()].filter(
+      (record) => record.stageKey === config.stageKey
+    );
+    for (let index = 0; index < stageFailedRecords.length; index += systemMigrationBatchSize) {
+      await context.assertActive();
+      const records = stageFailedRecords.slice(index, index + systemMigrationBatchSize);
+      const currentResources = await readFailedRecords({ config, failedRecords: records });
+      records.forEach((failedRecord, recordIndex) => {
+        if (!currentResources[recordIndex]) {
+          failedRecordMap.delete(getFailedRecordKey(failedRecord));
+        }
+      });
+      await context.reportFailedRecords([...failedRecordMap.values()]);
+    }
+  }
+  if (failedRecordMap.size > 0) {
+    await context.fail({
+      message: `${failedRecordMap.size} resources still lack a valid member Owner ACL`,
+      failedRecords: [...failedRecordMap.values()]
+    });
+  }
+  await context.reportProgress({
+    key: VALIDATION_STAGE_KEY,
+    status: SystemMigrationStatusEnum.succeeded
+  });
+
+  return {
+    appsProcessedCount: checkpoint.stages.apps.processedCount,
+    datasetsProcessedCount: checkpoint.stages.datasets.processedCount,
+    agentSkillsProcessedCount: checkpoint.stages.agent_skills.processedCount
+  };
+};

--- a/projects/app/src/migration/tasks/4170/20260905_backfill_resource_owner_acl/index.ts
+++ b/projects/app/src/migration/tasks/4170/20260905_backfill_resource_owner_acl/index.ts
@@ -26,6 +26,7 @@ const StageCheckpointSchema = z.object({
   endId: z.string().nullable(),
   lastId: z.string().nullable(),
   processedCount: z.number().int().nonnegative(),
+  updatedCount: z.number().int().nonnegative().default(0),
   total: z.number().int().nonnegative()
 });
 
@@ -45,6 +46,7 @@ const emptyStageCheckpoint = () => ({
   endId: null,
   lastId: null,
   processedCount: 0,
+  updatedCount: 0,
   total: 0
 });
 
@@ -164,6 +166,7 @@ export const backfillResourceOwnerAcl = async (context: SystemMigrationContext) 
   }) => {
     const result = await backfillResourceOwnerAclRecords({ config, records });
     replaceStageFailures({ config, records, failures: result.failures });
+    return result.updatedCount;
   };
   const readFailedRecord = async ({
     config,
@@ -226,8 +229,13 @@ export const backfillResourceOwnerAcl = async (context: SystemMigrationContext) 
           deleteFailedRecord(getFailedRecordKey(failedRecord));
         }
       });
-      await processRecords({ config, records: retryRecords });
+      const updatedCount = await processRecords({ config, records: retryRecords });
+      stageCheckpoint.updatedCount += updatedCount;
+      checkpoint.stages[config.stageKey] = stageCheckpoint;
       await reportFailedRecordsIfChanged();
+      if (updatedCount > 0) {
+        await context.saveCheckpoint(checkpoint);
+      }
     }
 
     while (stageCheckpoint.endId && stageCheckpoint.lastId !== stageCheckpoint.endId) {
@@ -240,9 +248,10 @@ export const backfillResourceOwnerAcl = async (context: SystemMigrationContext) 
       });
       if (records.length === 0) break;
 
-      await processRecords({ config, records });
+      const updatedCount = await processRecords({ config, records });
       stageCheckpoint.lastId = String(records.at(-1)!._id);
       stageCheckpoint.processedCount += records.length;
+      stageCheckpoint.updatedCount += updatedCount;
       checkpoint.stages[config.stageKey] = stageCheckpoint;
       await reportFailedRecordsIfChanged();
       await context.saveCheckpoint(checkpoint);
@@ -263,8 +272,13 @@ export const backfillResourceOwnerAcl = async (context: SystemMigrationContext) 
         limit: systemMigrationBatchSize
       });
       if (records.length === 0) break;
-      await processRecords({ config, records });
+      const updatedCount = await processRecords({ config, records });
+      stageCheckpoint.updatedCount += updatedCount;
+      checkpoint.stages[config.stageKey] = stageCheckpoint;
       await reportFailedRecordsIfChanged();
+      if (updatedCount > 0) {
+        await context.saveCheckpoint(checkpoint);
+      }
       tailLastId = String(records.at(-1)!._id);
     }
 
@@ -381,6 +395,9 @@ export const backfillResourceOwnerAcl = async (context: SystemMigrationContext) 
   return {
     appsProcessedCount: checkpoint.stages.apps.processedCount,
     datasetsProcessedCount: checkpoint.stages.datasets.processedCount,
-    agentSkillsProcessedCount: checkpoint.stages.agent_skills.processedCount
+    agentSkillsProcessedCount: checkpoint.stages.agent_skills.processedCount,
+    appsUpdatedCount: checkpoint.stages.apps.updatedCount,
+    datasetsUpdatedCount: checkpoint.stages.datasets.updatedCount,
+    agentSkillsUpdatedCount: checkpoint.stages.agent_skills.updatedCount
   };
 };

--- a/projects/app/src/migration/tasks/4170/20260905_backfill_resource_owner_acl/index.ts
+++ b/projects/app/src/migration/tasks/4170/20260905_backfill_resource_owner_acl/index.ts
@@ -71,7 +71,7 @@ const createFailedRecord = ({
 });
 
 /**
- * 分批扫描全部 App、Dataset 和 Agent Skill，仅为没有有效成员 owner 的资源补 team owner。
+ * 分批扫描全部 App、Dataset 和 personal Agent Skill，仅为没有有效成员 owner 的资源补 team owner。
  * 固定快照负责断点恢复，尾扫与最终校验覆盖滚动升级期间的新增数据。
  */
 export const backfillResourceOwnerAcl = async (context: SystemMigrationContext) => {
@@ -106,6 +106,34 @@ export const backfillResourceOwnerAcl = async (context: SystemMigrationContext) 
   const failedRecordMap = new Map(
     (await context.getFailedRecords()).map((record) => [getFailedRecordKey(record), record])
   );
+  let failedRecordSnapshotDirty = false;
+  const deleteFailedRecord = (key: string) => {
+    if (failedRecordMap.delete(key)) {
+      failedRecordSnapshotDirty = true;
+    }
+  };
+  const setFailedRecord = (record: SystemMigrationFailedRecord) => {
+    const key = getFailedRecordKey(record);
+    const current = failedRecordMap.get(key);
+    const unchanged =
+      current?.stageKey === record.stageKey &&
+      current.reason.message === record.reason.message &&
+      current.data.collection === record.data.collection &&
+      current.data.resourceType === record.data.resourceType &&
+      current.data.resourceId === record.data.resourceId &&
+      current.data.teamId === record.data.teamId;
+    if (unchanged) return;
+
+    failedRecordMap.set(key, record);
+    failedRecordSnapshotDirty = true;
+  };
+  /** 失败记录采用完整快照替换，仅在内容变化时触发昂贵的事务性重写。 */
+  const reportFailedRecordsIfChanged = async () => {
+    if (!failedRecordSnapshotDirty) return;
+
+    await context.reportFailedRecords([...failedRecordMap.values()]);
+    failedRecordSnapshotDirty = false;
+  };
   const replaceStageFailures = ({
     config,
     records,
@@ -115,12 +143,16 @@ export const backfillResourceOwnerAcl = async (context: SystemMigrationContext) 
     records: ResourceOwnerAclRecord[];
     failures: ResourceOwnerAclFailure[];
   }) => {
+    const failuresByResourceId = new Map(
+      failures.map((failure) => [String(failure.record._id), failure])
+    );
     for (const record of records) {
-      failedRecordMap.delete(`${config.stageKey}:${String(record._id)}`);
-    }
-    for (const failure of failures) {
-      const failedRecord = createFailedRecord({ config, failure });
-      failedRecordMap.set(getFailedRecordKey(failedRecord), failedRecord);
+      const failure = failuresByResourceId.get(String(record._id));
+      if (failure) {
+        setFailedRecord(createFailedRecord({ config, failure }));
+      } else {
+        deleteFailedRecord(`${config.stageKey}:${String(record._id)}`);
+      }
     }
   };
   const processRecords = async ({
@@ -143,7 +175,7 @@ export const backfillResourceOwnerAcl = async (context: SystemMigrationContext) 
     const resourceId = String(failedRecord.data.resourceId);
     const id = Types.ObjectId.isValid(resourceId) ? new Types.ObjectId(resourceId) : resourceId;
     return config.model.collection.findOne(
-      { _id: id as never },
+      { ...config.resourceFilter, _id: id as never },
       { projection: { _id: 1, teamId: 1 } }
     );
   };
@@ -182,16 +214,20 @@ export const backfillResourceOwnerAcl = async (context: SystemMigrationContext) 
     for (let index = 0; index < stageFailedRecords.length; index += systemMigrationBatchSize) {
       await context.assertActive();
       const retryFailedRecords = stageFailedRecords.slice(index, index + systemMigrationBatchSize);
-      const retryRecords = (
-        await readFailedRecords({ config, failedRecords: retryFailedRecords })
-      ).flatMap<ResourceOwnerAclRecord>((record) =>
+      const currentRetryRecords = await readFailedRecords({
+        config,
+        failedRecords: retryFailedRecords
+      });
+      const retryRecords = currentRetryRecords.flatMap<ResourceOwnerAclRecord>((record) =>
         record ? [{ _id: record._id, teamId: record.teamId }] : []
       );
-      for (const failedRecord of retryFailedRecords) {
-        failedRecordMap.delete(getFailedRecordKey(failedRecord));
-      }
+      retryFailedRecords.forEach((failedRecord, recordIndex) => {
+        if (!currentRetryRecords[recordIndex]) {
+          deleteFailedRecord(getFailedRecordKey(failedRecord));
+        }
+      });
       await processRecords({ config, records: retryRecords });
-      await context.reportFailedRecords([...failedRecordMap.values()]);
+      await reportFailedRecordsIfChanged();
     }
 
     while (stageCheckpoint.endId && stageCheckpoint.lastId !== stageCheckpoint.endId) {
@@ -208,7 +244,7 @@ export const backfillResourceOwnerAcl = async (context: SystemMigrationContext) 
       stageCheckpoint.lastId = String(records.at(-1)!._id);
       stageCheckpoint.processedCount += records.length;
       checkpoint.stages[config.stageKey] = stageCheckpoint;
-      await context.reportFailedRecords([...failedRecordMap.values()]);
+      await reportFailedRecordsIfChanged();
       await context.saveCheckpoint(checkpoint);
       await context.reportProgress({
         key: config.stageKey,
@@ -228,7 +264,7 @@ export const backfillResourceOwnerAcl = async (context: SystemMigrationContext) 
       });
       if (records.length === 0) break;
       await processRecords({ config, records });
-      await context.reportFailedRecords([...failedRecordMap.values()]);
+      await reportFailedRecordsIfChanged();
       tailLastId = String(records.at(-1)!._id);
     }
 
@@ -249,7 +285,7 @@ export const backfillResourceOwnerAcl = async (context: SystemMigrationContext) 
           message: 'Resource _id is not an ObjectId'
         }))
       });
-      await context.reportFailedRecords([...failedRecordMap.values()]);
+      await reportFailedRecordsIfChanged();
       invalidLastId = invalidRecords.at(-1)!._id;
     }
     checkpoint.stages[config.stageKey] = stageCheckpoint;
@@ -281,16 +317,17 @@ export const backfillResourceOwnerAcl = async (context: SystemMigrationContext) 
       for (const record of records) {
         const failureKey = `${config.stageKey}:${String(record._id)}`;
         if (validOwnerResourceIds.has(String(record._id))) {
-          failedRecordMap.delete(failureKey);
+          deleteFailedRecord(failureKey);
         } else if (!failedRecordMap.has(failureKey)) {
-          const failedRecord = createFailedRecord({
-            config,
-            failure: { record, message: 'Resource still has no valid member Owner ACL' }
-          });
-          failedRecordMap.set(failureKey, failedRecord);
+          setFailedRecord(
+            createFailedRecord({
+              config,
+              failure: { record, message: 'Resource still has no valid member Owner ACL' }
+            })
+          );
         }
       }
-      await context.reportFailedRecords([...failedRecordMap.values()]);
+      await reportFailedRecordsIfChanged();
       validationLastId = String(records.at(-1)!._id);
     }
 
@@ -311,7 +348,7 @@ export const backfillResourceOwnerAcl = async (context: SystemMigrationContext) 
           message: 'Resource _id is not an ObjectId'
         }))
       });
-      await context.reportFailedRecords([...failedRecordMap.values()]);
+      await reportFailedRecordsIfChanged();
       invalidLastId = invalidRecords.at(-1)!._id;
     }
 
@@ -324,10 +361,10 @@ export const backfillResourceOwnerAcl = async (context: SystemMigrationContext) 
       const currentResources = await readFailedRecords({ config, failedRecords: records });
       records.forEach((failedRecord, recordIndex) => {
         if (!currentResources[recordIndex]) {
-          failedRecordMap.delete(getFailedRecordKey(failedRecord));
+          deleteFailedRecord(getFailedRecordKey(failedRecord));
         }
       });
-      await context.reportFailedRecords([...failedRecordMap.values()]);
+      await reportFailedRecordsIfChanged();
     }
   }
   if (failedRecordMap.size > 0) {

--- a/projects/app/src/migration/tasks/4170/20260905_backfill_resource_owner_acl/service.ts
+++ b/projects/app/src/migration/tasks/4170/20260905_backfill_resource_owner_acl/service.ts
@@ -1,0 +1,325 @@
+import { OwnerRoleVal, PerResourceTypeEnum } from '@fastgpt/global/support/permission/constant';
+import { MongoAgentSkills } from '@fastgpt/service/core/ai/skill/model/schema';
+import { MongoApp } from '@fastgpt/service/core/app/schema';
+import { MongoDataset } from '@fastgpt/service/core/dataset/schema';
+import { Types, type Model } from '@fastgpt/service/common/mongo';
+import { MongoResourcePermission } from '@fastgpt/service/support/permission/schema';
+import { MongoTeamMember } from '@fastgpt/service/support/user/team/teamMemberSchema';
+import { MongoTeam } from '@fastgpt/service/support/user/team/teamSchema';
+
+export type ResourceOwnerAclStageKey = 'apps' | 'datasets' | 'agent_skills';
+
+export type ResourceOwnerAclConfig = {
+  stageKey: ResourceOwnerAclStageKey;
+  resourceType: PerResourceTypeEnum;
+  model: Model<any>;
+};
+
+export type ResourceOwnerAclRecord = {
+  _id: unknown;
+  teamId?: unknown;
+};
+
+export type ResourceOwnerAclFailure = {
+  record: ResourceOwnerAclRecord;
+  message: string;
+};
+
+const DB_CONCURRENCY = 20;
+
+/** 限制迁移批次内部的 Mongo 并发，避免一个批次横跨大量团队时瞬间打满连接池。 */
+const runWithConcurrency = async <Input, Output>({
+  items,
+  action
+}: {
+  items: Input[];
+  action: (item: Input) => Promise<Output>;
+}) => {
+  const results: Output[] = [];
+  for (let index = 0; index < items.length; index += DB_CONCURRENCY) {
+    results.push(...(await Promise.all(items.slice(index, index + DB_CONCURRENCY).map(action))));
+  }
+  return results;
+};
+
+export const resourceOwnerAclConfigs: ResourceOwnerAclConfig[] = [
+  { stageKey: 'apps', resourceType: PerResourceTypeEnum.app, model: MongoApp },
+  { stageKey: 'datasets', resourceType: PerResourceTypeEnum.dataset, model: MongoDataset },
+  {
+    stageKey: 'agent_skills',
+    resourceType: PerResourceTypeEnum.agentSkill,
+    model: MongoAgentSkills
+  }
+];
+
+const toObjectId = (value: unknown): Types.ObjectId | undefined => {
+  if (value instanceof Types.ObjectId) return value;
+
+  const valueString = String(value ?? '');
+  if (!Types.ObjectId.isValid(valueString)) return;
+  const objectId = new Types.ObjectId(valueString);
+  return String(objectId) === valueString ? objectId : undefined;
+};
+
+const getRecordKey = (record: ResourceOwnerAclRecord) => String(record._id);
+
+/** 固定单个资源集合的 ObjectId 扫描上界，避免在线新增记录让主扫描无法结束。 */
+export const initializeResourceOwnerAclSnapshot = async (config: ResourceOwnerAclConfig) => {
+  const lastResource = await config.model.collection
+    .find({ _id: { $type: 'objectId' } }, { projection: { _id: 1 } })
+    .sort({ _id: -1 })
+    .limit(1)
+    .next();
+  const endId = toObjectId(lastResource?._id);
+  const total = endId
+    ? await config.model.collection.countDocuments({
+        _id: { $type: 'objectId', $lte: endId }
+      })
+    : 0;
+
+  return { endId: endId ? String(endId) : null, total };
+};
+
+/** 按不可变 ObjectId 游标读取固定快照中的下一批资源。 */
+export const readResourceOwnerAclBatch = async ({
+  config,
+  endId,
+  lastId,
+  limit
+}: {
+  config: ResourceOwnerAclConfig;
+  endId?: string;
+  lastId: string | null;
+  limit: number;
+}): Promise<ResourceOwnerAclRecord[]> => {
+  const idRange: { $gt?: Types.ObjectId; $lte?: Types.ObjectId } = {};
+  if (lastId) idRange.$gt = new Types.ObjectId(lastId);
+  if (endId) idRange.$lte = new Types.ObjectId(endId);
+
+  return config.model.collection
+    .find(
+      {
+        _id: {
+          $type: 'objectId',
+          ...idRange
+        }
+      },
+      { projection: { _id: 1, teamId: 1 } }
+    )
+    .sort({ _id: 1 })
+    .limit(limit)
+    .toArray();
+};
+
+/** 按稳定 `_id` 游标读取无法作为 resourceId 写入 ACL 的异常资源。 */
+export const readInvalidResourceOwnerAclRecords = ({
+  config,
+  lastId,
+  limit
+}: {
+  config: ResourceOwnerAclConfig;
+  lastId?: unknown;
+  limit: number;
+}) =>
+  config.model.collection
+    .find(
+      {
+        _id: {
+          $not: { $type: 'objectId' },
+          ...(lastId === undefined ? {} : { $gt: lastId })
+        }
+      } as never,
+      { projection: { _id: 1, teamId: 1 } }
+    )
+    .sort({ _id: 1 })
+    .limit(limit)
+    .toArray();
+
+/** 按当前资源团队验证成员 Owner ACL，悬空成员或跨团队成员不视为有效 owner。 */
+export const findValidOwnerResourceIds = async ({
+  config,
+  records
+}: {
+  config: ResourceOwnerAclConfig;
+  records: ResourceOwnerAclRecord[];
+}) => {
+  const recordsByTeam = new Map<string, Types.ObjectId[]>();
+  for (const record of records) {
+    const resourceId = toObjectId(record._id);
+    const teamId = toObjectId(record.teamId);
+    if (!resourceId || !teamId) continue;
+    const resourceIds = recordsByTeam.get(String(teamId)) ?? [];
+    resourceIds.push(resourceId);
+    recordsByTeam.set(String(teamId), resourceIds);
+  }
+
+  const permissionRows = (
+    await runWithConcurrency({
+      items: [...recordsByTeam],
+      action: ([teamId, resourceIds]) =>
+        MongoResourcePermission.collection
+          .find(
+            {
+              teamId: new Types.ObjectId(teamId),
+              resourceType: config.resourceType,
+              resourceId: { $in: resourceIds },
+              tmbId: { $exists: true },
+              permission: OwnerRoleVal
+            },
+            { projection: { resourceId: 1, teamId: 1, tmbId: 1 } }
+          )
+          .toArray()
+    })
+  ).flat();
+  const tmbIds = permissionRows
+    .map((row) => toObjectId(row.tmbId))
+    .filter((tmbId): tmbId is Types.ObjectId => Boolean(tmbId));
+  const members =
+    tmbIds.length === 0
+      ? []
+      : await MongoTeamMember.collection
+          .find({ _id: { $in: tmbIds } }, { projection: { _id: 1, teamId: 1 } })
+          .toArray();
+  const memberTeamById = new Map(
+    members.map((member) => [String(member._id), String(member.teamId)])
+  );
+
+  return new Set(
+    permissionRows.flatMap((row) => {
+      const tmbId = toObjectId(row.tmbId);
+      const teamId = toObjectId(row.teamId);
+      const resourceId = toObjectId(row.resourceId);
+      if (!tmbId || !teamId || !resourceId) return [];
+      return memberTeamById.get(String(tmbId)) === String(teamId) ? [String(resourceId)] : [];
+    })
+  );
+};
+
+/**
+ * 只为缺少有效成员 Owner ACL 的资源补 team owner。
+ * 单条 ACL 使用唯一键 upsert，写入后再次验证，因此整个批次可以安全重放。
+ */
+export const backfillResourceOwnerAclRecords = async ({
+  config,
+  records
+}: {
+  config: ResourceOwnerAclConfig;
+  records: ResourceOwnerAclRecord[];
+}): Promise<{ failures: ResourceOwnerAclFailure[] }> => {
+  if (records.length === 0) return { failures: [] };
+
+  const validOwnerResourceIds = await findValidOwnerResourceIds({ config, records });
+  const ownerlessRecords = records.filter(
+    (record) => !validOwnerResourceIds.has(getRecordKey(record))
+  );
+  const failures = new Map<string, ResourceOwnerAclFailure>();
+  const recordsByTeam = new Map<string, ResourceOwnerAclRecord[]>();
+
+  for (const record of ownerlessRecords) {
+    const resourceId = toObjectId(record._id);
+    if (!resourceId) {
+      failures.set(getRecordKey(record), { record, message: 'Resource _id is not an ObjectId' });
+      continue;
+    }
+    const teamId = toObjectId(record.teamId);
+    if (!teamId) {
+      failures.set(getRecordKey(record), { record, message: 'Resource teamId is not an ObjectId' });
+      continue;
+    }
+    const teamRecords = recordsByTeam.get(String(teamId)) ?? [];
+    teamRecords.push(record);
+    recordsByTeam.set(String(teamId), teamRecords);
+  }
+
+  const teamIds = [...recordsByTeam.keys()].map((teamId) => new Types.ObjectId(teamId));
+  const teams =
+    teamIds.length === 0
+      ? []
+      : await MongoTeam.collection
+          .find({ _id: { $in: teamIds } }, { projection: { _id: 1, ownerId: 1 } })
+          .toArray();
+  const teamById = new Map(teams.map((team) => [String(team._id), team]));
+  const ownerPairs = teams.flatMap((team) => {
+    const ownerId = toObjectId(team.ownerId);
+    return ownerId ? [{ teamId: team._id, userId: ownerId }] : [];
+  });
+  const ownerMembers =
+    ownerPairs.length === 0
+      ? []
+      : await MongoTeamMember.collection
+          .find({ $or: ownerPairs }, { projection: { _id: 1, teamId: 1, userId: 1 } })
+          .toArray();
+  const ownerMemberByTeamId = new Map(
+    ownerMembers.map((member) => [String(member.teamId), member])
+  );
+
+  const writeActions: Array<() => Promise<void>> = [];
+  for (const [teamId, teamRecords] of recordsByTeam) {
+    const team = teamById.get(teamId);
+    const ownerId = toObjectId(team?.ownerId);
+    const ownerMember = ownerMemberByTeamId.get(teamId);
+    if (!team || !ownerId || !ownerMember) {
+      const errorMessage = (() => {
+        if (!team) return 'Resource team does not exist';
+        if (!ownerId) return 'Resource team has no valid ownerId';
+        return 'Resource team owner has no team member record';
+      })();
+      for (const record of teamRecords) {
+        failures.set(getRecordKey(record), { record, message: errorMessage });
+      }
+      continue;
+    }
+
+    for (const record of teamRecords) {
+      const resourceId = toObjectId(record._id)!;
+      writeActions.push(() =>
+        MongoResourcePermission.collection
+          .updateOne(
+            {
+              teamId: new Types.ObjectId(teamId),
+              resourceType: config.resourceType,
+              resourceId,
+              tmbId: ownerMember._id
+            },
+            { $set: { permission: OwnerRoleVal } },
+            { upsert: true }
+          )
+          .then(() => undefined)
+          .catch((error) => {
+            failures.set(getRecordKey(record), {
+              record,
+              message: error instanceof Error ? error.message : String(error)
+            });
+            return undefined;
+          })
+      );
+    }
+  }
+
+  await runWithConcurrency({ items: writeActions, action: (write) => write() });
+  const verifiedOwnerResourceIds = await findValidOwnerResourceIds({ config, records });
+  for (const record of records) {
+    const recordId = getRecordKey(record);
+    if (verifiedOwnerResourceIds.has(recordId)) {
+      failures.delete(recordId);
+      continue;
+    }
+
+    const resourceId = toObjectId(record._id);
+    const current = resourceId
+      ? await config.model.collection.findOne({ _id: resourceId }, { projection: { _id: 1 } })
+      : await config.model.collection.findOne(
+          { _id: record._id as never },
+          { projection: { _id: 1 } }
+        );
+    if (!current) {
+      failures.delete(recordId);
+      continue;
+    }
+    if (!failures.has(recordId)) {
+      failures.set(recordId, { record, message: 'Resource still has no valid member Owner ACL' });
+    }
+  }
+
+  return { failures: [...failures.values()] };
+};

--- a/projects/app/src/migration/tasks/4170/20260905_backfill_resource_owner_acl/service.ts
+++ b/projects/app/src/migration/tasks/4170/20260905_backfill_resource_owner_acl/service.ts
@@ -1,4 +1,5 @@
 import { OwnerRoleVal, PerResourceTypeEnum } from '@fastgpt/global/support/permission/constant';
+import { AgentSkillSourceEnum } from '@fastgpt/global/core/ai/skill/constants';
 import { MongoAgentSkills } from '@fastgpt/service/core/ai/skill/model/schema';
 import { MongoApp } from '@fastgpt/service/core/app/schema';
 import { MongoDataset } from '@fastgpt/service/core/dataset/schema';
@@ -13,6 +14,7 @@ export type ResourceOwnerAclConfig = {
   stageKey: ResourceOwnerAclStageKey;
   resourceType: PerResourceTypeEnum;
   model: Model<any>;
+  resourceFilter?: Record<string, unknown>;
 };
 
 export type ResourceOwnerAclRecord = {
@@ -48,7 +50,8 @@ export const resourceOwnerAclConfigs: ResourceOwnerAclConfig[] = [
   {
     stageKey: 'agent_skills',
     resourceType: PerResourceTypeEnum.agentSkill,
-    model: MongoAgentSkills
+    model: MongoAgentSkills,
+    resourceFilter: { source: AgentSkillSourceEnum.personal }
   }
 ];
 
@@ -66,13 +69,14 @@ const getRecordKey = (record: ResourceOwnerAclRecord) => String(record._id);
 /** 固定单个资源集合的 ObjectId 扫描上界，避免在线新增记录让主扫描无法结束。 */
 export const initializeResourceOwnerAclSnapshot = async (config: ResourceOwnerAclConfig) => {
   const lastResource = await config.model.collection
-    .find({ _id: { $type: 'objectId' } }, { projection: { _id: 1 } })
+    .find({ ...config.resourceFilter, _id: { $type: 'objectId' } }, { projection: { _id: 1 } })
     .sort({ _id: -1 })
     .limit(1)
     .next();
   const endId = toObjectId(lastResource?._id);
   const total = endId
     ? await config.model.collection.countDocuments({
+        ...config.resourceFilter,
         _id: { $type: 'objectId', $lte: endId }
       })
     : 0;
@@ -99,6 +103,7 @@ export const readResourceOwnerAclBatch = async ({
   return config.model.collection
     .find(
       {
+        ...config.resourceFilter,
         _id: {
           $type: 'objectId',
           ...idRange
@@ -124,6 +129,7 @@ export const readInvalidResourceOwnerAclRecords = ({
   config.model.collection
     .find(
       {
+        ...config.resourceFilter,
         _id: {
           $not: { $type: 'objectId' },
           ...(lastId === undefined ? {} : { $gt: lastId })
@@ -307,9 +313,12 @@ export const backfillResourceOwnerAclRecords = async ({
 
     const resourceId = toObjectId(record._id);
     const current = resourceId
-      ? await config.model.collection.findOne({ _id: resourceId }, { projection: { _id: 1 } })
+      ? await config.model.collection.findOne(
+          { ...config.resourceFilter, _id: resourceId },
+          { projection: { _id: 1 } }
+        )
       : await config.model.collection.findOne(
-          { _id: record._id as never },
+          { ...config.resourceFilter, _id: record._id as never },
           { projection: { _id: 1 } }
         );
     if (!current) {

--- a/projects/app/src/migration/tasks/4170/20260905_backfill_resource_owner_acl/service.ts
+++ b/projects/app/src/migration/tasks/4170/20260905_backfill_resource_owner_acl/service.ts
@@ -211,8 +211,8 @@ export const backfillResourceOwnerAclRecords = async ({
 }: {
   config: ResourceOwnerAclConfig;
   records: ResourceOwnerAclRecord[];
-}): Promise<{ failures: ResourceOwnerAclFailure[] }> => {
-  if (records.length === 0) return { failures: [] };
+}): Promise<{ failures: ResourceOwnerAclFailure[]; updatedCount: number }> => {
+  if (records.length === 0) return { failures: [], updatedCount: 0 };
 
   const validOwnerResourceIds = await findValidOwnerResourceIds({ config, records });
   const ownerlessRecords = records.filter(
@@ -259,6 +259,7 @@ export const backfillResourceOwnerAclRecords = async ({
     ownerMembers.map((member) => [String(member.teamId), member])
   );
 
+  const updatedResourceIds = new Set<string>();
   const writeActions: Array<() => Promise<void>> = [];
   for (const [teamId, teamRecords] of recordsByTeam) {
     const team = teamById.get(teamId);
@@ -278,6 +279,7 @@ export const backfillResourceOwnerAclRecords = async ({
 
     for (const record of teamRecords) {
       const resourceId = toObjectId(record._id)!;
+      const recordId = getRecordKey(record);
       writeActions.push(() =>
         MongoResourcePermission.collection
           .updateOne(
@@ -290,7 +292,11 @@ export const backfillResourceOwnerAclRecords = async ({
             { $set: { permission: OwnerRoleVal } },
             { upsert: true }
           )
-          .then(() => undefined)
+          .then((result) => {
+            if (result.modifiedCount > 0 || result.upsertedCount > 0) {
+              updatedResourceIds.add(recordId);
+            }
+          })
           .catch((error) => {
             failures.set(getRecordKey(record), {
               record,
@@ -330,5 +336,10 @@ export const backfillResourceOwnerAclRecords = async ({
     }
   }
 
-  return { failures: [...failures.values()] };
+  return {
+    failures: [...failures.values()],
+    updatedCount: [...updatedResourceIds].filter((resourceId) =>
+      verifiedOwnerResourceIds.has(resourceId)
+    ).length
+  };
 };

--- a/projects/app/src/pages/api/core/app/folder/create.ts
+++ b/projects/app/src/pages/api/core/app/folder/create.ts
@@ -53,15 +53,20 @@ async function handler(
 
   // Create app
   await mongoSessionRun(async (session) => {
-    const app = await MongoApp.create({
-      ...parseParentIdInMongo(parentId),
-      avatar: FolderImgUrl,
-      name,
-      intro,
-      teamId,
-      tmbId,
-      type
-    });
+    const [app] = await MongoApp.create(
+      [
+        {
+          ...parseParentIdInMongo(parentId),
+          avatar: FolderImgUrl,
+          name,
+          intro,
+          teamId,
+          tmbId,
+          type
+        }
+      ],
+      { session }
+    );
 
     await createResourceDefaultCollaborators({
       tmbId,

--- a/projects/app/src/pages/api/core/dataset/folder/create.ts
+++ b/projects/app/src/pages/api/core/dataset/folder/create.ts
@@ -49,15 +49,20 @@ async function handler(req: ApiRequestProps<CreateDatasetFolderBody>) {
   await checkCreateFolderDepth({ parentId, teamId, model: MongoDataset });
 
   await mongoSessionRun(async (session) => {
-    const dataset = await MongoDataset.create({
-      ...parseParentIdInMongo(parentId),
-      avatar: FolderImgUrl,
-      name,
-      intro,
-      teamId,
-      tmbId,
-      type: DatasetTypeEnum.folder
-    });
+    const [dataset] = await MongoDataset.create(
+      [
+        {
+          ...parseParentIdInMongo(parentId),
+          avatar: FolderImgUrl,
+          name,
+          intro,
+          teamId,
+          tmbId,
+          type: DatasetTypeEnum.folder
+        }
+      ],
+      { session }
+    );
 
     await createResourceDefaultCollaborators({
       tmbId,

--- a/projects/app/test/migration/registry.test.ts
+++ b/projects/app/test/migration/registry.test.ts
@@ -29,7 +29,8 @@ describe('validateSystemMigrationRegistry', () => {
       '20260903_backfill_evaluation_model_references',
       '20260903_backfill_app_model_references',
       '20260903_backfill_app_create_time',
-      '20260905_backfill_bill_metadata'
+      '20260905_backfill_bill_metadata',
+      '20260905_backfill_resource_owner_acl'
     ]);
     expect(systemMigrations.slice(1).every((migration) => !migration.blockStartup)).toBe(true);
     expect(

--- a/projects/app/test/migration/tasks/4170/20260905_backfill_resource_owner_acl/index.test.ts
+++ b/projects/app/test/migration/tasks/4170/20260905_backfill_resource_owner_acl/index.test.ts
@@ -190,7 +190,10 @@ describe('4170 resource owner ACL migration', () => {
     await expect(backfillResourceOwnerAcl(state.context)).resolves.toEqual({
       appsProcessedCount: 2,
       datasetsProcessedCount: 1,
-      agentSkillsProcessedCount: 1
+      agentSkillsProcessedCount: 1,
+      appsUpdatedCount: 2,
+      datasetsUpdatedCount: 1,
+      agentSkillsUpdatedCount: 0
     });
 
     await expect(
@@ -272,9 +275,12 @@ describe('4170 resource owner ACL migration', () => {
     const appId = new Types.ObjectId();
     await MongoApp.collection.insertOne({ _id: appId, teamId, name: 'App' });
 
-    await backfillResourceOwnerAcl(createContext().context);
     await expect(backfillResourceOwnerAcl(createContext().context)).resolves.toMatchObject({
-      appsProcessedCount: 1
+      appsUpdatedCount: 1
+    });
+    await expect(backfillResourceOwnerAcl(createContext().context)).resolves.toMatchObject({
+      appsProcessedCount: 1,
+      appsUpdatedCount: 0
     });
 
     await expect(
@@ -339,7 +345,8 @@ describe('4170 resource owner ACL migration', () => {
       name: 'Repaired owner'
     });
     await expect(backfillResourceOwnerAcl(state.context)).resolves.toMatchObject({
-      appsProcessedCount: 1
+      appsProcessedCount: 1,
+      appsUpdatedCount: 1
     });
     expect(state.getFailedRecords()).toEqual([]);
     expect(state.context.reportFailedRecords).toHaveBeenCalledTimes(2);
@@ -375,7 +382,9 @@ describe('4170 resource owner ACL migration', () => {
       }
     });
 
-    await backfillResourceOwnerAcl(state.context);
+    await expect(backfillResourceOwnerAcl(state.context)).resolves.toMatchObject({
+      appsUpdatedCount: 2
+    });
     await expect(
       MongoResourcePermission.collection.countDocuments({
         teamId,

--- a/projects/app/test/migration/tasks/4170/20260905_backfill_resource_owner_acl/index.test.ts
+++ b/projects/app/test/migration/tasks/4170/20260905_backfill_resource_owner_acl/index.test.ts
@@ -1,4 +1,4 @@
-import { AgentSkillTypeEnum } from '@fastgpt/global/core/ai/skill/constants';
+import { AgentSkillSourceEnum, AgentSkillTypeEnum } from '@fastgpt/global/core/ai/skill/constants';
 import { AppTypeEnum } from '@fastgpt/global/core/app/constants';
 import { DatasetTypeEnum } from '@fastgpt/global/core/dataset/constants';
 import {
@@ -152,7 +152,8 @@ describe('4170 resource owner ACL migration', () => {
       teamId,
       tmbId: otherTmbId,
       name: 'Skill',
-      type: AgentSkillTypeEnum.skill
+      type: AgentSkillTypeEnum.skill,
+      source: AgentSkillSourceEnum.personal
     });
     await MongoResourcePermission.collection.insertMany([
       {
@@ -241,6 +242,29 @@ describe('4170 resource owner ACL migration', () => {
       'validation:running',
       'validation:succeeded'
     ]);
+    expect(state.context.reportFailedRecords).not.toHaveBeenCalled();
+  });
+
+  it('skips system skills because they do not belong to a team ACL', async () => {
+    const systemSkillId = new Types.ObjectId();
+    await MongoAgentSkills.collection.insertOne({
+      _id: systemSkillId,
+      teamId: null,
+      tmbId: null,
+      name: 'System Skill',
+      type: AgentSkillTypeEnum.skill,
+      source: AgentSkillSourceEnum.system
+    });
+
+    const state = createContext();
+    await expect(backfillResourceOwnerAcl(state.context)).resolves.toMatchObject({
+      agentSkillsProcessedCount: 0
+    });
+    await expect(
+      MongoResourcePermission.collection.countDocuments({ resourceId: systemSkillId })
+    ).resolves.toBe(0);
+    expect(state.getFailedRecords()).toEqual([]);
+    expect(state.context.reportFailedRecords).not.toHaveBeenCalled();
   });
 
   it('is idempotent when the complete migration runs again', async () => {
@@ -306,6 +330,7 @@ describe('4170 resource owner ACL migration', () => {
         reason: { message: 'Resource team owner has no team member record' }
       })
     ]);
+    expect(state.context.reportFailedRecords).toHaveBeenCalledTimes(1);
 
     await MongoTeamMember.collection.insertOne({
       _id: ownerTmbId,
@@ -317,6 +342,7 @@ describe('4170 resource owner ACL migration', () => {
       appsProcessedCount: 1
     });
     expect(state.getFailedRecords()).toEqual([]);
+    expect(state.context.reportFailedRecords).toHaveBeenCalledTimes(2);
   });
 
   it('clears a saved failure when the resource was deleted before retry', async () => {

--- a/projects/app/test/migration/tasks/4170/20260905_backfill_resource_owner_acl/index.test.ts
+++ b/projects/app/test/migration/tasks/4170/20260905_backfill_resource_owner_acl/index.test.ts
@@ -1,0 +1,394 @@
+import { AgentSkillTypeEnum } from '@fastgpt/global/core/ai/skill/constants';
+import { AppTypeEnum } from '@fastgpt/global/core/app/constants';
+import { DatasetTypeEnum } from '@fastgpt/global/core/dataset/constants';
+import {
+  OwnerRoleVal,
+  PerResourceTypeEnum,
+  ReadRoleVal
+} from '@fastgpt/global/support/permission/constant';
+import type {
+  SystemMigrationFailedRecord,
+  SystemMigrationProgressInput
+} from '@fastgpt/global/migration/schema';
+import { MongoAgentSkills } from '@fastgpt/service/core/ai/skill/model/schema';
+import { MongoApp } from '@fastgpt/service/core/app/schema';
+import { MongoDataset } from '@fastgpt/service/core/dataset/schema';
+import { Types } from '@fastgpt/service/common/mongo';
+import { MongoResourcePermission } from '@fastgpt/service/support/permission/schema';
+import { MongoTeamMember } from '@fastgpt/service/support/user/team/teamMemberSchema';
+import { MongoTeam } from '@fastgpt/service/support/user/team/teamSchema';
+import { backfillResourceOwnerAcl } from '@/migration/tasks/4170/20260905_backfill_resource_owner_acl';
+import type { SystemMigrationContext } from '@/migration/registry';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createContext = ({
+  beforeSaveCheckpoint
+}: {
+  beforeSaveCheckpoint?: (callCount: number) => Promise<void>;
+} = {}) => {
+  let checkpoint: Record<string, unknown> | undefined;
+  let failedRecords: SystemMigrationFailedRecord[] = [];
+  const progress: SystemMigrationProgressInput[] = [];
+  let saveCheckpointCallCount = 0;
+
+  const context = {
+    migrationId: '20260905_backfill_resource_owner_acl',
+    runId: 'test-run',
+    signal: new AbortController().signal,
+    getCheckpoint: async (schema) =>
+      checkpoint === undefined ? undefined : schema.parse(checkpoint),
+    getFailedRecords: async () => structuredClone(failedRecords),
+    reportFailedRecords: vi.fn(async (records: SystemMigrationFailedRecord[]) => {
+      failedRecords = structuredClone(records);
+    }),
+    saveCheckpoint: vi.fn(async (value: Record<string, unknown>) => {
+      saveCheckpointCallCount += 1;
+      await beforeSaveCheckpoint?.(saveCheckpointCallCount);
+      checkpoint = structuredClone(value);
+    }),
+    reportProgress: vi.fn(async (value: SystemMigrationProgressInput) => {
+      progress.push(value);
+    }),
+    assertActive: vi.fn(async () => undefined),
+    fail: async (error) => {
+      if (error.failedRecords) failedRecords = structuredClone(error.failedRecords);
+      throw new Error(error.message);
+    },
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    }
+  } satisfies SystemMigrationContext;
+
+  return {
+    context,
+    getCheckpoint: () => checkpoint,
+    getFailedRecords: () => failedRecords,
+    getProgress: () => progress
+  };
+};
+
+const createTeam = async ({ createOwnerMember = true } = {}) => {
+  const teamId = new Types.ObjectId();
+  const ownerUserId = new Types.ObjectId();
+  const ownerTmbId = new Types.ObjectId();
+  await MongoTeam.collection.insertOne({
+    _id: teamId,
+    name: 'Owner ACL team',
+    ownerId: ownerUserId
+  });
+  if (createOwnerMember) {
+    await MongoTeamMember.collection.insertOne({
+      _id: ownerTmbId,
+      teamId,
+      userId: ownerUserId,
+      name: 'Owner'
+    });
+  }
+  return { teamId, ownerUserId, ownerTmbId };
+};
+
+const findOwnerPermission = ({
+  teamId,
+  resourceType,
+  resourceId,
+  tmbId
+}: {
+  teamId: Types.ObjectId;
+  resourceType: PerResourceTypeEnum;
+  resourceId: Types.ObjectId;
+  tmbId: Types.ObjectId;
+}) => MongoResourcePermission.collection.findOne({ teamId, resourceType, resourceId, tmbId });
+
+describe('4170 resource owner ACL migration', () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all([
+      MongoApp.collection.deleteMany({}),
+      MongoDataset.collection.deleteMany({}),
+      MongoAgentSkills.collection.deleteMany({}),
+      MongoResourcePermission.collection.deleteMany({}),
+      MongoTeamMember.collection.deleteMany({}),
+      MongoTeam.collection.deleteMany({})
+    ]);
+  });
+
+  it('checks every resource type while preserving resources that already have a valid owner', async () => {
+    const { teamId, ownerTmbId } = await createTeam();
+    const otherUserId = new Types.ObjectId();
+    const otherTmbId = new Types.ObjectId();
+    await MongoTeamMember.collection.insertOne({
+      _id: otherTmbId,
+      teamId,
+      userId: otherUserId,
+      name: 'Other member'
+    });
+    const appId = new Types.ObjectId();
+    const deletedFolderId = new Types.ObjectId();
+    const datasetId = new Types.ObjectId();
+    const skillId = new Types.ObjectId();
+    const groupId = new Types.ObjectId();
+    await MongoApp.collection.insertMany([
+      { _id: appId, teamId, tmbId: otherTmbId, name: 'App', type: AppTypeEnum.workflow },
+      {
+        _id: deletedFolderId,
+        teamId,
+        tmbId: otherTmbId,
+        name: 'Deleted folder',
+        type: AppTypeEnum.folder,
+        deleteTime: new Date()
+      }
+    ]);
+    await MongoDataset.collection.insertOne({
+      _id: datasetId,
+      teamId,
+      tmbId: otherTmbId,
+      name: 'Dataset',
+      type: DatasetTypeEnum.dataset
+    });
+    await MongoAgentSkills.collection.insertOne({
+      _id: skillId,
+      teamId,
+      tmbId: otherTmbId,
+      name: 'Skill',
+      type: AgentSkillTypeEnum.skill
+    });
+    await MongoResourcePermission.collection.insertMany([
+      {
+        teamId,
+        resourceType: PerResourceTypeEnum.app,
+        resourceId: appId,
+        tmbId: new Types.ObjectId(),
+        permission: OwnerRoleVal
+      },
+      {
+        teamId,
+        resourceType: PerResourceTypeEnum.dataset,
+        resourceId: datasetId,
+        tmbId: ownerTmbId,
+        permission: ReadRoleVal
+      },
+      {
+        teamId,
+        resourceType: PerResourceTypeEnum.dataset,
+        resourceId: datasetId,
+        groupId,
+        permission: ReadRoleVal
+      },
+      {
+        teamId,
+        resourceType: PerResourceTypeEnum.agentSkill,
+        resourceId: skillId,
+        tmbId: otherTmbId,
+        permission: OwnerRoleVal
+      }
+    ]);
+
+    const state = createContext();
+    await expect(backfillResourceOwnerAcl(state.context)).resolves.toEqual({
+      appsProcessedCount: 2,
+      datasetsProcessedCount: 1,
+      agentSkillsProcessedCount: 1
+    });
+
+    await expect(
+      findOwnerPermission({
+        teamId,
+        resourceType: PerResourceTypeEnum.app,
+        resourceId: appId,
+        tmbId: ownerTmbId
+      })
+    ).resolves.toMatchObject({ permission: OwnerRoleVal });
+    await expect(
+      findOwnerPermission({
+        teamId,
+        resourceType: PerResourceTypeEnum.app,
+        resourceId: deletedFolderId,
+        tmbId: ownerTmbId
+      })
+    ).resolves.toMatchObject({ permission: OwnerRoleVal });
+    await expect(
+      findOwnerPermission({
+        teamId,
+        resourceType: PerResourceTypeEnum.dataset,
+        resourceId: datasetId,
+        tmbId: ownerTmbId
+      })
+    ).resolves.toMatchObject({ permission: OwnerRoleVal });
+    await expect(
+      findOwnerPermission({
+        teamId,
+        resourceType: PerResourceTypeEnum.agentSkill,
+        resourceId: skillId,
+        tmbId: ownerTmbId
+      })
+    ).resolves.toBeNull();
+    await expect(
+      MongoResourcePermission.collection.findOne({ resourceId: datasetId, groupId })
+    ).resolves.toMatchObject({ permission: ReadRoleVal });
+    expect(state.getFailedRecords()).toEqual([]);
+    expect(state.getProgress().map(({ key, status }) => `${key}:${status}`)).toEqual([
+      'apps:running',
+      'apps:running',
+      'apps:succeeded',
+      'datasets:running',
+      'datasets:running',
+      'datasets:succeeded',
+      'agent_skills:running',
+      'agent_skills:running',
+      'agent_skills:succeeded',
+      'validation:running',
+      'validation:succeeded'
+    ]);
+  });
+
+  it('is idempotent when the complete migration runs again', async () => {
+    const { teamId, ownerTmbId } = await createTeam();
+    const appId = new Types.ObjectId();
+    await MongoApp.collection.insertOne({ _id: appId, teamId, name: 'App' });
+
+    await backfillResourceOwnerAcl(createContext().context);
+    await expect(backfillResourceOwnerAcl(createContext().context)).resolves.toMatchObject({
+      appsProcessedCount: 1
+    });
+
+    await expect(
+      MongoResourcePermission.collection.countDocuments({
+        teamId,
+        resourceType: PerResourceTypeEnum.app,
+        resourceId: appId,
+        tmbId: ownerTmbId
+      })
+    ).resolves.toBe(1);
+  });
+
+  it('replays safely after the ACL write succeeds but checkpoint persistence fails', async () => {
+    const { teamId, ownerTmbId } = await createTeam();
+    const appId = new Types.ObjectId();
+    await MongoApp.collection.insertOne({ _id: appId, teamId, name: 'Replay App' });
+    const state = createContext({
+      beforeSaveCheckpoint: async (callCount) => {
+        if (callCount === 2) throw new Error('checkpoint unavailable');
+      }
+    });
+
+    await expect(backfillResourceOwnerAcl(state.context)).rejects.toThrow('checkpoint unavailable');
+    await expect(backfillResourceOwnerAcl(state.context)).resolves.toMatchObject({
+      appsProcessedCount: 1
+    });
+    await expect(
+      MongoResourcePermission.collection.countDocuments({
+        teamId,
+        resourceId: appId,
+        tmbId: ownerTmbId
+      })
+    ).resolves.toBe(1);
+  });
+
+  it('keeps a structured failure until the missing team owner membership is repaired', async () => {
+    const { teamId, ownerUserId, ownerTmbId } = await createTeam({ createOwnerMember: false });
+    const appId = new Types.ObjectId();
+    await MongoApp.collection.insertOne({ _id: appId, teamId, name: 'Broken App' });
+    const state = createContext();
+
+    await expect(backfillResourceOwnerAcl(state.context)).rejects.toThrow(
+      '1 resources still lack a valid member Owner ACL'
+    );
+    expect(state.getFailedRecords()).toEqual([
+      expect.objectContaining({
+        stageKey: 'apps',
+        data: expect.objectContaining({
+          resourceType: PerResourceTypeEnum.app,
+          resourceId: String(appId),
+          teamId: String(teamId)
+        }),
+        reason: { message: 'Resource team owner has no team member record' }
+      })
+    ]);
+
+    await MongoTeamMember.collection.insertOne({
+      _id: ownerTmbId,
+      teamId,
+      userId: ownerUserId,
+      name: 'Repaired owner'
+    });
+    await expect(backfillResourceOwnerAcl(state.context)).resolves.toMatchObject({
+      appsProcessedCount: 1
+    });
+    expect(state.getFailedRecords()).toEqual([]);
+  });
+
+  it('clears a saved failure when the resource was deleted before retry', async () => {
+    const { teamId } = await createTeam({ createOwnerMember: false });
+    const appId = new Types.ObjectId();
+    await MongoApp.collection.insertOne({ _id: appId, teamId, name: 'Deleted broken App' });
+    const state = createContext();
+
+    await expect(backfillResourceOwnerAcl(state.context)).rejects.toThrow(
+      '1 resources still lack a valid member Owner ACL'
+    );
+    await MongoApp.collection.deleteOne({ _id: appId });
+
+    await expect(backfillResourceOwnerAcl(state.context)).resolves.toMatchObject({
+      appsProcessedCount: 1
+    });
+    expect(state.getFailedRecords()).toEqual([]);
+  });
+
+  it('backfills an owner-less resource created after the fixed snapshot', async () => {
+    const { teamId, ownerTmbId } = await createTeam();
+    const snapshotAppId = new Types.ObjectId();
+    const lateAppId = new Types.ObjectId();
+    await MongoApp.collection.insertOne({ _id: snapshotAppId, teamId, name: 'Snapshot App' });
+    const state = createContext({
+      beforeSaveCheckpoint: async (callCount) => {
+        if (callCount === 1) {
+          await MongoApp.collection.insertOne({ _id: lateAppId, teamId, name: 'Late App' });
+        }
+      }
+    });
+
+    await backfillResourceOwnerAcl(state.context);
+    await expect(
+      MongoResourcePermission.collection.countDocuments({
+        teamId,
+        tmbId: ownerTmbId,
+        resourceId: { $in: [snapshotAppId, lateAppId] },
+        permission: OwnerRoleVal
+      })
+    ).resolves.toBe(2);
+  });
+
+  it('does not start a business write after losing the migration lease', async () => {
+    const { teamId } = await createTeam();
+    await MongoApp.collection.insertOne({ _id: new Types.ObjectId(), teamId, name: 'Lease App' });
+    const state = createContext();
+    state.context.assertActive.mockRejectedValue(new Error('lease lost'));
+    const updateSpy = vi.spyOn(MongoResourcePermission.collection, 'updateOne');
+
+    await expect(backfillResourceOwnerAcl(state.context)).rejects.toThrow('lease lost');
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports non-ObjectId resources instead of guessing an ACL reference', async () => {
+    const { teamId } = await createTeam();
+    await MongoApp.collection.insertOne({
+      _id: 'legacy-invalid-app-id' as never,
+      teamId,
+      name: 'Invalid App'
+    });
+    const state = createContext();
+
+    await expect(backfillResourceOwnerAcl(state.context)).rejects.toThrow(
+      '1 resources still lack a valid member Owner ACL'
+    );
+    expect(state.getFailedRecords()).toEqual([
+      expect.objectContaining({
+        stageKey: 'apps',
+        data: expect.objectContaining({ resourceId: 'legacy-invalid-app-id' }),
+        reason: { message: 'Resource _id is not an ObjectId' }
+      })
+    ]);
+  });
+});


### PR DESCRIPTION
## What

- add a non-blocking `20260905_backfill_resource_owner_acl` system migration
- scan every App, Dataset, and Agent Skill, including folders and soft-deleted records
- grant the current team owner `OwnerRoleVal` only when a resource has no valid member owner
- preserve all unrelated ACL rows and upgrade only the team owner's existing row when necessary
- add checkpoint recovery, failed-record retry, rolling-upgrade tail scans, and final validation
- add system migration copy for all supported locales

## Why

Historical migrations and missed creation paths can leave resources without a materialized member
owner ACL. Resource `tmbId` remains a compatibility fallback in some authorization paths, but it does
not provide a complete `resource_permissions` snapshot for list, collaboration, and inheritance flows.

The team owner is used only as a fallback for owner-less resources. Resources that already have any
valid member owner remain unchanged.

## Verification

- `pnpm test projects/app/test/migration/tasks/4170/20260905_backfill_resource_owner_acl/index.test.ts projects/app/test/migration/registry.test.ts`
- `pnpm --filter @fastgpt/app typecheck`
- ESLint on changed TypeScript files
- `git diff --check`

The focused migration and registry suites pass 15 tests.
