### PR TITLE
fix(sandbox): 补充执行失败响应中的堆栈和用户输出

### DIFF
--- a/projects/code-sandbox/src/isolated/python-bootstrap.py
+++ b/projects/code-sandbox/src/isolated/python-bootstrap.py
@@ -58,6 +58,7 @@ _open_guard = False
 _path_guard = False
 _logs = []
 _log_size = 0
+_logs_truncated = False
 _MAX_LOG_SIZE = 1024 * 1024
 _timeout_stage = 0
 _audit_hook_installed = False
@@ -84,6 +85,28 @@ _PROTECTED_BUILTINS = _FORBIDDEN_BUILTINS | frozenset({
 def _write_result(payload):
     sys.stdout.write(_original_json_dumps({'type': 'result', **payload}, ensure_ascii=False, default=str) + '\n')
     sys.stdout.flush()
+
+
+def _format_execution_error(error):
+    """返回异常链、traceback 和失败前输出；限制诊断长度，避免覆盖原始错误。"""
+    diagnostic_limit = 16 * 1024
+    try:
+        detail = ''.join(_tb.format_exception(type(error), error, error.__traceback__)).rstrip()
+    except Exception:
+        # 异常对象的格式化也可能报错，此时仍返回合法的失败响应。
+        detail = type(error).__name__ + ': unable to format exception'
+    if len(detail) > diagnostic_limit:
+        # 保留异常类型及原因开头，超长异常消息也不能把它们从诊断中挤掉。
+        detail = detail[:diagnostic_limit] + '\n[error truncated]'
+    logs = '\n'.join(_logs)
+    if logs or _logs_truncated:
+        detail += '\nConsole output:\n'
+        if len(logs) > diagnostic_limit:
+            detail += '[earlier logs truncated]\n'
+        detail += logs[-diagnostic_limit:]
+        if _logs_truncated:
+            detail += '\n[log capture limit reached]'
+    return detail
 
 
 def _init_request_limits(limits):
@@ -585,11 +608,13 @@ def _init_task_tmpdir(path):
 
 
 def _safe_print(*args, **kwargs):
-    global _log_size
+    global _log_size, _logs_truncated
     line = ' '.join(str(a) for a in args)
     if _log_size + len(line) <= _MAX_LOG_SIZE:
         _logs.append(line)
         _log_size += len(line)
+    else:
+        _logs_truncated = True
 
 
 def _timeout_handler(signum, frame):
@@ -755,12 +780,13 @@ def _call_main(user_main, variables):
 
 
 def _run_task(msg):
-    global _allowed_modules, _builtins_proxy, _request_count, _logs, _log_size, _timeout_stage
+    global _allowed_modules, _builtins_proxy, _request_count, _logs, _log_size, _logs_truncated, _timeout_stage
     _allowed_modules = set(msg.get('allowedModules', []))
     _init_request_limits(msg.get('requestLimits'))
     _request_count = 0
     _logs = []
     _log_size = 0
+    _logs_truncated = False
     _timeout_stage = 0
 
     code = msg.get('code', '')
@@ -837,7 +863,7 @@ def _run_task(msg):
         _write_result({'success': True, 'data': {'codeReturn': result, 'log': '\n'.join(_logs)}})
     except (Exception, SystemExit) as e:
         signal.alarm(0)
-        _write_result({'success': False, 'message': str(e)})
+        _write_result({'success': False, 'message': _format_execution_error(e)})
     finally:
         _restore_modules(snapshots)
         _builtins.__import__ = _original_import

--- a/projects/code-sandbox/src/pool/base-process-pool.ts
+++ b/projects/code-sandbox/src/pool/base-process-pool.ts
@@ -395,10 +395,15 @@ export abstract class BaseProcessPool {
             responseLength: line.length,
             error: inspect(error, { depth: null, maxStringLength: null, maxArrayLength: null })
           });
-          // 将异常类型和原因返回给调用方，完整堆栈仍通过服务端日志排查。
+          // 在 settle 回收 worker、清空缓冲区前读取 stderr，供 API 调用方排查。
+          // 附带 worker 标识和响应长度以关联服务端日志，完整堆栈仍仅记录在服务端。
           const errorMessage =
             error instanceof Error ? `${error.name}: ${error.message}` : inspect(error);
-          settle({ success: false, message: `Invalid worker response: ${errorMessage}` });
+          const stderr = this.formatStderr(worker);
+          settle({
+            success: false,
+            message: `Invalid worker response: ${errorMessage} | workerId: ${worker.id} | responseLength: ${line.length}${stderr}`
+          });
         }
       };
 

--- a/projects/code-sandbox/src/pool/worker.ts
+++ b/projects/code-sandbox/src/pool/worker.ts
@@ -12,6 +12,7 @@
  */
 import { createInterface } from 'readline';
 import { createRequire } from 'module';
+import { inspect } from 'util';
 import * as crypto from 'crypto';
 import { parse } from 'acorn';
 import { simple as walk } from 'acorn-walk';
@@ -602,12 +603,15 @@ rl.on('line', async (line: string) => {
   const { code, variables, timeoutMs } = msg;
   const logs: string[] = [];
   let logSize = 0;
+  let logsTruncated = false;
   const MAX_LOG_SIZE = 1024 * 1024; // 1MB
   const _consoleLog = (...args: any[]) => {
     const line = args.map((a) => (typeof a === 'object' ? _JSONStringify(a) : String(a))).join(' ');
     if (logSize + line.length <= MAX_LOG_SIZE) {
       logs.push(line);
       logSize += line.length;
+    } else {
+      logsTruncated = true;
     }
   };
   const safeConsole = {
@@ -823,9 +827,30 @@ rl.on('line', async (line: string) => {
     });
   } catch (err: any) {
     _workerClearTimeout(timer);
+    // 失败时也返回堆栈、cause 和执行输出；限制诊断长度，避免挤占协议输出额度。
+    const diagnosticLimit = 16 * 1024;
+    const errorDetail = (() => {
+      try {
+        return typeof err === 'string'
+          ? err
+          : inspect(err, { depth: 4, customInspect: false, getters: false });
+      } catch {
+        // 用户可以抛出任意对象，格式化异常不能再次破坏 worker 响应。
+        return 'Unable to format thrown value';
+      }
+    })();
+    const errorText =
+      errorDetail.length > diagnosticLimit
+        ? `${errorDetail.slice(0, diagnosticLimit)}\n[error truncated]`
+        : errorDetail;
+    const logText = logs.join('\n');
+    const consoleDetail =
+      logText || logsTruncated
+        ? `\nConsole output:\n${logText.length > diagnosticLimit ? '[earlier logs truncated]\n' : ''}${logText.slice(-diagnosticLimit)}${logsTruncated ? '\n[log capture limit reached]' : ''}`
+        : '';
     writeLine({
       success: false,
-      message: err?.message ?? String(err),
+      message: `${errorText}${consoleDetail}`,
       ...(timedOut ? { workerRecycle: 'timeout' } : {})
     });
   } finally {

--- a/projects/code-sandbox/test/unit/process-pool.test.ts
+++ b/projects/code-sandbox/test/unit/process-pool.test.ts
@@ -16,6 +16,80 @@ import { PythonIsolatedRunner } from '../../src/isolated/python-isolated-runner'
 // ============================================================
 // JS ProcessPool
 // ============================================================
+describe('JS 错误诊断', () => {
+  let pool: ProcessPool;
+
+  afterEach(async () => {
+    await pool?.shutdown();
+  });
+
+  it('返回异常堆栈、cause 和失败前 console 输出', async () => {
+    pool = new ProcessPool(1);
+    await pool.init();
+    const result = await pool.execute({
+      code: `async function main() {
+        console.log('before failure');
+        throw new TypeError('outer failure', { cause: new Error('root failure') });
+      }`,
+      variables: {}
+    });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('TypeError: outer failure');
+    expect(result.message).toContain('at main');
+    expect(result.message).toContain('root failure');
+    expect(result.message).toContain('Console output:\nbefore failure');
+  });
+
+  it.each(['null', "'plain failure'", "{ reason: 'object failure' }"])(
+    '抛出非 Error 值 %s 时仍返回失败原因',
+    async (value) => {
+      pool = new ProcessPool(1);
+      await pool.init();
+      const result = await pool.execute({
+        code: `async function main() { throw ${value}; }`,
+        variables: {}
+      });
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/null|plain failure|object failure/);
+      expect(result.message).not.toContain('Console output:');
+    }
+  );
+
+  it('语法错误返回具体原因和位置', async () => {
+    pool = new ProcessPool(1);
+    await pool.init();
+    const result = await pool.execute({
+      code: 'async function main( {',
+      variables: {}
+    });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('SyntaxError');
+    expect(result.message).toContain('Unexpected token');
+    expect(result.message).toMatch(/1:\d+/);
+  });
+
+  it('错误和输出过长时保留原始错误并标记截断', async () => {
+    pool = new ProcessPool(1);
+    await pool.init();
+    const result = await pool.execute({
+      code: `async function main() {
+        console.log('x'.repeat(20000));
+        console.log('last captured line');
+        console.log('x'.repeat(1024 * 1024));
+        throw new Error('original failure ' + 'x'.repeat(20000));
+      }`,
+      variables: {}
+    });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Error: original failure');
+    expect(result.message).toContain('[error truncated]');
+    expect(result.message).toContain('[earlier logs truncated]');
+    expect(result.message).toContain('last captured line');
+    expect(result.message).toContain('[log capture limit reached]');
+    expect(result.message!.length).toBeLessThan(34000);
+  });
+});
+
 describe('ProcessPool 生命周期', () => {
   let pool: ProcessPool;
 

--- a/projects/code-sandbox/test/unit/python-isolated-runner.test.ts
+++ b/projects/code-sandbox/test/unit/python-isolated-runner.test.ts
@@ -31,6 +31,65 @@ describe('PythonIsolatedRunner 兼容性', () => {
     return undefined;
   }
 
+  it('错误诊断返回 traceback、异常链和失败前 print 输出', async () => {
+    const r = await createRunner(1);
+    const result = await r.execute({
+      code: `def main():
+    print("before failure")
+    try:
+        raise ValueError("root failure")
+    except ValueError as e:
+        raise RuntimeError("outer failure") from e`,
+      variables: {}
+    });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Traceback (most recent call last)');
+    expect(result.message).toContain('ValueError: root failure');
+    expect(result.message).toContain('RuntimeError: outer failure');
+    expect(result.message).toContain('line 6, in main');
+    expect(result.message).toContain('Console output:\nbefore failure');
+  });
+
+  it('错误诊断在语法错误时返回行号和具体原因', async () => {
+    const r = await createRunner(1);
+    const result = await r.execute({ code: 'def main(:\n    pass', variables: {} });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('SyntaxError');
+    expect(result.message).toContain('line 1');
+    expect(result.message).not.toContain('Console output:');
+  });
+
+  it('错误诊断截断过长输出并标记采集上限', async () => {
+    const r = await createRunner(1);
+    const result = await r.execute({
+      code: `def main():
+    print("x" * 20000)
+    print("last captured line")
+    print("x" * (1024 * 1024))
+    raise ValueError("original failure")`,
+      variables: {}
+    });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('ValueError: original failure');
+    expect(result.message).toContain('[earlier logs truncated]');
+    expect(result.message).toContain('last captured line');
+    expect(result.message).toContain('[log capture limit reached]');
+    expect(result.message!.length).toBeLessThan(34000);
+  });
+
+  it('错误诊断截断超长异常仍保留异常类型和原因开头', async () => {
+    const r = await createRunner(1);
+    const result = await r.execute({
+      code: `def main():
+    raise ValueError("original failure " + "x" * 20000)`,
+      variables: {}
+    });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('ValueError: original failure');
+    expect(result.message).toContain('[error truncated]');
+    expect(result.message!.length).toBeLessThan(17000);
+  });
+
   it('支持 main() 无参数、print log 和 JSON 返回', async () => {
     const r = await createRunner();
 


### PR DESCRIPTION
用户代码执行失败时，沙箱此前只返回异常 message，丢失堆栈和失败前输出，导致 API 调用方及响应日志缺少排查信息。

本次为 JS/Python 失败响应补充异常堆栈、异常链及已捕获的 console/print 输出；错误详情与输出分别限制为 16K 字符并标记截断。响应沿用现有 warn 日志记录。worker 响应解析失败时额外返回 workerId、响应长度和已捕获的 stderr。

验证：新增错误诊断局部测试 10 项通过，覆盖异常链、语法错误、非 Error 抛出及截断行为；原响应解析局部测试 2 项通过。提交钩子 ESLint、Prettier 检查通过。未运行全量测试。

限制：进程被强制终止时，尚未发送的 worker 内输出仍可能丢失。
