### PR TITLE
fix(web): folder picker empty state and clear selection when switching folders

### DIFF
--- a/projects/app/src/components/common/folder/SelectOneResource.tsx
+++ b/projects/app/src/components/common/folder/SelectOneResource.tsx
@@ -67,7 +67,9 @@ const SelectOneResource = ({
     params: { parentId: currentParentId },
     refreshDeps: [currentParentId],
     showNoMoreTip: false,
-    EmptyTip: <EmptyTip text={t('common:folder.empty')} />
+    EmptyTip: (
+      <EmptyTip text={t('common:folder.empty')} flex={1} mt={0} py={0} justifyContent={'center'} />
+    )
   });
   const isAutoHeight = h === 'auto';
 

--- a/projects/app/src/components/common/folder/SelectOneResource.tsx
+++ b/projects/app/src/components/common/folder/SelectOneResource.tsx
@@ -10,6 +10,7 @@ import MyIcon from '@fastgpt/web/components/common/Icon';
 import Avatar from '@fastgpt/web/components/common/Avatar';
 import { useScrollPagination } from '@fastgpt/web/hooks/useScrollPagination';
 import { FolderImgUrl } from '@fastgpt/global/common/file/image/constants';
+import EmptyTip from '@fastgpt/web/components/common/EmptyTip';
 import { useTranslation } from 'next-i18next';
 
 export type SelectOneResourceItemType = GetResourceListItemResponse & {
@@ -65,7 +66,8 @@ const SelectOneResource = ({
     pageSize: 50,
     params: { parentId: currentParentId },
     refreshDeps: [currentParentId],
-    showNoMoreTip: false
+    showNoMoreTip: false,
+    EmptyTip: <EmptyTip text={t('common:folder.empty')} />
   });
   const isAutoHeight = h === 'auto';
 
@@ -80,6 +82,9 @@ const SelectOneResource = ({
   };
 
   const enterFolder = (item: ResourcePathItemType) => {
+    if (selectFolder) {
+      onSelect();
+    }
     setPath((state) => (state[state.length - 1]?.id === item.id ? state : [...state, item]));
   };
 
@@ -125,6 +130,9 @@ const SelectOneResource = ({
                 if (index === 0) {
                   selectRoot();
                   return;
+                }
+                if (selectFolder) {
+                  onSelect();
                 }
                 setPath((state) => state.slice(0, index + 1));
               }}

--- a/projects/app/src/pageComponents/dashboard/agent/context.tsx
+++ b/projects/app/src/pageComponents/dashboard/agent/context.tsx
@@ -192,7 +192,6 @@ const AppListContextProvider = ({
       ],
       pageSize,
       throttleWait: 500,
-      refreshOnWindowFocus: true,
       showPaginationTip
     }
   );


### PR DESCRIPTION
## What changed

Fix two issues in the shared folder picker (`SelectOneResource`) used by the move dialogs of apps / skills / datasets:

- **Empty folder showed a blank area.** The picker now renders the existing `EmptyTip` with the existing `common:folder.empty` text, centered in the remaining space. The empty state fills the flex container (`flex=1`, `mt=0`, `py=0`) so it no longer adds height that pushes the modal body into scrolling.
- **Stale selection when switching folders.** After selecting a folder in `selectFolder` mode, entering a subfolder (arrow) or clicking a breadcrumb kept the previous selection, so the confirm target did not match the folder being browsed. Navigation now clears the selection, which resets the highlight and disables the confirm button. Usages without `selectFolder` (app select popover, chat app switcher) keep their current behavior.

## Other changes in this branch

- Remove `refreshOnWindowFocus: true` from the app list pagination request in `dashboard/agent/context.tsx`.
- Update the `pro` submodule pointer.

## Files

- `projects/app/src/components/common/folder/SelectOneResource.tsx`
- `projects/app/src/pageComponents/dashboard/agent/context.tsx`

## How to verify

- `pnpm --filter @fastgpt/app typecheck`
- Open the move dialog of an app / skill / dataset and enter an empty folder: the empty state is shown instead of a blank area, without an inner scrollbar.
- Select a folder, then enter a subfolder through the arrow or click a breadcrumb item: the highlight is cleared and the confirm button becomes disabled; the root breadcrumb still clears the selection.
