### PR TITLE
feat(ui): enhance multiple select for large option lists

### DIFF
--- a/packages/web/components/common/MySelect/MultipleSelect.tsx
+++ b/packages/web/components/common/MySelect/MultipleSelect.tsx
@@ -4,7 +4,6 @@ import {
   type ButtonProps,
   Checkbox,
   Flex,
-  Input,
   Menu,
   MenuButton,
   MenuItem,
@@ -23,6 +22,10 @@ import { shadowLight } from '../../../styles/theme';
 import { useMemoEnhance } from '../../../hooks/useMemoEnhance';
 import MyLoading from '../MyLoading';
 import { selectSizeStyleMap, type MySelectSize } from './styles';
+import EmptyTip from '../EmptyTip';
+import FilterSearchInput, { filterSelectOptionsBySearch } from '../TagFilter/FilterSearchInput';
+import { useStaticVirtualList } from '../../../hooks/useVirtualList';
+import MyIconButton from '../Icon/button';
 
 const menuItemStyles: MenuItemProps = {
   borderRadius: 'sm',
@@ -72,12 +75,14 @@ export type SelectProps<T = any> = {
     icon?: string;
     label: string | React.ReactNode;
     value: T;
+    searchText?: string;
   }[];
   value: T[];
   isSelectAll?: boolean;
   setIsSelectAll?: React.Dispatch<React.SetStateAction<boolean>>;
 
   placeholder?: string;
+  /** true 展示全部已选标签并自动换行；false 单行展示并以 +N 收起溢出项。 */
   itemWrap?: boolean;
   onSelect: (val: T[]) => void;
   closeable?: boolean;
@@ -89,6 +94,15 @@ export type SelectProps<T = any> = {
 
   inputValue?: string;
   setInputValue?: (val: string) => void;
+  isSearch?: boolean;
+  searchPlaceholder?: string;
+  /** 受控搜索默认交给调用方过滤；非受控搜索默认在组件内过滤。 */
+  filterLocal?: boolean;
+
+  /** 适用于已经一次性加载完成的大列表；分页列表请在外部使用 useVirtualList。 */
+  virtualScroll?: boolean;
+  virtualListHeight?: number;
+  emptyText?: React.ReactNode;
 
   onOpenFunc?: () => void;
 
@@ -103,13 +117,17 @@ type SelectedItemType<T> = {
   value: T;
 };
 
+/**
+ * 通用多选器：默认以单行 +N 展示选中项，也可完整换行展示。
+ * 搜索位于展开菜单内；静态大列表可启用虚拟滚动，远程分页由调用方管理。
+ */
 const MultipleSelect = <T = any,>({
   value: initialValue = [],
   placeholder,
   list = [],
   onSelect,
   closeable = false,
-  itemWrap = true,
+  itemWrap = false,
   ScrollData,
   isSelectAll,
   setIsSelectAll,
@@ -120,6 +138,12 @@ const MultipleSelect = <T = any,>({
 
   inputValue,
   setInputValue,
+  isSearch = false,
+  searchPlaceholder,
+  filterLocal,
+  virtualScroll = false,
+  virtualListHeight = 240,
+  emptyText,
 
   onOpenFunc,
 
@@ -129,19 +153,21 @@ const MultipleSelect = <T = any,>({
   isLoading,
   ...props
 }: SelectProps<T>) => {
-  const SearchInputRef = useRef<HTMLInputElement>(null);
   const tagsContainerRef = useRef<HTMLDivElement>(null);
-  void itemWrap;
 
   const { t } = useTranslation();
   const { isOpen, onOpen: originalOnOpen, onClose } = useDisclosure();
+  const [innerInputValue, setInnerInputValue] = useState('');
 
   const onOpen = useCallback(() => {
     originalOnOpen();
     onOpenFunc?.();
   }, [originalOnOpen, onOpenFunc]);
 
-  const canInput = setInputValue !== undefined;
+  const canSearch = isSearch || setInputValue !== undefined;
+  const searchValue = inputValue ?? innerInputValue;
+  const setSearchValue = setInputValue ?? setInnerInputValue;
+  const shouldFilterLocal = filterLocal ?? setInputValue === undefined;
 
   const [visibleItems, setVisibleItems] = useState<SelectedItemType<T>[]>([]);
   const [overflowItems, setOverflowItems] = useState<SelectedItemType<T>[]>([]);
@@ -174,21 +200,11 @@ const MultipleSelect = <T = any,>({
         }
       : {};
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Backspace' && (!inputValue || inputValue === '')) {
-        const newValue = [...formatValue];
-        newValue.pop();
-        onSelect(newValue);
-      }
-    },
-    [inputValue, formatValue, onSelect]
-  );
   useEffect(() => {
     if (!isOpen) {
-      setInputValue?.('');
+      setSearchValue('');
     }
-  }, [isOpen, setInputValue]);
+  }, [isOpen, setSearchValue]);
 
   const onclickItem = useCallback(
     (val: T) => {
@@ -220,6 +236,8 @@ const MultipleSelect = <T = any,>({
 
   // 动态长度计算器 - 计算一行能展示多少个tag，剩余用+n表示
   const calculateLayout = useCallback(() => {
+    if (itemWrap) return;
+
     if (!tagsContainerRef.current || selectedItems.length === 0) {
       setVisibleItems(selectedItems);
       setOverflowItems([]);
@@ -295,11 +313,11 @@ const MultipleSelect = <T = any,>({
 
     setVisibleItems(selectedItems.slice(0, visibleCount));
     setOverflowItems(selectedItems.slice(visibleCount));
-  }, [closeable, formLabel, selectedItems, size, tagWidth]);
+  }, [closeable, formLabel, itemWrap, selectedItems, size, tagWidth]);
 
   // 动态监听容器宽度变化并重新计算布局
   useEffect(() => {
-    if (!tagsContainerRef.current) return;
+    if (itemWrap || !tagsContainerRef.current) return;
 
     // 创建 ResizeObserver 监听容器宽度变化
     const resizeObserver = new ResizeObserver(() => {
@@ -321,7 +339,7 @@ const MultipleSelect = <T = any,>({
     return () => {
       resizeObserver.disconnect();
     };
-  }, [calculateLayout]);
+  }, [calculateLayout, itemWrap]);
 
   // 当选中项目、样式等发生变化时重新计算
   useEffect(() => {
@@ -330,34 +348,69 @@ const MultipleSelect = <T = any,>({
     });
   }, [calculateLayout]);
 
+  const visibleList = useMemo(
+    () => (canSearch && shouldFilterLocal ? filterSelectOptionsBySearch(list, searchValue) : list),
+    [canSearch, list, searchValue, shouldFilterLocal]
+  );
+  const shouldUseVirtualList = virtualScroll && !ScrollData;
+  const {
+    containerRef: virtualListRef,
+    virtualDataList,
+    topPlaceholderHeight,
+    bottomPlaceholderHeight,
+    scrollToTop
+  } = useStaticVirtualList({
+    data: visibleList,
+    itemHeight: 40,
+    overscan: 6
+  });
+
+  useEffect(() => {
+    if (shouldUseVirtualList) scrollToTop();
+  }, [scrollToTop, searchValue, shouldUseVirtualList]);
+
+  const renderListItem = useCallback(
+    (item: (typeof list)[number], index: number, virtual = false) => {
+      const isSelected = isAllSelected || formatValue.includes(item.value);
+      return (
+        <MenuItem
+          key={index}
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            onclickItem(item.value);
+          }}
+          whiteSpace={'pre-wrap'}
+          fontSize={'sm'}
+          gap={2}
+          {...menuItemStyles}
+          {...(virtual
+            ? {
+                h: '40px',
+                minH: '40px',
+                py: 0,
+                mb: 0,
+                _notLast: { mb: 0 }
+              }
+            : {})}
+          color={isSelected ? 'primary.600' : 'myGray.900'}
+        >
+          <Checkbox isChecked={isSelected} />
+          {item.icon && <MyAvatar src={item.icon} w={'1rem'} borderRadius={'0'} />}
+          <Box flex={'1 0 0'}>{item.label}</Box>
+        </MenuItem>
+      );
+    },
+    [formatValue, isAllSelected, onclickItem]
+  );
+
   const ListRender = useMemo(() => {
-    return (
-      <>
-        {list.map((item, i) => {
-          const isSelected = isAllSelected || formatValue.includes(item.value);
-          return (
-            <MenuItem
-              key={i}
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                onclickItem(item.value);
-              }}
-              whiteSpace={'pre-wrap'}
-              fontSize={'sm'}
-              gap={2}
-              {...menuItemStyles}
-              color={isSelected ? 'primary.600' : 'myGray.900'}
-            >
-              <Checkbox isChecked={isSelected} />
-              {item.icon && <MyAvatar src={item.icon} w={'1rem'} borderRadius={'0'} />}
-              <Box flex={'1 0 0'}>{item.label}</Box>
-            </MenuItem>
-          );
-        })}
-      </>
-    );
-  }, [list, isAllSelected, formatValue, onclickItem]);
+    if (shouldUseVirtualList) {
+      return <>{virtualDataList.map((item) => renderListItem(item.data, item.index, true))}</>;
+    }
+
+    return <>{visibleList.map((item, index) => renderListItem(item, index))}</>;
+  }, [renderListItem, shouldUseVirtualList, virtualDataList, visibleList]);
 
   return (
     <Box h={'100%'} w={'100%'}>
@@ -387,9 +440,11 @@ const MultipleSelect = <T = any,>({
           }}
           opacity={isDisabled ? 0.6 : 1}
           {...props}
+          minH={selectSizeStyleMap[size].h}
+          h={itemWrap ? 'auto' : selectSizeStyleMap[size].h}
           {...openedMenuButtonStyle}
         >
-          <Flex alignItems={'center'} w={'100%'} h={'100%'} py={1.5}>
+          <Flex alignItems={'center'} w={'100%'} minH={'100%'} py={1.5}>
             {formLabel && (
               <Flex alignItems={'center'}>
                 <Box color={'myGray.600'} fontSize={formLabelFontSize} whiteSpace={'nowrap'}>
@@ -407,79 +462,70 @@ const MultipleSelect = <T = any,>({
                 ref={tagsContainerRef}
                 flex={'1 0 0'}
                 gap={1}
-                flexWrap={'nowrap'}
+                flexWrap={itemWrap ? 'wrap' : 'nowrap'}
                 overflow={'hidden'}
                 alignItems={'center'}
               >
-                {(!isOpen || !canInput) &&
-                  (isAllSelected ? (
-                    <Box fontSize={formLabelFontSize} color={'myGray.900'}>
-                      {t('common:All')}
-                    </Box>
-                  ) : (
-                    <>
-                      {visibleItems.map((item, i) => (
-                        <MyTag
-                          className="tag-icon"
-                          key={i}
-                          bg={'primary.100'}
-                          color={'primary.700'}
-                          type={'fill'}
-                          borderRadius={'sm'}
-                          {...selectedTagSizeStyle}
-                          flexShrink={0}
-                          {...selectedTagStyle}
-                          {...tagStyle}
-                        >
-                          {item.label}
-                          {closeable && (
-                            <MyIcon
-                              name={'common/closeLight'}
-                              ml={1}
-                              w="0.8rem"
-                              cursor={'pointer'}
-                              _hover={{
-                                color: 'red.500'
-                              }}
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                e.preventDefault();
-                                onclickItem(item.value);
-                              }}
-                            />
-                          )}
-                        </MyTag>
-                      ))}
-                      {overflowItems.length > 0 && (
-                        <Box
-                          {...selectedTagSizeStyle}
-                          display={'flex'}
-                          alignItems={'center'}
-                          flexShrink={0}
-                          borderRadius={'lg'}
-                          bg={'myGray.100'}
-                        >
-                          +{overflowItems.length}
-                        </Box>
-                      )}
-                    </>
-                  ))}
-                {canInput && isOpen && (
-                  <Input
-                    value={inputValue}
-                    onChange={(e) => setInputValue?.(e.target.value)}
-                    onKeyDown={handleKeyDown}
-                    ref={SearchInputRef}
-                    autoFocus
-                    onBlur={() => {
-                      setTimeout(() => {
-                        SearchInputRef?.current?.focus();
-                      }, 0);
-                    }}
-                    h={6}
-                    variant={'unstyled'}
-                    border={'none'}
-                  />
+                {isAllSelected ? (
+                  <Box fontSize={formLabelFontSize} color={'myGray.900'}>
+                    {t('common:All')}
+                  </Box>
+                ) : (
+                  <>
+                    {(itemWrap ? selectedItems : visibleItems).map((item, i) => (
+                      <MyTag
+                        className="tag-icon"
+                        key={i}
+                        bg={'primary.100'}
+                        color={'primary.700'}
+                        type={'fill'}
+                        borderRadius={'sm'}
+                        {...selectedTagSizeStyle}
+                        flexShrink={0}
+                        {...selectedTagStyle}
+                        pr={closeable ? 1 : undefined}
+                        {...tagStyle}
+                      >
+                        {item.label}
+                        {closeable && (
+                          <MyIconButton
+                            icon={'common/closeLight'}
+                            tip={t('common:Remove')}
+                            ml={1}
+                            p={1}
+                            size={'0.8rem'}
+                            position={'relative'}
+                            zIndex={2}
+                            pointerEvents={'auto'}
+                            hoverColor={'red.500'}
+                            hoverBg={'red.50'}
+                            onPointerDown={(e) => {
+                              // 在外层 MenuButton 处理 click 前完成删除，并阻止其抢占事件。
+                              e.stopPropagation();
+                              e.preventDefault();
+                              onclickItem(item.value);
+                            }}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              e.preventDefault();
+                            }}
+                          />
+                        )}
+                      </MyTag>
+                    ))}
+                    {!itemWrap && overflowItems.length > 0 && (
+                      <Box
+                        {...selectedTagSizeStyle}
+                        display={'flex'}
+                        alignItems={'center'}
+                        flexShrink={0}
+                        borderRadius={'lg'}
+                        bg={'myGray.100'}
+                      >
+                        +{overflowItems.length}
+                      </Box>
+                    )}
+                  </>
                 )}
               </Flex>
             )}
@@ -497,9 +543,19 @@ const MultipleSelect = <T = any,>({
           }
           zIndex={99}
           maxH={'40vh'}
-          overflowY={'auto'}
+          overflowY={shouldUseVirtualList ? 'hidden' : 'auto'}
           position={'relative'}
         >
+          {canSearch && (
+            <Box mb={1}>
+              <FilterSearchInput
+                value={searchValue}
+                placeholder={searchPlaceholder ?? t('common:Search')}
+                onChange={setSearchValue}
+              />
+            </Box>
+          )}
+
           {setIsSelectAll && (
             <>
               <MenuItem
@@ -523,7 +579,25 @@ const MultipleSelect = <T = any,>({
             </>
           )}
 
-          {ScrollData ? <ScrollData minH={20}>{ListRender}</ScrollData> : ListRender}
+          {ScrollData ? (
+            <ScrollData minH={20}>{ListRender}</ScrollData>
+          ) : visibleList.length === 0 && !isLoading ? (
+            <EmptyTip py={8} text={emptyText} />
+          ) : shouldUseVirtualList ? (
+            <Box
+              ref={virtualListRef}
+              h={`min(${Math.min(visibleList.length * 40, virtualListHeight)}px, calc(40vh - ${
+                canSearch ? 44 : 12
+              }px))`}
+              overflowY={'auto'}
+            >
+              {topPlaceholderHeight > 0 && <Box h={`${topPlaceholderHeight}px`} />}
+              {ListRender}
+              {bottomPlaceholderHeight > 0 && <Box h={`${bottomPlaceholderHeight}px`} />}
+            </Box>
+          ) : (
+            ListRender
+          )}
 
           {menuBottomSlot && (
             <>

--- a/packages/web/hooks/useVirtualList.tsx
+++ b/packages/web/hooks/useVirtualList.tsx
@@ -176,6 +176,42 @@ const useVirtualWindow = <T,>({
 };
 
 /**
+ * 为已经一次性加载到内存的数据提供固定高度虚拟窗口。
+ *
+ * 与 `useVirtualList` 的分页版本分离：调用方仍持有完整数据，只把视口附近的项目交给 DOM
+ * 渲染。适用于模型配置等数据量较大、但后端无需分页的管理列表。
+ */
+export const useStaticVirtualList = <T,>({
+  data,
+  itemHeight,
+  overscan = defaultOverscan
+}: {
+  data: T[];
+  itemHeight: number;
+  overscan?: number;
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { list, topPlaceholderHeight, bottomPlaceholderHeight } = useVirtualWindow({
+    data,
+    containerRef,
+    itemHeight,
+    overscan
+  });
+
+  const scrollToTop = useMemoizedFn(() => {
+    if (containerRef.current) containerRef.current.scrollTop = 0;
+  });
+
+  return {
+    containerRef,
+    virtualDataList: list,
+    topPlaceholderHeight,
+    bottomPlaceholderHeight,
+    scrollToTop
+  };
+};
+
+/**
  * 提供固定滚动容器中的虚拟列表和 offset 分页加载。
  * 只渲染视口附近的数据，分页请求仍由 useScrollPagination 统一处理，支持搜索刷新和空状态。
  */


### PR DESCRIPTION
## What

- Move multiple-select search into the opened menu
- Support local search and externally controlled remote search
- Support full wrapping tags or a compact single-line `+N` summary
- Make removable tags use the shared icon button with reliable pointer handling
- Add empty-result rendering
- Add optional static virtual scrolling for large in-memory option lists
- Add a reusable `useStaticVirtualList` hook alongside the paginated virtual-list hook

## Verification

- ESLint and Prettier passed for both changed files
- TypeScript reported no errors in the changed files
- `git diff --check` passed

## Scope

This PR is based on `main` and contains only the shared MultipleSelect component plus its static virtual-list dependency. It does not include model-management consumers or dataset changes.