### PR TITLE
chore(i18n): rename website dataset label

### DIFF
--- a/packages/web/i18n/en/dataset.json
+++ b/packages/web/i18n/en/dataset.json
@@ -192,7 +192,7 @@
   "vector_model_max_tokens_tip": "Each chunk of data has a maximum length of 3000 tokens",
   "vllm_model": "Image understanding model",
   "vllm_model_tip": "Uses image captioning to generate text descriptions for images in documents, improving text search",
-  "website_dataset": "Web sync",
+  "website_dataset": "Website Knowledge Base",
   "website_dataset_desc": "Build a Dataset by crawling web pages in batches",
   "website_info": "Website Information",
   "yuque_dataset": "Yuque Dataset",

--- a/packages/web/i18n/ko-KR/dataset.json
+++ b/packages/web/i18n/ko-KR/dataset.json
@@ -192,7 +192,7 @@
   "vector_model_max_tokens_tip": "각 데이터 청크의 최대 길이는 3000토큰입니다",
   "vllm_model": "이미지 이해 모델",
   "vllm_model_tip": "문서 내 이미지를 자동으로 태깅하고 텍스트 설명을 생성하여 텍스트 검색을 돕습니다",
-  "website_dataset": "웹 동기화",
+  "website_dataset": "웹사이트 지식베이스",
   "website_dataset_desc": "웹 페이지 데이터를 일괄 크롤링하여 데이터셋을 구축합니다",
   "website_info": "웹사이트 정보",
   "yuque_dataset": "Yuque 데이터셋",

--- a/packages/web/i18n/zh-CN/dataset.json
+++ b/packages/web/i18n/zh-CN/dataset.json
@@ -192,7 +192,7 @@
   "vector_model_max_tokens_tip": "每个分块数据，最大长度为 3000 tokens",
   "vllm_model": "图片理解模型",
   "vllm_model_tip": "自动标注文档里的图片并生成文本描述，辅助文本检索",
-  "website_dataset": "Web 站点同步",
+  "website_dataset": "网站知识库",
   "website_dataset_desc": "通过爬虫，批量爬取网页数据构建知识库",
   "website_info": "网站信息",
   "yuque_dataset": "语雀知识库",

--- a/packages/web/i18n/zh-Hant/dataset.json
+++ b/packages/web/i18n/zh-Hant/dataset.json
@@ -192,7 +192,7 @@
   "vector_model_max_tokens_tip": "每個分塊資料，最大長度為 3000 tokens",
   "vllm_model": "圖片理解模型",
   "vllm_model_tip": "自動標註文件裡的圖片並生成文字描述，輔助文字檢索",
-  "website_dataset": "網站同步",
+  "website_dataset": "網站知識庫",
   "website_dataset_desc": "通過爬蟲，批量爬取網頁數據構建知識庫",
   "website_info": "網站資訊",
   "yuque_dataset": "Yuque 知識庫",


### PR DESCRIPTION
## What

Rename the website dataset entry consistently across all supported locales:

- English: `Web sync` → `Website Knowledge Base`
- Simplified Chinese: `Web 站点同步` → `网站知识库`
- Traditional Chinese and Korean equivalents

## Scope

This PR only changes the four dataset translation resources and is independent from administrator model management.