### PR TITLE
fix(sandbox): honor AGENT_SANDBOX_ENABLE_VOLUME and skip volume-manager when disabled

### DIFF
--- a/packages/service/core/ai/sandbox/application/runtime/client.ts
+++ b/packages/service/core/ai/sandbox/application/runtime/client.ts
@@ -21,6 +21,7 @@ import {
   getSessionVolumeClaimName,
   type VolumeManagerResult
 } from '../../infrastructure/volume/service';
+import { getVolumeManagerEnvConfig } from '../../infrastructure/volume/config';
 import { buildRuntimeSandboxAdapter } from '../../infrastructure/provider/adapter';
 import { getConfiguredSandboxProvider } from '../../infrastructure/provider/config';
 import { ensureConnectedSandboxRunning } from '../../infrastructure/provider/lifecycle';
@@ -258,7 +259,7 @@ export class SandboxClient {
         throw new Error(`Sandbox belongs to provider ${current.provider}`);
       }
       let workspaceClaimName: string | undefined;
-      if (this.providerName === 'opensandbox') {
+      if (this.providerName === 'opensandbox' && getVolumeManagerEnvConfig().enable) {
         workspaceClaimName = getSessionVolumeClaimName(current.storage);
         if (!workspaceClaimName) {
           throw new Error(`OpenSandbox ${this.sandboxId} has no persisted workspace claimName`);
@@ -559,7 +560,7 @@ export const getSandboxClient = async (
         createConfig: opts.createConfig
       });
     }
-    if (!vmConfig && providerName === 'opensandbox') {
+    if (!vmConfig && providerName === 'opensandbox' && getVolumeManagerEnvConfig().enable) {
       const instance = await findSandboxInstanceBySource({
         sourceType: sandboxClientProps.sourceType,
         sourceId: sandboxClientProps.sourceId,

--- a/packages/service/core/ai/sandbox/infrastructure/volume/config.ts
+++ b/packages/service/core/ai/sandbox/infrastructure/volume/config.ts
@@ -20,7 +20,7 @@ export type VolumeManagerConfig = {
  */
 export function getVolumeManagerEnvConfig(): VolumeManagerConfig {
   return {
-    enable: true,
+    enable: serviceEnv.AGENT_SANDBOX_ENABLE_VOLUME,
     url: serviceEnv.AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_URL!,
     token: serviceEnv.AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_TOKEN,
     volumeNamePrefix: serviceEnv.AGENT_SANDBOX_OPENSANDBOX_VOLUME_NAME_PREFIX,

--- a/packages/service/env.ts
+++ b/packages/service/env.ts
@@ -117,6 +117,9 @@ export const serviceEnv = createEnv({
       description: 'OpenSandbox 使用的运行态镜像；启用 opensandbox 时必填'
     }),
     AGENT_SANDBOX_OPENSANDBOX_USE_SERVER_PROXY: BoolSchema.default(true),
+    AGENT_SANDBOX_ENABLE_VOLUME: BoolSchema.default(true).meta({
+      description: '是否为 OpenSandbox 启用 volume-manager 持久卷；关闭后跳过全部卷逻辑'
+    }),
     AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_URL: UrlSchema.optional(),
     AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_TOKEN: z.string().optional(),
     AGENT_SANDBOX_OPENSANDBOX_VOLUME_NAME_PREFIX: SandboxVolumeNameSchema.default(

--- a/packages/service/test/core/ai/sandbox/infrastructure/volume/config.test.ts
+++ b/packages/service/test/core/ai/sandbox/infrastructure/volume/config.test.ts
@@ -14,6 +14,7 @@ describe('sandbox volume config', () => {
   it('reads volume-manager configuration from service env', async () => {
     vi.doMock('@fastgpt/service/env', () => ({
       serviceEnv: {
+        AGENT_SANDBOX_ENABLE_VOLUME: true,
         AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_URL: 'http://volume-manager.local',
         AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_TOKEN: 'volume-token',
         AGENT_SANDBOX_OPENSANDBOX_VOLUME_NAME_PREFIX: 'custom-volume',
@@ -31,4 +32,20 @@ describe('sandbox volume config', () => {
       storageSize: '5Gi'
     });
   });
+
+  it('disables volume-manager when AGENT_SANDBOX_ENABLE_VOLUME is false', async () => {
+    vi.doMock('@fastgpt/service/env', () => ({
+      serviceEnv: {
+        AGENT_SANDBOX_ENABLE_VOLUME: false,
+        AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_URL: 'http://volume-manager.local',
+        AGENT_SANDBOX_OPENSANDBOX_VOLUME_NAME_PREFIX: 'custom-volume',
+        AGENT_SANDBOX_STORAGE_SIZE_GI: 5
+      }
+    }));
+
+    const { getVolumeManagerEnvConfig } = await loadVolumeConfigModule();
+
+    expect(getVolumeManagerEnvConfig().enable).toBe(false);
+  });
+
 });

--- a/packages/service/test/core/ai/sandbox/infrastructure/volume/service.test.ts
+++ b/packages/service/test/core/ai/sandbox/infrastructure/volume/service.test.ts
@@ -25,6 +25,18 @@ import {
 } from '@fastgpt/service/core/ai/sandbox/infrastructure/volume/service';
 
 describe('sandbox volume service', () => {
+  it('skips volume-manager entirely when disabled', async () => {
+    volumeConfigMock.config = { ...volumeConfigMock.config, enable: false };
+    const fetchMock = vi.fn(async () => {
+      throw new Error('volume-manager must not be called when disabled');
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(getSessionVolumeConfig('claim-1')).resolves.toBeUndefined();
+    await expect(deleteSessionVolume('claim-1')).resolves.toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   beforeEach(() => {
     vi.unstubAllGlobals();
     volumeConfigMock.config = {


### PR DESCRIPTION
## 问题背景

参见 #7664：`AGENT_SANDBOX_ENABLE_VOLUME=false` 的部署在创建 skill sandbox 时报 `claimName expected string, got undefined`。根因在代码侧：该环境变量从未被读取——`getVolumeManagerEnvConfig()` 硬编码 `enable: true`，runtime client 的两处 opensandbox 分支也无条件生成/要求 workspace claimName，导致关闭卷的部署仍走完整的 volume-manager 请求路径。

## 修改内容

- `packages/service/env.ts`：新增 `AGENT_SANDBOX_ENABLE_VOLUME`（BoolSchema，默认 `true`，存量部署行为不变）
- `infrastructure/volume/config.ts`：`enable` 从 `serviceEnv.AGENT_SANDBOX_ENABLE_VOLUME` 读取
- `application/runtime/client.ts`：两处 opensandbox 分支加 `enable` 守卫——claimName 分配/校验块与 `getSandboxClient` 的 vmConfig 构建块；关闭时不分配 claim、不要求持久化记录，sandbox 照常创建（与 `getSessionVolumeConfig`/`deleteSessionVolume` 既有的跳过语义一致）

## 测试

- 新增/更新 `test/core/ai/sandbox/infrastructure/volume/{config,service}.test.ts`：
  - `AGENT_SANDBOX_ENABLE_VOLUME=false` 时 `enable` 为 false；关闭时 `getSessionVolumeConfig`/`deleteSessionVolume` 不发起任何 fetch 且返回 undefined
  - 既有用例 mock 补上新字段
- 本地红绿对照：还原 env/config 两文件后判别用例失败（`enable: undefined`），恢复后 volume 目录 17/17 通过

Fixes #7664