### PR TITLE
fix(workflow): always specify tool param node as agent generated

### DIFF
--- a/packages/global/core/workflow/migration/legacy/workflow.ts
+++ b/packages/global/core/workflow/migration/legacy/workflow.ts
@@ -223,15 +223,28 @@ export const migrateLegacyWorkflowStructureToCurrent = (
           !!node.toolConfig?.systemTool ||
           !!node.pluginId?.startsWith('systemTool-') ||
           !!node.pluginId?.startsWith('commercial-'));
-      const inputs = node.inputs.map((input) =>
-        migrateLegacyFlowNodeInputToCurrent(
+      const inputs = node.inputs.map((input) => {
+        const sourceInput = (() => {
+          // toolParams 的全部输入均由 Agent 工具调用生成。
+          if (node.flowNodeType === FlowNodeTypeEnum.toolParams) {
+            return {
+              ...input,
+              defaultToAgentGenerated: true,
+              selectedType: FlowNodeInputTypeEnum.agentGenerated
+            };
+          }
+
           // HTTP 468 的旧默认模式规则与普通工作流输入不同，先单独恢复再做通用归一。
-          node.flowNodeType === FlowNodeTypeEnum.httpRequest468
+          return node.flowNodeType === FlowNodeTypeEnum.httpRequest468
             ? migrateLegacyHttpToolInputDefaultMode(input)
-            : input,
-          { isTool, allowLegacyToolDescriptionFallback }
-        )
-      );
+            : input;
+        })();
+
+        return migrateLegacyFlowNodeInputToCurrent(sourceInput, {
+          isTool: isTool || node.flowNodeType === FlowNodeTypeEnum.toolParams,
+          allowLegacyToolDescriptionFallback
+        });
+      });
 
       const migratedInputs =
         node.flowNodeType === FlowNodeTypeEnum.agent

--- a/packages/global/test/core/workflow/migration/schema.test.ts
+++ b/packages/global/test/core/workflow/migration/schema.test.ts
@@ -873,6 +873,62 @@ describe('workflow migration boundary', () => {
     expect(input.defaultToAgentGenerated).toBe(true);
   });
 
+  it('migrates every 4.15 tool parameter to Agent generation', async () => {
+    const [agentGeneratedInput, referenceInput] = (
+      await migrateWorkflowToCurrent({
+        nodes: [
+          {
+            nodeId: 'tool-params',
+            flowNodeType: 'toolParams',
+            name: 'Custom tool variables',
+            inputs: [
+              {
+                valueType: WorkflowIOValueTypeEnum.string,
+                renderTypeList: [FlowNodeInputTypeEnum.reference],
+                key: 'aaa',
+                label: 'aaa',
+                toolDescription: 'aaaaa',
+                required: true,
+                canEdit: true,
+                customInputConfig: {
+                  selectValueTypeList: [WorkflowIOValueTypeEnum.string],
+                  showDescription: true
+                },
+                enum: ''
+              },
+              {
+                valueType: WorkflowIOValueTypeEnum.string,
+                renderTypeList: [FlowNodeInputTypeEnum.reference],
+                selectedType: FlowNodeInputTypeEnum.reference,
+                value: ['source-node', 'output'],
+                key: 'reference',
+                label: 'reference',
+                toolDescription: 'Linked value',
+                required: true,
+                canEdit: true,
+                customInputConfig: {
+                  selectValueTypeList: [WorkflowIOValueTypeEnum.string],
+                  showDescription: true
+                }
+              }
+            ],
+            outputs: []
+          }
+        ]
+      } as any)
+    ).nodes[0].inputs;
+
+    expect(agentGeneratedInput).toMatchObject({
+      defaultToAgentGenerated: true,
+      selectedType: FlowNodeInputTypeEnum.agentGenerated,
+      renderTypeList: [FlowNodeInputTypeEnum.agentGenerated, FlowNodeInputTypeEnum.reference]
+    });
+    expect(referenceInput).toMatchObject({
+      defaultToAgentGenerated: true,
+      selectedType: FlowNodeInputTypeEnum.agentGenerated
+    });
+  });
+
   it('moves a legacy MCP ToolSet input into toolConfig', async () => {
     const result = await migrateWorkflowToCurrent({
       nodes: [

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/components/ToolParamsEditModal/constants.ts
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/components/ToolParamsEditModal/constants.ts
@@ -7,7 +7,8 @@ import type { FlowNodeInputItemType } from '@fastgpt/global/core/workflow/type/i
 
 export const defaultToolParamFormData: FlowNodeInputItemType = {
   valueType: WorkflowIOValueTypeEnum.string,
-  renderTypeList: [FlowNodeInputTypeEnum.reference],
+  renderTypeList: [FlowNodeInputTypeEnum.agentGenerated, FlowNodeInputTypeEnum.reference],
+  selectedType: FlowNodeInputTypeEnum.agentGenerated,
   defaultToAgentGenerated: true,
   key: '',
   label: '',

--- a/projects/app/test/pageComponents/app/detail/WorkflowComponents/Flow/nodes/components/ToolParamsEditModal/constants.test.ts
+++ b/projects/app/test/pageComponents/app/detail/WorkflowComponents/Flow/nodes/components/ToolParamsEditModal/constants.test.ts
@@ -3,6 +3,10 @@ import { defaultToolParamFormData } from '@/pageComponents/app/detail/WorkflowCo
 
 describe('ToolParamsEditModal constants', () => {
   it('creates new dynamic tool params with the Agent-generated default', () => {
-    expect(defaultToolParamFormData.defaultToAgentGenerated).toBe(true);
+    expect(defaultToolParamFormData).toMatchObject({
+      defaultToAgentGenerated: true,
+      selectedType: 'agentGenerated',
+      renderTypeList: ['agentGenerated', 'reference']
+    });
   });
 });


### PR DESCRIPTION
Fixes tool param node in legacy data (prior to `4.16.0`) not working after upgrade.