### PR TITLE
fix(ai): harden model field mapping and empty migrations

### DIFF
--- a/packages/service/core/ai/llm/request/requestBody.ts
+++ b/packages/service/core/ai/llm/request/requestBody.ts
@@ -60,7 +60,15 @@ export const llmCompletionsBodyFormat = async <T extends ChatCompletionCreatePar
   requestBody: InferCompletionsBody<T>;
   modelData: LLMSystemModelDataType;
 }> => {
-  const { tools, tool_choice, parallel_tool_calls, toolCallMode, ...body } = input;
+  // 内部模型对象只参与配置计算，不能进入后续请求字段映射的数据源。
+  const {
+    model: modelData,
+    tools,
+    tool_choice,
+    parallel_tool_calls,
+    toolCallMode,
+    ...body
+  } = input;
   const sanitizedTools = sanitizeCompletionTools(tools);
   // 这些字段只影响 FastGPT 自身逻辑，不能透传给模型供应商。
   delete body.retainDatasetCite;
@@ -69,8 +77,6 @@ export const llmCompletionsBodyFormat = async <T extends ChatCompletionCreatePar
   delete body.useVideo;
   delete body.extractFiles;
   delete body.requestOrigin;
-
-  const modelData = body.model;
 
   const response_format = (() => {
     if (!body.response_format?.type) return undefined;
@@ -145,13 +151,24 @@ export const llmCompletionsBodyFormat = async <T extends ChatCompletionCreatePar
   }
 
   if (modelData.config.fieldMap) {
-    Object.entries(modelData.config.fieldMap).forEach(([sourceKey, targetKey]) => {
-      // 部分兼容模型使用非 OpenAI 字段名，通过 fieldMap 在最后一层做字段替换。
-      // @ts-ignore
-      requestBody[targetKey] = body[sourceKey];
-      // @ts-ignore
-      delete requestBody[sourceKey];
-    });
+    // 从归一化且经过能力裁剪的快照取值；先统一移除源字段再写目标，
+    // 让同名、交换及链式映射不受配置声明顺序影响，也不恢复已裁剪字段。
+    const snapshot: Record<string, unknown> = { ...requestBody };
+    const mappings = Object.entries(modelData.config.fieldMap).filter(([sourceKey]) =>
+      Object.hasOwn(snapshot, sourceKey)
+    );
+    const sourceKeys = new Set(mappings.map(([sourceKey]) => sourceKey));
+    const targetKeys = new Set<string>();
+    for (const [, targetKey] of mappings) {
+      if (targetKeys.has(targetKey)) {
+        throw new Error(`Duplicate model fieldMap target: ${targetKey}`);
+      }
+      targetKeys.add(targetKey);
+    }
+    requestBody = Object.fromEntries([
+      ...Object.entries(snapshot).filter(([key]) => !sourceKeys.has(key)),
+      ...mappings.map(([sourceKey, targetKey]) => [targetKey, snapshot[sourceKey]])
+    ]) as T;
   }
 
   // defaultConfig 作为模型配置的最终兜底，允许覆盖上面计算出的默认值。

--- a/packages/service/test/core/ai/llm/request/requestBody.test.ts
+++ b/packages/service/test/core/ai/llm/request/requestBody.test.ts
@@ -247,6 +247,112 @@ describe('llmCompletionsBodyFormat', () => {
     expect(requestBody).toHaveProperty('max_completion_tokens', 300);
   });
 
+  it('maps the wire model identifier without exposing internal model configuration', async () => {
+    const model = createModel({
+      requestAuth: 'test-only-secret',
+      config: { fieldMap: { model: 'model_name' } }
+    });
+    const snapshot = structuredClone(model);
+    const { requestBody, modelData } = await llmCompletionsBodyFormat({
+      model,
+      messages,
+      stream: false
+    });
+
+    expect(requestBody).toHaveProperty('model_name', 'gpt-4o');
+    expect(requestBody).not.toHaveProperty('model');
+    expect(JSON.stringify(requestBody)).not.toContain('test-only-secret');
+    expect(modelData).toBe(model);
+    expect(model).toEqual(snapshot);
+  });
+
+  it('maps normalized tokens and stop values rather than raw inputs', async () => {
+    const model = createModel({
+      config: { fieldMap: { max_tokens: 'limit', stop: 'stop_sequences' } }
+    });
+    const { requestBody } = await llmCompletionsBodyFormat({
+      model,
+      messages,
+      stream: false,
+      max_tokens: 5000,
+      stop: 'END|STOP'
+    });
+    expect(requestBody).toMatchObject({ limit: 1000, stop_sequences: ['END', 'STOP'] });
+    expect(requestBody).not.toHaveProperty('max_tokens');
+    expect(requestBody).not.toHaveProperty('stop');
+  });
+
+  it('does not restore removed or absent fields through mapping', async () => {
+    const model = createModel({
+      config: {
+        showStopSign: false,
+        fieldMap: { stop: 'stop_sequences', useVision: 'vision', absent: 'model' }
+      }
+    });
+    const { requestBody } = await llmCompletionsBodyFormat({
+      model,
+      messages,
+      stream: false,
+      stop: 'END',
+      useVision: true
+    });
+    expect(requestBody).toHaveProperty('model', 'gpt-4o');
+    expect(requestBody).not.toHaveProperty('stop_sequences');
+    expect(requestBody).not.toHaveProperty('vision');
+  });
+
+  it('preserves identity mappings, zero and false values', async () => {
+    const model = createModel({
+      config: { fieldMap: { model: 'model', top_p: 'p', stream: 'streaming' } }
+    });
+    const { requestBody } = await llmCompletionsBodyFormat({
+      model,
+      messages,
+      stream: false,
+      top_p: 0
+    });
+    expect(requestBody).toMatchObject({ model: 'gpt-4o', p: 0, streaming: false });
+  });
+
+  it('applies swapped and chained mappings from a single snapshot', async () => {
+    for (const fieldMap of [
+      { model: 'stream', stream: 'model' },
+      { stream: 'model', model: 'stream' }
+    ]) {
+      const { requestBody } = await llmCompletionsBodyFormat({
+        model: createModel({ config: { fieldMap } }),
+        messages,
+        stream: false
+      });
+      expect(requestBody).toMatchObject({ stream: 'gpt-4o', model: false });
+    }
+    const { requestBody } = await llmCompletionsBodyFormat({
+      model: createModel({ config: { fieldMap: { model: 'stream', stream: 'streaming' } } }),
+      messages,
+      stream: false
+    });
+    expect(requestBody).toMatchObject({ stream: 'gpt-4o', streaming: false });
+    expect(requestBody).not.toHaveProperty('model');
+  });
+
+  it('rejects duplicate active destinations while keeping defaultConfig precedence', async () => {
+    await expect(
+      llmCompletionsBodyFormat({
+        model: createModel({ config: { fieldMap: { model: 'target', stream: 'target' } } }),
+        messages,
+        stream: false
+      })
+    ).rejects.toThrow('Duplicate model fieldMap target: target');
+    const { requestBody } = await llmCompletionsBodyFormat({
+      model: createModel({
+        config: { fieldMap: { model: 'target' }, defaultConfig: { target: 'override' } }
+      }),
+      messages,
+      stream: false
+    });
+    expect(requestBody).toHaveProperty('target', 'override');
+  });
+
   it('should throw when json schema cannot be parsed', async () => {
     const model = createModel();
 

--- a/projects/app/src/migration/tasks/20260903_backfill_model_permissions/index.ts
+++ b/projects/app/src/migration/tasks/20260903_backfill_model_permissions/index.ts
@@ -21,6 +21,8 @@ export const backfillModelPermissionReferences = async (context: SystemMigration
           model: MongoResourcePermission,
           query: { resourceType: PerResourceTypeEnum.model },
           transform: (record) => {
+            // 空目录不代表权限已废弃；保留现场并交给增量框架记录可重试失败。
+            catalog.assertAvailable();
             if (record.resourceId && catalog.hasModelId(record.resourceId)) return {};
 
             // 权限只需确认模型身份，类型不参与匹配。

--- a/projects/app/src/migration/tasks/4163_model_references/modelCatalog.ts
+++ b/projects/app/src/migration/tasks/4163_model_references/modelCatalog.ts
@@ -12,6 +12,8 @@ export type ModelCatalog = Awaited<ReturnType<typeof loadModelCatalog>>;
  * 为单个迁移任务加载一份独立的系统模型快照。
  * 普通资源只接受有效 modelId 或名称、类型完全匹配的旧模型；App 功能开启但引用为空时，
  * 还可以显式调用默认回退：优先系统默认，其次按 _id 稳定选择首个兼容模型。
+ * 空目录是新安装的合法状态；仅在实际解析引用或默认模型时要求目录可用，
+ * 由增量迁移记录逐条失败，避免空集合误报失败或历史引用被跳过后无法重试。
  */
 export const loadModelCatalog = async () => {
   const [models, defaultModelIds] = await Promise.all([
@@ -20,9 +22,13 @@ export const loadModelCatalog = async () => {
     >,
     findSystemDefaultModelIds()
   ]);
-  if (models.length === 0) {
-    throw new Error('ai_models is empty; wait for model bootstrap before running 4163 migrations');
-  }
+  /** 仅保护需要模型目录的操作，空集合和无引用资源仍可按正常流程完成迁移。 */
+  const assertAvailable = () => {
+    if (models.length === 0) {
+      throw new Error('Cannot migrate model references while ai_models is empty');
+    }
+  };
+  const hasReference = (value: unknown) => value !== undefined && value !== null && value !== '';
 
   const modelByName = new Map(models.map((model) => [model.model, model]));
   const modelById = new Map(models.map((model) => [String(model._id), model]));
@@ -32,11 +38,17 @@ export const loadModelCatalog = async () => {
     (!requirement.vision || ('vision' in model.config && model.config.vision === true));
 
   return {
+    // 权限清理必须先证明目录可用，不能把空目录中的全部 ACL 判断为悬空权限。
+    assertAvailable,
     resolveModelIdByName: (modelName: string | undefined): string | undefined => {
-      const model = modelName ? modelByName.get(modelName) : undefined;
+      if (!modelName) return;
+      assertAvailable();
+      const model = modelByName.get(modelName);
       return model ? String(model._id) : undefined;
     },
     hasMatchingModelId: (modelId: unknown, requirement: ModelRequirement) => {
+      if (!hasReference(modelId)) return false;
+      assertAvailable();
       const model = modelById.get(String(modelId));
       return !!model && matchesRequirement(model, requirement);
     },
@@ -49,6 +61,8 @@ export const loadModelCatalog = async () => {
       modelId?: unknown;
       requirement: ModelRequirement;
     }): string | undefined => {
+      if (!legacyModel && !hasReference(modelId)) return;
+      assertAvailable();
       const currentModel = modelId === undefined ? undefined : modelById.get(String(modelId));
       if (currentModel && matchesRequirement(currentModel, requirement)) {
         return String(currentModel._id);
@@ -61,6 +75,7 @@ export const loadModelCatalog = async () => {
     },
     /** App 功能开启但没有可解析引用时，优先使用系统默认，其次确定性选择首个兼容模型。 */
     resolveFallbackModelId: (requirement: ModelRequirement): string | undefined => {
+      assertAvailable();
       const configuredDefaultId = defaultModelIds[requirement.type];
       const configuredDefault = configuredDefaultId
         ? modelById.get(configuredDefaultId)
@@ -72,6 +87,10 @@ export const loadModelCatalog = async () => {
       const firstMatchingModel = models.find((model) => matchesRequirement(model, requirement));
       return firstMatchingModel ? String(firstMatchingModel._id) : undefined;
     },
-    hasModelId: (modelId: unknown) => modelById.has(String(modelId))
+    hasModelId: (modelId: unknown) => {
+      if (!hasReference(modelId)) return false;
+      assertAvailable();
+      return modelById.has(String(modelId));
+    }
   };
 };

--- a/projects/app/test/migration/4163ModelReferences.test.ts
+++ b/projects/app/test/migration/4163ModelReferences.test.ts
@@ -10,6 +10,9 @@ import { MongoApp } from '@fastgpt/service/core/app/schema';
 import { MongoAppTemplate } from '@fastgpt/service/core/app/templates/templateSchema';
 import { MongoAppVersion } from '@fastgpt/service/core/app/version/schema';
 import { MongoResourcePermission } from '@fastgpt/service/support/permission/schema';
+import { MongoEvaluation } from '@fastgpt/service/core/app/evaluation/evalSchema';
+import { SystemMigrationStatusEnum } from '@fastgpt/global/migration/constants';
+import { backfillEvaluationModelReferences } from '@/migration/tasks/20260903_backfill_evaluation_model_references';
 import { Types } from '@fastgpt/service/common/mongo';
 import { PerResourceTypeEnum } from '@fastgpt/global/support/permission/constant';
 import {
@@ -22,6 +25,9 @@ import { backfillDatasetModelReferences } from '@/migration/tasks/20260903_backf
 import { backfillModelPermissionReferences } from '@/migration/tasks/20260903_backfill_model_permissions';
 import type { SystemMigrationContext } from '@/migration/registry';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSystemMigrationRunner } from '@/migration/runner';
+import { systemMigrations } from '@/migration/registry';
+import { getMigrationStates } from '@/migration/entity';
 
 const cacheMocks = vi.hoisted(() => ({ clearAllMyModelsCache: vi.fn() }));
 
@@ -96,11 +102,170 @@ describe('4163 dataset model reference migration', () => {
       MongoAIModel.deleteMany({}),
       MongoAIDefaultModel.deleteMany({}),
       MongoDataset.deleteMany({}),
+      MongoEvaluation.deleteMany({}),
       MongoResourcePermission.deleteMany({ resourceType: PerResourceTypeEnum.model }),
       MongoApp.deleteMany({}),
       MongoAppVersion.deleteMany({}),
       MongoAppTemplate.deleteMany({})
     ]);
+  });
+
+  it.each([
+    { run: backfillModelPermissionReferences, stages: ['permissions'] },
+    { run: backfillDatasetModelReferences, stages: ['datasets'] },
+    { run: backfillEvaluationModelReferences, stages: ['evaluations'] },
+    { run: backfillAppModelReferences, stages: ['apps', 'app_versions', 'app_templates'] }
+  ])('completes empty $stages stages without installed models', async ({ run, stages }) => {
+    const state = createContext();
+    await run(state.context);
+    expect([...state.getProgress().keys()]).toEqual(stages);
+    for (const progress of state.getProgress().values()) {
+      expect(progress).toMatchObject({
+        status: SystemMigrationStatusEnum.succeeded,
+        current: 0,
+        total: 0
+      });
+    }
+    expect(state.getFailedRecords()).toEqual([]);
+  });
+
+  it('commits succeeded states through the runner for all four empty reference migrations', async () => {
+    const migrations = systemMigrations.filter((migration) =>
+      [
+        '20260903_backfill_model_permissions',
+        '20260903_backfill_dataset_model_references',
+        '20260903_backfill_evaluation_model_references',
+        '20260903_backfill_app_model_references'
+      ].includes(migration.id)
+    );
+    const runner = createSystemMigrationRunner({
+      migrations,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    });
+    try {
+      await runner.start();
+      await runner.tick();
+      const states = await getMigrationStates(migrations.map(({ id }) => id));
+      expect(states).toHaveLength(4);
+      for (const state of states) {
+        expect(state.status).toBe(SystemMigrationStatusEnum.succeeded);
+        expect(state.lastError).toBeUndefined();
+        expect(Object.values(state.result ?? {}).every((count) => count === 0)).toBe(true);
+      }
+    } finally {
+      runner.stop();
+    }
+  });
+
+  it('migrates resources without model references when the catalog is empty', async () => {
+    await MongoDataset.collection.insertOne({
+      _id: new Types.ObjectId(),
+      name: 'Folder',
+      type: 'folder'
+    });
+    await MongoApp.collection.insertOne({
+      _id: new Types.ObjectId(),
+      name: 'Non-AI workflow',
+      modules: [],
+      edges: []
+    });
+    await expect(backfillDatasetModelReferences(createContext().context)).resolves.toEqual({
+      processedCount: 1
+    });
+    await expect(backfillAppModelReferences(createContext().context)).resolves.toMatchObject({
+      appsProcessedCount: 1
+    });
+  });
+
+  it('preserves legacy ACLs with an empty catalog and retries them after models are installed', async () => {
+    const permissionId = new Types.ObjectId();
+    await MongoResourcePermission.collection.insertOne({
+      _id: permissionId,
+      resourceType: PerResourceTypeEnum.model,
+      resourceName: 'legacy-model'
+    });
+    const state = createContext();
+    await expect(backfillModelPermissionReferences(state.context)).rejects.toThrow('1 records');
+    expect(state.getFailedRecords()).toEqual([
+      expect.objectContaining({
+        stageKey: 'permissions',
+        data: expect.objectContaining({ recordId: String(permissionId) })
+      })
+    ]);
+    await expect(
+      MongoResourcePermission.collection.findOne({ _id: permissionId })
+    ).resolves.toMatchObject({ resourceName: 'legacy-model' });
+    const model = await createStoredModel({ model: 'legacy-model', type: ModelTypeEnum.llm });
+    await expect(backfillModelPermissionReferences(state.context)).resolves.toEqual({
+      processedCount: 1
+    });
+    expect(state.getFailedRecords()).toEqual([]);
+    await expect(
+      MongoResourcePermission.collection.findOne({ _id: permissionId })
+    ).resolves.toMatchObject({ resourceId: model._id });
+  });
+
+  it('does not delete malformed ACLs when the entire model catalog is empty', async () => {
+    const permissionId = new Types.ObjectId();
+    await MongoResourcePermission.collection.insertOne({
+      _id: permissionId,
+      resourceType: PerResourceTypeEnum.model
+    });
+    await expect(backfillModelPermissionReferences(createContext().context)).rejects.toThrow(
+      '1 records'
+    );
+    expect(await MongoResourcePermission.collection.countDocuments({ _id: permissionId })).toBe(1);
+  });
+
+  it('preserves dataset and evaluation references and recovers past their checkpoint', async () => {
+    const datasetId = new Types.ObjectId();
+    const evaluationId = new Types.ObjectId();
+    await MongoDataset.collection.insertOne({ _id: datasetId, vectorModel: 'embedding' });
+    await MongoEvaluation.collection.insertOne({ _id: evaluationId, evalModel: 'llm' });
+    const datasetState = createContext();
+    const evaluationState = createContext();
+    await expect(backfillDatasetModelReferences(datasetState.context)).rejects.toThrow('1 records');
+    await expect(backfillEvaluationModelReferences(evaluationState.context)).rejects.toThrow(
+      '1 records'
+    );
+    await expect(MongoDataset.collection.findOne({ _id: datasetId })).resolves.not.toHaveProperty(
+      'vectorModelId'
+    );
+    await expect(
+      MongoEvaluation.collection.findOne({ _id: evaluationId })
+    ).resolves.not.toHaveProperty('evalModelId');
+    const embedding = await createStoredModel({
+      model: 'embedding',
+      type: ModelTypeEnum.embedding
+    });
+    const llm = await createStoredModel({ model: 'llm', type: ModelTypeEnum.llm });
+    await backfillDatasetModelReferences(datasetState.context);
+    await backfillEvaluationModelReferences(evaluationState.context);
+    expect(datasetState.getFailedRecords()).toEqual([]);
+    expect(evaluationState.getFailedRecords()).toEqual([]);
+    await expect(MongoDataset.collection.findOne({ _id: datasetId })).resolves.toMatchObject({
+      vectorModelId: String(embedding._id)
+    });
+    await expect(MongoEvaluation.collection.findOne({ _id: evaluationId })).resolves.toMatchObject({
+      evalModelId: String(llm._id)
+    });
+  });
+
+  it('retains an app requiring a default model until the catalog becomes available', async () => {
+    const appId = new Types.ObjectId();
+    const chatConfig = { questionGuide: { open: true } };
+    await MongoApp.collection.insertOne({ _id: appId, modules: [], edges: [], chatConfig });
+    const state = createContext();
+    await expect(backfillAppModelReferences(state.context)).rejects.toThrow('1 records');
+    await expect(MongoApp.collection.findOne({ _id: appId })).resolves.toMatchObject({
+      chatConfig
+    });
+    const llm = await createStoredModel({ model: 'llm', type: ModelTypeEnum.llm });
+    await backfillAppModelReferences(state.context);
+    expect(state.getFailedRecords()).toEqual([]);
+    await expect(MongoApp.collection.findOne({ _id: appId })).resolves.toMatchObject({
+      chatConfig: { questionGuide: { open: true, modelId: String(llm._id) } }
+    });
   });
 
   it('migrates model permissions, deletes dangling entries, and clears only the permission cache', async () => {

--- a/projects/app/test/migration/tasks/4163_model_references/modelCatalog.test.ts
+++ b/projects/app/test/migration/tasks/4163_model_references/modelCatalog.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Types } from '@fastgpt/service/common/mongo';
+import { ModelTypeEnum } from '@fastgpt/global/core/ai/constants';
+import { MongoAIModel } from '@fastgpt/service/core/ai/config/schema';
+import { MongoAIDefaultModel } from '@fastgpt/service/core/ai/defaultModel/schema';
+import { loadModelCatalog } from '@/migration/tasks/4163_model_references/modelCatalog';
+
+describe('loadModelCatalog', () => {
+  const llmRequirement = { type: ModelTypeEnum.llm };
+  const visionRequirement = { type: ModelTypeEnum.llm, vision: true };
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    await MongoAIModel.deleteMany({});
+    await MongoAIDefaultModel.deleteMany({});
+  });
+
+  it('accepts an empty catalog but guards every operation needing a model', async () => {
+    const catalog = await loadModelCatalog();
+    for (const modelId of [undefined, null, '']) {
+      expect(catalog.hasModelId(modelId)).toBe(false);
+      expect(catalog.hasMatchingModelId(modelId, llmRequirement)).toBe(false);
+      expect(catalog.resolveModelId({ modelId, requirement: llmRequirement })).toBeUndefined();
+    }
+    expect(catalog.resolveModelIdByName(undefined)).toBeUndefined();
+    expect(catalog.resolveModelIdByName('')).toBeUndefined();
+    for (const resolve of [
+      () => catalog.assertAvailable(),
+      () => catalog.hasModelId('id'),
+      () => catalog.hasMatchingModelId('id', llmRequirement),
+      () => catalog.resolveModelIdByName('legacy'),
+      () => catalog.resolveModelId({ legacyModel: 'legacy', requirement: llmRequirement }),
+      () => catalog.resolveModelId({ modelId: 'id', requirement: llmRequirement }),
+      () => catalog.resolveFallbackModelId(llmRequirement)
+    ]) {
+      expect(resolve).toThrow('Cannot migrate model references while ai_models is empty');
+    }
+  });
+
+  it('preserves ID precedence, exact legacy matching and deterministic typed defaults', async () => {
+    const ids = [new Types.ObjectId(), new Types.ObjectId(), new Types.ObjectId()];
+    await MongoAIModel.collection.insertMany([
+      { _id: ids[0], scope: 'system', model: 'llm', type: 'llm', isActive: false, config: {} },
+      {
+        _id: ids[1],
+        scope: 'system',
+        model: 'vision',
+        type: 'llm',
+        isActive: true,
+        config: { vision: true }
+      },
+      {
+        _id: ids[2],
+        scope: 'system',
+        model: 'embedding',
+        type: 'embedding',
+        isActive: true,
+        config: {}
+      }
+    ]);
+    await MongoAIDefaultModel.collection.insertOne({
+      scope: 'system',
+      defaultModelIds: {
+        llm: String(ids[1]),
+        embedding: String(ids[0]),
+        tts: new Types.ObjectId().toString()
+      }
+    });
+    const catalog = await loadModelCatalog();
+    expect(() => catalog.assertAvailable()).not.toThrow();
+    expect(catalog.hasModelId(ids[0])).toBe(true);
+    expect(catalog.hasModelId('missing')).toBe(false);
+    expect(catalog.hasMatchingModelId(ids[0], llmRequirement)).toBe(true);
+    expect(catalog.hasMatchingModelId(ids[0], visionRequirement)).toBe(false);
+    expect(catalog.hasMatchingModelId(ids[1], visionRequirement)).toBe(true);
+    expect(catalog.hasMatchingModelId(ids[2], llmRequirement)).toBe(false);
+    expect(catalog.hasMatchingModelId('missing', llmRequirement)).toBe(false);
+    expect(catalog.resolveModelIdByName('llm')).toBe(String(ids[0]));
+    expect(catalog.resolveModelIdByName('missing')).toBeUndefined();
+    expect(
+      catalog.resolveModelId({
+        modelId: ids[0],
+        legacyModel: 'vision',
+        requirement: llmRequirement
+      })
+    ).toBe(String(ids[0]));
+    expect(
+      catalog.resolveModelId({
+        modelId: ids[2],
+        legacyModel: 'vision',
+        requirement: llmRequirement
+      })
+    ).toBe(String(ids[1]));
+    expect(
+      catalog.resolveModelId({ legacyModel: 'embedding', requirement: llmRequirement })
+    ).toBeUndefined();
+    expect(
+      catalog.resolveModelId({ legacyModel: 'missing', requirement: llmRequirement })
+    ).toBeUndefined();
+    expect(catalog.resolveFallbackModelId(llmRequirement)).toBe(String(ids[1]));
+    expect(catalog.resolveFallbackModelId({ type: ModelTypeEnum.embedding })).toBe(String(ids[2]));
+    expect(catalog.resolveFallbackModelId({ type: ModelTypeEnum.tts })).toBeUndefined();
+    expect(catalog.resolveFallbackModelId({ type: ModelTypeEnum.stt })).toBeUndefined();
+
+    await MongoAIDefaultModel.deleteMany({});
+    const fallbackCatalog = await loadModelCatalog();
+    expect(fallbackCatalog.resolveFallbackModelId(llmRequirement)).toBe(String(ids[0]));
+    expect(fallbackCatalog.resolveFallbackModelId(visionRequirement)).toBe(String(ids[1]));
+  });
+
+  it('propagates database failures instead of treating them as an empty installation', async () => {
+    vi.spyOn(MongoAIModel, 'find').mockImplementation(() => {
+      throw new Error('database unavailable');
+    });
+    await expect(loadModelCatalog()).rejects.toThrow('database unavailable');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the confirmed V4.17.0 review fixes on `fix-4170`.

- Keep internal model configuration separate from the outbound LLM request. Apply `fieldMap` to a normalized, capability-filtered snapshot; preserve same-key, swapped and chained mappings, skip absent fields, reject duplicate active targets and retain `defaultConfig` precedence.
- Accept an empty model catalog on fresh installations. Require a populated catalog only when resolving actual references or defaults. Preserve historical references and ACLs as retryable failed records instead of silently skipping or deleting them.
- Keep migration IDs, ordering, checkpoint format, lease fencing and failure policies unchanged. These are fixes to the unreleased V4.17.0 migrations.
- Update the pro submodule to the companion knowledge-candidate fix: https://github.com/labring/fastgpt-pro/pull/1120. Merge the pro PR first; align the gitlink if its merge changes the commit SHA.

The accepted startup-order/permission-window behavior and the deferred LDAP item are unchanged. No deployment YAML changes.

## Validation

71 relevant tests passed (no full-suite run):

- LLM request formatting: 11 tests.
- Model-reference migration, including real Runner completion on an empty installation: 22 tests.
- Model catalog edge cases: 3 tests.
- Existing migration Runner: 10 tests.
- Existing legacy model migration service: 15 tests.
- Pro dataset-candidate and Agent helper processor: 10 tests.

App and pro `tsc --noEmit --incremental false` passed. ESLint, Prettier and `git diff --check` passed.

Targeted line coverage: request formatting 96.72%; model catalog 100%. Regression tests confirm ACL preservation and recovery after the checkpoint once models become available.
