### PR TITLE
feat(workflow): show first-token response time in AI chat node

### DIFF
--- a/packages/global/core/workflow/runtime/type.ts
+++ b/packages/global/core/workflow/runtime/type.ts
@@ -47,6 +47,7 @@ export const DispatchNodeResponseSchema = z
       .optional()
       .meta({ description: '模块名 i18n 插值参数' }),
     runningTime: z.number().optional().meta({ description: '运行时间: 秒' }),
+    firstTokenTime: z.number().optional().meta({ description: '首 token 响应时间: 秒' }),
     query: z.string().optional().meta({ description: '查询语句' }),
     textOutput: z.string().optional().meta({ description: '文本输出' }),
 

--- a/packages/service/core/workflow/dispatch/ai/chat/dispatchChatCompletion.ts
+++ b/packages/service/core/workflow/dispatch/ai/chat/dispatchChatCompletion.ts
@@ -130,6 +130,9 @@ export const dispatchChatCompletion = async (props: ChatProps): Promise<ChatResp
       })()
     ]);
 
+    const requestStartTime = Date.now();
+    let firstTokenTime: number | undefined; // 首个模型输出 token 到达时刻(含思考)
+
     const {
       completeMessages,
       reasoningText,
@@ -165,10 +168,12 @@ export const dispatchChatCompletion = async (props: ChatProps): Promise<ChatResp
       teamId: runningUserInfo.teamId,
       isAborted: checkIsStopping,
       onReasoning({ text }) {
+        firstTokenTime ??= Date.now();
         if (!aiChatReasoning) return;
         workflowStreamResponse?.(workflowSseEvent.reasoningDelta(text));
       },
       onStreaming({ text }) {
+        firstTokenTime ??= Date.now();
         if (!isResponseAnswerText) return;
         workflowStreamResponse?.(workflowSseEvent.answerDelta(text));
       }
@@ -177,6 +182,11 @@ export const dispatchChatCompletion = async (props: ChatProps): Promise<ChatResp
     if (responseEmptyTip) {
       return getNodeErrResponse({ error: responseEmptyTip });
     }
+
+    const firstTokenTimeSec =
+      firstTokenTime === undefined
+        ? undefined
+        : +((firstTokenTime - requestStartTime) / 1000).toFixed(2);
 
     const { totalPoints } = formatModelChars2Points({
       model: modelConstantsData,
@@ -210,7 +220,8 @@ export const dispatchChatCompletion = async (props: ChatProps): Promise<ChatResp
           historyPreview: getHistoryPreview(chatCompleteMessages, 10000, aiChatVision),
           contextTotalLen: completeMessages.length,
           finishReason: finish_reason,
-          llmRequestIds: [requestId] // 记录 LLM 请求追踪 ID
+          llmRequestIds: [requestId], // 记录 LLM 请求追踪 ID
+          firstTokenTime: firstTokenTimeSec
         }
       });
     }
@@ -235,7 +246,8 @@ export const dispatchChatCompletion = async (props: ChatProps): Promise<ChatResp
         historyPreview: getHistoryPreview(chatCompleteMessages, 10000, aiChatVision),
         contextTotalLen: completeMessages.length,
         finishReason: finish_reason,
-        llmRequestIds: [requestId] // 记录 LLM 请求追踪 ID
+        llmRequestIds: [requestId], // 记录 LLM 请求追踪 ID
+        firstTokenTime: firstTokenTimeSec
       },
       [DispatchNodeResponseKeyEnum.toolResponse]: answerText
     };

--- a/packages/web/i18n/en/chat.json
+++ b/packages/web/i18n/en/chat.json
@@ -107,6 +107,7 @@
   "response.extension_model": "Query rewriting Model",
   "response.extract_description": "Extract Background Description",
   "response.extract_result": "Extraction Result",
+  "response.first_token_time": "First token response time",
   "response.form_input_result": "Form Input Result",
   "response.headers": "Headers",
   "response.history_preview": "History Preview (Only Partial Content Displayed)",

--- a/packages/web/i18n/ko-KR/chat.json
+++ b/packages/web/i18n/ko-KR/chat.json
@@ -107,6 +107,7 @@
   "response.extension_model": "쿼리 재작성 모델",
   "response.extract_description": "배경 설명 추출",
   "response.extract_result": "추출 결과",
+  "response.first_token_time": "첫 토큰 응답 시간",
   "response.form_input_result": "폼 입력 결과",
   "response.headers": "헤더",
   "response.history_preview": "이력 미리보기(일부 내용만 표시)",

--- a/packages/web/i18n/zh-CN/chat.json
+++ b/packages/web/i18n/zh-CN/chat.json
@@ -107,6 +107,7 @@
   "response.extension_model": "问题优化模型",
   "response.extract_description": "提取背景描述",
   "response.extract_result": "提取结果",
+  "response.first_token_time": "首 token 响应时间",
   "response.form_input_result": "表单输入结果",
   "response.headers": "请求头",
   "response.history_preview": "记录预览(仅展示部分内容)",

--- a/packages/web/i18n/zh-Hant/chat.json
+++ b/packages/web/i18n/zh-Hant/chat.json
@@ -107,6 +107,7 @@
   "response.extension_model": "問題最佳化模型",
   "response.extract_description": "提取背景描述",
   "response.extract_result": "提取結果",
+  "response.first_token_time": "首 token 響應時間",
   "response.form_input_result": "表單輸入結果",
   "response.headers": "請求頭",
   "response.history_preview": "記錄預覽（僅顯示部分內容）",

--- a/projects/app/src/components/core/chat/components/WholeResponseModal/ResponseRows.tsx
+++ b/projects/app/src/components/core/chat/components/WholeResponseModal/ResponseRows.tsx
@@ -165,6 +165,13 @@ export const AiChatRows = ({
           />
         </>
       )}
+      {activeModule.firstTokenTime !== undefined && (
+        <Row
+          label={t('chat:response.first_token_time')}
+          value={`${activeModule.firstTokenTime}s`}
+          renderStringAsMarkdown={false}
+        />
+      )}
       <LlmRequestIdsRow
         requestIds={activeModule.llmRequestIds}
         onOpenRequestIdDetail={onOpenRequestIdDetail}


### PR DESCRIPTION
Measure time from LLM request start to the first streamed output token (whichever arrives first: reasoning or answer) inside the AI chat node runtime, and persist it into the node responseData as firstTokenTime (s).

Render it as a new row ahead of "模型请求 ID" in the shared AI chat response card, which covers both the workflow node debug result and the whole-response / history detail modal.

备注：无需考虑 隐藏 AI 思考、隐藏 AI 输出等开关

### validate
<img width="878" height="737" alt="image" src="https://github.com/user-attachments/assets/1cd757d1-c907-4248-b44a-53f1221f5523" />
