### PR TITLE
fix: correct pagination empty state and scroll behavior

### DIFF
--- a/packages/web/hooks/usePagination.tsx
+++ b/packages/web/hooks/usePagination.tsx
@@ -133,7 +133,7 @@ export function usePagination<DataT, ResT = unknown>(
   const paginationRef = useRef<HTMLDivElement>(null);
   const totalDataLength = useMemo(() => Math.max(total, data.length), [total, data.length]);
 
-  const isEmpty = total === 0 && !isLoading;
+  const isEmpty = total === 0 && !isLoading && !error;
   const noMore = data.length > 0 && data.length >= totalDataLength;
 
   const fetchData = useMemoizedFn(
@@ -368,7 +368,14 @@ export function usePagination<DataT, ResT = unknown>(
       // Watch scroll position
       useThrottleEffect(
         () => {
-          if (!ref?.current || type !== 'scroll' || noMore || isLoading || data.length === 0)
+          if (
+            !ref?.current ||
+            type !== 'scroll' ||
+            noMore ||
+            isLoading ||
+            error ||
+            data.length === 0
+          )
             return;
           const { scrollTop, scrollHeight, clientHeight } = ref.current;
 
@@ -380,7 +387,7 @@ export function usePagination<DataT, ResT = unknown>(
             fetchData(pageNum + 1, ref);
           }
         },
-        [scroll, isLoading],
+        [data, error, scroll],
         { wait: 50 }
       );
 

--- a/packages/web/hooks/useScrollPagination.tsx
+++ b/packages/web/hooks/useScrollPagination.tsx
@@ -37,6 +37,7 @@ export function useScrollPagination<
     showErrorToast = true,
     disabled = false,
     showNoMoreTip = true,
+    showPaginationTip = true,
 
     ...props
   }: {
@@ -48,6 +49,7 @@ export function useScrollPagination<
     showErrorToast?: boolean;
     disabled?: boolean;
     showNoMoreTip?: boolean;
+    showPaginationTip?: boolean;
   } & Parameters<typeof useRequest>[1]
 ) {
   const { t } = useTranslation();
@@ -57,6 +59,7 @@ export function useScrollPagination<
   const [total, setTotal] = useState(0);
   const [hasLoaded, setHasLoaded] = useState(false);
   const [isLoading, { setTrue, setFalse }] = useBoolean(false);
+  const [error, setError] = useState<Error | null>(null);
   const requestedOffsetRef = useRef<number>();
   const requestControllerRef = useRef<AbortController>();
   const requestIdRef = useRef(0);
@@ -102,6 +105,7 @@ export function useScrollPagination<
       } else if (init) {
         setFalse();
       }
+      setError(null);
 
       if (init && !silent) {
         setData([]);
@@ -157,6 +161,7 @@ export function useScrollPagination<
         if (requestController.signal.aborted || requestId !== requestIdRef.current) return;
 
         requestedOffsetRef.current = undefined;
+        setError(error instanceof Error ? error : new Error(String(error)));
         if (showErrorToast) {
           toast({
             title: t(getErrText(error, t('common:core.chat.error.data_error'))),
@@ -209,7 +214,7 @@ export function useScrollPagination<
       // Watch scroll position
       useThrottleEffect(
         () => {
-          if (!ref?.current || noMore || isLoading || data.length === 0) return;
+          if (!ref?.current || noMore || isLoading || error || data.length === 0) return;
           const { scrollTop, scrollHeight, clientHeight } = ref.current;
 
           if (
@@ -220,7 +225,7 @@ export function useScrollPagination<
             loadData({ init: false, ScrollContainerRef: ref });
           }
         },
-        [scroll],
+        [error, scroll],
         { wait: 50 }
       );
 
@@ -241,6 +246,7 @@ export function useScrollPagination<
           )}
           {children}
           {scrollLoadType === 'bottom' &&
+            showPaginationTip &&
             !isEmpty &&
             !(isLoading && data.length === 0) &&
             (showNoMoreTip || !noMore) && (
@@ -284,6 +290,7 @@ export function useScrollPagination<
   return {
     ScrollData,
     isLoading,
+    error,
     total: Math.max(total, data.length),
     isEmpty,
     data,

--- a/packages/web/hooks/useVirtualList.tsx
+++ b/packages/web/hooks/useVirtualList.tsx
@@ -236,9 +236,8 @@ export function useVirtualList<
 ) {
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
-  const { data, total, setData, setTotal, isLoading, fetchData, refreshList } = useScrollPagination(
-    api,
-    {
+  const { data, total, setData, setTotal, isLoading, error, fetchData, refreshList } =
+    useScrollPagination(api, {
       refreshDeps,
       pageSize,
       params,
@@ -247,11 +246,10 @@ export function useVirtualList<
       disabled,
       showNoMoreTip,
       throttleWait
-    }
-  );
+    });
 
   const noMore = data.length >= total;
-  const isEmpty = total === 0 && !isLoading;
+  const isEmpty = total === 0 && !isLoading && !error;
   const loadText = isLoading
     ? t('common:is_requesting')
     : noMore
@@ -270,14 +268,14 @@ export function useVirtualList<
   useThrottleEffect(
     () => {
       const container = containerRef.current;
-      if (!container || noMore || isLoading || data.length === 0) return;
+      if (!container || noMore || isLoading || error || data.length === 0) return;
 
       const { scrollTop, scrollHeight, clientHeight } = container;
       if (scrollTop + clientHeight >= scrollHeight - loadMoreThreshold) {
         fetchData({ init: false, ScrollContainerRef: containerRef });
       }
     },
-    [data.length, fetchData, isLoading, noMore, scroll],
+    [data, error, fetchData, noMore, scroll],
     { wait: 50 }
   );
 
@@ -289,13 +287,14 @@ export function useVirtualList<
       data.length === 0 ||
       data.length >= total ||
       isLoading ||
+      error ||
       container.scrollHeight > container.clientHeight + loadMoreThreshold
     ) {
       return;
     }
 
     fetchData({ init: false, ScrollContainerRef: containerRef });
-  }, [data.length, fetchData, isLoading, total]);
+  }, [data, error, fetchData, isLoading, total]);
 
   const scroll2Top = useMemoizedFn(() => {
     if (containerRef.current) {

--- a/packages/web/i18n/en/common.json
+++ b/packages/web/i18n/en/common.json
@@ -921,6 +921,7 @@
   "move.confirm": "Confirm move",
   "move_success": "Moved Successfully",
   "move_to": "Move to",
+  "move_to_root": "Move to root",
   "n_agent_amount": "{{amount}} Agent limit",
   "n_ai_points": "{{amount}} points",
   "n_app_registration_amount": "{{amount}} app registrations",

--- a/packages/web/i18n/ko-KR/common.json
+++ b/packages/web/i18n/ko-KR/common.json
@@ -918,6 +918,7 @@
   "move.confirm": "이동 확인",
   "move_success": "이동되었습니다",
   "move_to": "다음으로 이동",
+  "move_to_root": "루트로 이동",
   "n_agent_amount": "{{amount}}개 에이전트 한도",
   "n_ai_points": "{{amount}} 포인트",
   "n_app_registration_amount": "{{amount}}개 앱 등록",

--- a/packages/web/i18n/zh-CN/common.json
+++ b/packages/web/i18n/zh-CN/common.json
@@ -921,6 +921,7 @@
   "move.confirm": "确认移动",
   "move_success": "移动成功",
   "move_to": "移动到",
+  "move_to_root": "移动到根目录",
   "n_agent_amount": "{{amount}} 个 Agent",
   "n_ai_points": "{{amount}} 积分",
   "n_app_registration_amount": "{{amount}} 个应用备案",

--- a/packages/web/i18n/zh-Hant/common.json
+++ b/packages/web/i18n/zh-Hant/common.json
@@ -921,6 +921,7 @@
   "move.confirm": "確認移動",
   "move_success": "移動成功",
   "move_to": "移動至",
+  "move_to_root": "移動至根目錄",
   "n_agent_amount": "{{amount}} 個 Agent",
   "n_ai_points": "{{amount}} 積分",
   "n_app_registration_amount": "{{amount}} 個應用程式備案",

--- a/packages/web/test/hooks/usePagination.test.ts
+++ b/packages/web/test/hooks/usePagination.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+
+import React, { useEffect, useLayoutEffect } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PaginationProps, PaginationResponse } from '@fastgpt/global/openapi/api';
+import { usePagination } from '../../hooks/usePagination';
+
+const reactGlobals = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+reactGlobals.IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  router: {
+    query: {},
+    pathname: '/test'
+  },
+  toast: vi.fn()
+}));
+
+vi.mock('next/router', () => ({
+  useRouter: () => mocks.router
+}));
+
+vi.mock('../../hooks/useSystem', () => ({
+  useSystem: () => ({ isPc: false })
+}));
+
+vi.mock('../../hooks/useToast', () => ({
+  useToast: () => ({ toast: mocks.toast })
+}));
+
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}));
+
+vi.mock('../../components/common/Icon', () => ({
+  default: () => null
+}));
+
+vi.mock('../../components/common/MyMenu', () => ({
+  default: () => null
+}));
+
+vi.mock('@chakra-ui/react', () => ({
+  Box: React.forwardRef<HTMLDivElement, React.PropsWithChildren<Record<string, unknown>>>(
+    function MockBox({ children, ...props }, ref) {
+      return React.createElement('div', { ...props, ref }, children);
+    }
+  ),
+  Flex: React.forwardRef<HTMLDivElement, React.PropsWithChildren<Record<string, unknown>>>(
+    function MockFlex({ children, ...props }, ref) {
+      return React.createElement('div', { ...props, ref }, children);
+    }
+  )
+}));
+
+vi.mock('ahooks', async () => {
+  const actual = await vi.importActual<typeof import('ahooks')>('ahooks');
+  const { useEffect: useReactEffect } = await vi.importActual<typeof import('react')>('react');
+
+  return {
+    ...actual,
+    useRequest: (
+      service: () => Promise<unknown>,
+      options: { manual?: boolean; refreshDeps?: unknown[] } = {}
+    ) => {
+      const refreshDepsKey = JSON.stringify(options.refreshDeps ?? []);
+
+      useReactEffect(() => {
+        if (options.manual === false) {
+          void service();
+        }
+      }, [options.manual, refreshDepsKey]);
+
+      return { runAsync: service };
+    }
+  };
+});
+
+type TestItem = string;
+type TestResponse = PaginationResponse<TestItem>;
+type TestRequest = {
+  params: PaginationProps<undefined>;
+  resolve: (response: TestResponse) => void;
+  reject: (error: unknown) => void;
+};
+
+const createDeferredApi = () => {
+  const requests: TestRequest[] = [];
+  const api = vi.fn((params: PaginationProps<undefined>) => {
+    return new Promise<TestResponse>((resolve, reject) => {
+      requests.push({ params, resolve, reject });
+    });
+  });
+
+  return { api, requests };
+};
+
+type HarnessProps = {
+  api: (params: PaginationProps<undefined>) => Promise<TestResponse>;
+  onState: (state: ReturnType<typeof usePagination<TestItem, TestItem>>) => void;
+};
+
+const Harness = ({ api, onState }: HarnessProps) => {
+  const state = usePagination(api, {
+    type: 'scroll',
+    defaultPageSize: 1
+  });
+
+  useLayoutEffect(() => {
+    const container = document.querySelector('[data-testid="scroll-data"]');
+    if (!(container instanceof HTMLDivElement)) return;
+
+    Object.defineProperty(container, 'clientHeight', {
+      configurable: true,
+      value: 100
+    });
+    Object.defineProperty(container, 'scrollHeight', {
+      configurable: true,
+      value: 100
+    });
+  });
+
+  useEffect(() => onState(state), [onState, state]);
+
+  return React.createElement(
+    state.ScrollData,
+    { 'data-testid': 'scroll-data' },
+    React.createElement('span', null, state.data.join(','))
+  );
+};
+
+const renderHarness = async (root: Root, props: HarnessProps) => {
+  await act(async () => {
+    root.render(React.createElement(Harness, props));
+    await Promise.resolve();
+  });
+};
+
+describe('usePagination', () => {
+  beforeEach(() => {
+    vi.stubGlobal('React', React);
+    vi.useFakeTimers();
+    mocks.router.query = {};
+    mocks.toast.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('stops automatic retries after a failed scroll page and allows manual retry', async () => {
+    const { api, requests } = createDeferredApi();
+    const onState = vi.fn();
+    const root = createRoot(document.createElement('div'));
+
+    await renderHarness(root, { api, onState });
+    expect(requests[0]?.params.pageNum).toBe(1);
+
+    await act(async () => {
+      requests[0].resolve({ list: ['first'], total: 2 });
+      await Promise.resolve();
+      vi.advanceTimersByTime(60);
+      await Promise.resolve();
+    });
+
+    expect(requests[1]?.params.pageNum).toBe(2);
+
+    await act(async () => {
+      requests[1].reject(new Error('request failed'));
+      await Promise.resolve();
+      vi.advanceTimersByTime(60);
+      await Promise.resolve();
+    });
+
+    expect(requests).toHaveLength(2);
+    expect(onState.mock.lastCall?.[0].error).toBeInstanceOf(Error);
+
+    await act(async () => {
+      onState.mock.lastCall?.[0].getData(2);
+      await Promise.resolve();
+    });
+
+    expect(requests).toHaveLength(3);
+    expect(requests[2]?.params.pageNum).toBe(2);
+    root.unmount();
+  });
+});

--- a/packages/web/test/hooks/useScrollPagination.test.ts
+++ b/packages/web/test/hooks/useScrollPagination.test.ts
@@ -16,11 +16,19 @@ vi.mock('../../hooks/useToast', () => ({
 }));
 
 vi.mock('../../components/common/MyBox', () => ({
-  default: () => null
+  default: React.forwardRef<HTMLDivElement, React.PropsWithChildren<Record<string, unknown>>>(
+    function MockMyBox({ children, ...props }, ref) {
+      return React.createElement('div', { ...props, ref }, children);
+    }
+  )
 }));
 
 vi.mock('@chakra-ui/react', () => ({
-  Box: () => null
+  Box: React.forwardRef<HTMLDivElement, React.PropsWithChildren<Record<string, unknown>>>(
+    function MockBox({ children, ...props }, ref) {
+      return React.createElement('div', { ...props, ref }, children);
+    }
+  )
 }));
 
 vi.mock('../../hooks/useRequest', async () => {
@@ -52,32 +60,39 @@ type RequestRecord = {
   params: ListParams;
   controller?: AbortController;
   resolve: (response: ListResponse) => void;
+  reject: (error: unknown) => void;
 };
 
 type HarnessProps = {
   query: string;
   api: (params: ListParams, controller?: AbortController) => Promise<ListResponse>;
   onState: (state: ReturnType<typeof useScrollPagination<ListParams, ListResponse>>) => void;
+  showPaginationTip?: boolean;
 };
 
-const Harness = ({ query, api, onState }: HarnessProps) => {
+const Harness = ({ query, api, onState, showPaginationTip = true }: HarnessProps) => {
   const state = useScrollPagination(api, {
     pageSize: 10,
     params: { query },
     refreshDeps: [query],
-    showErrorToast: false
+    showErrorToast: false,
+    showPaginationTip
   });
 
   useEffect(() => onState(state), [onState, state]);
 
-  return null;
+  return React.createElement(
+    state.ScrollData,
+    { 'data-testid': 'scroll-data' },
+    React.createElement('span', { 'data-testid': 'scroll-content' })
+  );
 };
 
 const createDeferredApi = () => {
   const requests: RequestRecord[] = [];
   const api = vi.fn((params: ListParams, controller?: AbortController) => {
-    return new Promise<ListResponse>((resolve) => {
-      requests.push({ params, controller, resolve });
+    return new Promise<ListResponse>((resolve, reject) => {
+      requests.push({ params, controller, resolve, reject });
     });
   });
 
@@ -138,5 +153,59 @@ describe('useScrollPagination', () => {
 
     expect(onState.mock.lastCall?.[0].data).toEqual(['second']);
     root.unmount();
+  });
+
+  it('exposes request errors and allows an explicit refresh retry', async () => {
+    const { api, requests } = createDeferredApi();
+    const onState = vi.fn();
+    const root = createRoot(document.createElement('div'));
+
+    await renderHarness(root, { query: 'retry', api, onState });
+
+    await act(async () => {
+      requests[0].reject(new Error('request failed'));
+      await Promise.resolve();
+    });
+
+    expect(onState.mock.lastCall?.[0].error).toBeInstanceOf(Error);
+
+    await act(async () => {
+      onState.mock.lastCall?.[0].refreshList();
+      await Promise.resolve();
+    });
+
+    expect(requests).toHaveLength(2);
+    root.unmount();
+  });
+
+  it('hides both pagination footer states when disabled', async () => {
+    const { api, requests } = createDeferredApi();
+    const onState = vi.fn();
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        React.createElement(Harness, {
+          query: 'without-footer',
+          api,
+          onState,
+          showPaginationTip: false
+        })
+      );
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      requests[0].resolve({ list: ['one'], total: 1 });
+      await Promise.resolve();
+    });
+
+    const scrollData = document.querySelector('[data-testid="scroll-data"]');
+    expect(scrollData?.textContent).not.toContain('common:request_end');
+    expect(scrollData?.textContent).not.toContain('common:request_more');
+    root.unmount();
+    host.remove();
   });
 });

--- a/packages/web/test/hooks/useVirtualList.test.ts
+++ b/packages/web/test/hooks/useVirtualList.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+import React, { useLayoutEffect } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useVirtualList } from '../../hooks/useVirtualList';
+
+const mocks = vi.hoisted(() => ({
+  paginationState: {
+    data: ['item'],
+    total: 2,
+    isLoading: false,
+    error: null as Error | null,
+    setData: vi.fn(),
+    setTotal: vi.fn(),
+    fetchData: vi.fn(),
+    refreshList: vi.fn()
+  }
+}));
+
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}));
+
+vi.mock('../../hooks/useScrollPagination', () => ({
+  useScrollPagination: () => mocks.paginationState
+}));
+
+vi.mock('@chakra-ui/react', () => ({
+  Box: React.forwardRef<HTMLDivElement, React.PropsWithChildren<Record<string, unknown>>>(
+    function MockBox({ children, ...props }, ref) {
+      return React.createElement('div', { ...props, ref }, children);
+    }
+  )
+}));
+
+type HarnessProps = {
+  version: number;
+};
+
+const Harness = ({ version }: HarnessProps) => {
+  const state = useVirtualList(vi.fn(), {
+    itemHeight: 40,
+    pageSize: 10
+  });
+
+  useLayoutEffect(() => {
+    const container = state.containerRef.current;
+    if (!container) return;
+
+    Object.defineProperty(container, 'clientHeight', {
+      configurable: true,
+      value: 100
+    });
+    Object.defineProperty(container, 'scrollHeight', {
+      configurable: true,
+      value: 100
+    });
+  }, [state.containerRef, version]);
+
+  return React.createElement(
+    state.ScrollList,
+    { 'data-testid': 'scroll-list' },
+    React.createElement('div', { key: version }, mocks.paginationState.data.join(','))
+  );
+};
+
+const createTestRoot = () => {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  return { host, root: createRoot(host) };
+};
+
+const renderHarness = async (root: Root, version: number) => {
+  await act(async () => {
+    root.render(React.createElement(Harness, { version }));
+    await Promise.resolve();
+  });
+};
+
+describe('useVirtualList', () => {
+  beforeEach(() => {
+    mocks.paginationState.data = ['item'];
+    mocks.paginationState.total = 2;
+    mocks.paginationState.isLoading = false;
+    mocks.paginationState.error = null;
+    mocks.paginationState.fetchData.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('stops automatic pagination after a failed request', async () => {
+    const { host, root } = createTestRoot();
+    await renderHarness(root, 0);
+
+    mocks.paginationState.fetchData.mockClear();
+    mocks.paginationState.isLoading = true;
+    await renderHarness(root, 1);
+
+    mocks.paginationState.fetchData.mockClear();
+    mocks.paginationState.isLoading = false;
+    mocks.paginationState.error = new Error('request failed');
+    await renderHarness(root, 2);
+
+    expect(mocks.paginationState.fetchData).not.toHaveBeenCalled();
+
+    mocks.paginationState.error = null;
+    await act(async () => {
+      mocks.paginationState.fetchData({ init: false });
+      await Promise.resolve();
+    });
+    expect(mocks.paginationState.fetchData).toHaveBeenCalledTimes(1);
+
+    root.unmount();
+    host.remove();
+  });
+
+  it('continues automatic pagination when a successful response changes the data', async () => {
+    const { host, root } = createTestRoot();
+    await renderHarness(root, 0);
+    mocks.paginationState.fetchData.mockClear();
+
+    mocks.paginationState.data = ['updated'];
+    await renderHarness(root, 1);
+
+    expect(mocks.paginationState.fetchData).toHaveBeenCalled();
+    root.unmount();
+    host.remove();
+  });
+});

--- a/projects/app/src/components/common/folder/MoveModal.tsx
+++ b/projects/app/src/components/common/folder/MoveModal.tsx
@@ -24,6 +24,7 @@ type Props = {
 const MoveModal = ({ moveResourceId, title, server, onConfirm, onClose, moveHint }: Props) => {
   const { t } = useTranslation();
   const [selectedId, setSelectedId] = useState<ParentIdType>();
+  const [isAtRoot, setIsAtRoot] = useState(true);
   const hasSelection = selectedId !== undefined;
 
   const onSelect = (item?: SelectOneResourceItemType) => {
@@ -34,10 +35,10 @@ const MoveModal = ({ moveResourceId, title, server, onConfirm, onClose, moveHint
     setSelectedId(item.id === rootId ? null : item.id);
   };
 
-  const { runAsync: onConfirmSelect, loading: confirming } = useRequest(
-    () => {
-      if (!hasSelection) return Promise.reject('');
-      return onConfirm(selectedId);
+  const { runAsync: onConfirmMove, loading: confirming } = useRequest(
+    (parentId: ParentIdType) => {
+      if (parentId === undefined) return Promise.reject('');
+      return onConfirm(parentId);
     },
     {
       onSuccess: onClose,
@@ -58,10 +59,20 @@ const MoveModal = ({ moveResourceId, title, server, onConfirm, onClose, moveHint
       }}
       footer={
         <>
+          {isAtRoot && (
+            <Button variant={'primary'} isLoading={confirming} onClick={() => onConfirmMove(null)}>
+              {t('common:move_to_root')}
+            </Button>
+          )}
+          <Box flex={1} />
           <Button variant={'whiteBase'} onClick={onClose}>
             {t('common:Cancel')}
           </Button>
-          <Button isLoading={confirming} isDisabled={!hasSelection} onClick={onConfirmSelect}>
+          <Button
+            isLoading={confirming}
+            isDisabled={!hasSelection}
+            onClick={() => onConfirmMove(selectedId)}
+          >
             {t('common:Confirm')}
           </Button>
         </>
@@ -85,6 +96,7 @@ const MoveModal = ({ moveResourceId, title, server, onConfirm, onClose, moveHint
           server={server}
           value={selectedId}
           onSelect={onSelect}
+          onCurrentParentIdChange={(parentId) => setIsAtRoot(parentId === null)}
           selectFolder
           disabledIds={[moveResourceId]}
           maxH={'100%'}

--- a/projects/app/src/components/common/folder/SelectOneResource.tsx
+++ b/projects/app/src/components/common/folder/SelectOneResource.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Box, type BoxProps, Flex } from '@chakra-ui/react';
 import {
   type GetResourceFolderListProps,
@@ -29,6 +29,7 @@ const SelectOneResource = ({
   server,
   value,
   onSelect,
+  onCurrentParentIdChange,
   maxH = ['80vh', '600px'],
   h = '100%',
   selectFolder = false,
@@ -37,6 +38,7 @@ const SelectOneResource = ({
   server: SelectOneResourceServer;
   value?: ParentIdType;
   onSelect: (e?: SelectOneResourceItemType) => any;
+  onCurrentParentIdChange?: (parentId: ParentIdType) => void;
   maxH?: BoxProps['maxH'];
   h?: BoxProps['h'];
   selectFolder?: boolean;
@@ -55,6 +57,10 @@ const SelectOneResource = ({
   const [path, setPath] = useState<ResourcePathItemType[]>([rootItem]);
   const currentParentId = path[path.length - 1]?.id === rootId ? null : path[path.length - 1]?.id;
 
+  useEffect(() => {
+    onCurrentParentIdChange?.(currentParentId);
+  }, [currentParentId, onCurrentParentIdChange]);
+
   const { data, ScrollData } = useScrollPagination(server, {
     pageSize: 50,
     params: { parentId: currentParentId },
@@ -68,7 +74,7 @@ const SelectOneResource = ({
 
   const selectRoot = () => {
     if (selectFolder) {
-      onSelect(value === null ? undefined : rootItem);
+      onSelect();
     }
     setPath([rootItem]);
   };
@@ -111,13 +117,7 @@ const SelectOneResource = ({
               px={1.5}
               py={0.5}
               borderRadius={'sm'}
-              color={
-                selectFolder && item.id === rootId && value === null
-                  ? 'primary.600'
-                  : index === path.length - 1
-                    ? 'myGray.900'
-                    : 'myGray.500'
-              }
+              color={index === path.length - 1 ? 'myGray.900' : 'myGray.500'}
               fontSize={'xs'}
               cursor={'pointer'}
               _hover={{ bg: 'myGray.100', color: 'primary.600' }}

--- a/projects/app/src/pageComponents/account/team/MemberTable.tsx
+++ b/projects/app/src/pageComponents/account/team/MemberTable.tsx
@@ -286,7 +286,7 @@ function MemberTable({ Tabs }: { Tabs: React.ReactNode }) {
 
       <MyBox isLoading={isLoading} flex={['0 0 auto', '1 0 0']} h={['auto', 0]} minH={0}>
         <MemberScrollData px={6} h={['auto', '100%']} overflowY={['visible', 'auto']}>
-          <TableContainer overflow={'unset'} fontSize={'sm'}>
+          <TableContainer overflow={'unset'} fontSize={'sm'} flexShrink={0}>
             <Table overflow={'unset'}>
               <Thead>
                 <Tr bgColor={'white !important'}>

--- a/projects/app/src/pageComponents/account/team/OrgManage/index.tsx
+++ b/projects/app/src/pageComponents/account/team/OrgManage/index.tsx
@@ -156,9 +156,16 @@ function OrgTable({ Tabs }: { Tabs: React.ReactNode }) {
             <Path paths={paths} rootName={userInfo?.team?.teamName} onClick={onPathClick} />
           )}
         </Box>
-        <Flex flex={['0 0 auto', '1 0 0']} h={['auto', 0]} w={'100%'} gap={'4'}>
-          <MemberScrollData flex="1" isLoading={isLoading}>
-            <TableContainer>
+        <Flex flex={['0 0 auto', '1 0 0']} h={['auto', 0]} minH={0} w={'100%'} gap={'4'}>
+          <MemberScrollData
+            flex={['0 0 auto', '1 0 0']}
+            h={['auto', '100%']}
+            minH={0}
+            overflowY={['visible', 'auto']}
+            isLoading={isLoading}
+          >
+            {/* 禁用 flex 压缩：否则容器会被压到可用高度并用 overflow-y:hidden 裁掉剩余行，父级无法滚动 */}
+            <TableContainer flexShrink={0}>
               <Table>
                 <Thead>
                   <Tr bg={'white !important'}>

--- a/projects/app/src/pageComponents/dashboard/agent/List.tsx
+++ b/projects/app/src/pageComponents/dashboard/agent/List.tsx
@@ -453,6 +453,8 @@ const List = () => {
       ScrollContainerRef={scrollContainerRef}
       h={'full'}
       minH={0}
+      pr={folderDetail ? [3, 2] : [3, 6]}
+      mr={folderDetail ? [-3, -2] : [-3, -6]}
       showLoadingOverlay={false}
     >
       <>

--- a/projects/app/src/pageComponents/dashboard/agent/context.tsx
+++ b/projects/app/src/pageComponents/dashboard/agent/context.tsx
@@ -94,7 +94,13 @@ export const AppListContext = createContext<AppListContextType>({
   pageSize: 50
 });
 
-const AppListContextProvider = ({ children }: { children: ReactNode }) => {
+const AppListContextProvider = ({
+  children,
+  showPaginationTip = true
+}: {
+  children: ReactNode;
+  showPaginationTip?: boolean;
+}) => {
   const { t } = useTranslation();
   const router = useRouter();
   const { parentId = null, type: queryType = 'all' } = router.query as {
@@ -186,7 +192,8 @@ const AppListContextProvider = ({ children }: { children: ReactNode }) => {
       ],
       pageSize,
       throttleWait: 500,
-      refreshOnWindowFocus: true
+      refreshOnWindowFocus: true,
+      showPaginationTip
     }
   );
   const loadMyApps = useCallback(() => fetchData({ init: true }), [fetchData]);

--- a/projects/app/src/pageComponents/dashboard/skill/List.tsx
+++ b/projects/app/src/pageComponents/dashboard/skill/List.tsx
@@ -581,6 +581,8 @@ const List = ({
       ScrollContainerRef={scrollContainerRef}
       h={'full'}
       minH={0}
+      pr={[3, 6]}
+      mr={[-3, -6]}
       showLoadingOverlay={false}
     >
       <>

--- a/projects/app/src/pageComponents/dashboard/skill/context.tsx
+++ b/projects/app/src/pageComponents/dashboard/skill/context.tsx
@@ -143,6 +143,7 @@ const SkillListContextProvider = ({ children }: { children: ReactNode }) => {
         isPc
       ],
       pageSize,
+      showPaginationTip: false,
       throttleWait: 500,
       refreshOnWindowFocus: false
     }

--- a/projects/app/src/pageComponents/dataset/list/List.tsx
+++ b/projects/app/src/pageComponents/dataset/list/List.tsx
@@ -419,6 +419,8 @@ function List() {
       ScrollContainerRef={scrollContainerRef}
       h={'full'}
       minH={0}
+      pr={folderDetail ? [3, 2] : [3, 6]}
+      mr={folderDetail ? [-3, -2] : [-3, -6]}
       showLoadingOverlay={false}
     >
       <>

--- a/projects/app/src/pageComponents/dataset/list/context.tsx
+++ b/projects/app/src/pageComponents/dataset/list/context.tsx
@@ -157,7 +157,8 @@ function DatasetContextProvider({ children }: { children: React.ReactNode }) {
       ],
       pageSize,
       throttleWait: 300,
-      refreshOnWindowFocus: false
+      refreshOnWindowFocus: false,
+      showPaginationTip: false
     }
   );
   const loadMyDatasets = useCallback(() => fetchData({ init: true }), [fetchData]);

--- a/projects/app/src/pages/account/team/index.tsx
+++ b/projects/app/src/pages/account/team/index.tsx
@@ -166,9 +166,10 @@ const Team = () => {
           pt={[4, 6]}
           px={teamTab === TeamTabEnum.org ? 6 : 0}
           flex={['0 0 auto', '1 0 0']}
+          minH={0}
           display={'flex'}
           flexDirection={'column'}
-          overflow={teamTab === TeamTabEnum.org ? ['visible', 'auto'] : ['visible', 'hidden']}
+          overflow={['visible', 'hidden']}
         >
           {teamTab === TeamTabEnum.member && <MemberTable Tabs={Tabs} />}
           {teamTab === TeamTabEnum.org && <OrgManage Tabs={Tabs} />}

--- a/projects/app/src/pages/dashboard/agent/index.tsx
+++ b/projects/app/src/pages/dashboard/agent/index.tsx
@@ -265,7 +265,7 @@ function ContextRender() {
   return (
     <DashboardContainer>
       {({ MenuIcon }) => (
-        <AppListContextProvider>
+        <AppListContextProvider showPaginationTip={false}>
           <MyApps MenuIcon={MenuIcon} />
         </AppListContextProvider>
       )}

--- a/projects/app/src/pages/dashboard/tool/index.tsx
+++ b/projects/app/src/pages/dashboard/tool/index.tsx
@@ -245,7 +245,7 @@ function ContextRender() {
   return (
     <DashboardContainer>
       {({ MenuIcon }) => (
-        <AppListContextProvider>
+        <AppListContextProvider showPaginationTip={false}>
           <MyTools MenuIcon={MenuIcon} />
         </AppListContextProvider>
       )}


### PR DESCRIPTION
## Summary

Fixes pagination state handling and list scrolling regressions across the paginated resource lists.

### Hooks (`packages/web/hooks`)

- `usePagination` / `useScrollPagination` / `useVirtualList`: track request failures and stop auto-loading further pages after a failed request. Previously the scroll watcher kept re-triggering `fetchData` while the request was in flight/failed, which caused repeated requests against a broken endpoint.
- `isEmpty` is no longer reported while an error is present, so the empty placeholder and the error toast/tip do not appear at the same time.
- `useScrollPagination` now exposes `error` and a new `showPaginationTip` option, letting callers hide the built-in "loading / no more" tip when the container renders its own footer.
- Scroll watchers now depend on `data` instead of `data.length`, so a same-size refresh still advances the next page correctly.

### App

- Folder move modal: add a "Move to root" action; `SelectOneResource` reports the current parent folder via `onCurrentParentIdChange`, so the button only shows when moving to the root is actually possible.
- Dashboard agent/dataset/skill lists: align the scroll container padding with the folder detail layout.
- Team page: fix nested flex scrolling — the member/org table container is no longer flex-shrunk and clipped by `overflow-y: hidden`, so the parent container scrolls the full table.

### i18n

- Add `move_to_root` for `en`, `zh-CN`, `zh-Hant`, `ko-KR`.

### Tests

- Add `usePagination`, `useVirtualList` hook tests and extend `useScrollPagination` tests to cover the error / no-auto-retry behavior.

## Verification

```
pnpm test packages/web/test/hooks/usePagination.test.ts \
  packages/web/test/hooks/useScrollPagination.test.ts \
  packages/web/test/hooks/useVirtualList.test.ts
```

Result: 3 test files passed, 7 tests passed.
