### PR TITLE
fix: preserve literal backslashes during markdown cleanup

### DIFF
--- a/packages/global/common/string/markdown.ts
+++ b/packages/global/common/string/markdown.ts
@@ -1,7 +1,7 @@
 import { batchRun } from '../system/utils';
 import { simpleText } from './tools';
 
-/* Delete redundant text in markdown */
+/** 清理 Markdown 冗余格式，仅移除指定特殊字符前的转义，保留普通文本中的反斜杠。 */
 export const simpleMarkdownText = (rawText: string) => {
   rawText = simpleText(rawText);
 
@@ -17,7 +17,8 @@ export const simpleMarkdownText = (rawText: string) => {
   });
 
   // replace special #\.* ……
-  const reg1 = /\\([#`!*()+-_\[\]{}\\.])/g;
+  // 连字符放在字符组末尾，避免形成包含数字和大写字母的 +-_ 范围。
+  const reg1 = /\\([#`!*()+_\[\]{}\\.-])/g;
   if (reg1.test(rawText)) {
     rawText = rawText.replace(reg1, '$1');
   }

--- a/packages/global/test/common/string/markdown.test.ts
+++ b/packages/global/test/common/string/markdown.test.ts
@@ -29,6 +29,17 @@ describe('markdown 字符串处理函数测试', () => {
       expect(result).toBe('# * ( ) [ ]');
     });
 
+    it.each(['C:\\Users\\Alice', String.raw`\Delta + \Omega`, String.raw`\1`])(
+      '应该保留非 Markdown 转义中的反斜杠: %s',
+      (input) => {
+        expect(simpleMarkdownText(input)).toBe(input);
+      }
+    );
+
+    it('应该继续移除连字符、加号和下划线的转义', () => {
+      expect(simpleMarkdownText(String.raw`\- \+ \_`)).toBe('- + _');
+    });
+
     it('应该替换双反斜杠换行符', () => {
       const input = 'Line1\\\\nLine2';
       const result = simpleMarkdownText(input);
@@ -298,6 +309,12 @@ describe('markdown 字符串处理函数测试', () => {
   });
 
   describe('parseMarkdownBase64Images markdown 清理', () => {
+    it('应该在文件内容清理后保留 Windows 路径和公式命令', async () => {
+      const rawText = String.raw`C:\Users\Alice contains $\Delta + \Omega$`;
+
+      expect(await parseMarkdownBase64Images(rawText)).toBe(rawText);
+    });
+
     it('应该处理不带上传控制器的 Markdown', async () => {
       const rawText = '# Title\n\nSome text\n\n';
       const result = await parseMarkdownBase64Images(rawText);


### PR DESCRIPTION
Markdown cleanup currently removes literal backslashes before uppercase letters and digits. For example, importing text containing `C:\Users\Alice` produces `C:UsersAlice`, and `\Delta + \Omega` becomes `Delta + Omega`.

The character class in `simpleMarkdownText` contains `+-_`, which is interpreted as an ASCII range rather than three literal characters. Move the hyphen to the end of the class so Windows paths, formula commands and numeric backslash sequences are preserved. Existing cleanup of escaped Markdown characters is retained.

This affects file-content cleanup through `parseMarkdownBase64Images`, including `readFileRawText` and document parser integrations.

Validation:

- Added regressions for Windows paths, uppercase formula commands and numeric sequences, plus coverage through `parseMarkdownBase64Images` and a check for escaped `-`, `+` and `_`.
- Before the fix: 4 regression failures, 43 passing tests.
- After the fix: `pnpm test packages/global/test/common/string/markdown.test.ts` — all 47 tests pass.
- Prettier checks and `git diff --check` pass.

Tests used Node 22.23.2 and Vitest 4.1.5 with minimal test dependencies; no full application environment was started.
