### PR TITLE
fix(ci): init pro submodule only in pro-admin workflows

### DIFF
--- a/.github/workflows/preview-admin-build.yml
+++ b/.github/workflows/preview-admin-build.yml
@@ -50,7 +50,9 @@ jobs:
             if [ -n "${PRO_SUBMODULE_TOKEN}" ]; then
               git config --global url."https://x-access-token:${PRO_SUBMODULE_TOKEN}@github.com/".insteadOf "https://github.com/"
             fi
-            git submodule update --init --recursive
+            # 只 init pro：本 workflow 只构建 admin（pro），max 非依赖；
+            # 全量 init 会因 PRO_SUBMODULE_TOKEN 未授权 fastgpt-max 而 403。
+            git submodule update --init --recursive pro
           fi
 
       - name: Set up Docker Buildx

--- a/.github/workflows/test-fastgpt-pro.yaml
+++ b/.github/workflows/test-fastgpt-pro.yaml
@@ -58,7 +58,10 @@ jobs:
             if [ -n "${PRO_SUBMODULE_TOKEN}" ]; then
               git config --global url."https://x-access-token:${PRO_SUBMODULE_TOKEN}@github.com/".insteadOf "https://github.com/"
             fi
-            git submodule update --init --recursive --jobs 8
+            # 只 init pro：本 workflow 只消费 pro/admin，max 由 checkout 的
+            # GITHUB_TOKEN 对同 org private 仓库无权拉取（PRO_SUBMODULE_TOKEN
+            # 亦未授权 fastgpt-max），全量 init 会 403。
+            git submodule update --init --recursive --jobs 8 pro
           fi
       - name: Install system deps for node-canvas
         run: |


### PR DESCRIPTION
test-fastgpt-pro and preview-admin-build workflows consume only pro/admin but run full `git submodule update --init --recursive`, which also clones max. PRO_SUBMODULE_TOKEN has no fastgpt-max access → 403 on any PR that adds the max submodule (#7681). Scope submodule init to the pro path.