### PR TITLE
fix(sandbox): log worker response handling errors

### DIFF
--- a/projects/code-sandbox/src/pool/base-process-pool.ts
+++ b/projects/code-sandbox/src/pool/base-process-pool.ts
@@ -8,7 +8,7 @@
 import { spawn, execFile, execFileSync, type ChildProcess } from 'child_process';
 import { createInterface, type Interface } from 'readline';
 import { readdirSync, readFileSync } from 'fs';
-import { promisify } from 'util';
+import { inspect, promisify } from 'util';
 import { platform } from 'os';
 import { env, RUNTIME_MEMORY_OVERHEAD_MB } from '../env';
 import type { ExecuteOptions, ExecuteResult } from '../types';
@@ -388,7 +388,13 @@ export abstract class BaseProcessPool {
             );
           }
           settle(result, { recycleWorker: Boolean(recycleReason) });
-        } catch {
+        } catch (error) {
+          // 此处也会捕获解析后的同步处理异常；保留完整堆栈和 cause，不额外记录用户响应正文。
+          serverLogger.error(`${this.tag}: failed to parse or handle worker response`, {
+            workerId: worker.id,
+            responseLength: line.length,
+            error: inspect(error, { depth: null, maxStringLength: null, maxArrayLength: null })
+          });
           settle({ success: false, message: 'Invalid worker response' });
         }
       };

--- a/projects/code-sandbox/test/unit/base-process-pool.test.ts
+++ b/projects/code-sandbox/test/unit/base-process-pool.test.ts
@@ -1,0 +1,72 @@
+import { ChildProcess } from 'child_process';
+import { createInterface } from 'readline';
+import { PassThrough } from 'stream';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BaseProcessPool, type PoolWorker } from '../../src/pool/base-process-pool';
+
+const { logError } = vi.hoisted(() => ({ logError: vi.fn() }));
+
+vi.mock('../../src/utils/logger', () => ({
+  getLogger: () => ({ error: logError }),
+  LogCategories: { MODULE: { SANDBOX: { SERVER: ['sandbox', 'server'] } } }
+}));
+
+class ResponseTestPool extends BaseProcessPool {
+  constructor() {
+    super(1, {
+      name: 'ResponseTest',
+      workerScript: '',
+      spawnCommand: () => '',
+      allowedModules: []
+    });
+  }
+
+  /** 直接驱动行协议，避免为日志测试启动真实沙箱进程。 */
+  run(worker: PoolWorker) {
+    return this.sendTask(worker, { code: 'test', variables: {}, timeoutMs: 1000 }, 1000);
+  }
+}
+
+describe('BaseProcessPool worker response logging', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it.each([
+    ['debug: task started', 'SyntaxError'],
+    ['null', 'TypeError']
+  ])('记录响应 %s 的完整异常且不改变返回结果', async (line, errorName) => {
+    const proc = new ChildProcess();
+    proc.stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const rl = createInterface({ input: stdout });
+    const stderrRl = createInterface({ input: stderr });
+    const worker: PoolWorker = { proc, rl, stderrRl, busy: true, id: 7, stderrBuf: [] };
+
+    try {
+      const result = new ResponseTestPool().run(worker);
+      rl.emit('line', line);
+
+      await expect(result).resolves.toEqual({
+        success: false,
+        message: 'Invalid worker response'
+      });
+      expect(logError).toHaveBeenCalledOnce();
+      expect(logError).toHaveBeenCalledWith(
+        expect.stringContaining('failed to parse or handle worker response'),
+        {
+          workerId: 7,
+          responseLength: line.length,
+          error: expect.stringContaining(errorName)
+        }
+      );
+      expect(logError.mock.calls[0][1].error).toContain('at ');
+      expect(rl.listenerCount('line')).toBe(0);
+    } finally {
+      rl.close();
+      stderrRl.close();
+      stdout.destroy();
+      stderr.destroy();
+      proc.stdin.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## 改动
- 为 worker 响应解析及同步处理异常补充 error 日志，保留异常堆栈和 cause，并记录 worker ID、响应长度。
- 使用现有日志 SDK，遵循终端及 OTLP 采集配置，不额外记录原始响应正文，不改变错误返回行为。
- 补充非法 JSON 和合法 JSON null 导致处理异常的回归测试。

## 验证
- pnpm test projects/code-sandbox/test/unit/base-process-pool.test.ts：2 个测试通过。
- Prettier、git diff --check 和提交钩子的 ESLint 检查通过。

## 范围
- 不修改部署配置或 SigNoz 环境变量。
- 本 PR 仅覆盖 worker 响应处理异常；不包含其他 worker 退出、通信或 Python 异常入口的日志补齐。