### PR TITLE
fix(sandbox): honor a volume-manager enable switch in skill sandboxes

### DIFF
--- a/packages/service/core/ai/sandbox/application/runtime/client.ts
+++ b/packages/service/core/ai/sandbox/application/runtime/client.ts
@@ -24,6 +24,7 @@ import {
 import { buildRuntimeSandboxAdapter } from '../../infrastructure/provider/adapter';
 import { getConfiguredSandboxProvider } from '../../infrastructure/provider/config';
 import { ensureConnectedSandboxRunning } from '../../infrastructure/provider/lifecycle';
+import { getVolumeManagerEnvConfig } from '../../infrastructure/volume/config';
 import { deleteSandboxResource, stopSandboxResource } from '../resource';
 import {
   createSandboxProvisioningInstance,
@@ -559,7 +560,7 @@ export const getSandboxClient = async (
         createConfig: opts.createConfig
       });
     }
-    if (!vmConfig && providerName === 'opensandbox') {
+    if (!vmConfig && providerName === 'opensandbox' && getVolumeManagerEnvConfig().enable) {
       const instance = await findSandboxInstanceBySource({
         sourceType: sandboxClientProps.sourceType,
         sourceId: sandboxClientProps.sourceId,

--- a/packages/service/core/ai/sandbox/infrastructure/volume/config.ts
+++ b/packages/service/core/ai/sandbox/infrastructure/volume/config.ts
@@ -19,8 +19,12 @@ export type VolumeManagerConfig = {
  * volume-manager 只负责分配持久卷，OpenSandbox 的挂载路径由运行态固定为 /workspace。
  */
 export function getVolumeManagerEnvConfig(): VolumeManagerConfig {
+  const enable =
+    serviceEnv.AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_ENABLE &&
+    !!serviceEnv.AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_URL;
+
   return {
-    enable: true,
+    enable,
     url: serviceEnv.AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_URL!,
     token: serviceEnv.AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_TOKEN,
     volumeNamePrefix: serviceEnv.AGENT_SANDBOX_OPENSANDBOX_VOLUME_NAME_PREFIX,

--- a/packages/service/env.ts
+++ b/packages/service/env.ts
@@ -117,6 +117,12 @@ export const serviceEnv = createEnv({
       description: 'OpenSandbox 使用的运行态镜像；启用 opensandbox 时必填'
     }),
     AGENT_SANDBOX_OPENSANDBOX_USE_SERVER_PROXY: BoolSchema.default(true),
+    AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_ENABLE: BoolSchema.default(true).meta({
+      description:
+        'Enable the volume-manager integration for OpenSandbox persistent workspaces. ' +
+        'Set to false to run sandboxes without persistent volumes (e.g. when no ' +
+        'volume-manager is deployed); skill/agent sandboxes will skip all volume logic.'
+    }),
     AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_URL: UrlSchema.optional(),
     AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_TOKEN: z.string().optional(),
     AGENT_SANDBOX_OPENSANDBOX_VOLUME_NAME_PREFIX: SandboxVolumeNameSchema.default(

--- a/packages/service/test/core/ai/sandbox/infrastructure/volume/config.test.ts
+++ b/packages/service/test/core/ai/sandbox/infrastructure/volume/config.test.ts
@@ -14,6 +14,7 @@ describe('sandbox volume config', () => {
   it('reads volume-manager configuration from service env', async () => {
     vi.doMock('@fastgpt/service/env', () => ({
       serviceEnv: {
+        AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_ENABLE: true,
         AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_URL: 'http://volume-manager.local',
         AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_TOKEN: 'volume-token',
         AGENT_SANDBOX_OPENSANDBOX_VOLUME_NAME_PREFIX: 'custom-volume',
@@ -30,5 +31,40 @@ describe('sandbox volume config', () => {
       volumeNamePrefix: 'custom-volume',
       storageSize: '5Gi'
     });
+  });
+
+  it('disables the volume manager when AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_ENABLE=false', async () => {
+    vi.doMock('@fastgpt/service/env', () => ({
+      serviceEnv: {
+        AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_ENABLE: false,
+        AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_URL: 'http://volume-manager.local',
+        AGENT_SANDBOX_OPENSANDBOX_VOLUME_NAME_PREFIX: 'custom-volume',
+        AGENT_SANDBOX_STORAGE_SIZE_GI: 5
+      }
+    }));
+
+    const { getVolumeManagerEnvConfig } = await loadVolumeConfigModule();
+
+    const config = getVolumeManagerEnvConfig();
+    expect(config.enable).toBe(false);
+  });
+
+  it('disables the volume manager when no volume-manager URL is configured', async () => {
+    // K8s env-injection timing or a missing deployment leaves the URL undefined:
+    // without this guard the undefined prefix/URL would flow into claimName
+    // generation and Zod validation (issue #7664).
+    vi.doMock('@fastgpt/service/env', () => ({
+      serviceEnv: {
+        AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_ENABLE: true,
+        AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_URL: undefined,
+        AGENT_SANDBOX_OPENSANDBOX_VOLUME_NAME_PREFIX: 'custom-volume',
+        AGENT_SANDBOX_STORAGE_SIZE_GI: 5
+      }
+    }));
+
+    const { getVolumeManagerEnvConfig } = await loadVolumeConfigModule();
+
+    const config = getVolumeManagerEnvConfig();
+    expect(config.enable).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

`getVolumeManagerEnvConfig` (`packages/service/core/ai/sandbox/infrastructure/volume/config.ts`) hardcoded `enable: true`, so the volume-manager path always ran for OpenSandbox sandboxes. When `AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_URL` is unset — Kubernetes env-injection timing, or a deployment without a volume-manager — the undefined `volumeNamePrefix`/URL flow into claimName generation and the create call dies with a Zod `claimName expected string` error **before any network request is made**, which is exactly the symptom in #7664 (skill-sandbox creation fails, `rawBody: undefined` in the log).

The reporter asked for two things:

1. a `enableVolume` guard so skill sandboxes skip volume-manager logic when it is off (agent sandboxes already behave this way);
2. config that doesn't snapshot env only at module-load time.

## Fix

1. **New switch** `AGENT_SANDBOX_OPENSANDBOX_VOLUME_MANAGER_ENABLE` in `packages/service/env.ts` (`BoolSchema.default(true)` — backward compatible: existing deployments behave exactly as before).
2. **`getVolumeManagerEnvConfig`** now enables only when the switch is on **AND** a volume-manager URL is configured — the missing-URL case (K8s timing, no deployment) can no longer flow `undefined` into claimName generation.
3. **`getSandboxClient`** (`runtime/client.ts`) skips the whole claimName/volume branch when the volume manager is disabled, so skill sandboxes (`sourceType: skillEdit`) and agent sandboxes share the same guard behavior.

## Tests

`packages/service/test/core/ai/sandbox/infrastructure/volume/config.test.ts` extended (3 passed):

- existing happy path unchanged (URL + prefix + token → `enable: true`);
- `..._ENABLE=false` → `enable: false` even with a URL configured;
- URL undefined (K8s timing / no deployment) → `enable: false`, guarding the claimName generation path from #7664.

Local run: `pnpm exec vitest run test/core/ai/sandbox/infrastructure/volume/config.test.ts` → 3 passed.

Fixes #7664
