### PR TITLE
fix: simpleText 的空白正则会删掉正文里的 ]]

### DIFF
--- a/packages/global/common/string/tools.ts
+++ b/packages/global/common/string/tools.ts
@@ -17,10 +17,13 @@ export const hashStr = (str: string) => {
 /* simple text, remove chinese space and extra \n */
 export const simpleText = (text = '') => {
   text = text.trim();
-  text = text.replace(/([\u4e00-\u9fa5])[\s&&[^\n]]+([\u4e00-\u9fa5])/g, '$1$2');
+  // `[^\S\r\n]` \u662f\u201c\u9664\u6362\u884c\u5916\u7684\u7a7a\u767d\u201d\uff1b`[\s&&[^\n]]` \u7684\u4ea4\u96c6\u5199\u6cd5\u53ea\u5728 v \u6807\u5fd7\u4e0b\u6210\u7acb\uff0c
+  // \u666e\u901a\u6b63\u5219\u4f1a\u628a\u672b\u5c3e\u7684 `]` \u5f53\u5b57\u9762\u91cf\uff0c\u53cd\u800c\u4f1a\u5220\u6389\u6b63\u6587\u91cc\u7684 `]]`\u3002
+  text = text.replace(/([\u4e00-\u9fa5])[^\S\r\n]+([\u4e00-\u9fa5])/g, '$1$2');
   text = text.replace(/\r\n|\r/g, '\n');
   text = text.replace(/\n{3,}/g, '\n\n');
-  text = text.replace(/[\s&&[^\n]]{2,}/g, ' ');
+  // \u53ea\u538b\u7f29\u884c\u5185\u591a\u4f59\u7a7a\u767d\uff0c\u884c\u9996\u7f29\u8fdb\u4fdd\u7559\uff0c\u907f\u514d\u7834\u574f\u4ee3\u7801\u5757\u3002
+  text = text.replace(/(?<=\S)[^\S\r\n]{2,}/g, ' ');
   text = text.replace(/[\x00-\x08]/g, ' ');
 
   return text;

--- a/packages/global/test/common/string/markdown.test.ts
+++ b/packages/global/test/common/string/markdown.test.ts
@@ -392,7 +392,8 @@ describe('markdown 字符串处理函数测试', () => {
       const text = `before ![alt](data:image/png;base64,${base64Data}) after`;
       const result = await parseMarkdownBase64Images(text);
 
-      expect(result).toBe('before  after');
+      // 图片被删除后留下的多余空白由 simpleText 压缩成一个空格
+      expect(result).toBe('before after');
       expect(result).not.toContain('data:image/png;base64');
     });
 

--- a/packages/global/test/common/string/tools.test.ts
+++ b/packages/global/test/common/string/tools.test.ts
@@ -31,8 +31,22 @@ describe('string tools', () => {
 
   it('should normalize text formatting', () => {
     const input = '  你 好 \r\n\r\n\r\nfoo\x00bar  ';
-    expect(simpleText(input)).toBe('你 好 \n\nfoo bar');
-    expect(simpleText('a   b')).toBe('a   b');
+    expect(simpleText(input)).toBe('你好 \n\nfoo bar');
+    expect(simpleText('a   b')).toBe('a b');
+  });
+
+  it('should collapse blanks between chinese characters', () => {
+    expect(simpleText('中文  中文')).toBe('中文中文');
+    expect(simpleText('中文\t中文')).toBe('中文中文');
+    // 全角空格
+    expect(simpleText('中文　中文')).toBe('中文中文');
+  });
+
+  it('should keep brackets and line indentation while normalizing blanks', () => {
+    expect(simpleText('参考 [[ 知识库 ]] 一节')).toBe('参考 [[ 知识库 ]] 一节');
+    expect(simpleText('{"matrix": [[]]}')).toBe('{"matrix": [[]]}');
+    expect(simpleText('中文 ]中文')).toBe('中文 ]中文');
+    expect(simpleText('def f():\n    return 1')).toBe('def f():\n    return 1');
   });
 
   it('should replace sensitive text', () => {


### PR DESCRIPTION
## 现象

往知识库里导入一段带 `]]` 的文本，`]]` 会凭空消失：

| 原文 | 入库后 |
| --- | --- |
| `参考 [[ 知识库 ]] 一节` | `参考 [[ 知识库  一节` |
| `{"matrix": [[]]}` | `{"matrix": [ }` |
| `value = arr[ ]]` | `value = arr[ ` |

同时 `simpleText` 注释里写的 “remove chinese space” 一直没生效：`中文  中文` 原样保留，多余空白也没有被压缩。

## 原因

`packages/global/common/string/tools.ts` 的两条规则用了字符组交集写法：

```js
text = text.replace(/([一-龥])[\s&&[^\n]]+([一-龥])/g, '$1$2');
text = text.replace(/[\s&&[^\n]]{2,}/g, ' ');
```

`&&` 交集只在 `v` 标志下成立。没有 `v` 时字符组在第一个 `]` 处就闭合了（组内是空白、`&`、`[`、`^`），后面那个 `]` 变成**字面量**并被量词修饰。所以第二条规则实际匹配的是「一个空白/`[`/`&`/`^` + 两个及以上 `]`」，命中后整段替换成一个空格 —— 空白没压缩，反而把正文的 `]]` 删掉了；第一条同理，删的是中文之间的 ` ]`。

`simpleText` 在这些路径上都会跑到：`textSplitter` 的每个分块、`simpleMarkdownText` / `readFileRawText`（含 Doc2X 等解析结果）、以及 `/api/core/dataset/data/insertData`。

## 修改

改用 `[^\S\r\n]`（除换行外的空白，顺带覆盖全角空格 U+3000）。

压缩行内空白那条加了 `(?<=\S)`：只压缩行内多余空白，**保留行首缩进**，避免把知识库里代码块的缩进压掉。（`replaceSensitiveText` 已经在用后行断言，运行环境一致。）

因为这一步以前从未真正生效，有 3 处旧断言记录的是当时的实际行为，需要跟着更新：

- `simpleText('a   b')`：`'a   b'` → `'a b'`
- `simpleText('  你 好 \r\n\r\n\r\nfoo\x00bar  ')`：`'你 好 \n\nfoo bar'` → `'你好 \n\nfoo bar'`（注释承诺的中文空格去除现在生效了）
- `parseMarkdownBase64Images('before ![alt](data:…) after')`：`'before  after'` → `'before after'`（图片被删后留下的双空格现在会被压成一个）

如果你们更希望完全保持现状、不启用空白压缩，我可以把第二条规则直接去掉，只保留「不再删 `]]`」这部分，改动会更小 —— 按你们的偏好来即可。

## 验证

```
cd packages/global
vitest run --config vitest.config.ts --coverage.enabled=false --maxWorkers=1 --no-fileParallelism \
  test/common/string/tools.test.ts test/common/string/markdown.test.ts
```

- 修改前（只加测试、不改实现）：`Test Files 1 failed | 1 passed (2)`，`Tests 3 failed | 56 passed (59)`
  - `expected '参考 [[ 知识库  一节' to be '参考 [[ 知识库 ]] 一节'`
  - `expected '中文  中文' to be '中文中文'`
  - `expected '你 好 \n\nfoo bar' to be '你好 \n\nfoo bar'`
- 修改后，跑完整目录 `test/common/string`：`Test Files 7 passed (7)`，`Tests 130 passed (130)`

新增的回归用例同时钉住了「不删 `]]`」和「保留行首缩进」：

```js
expect(simpleText('参考 [[ 知识库 ]] 一节')).toBe('参考 [[ 知识库 ]] 一节');
expect(simpleText('{"matrix": [[]]}')).toBe('{"matrix": [[]]}');
expect(simpleText('def f():\n    return 1')).toBe('def f():\n    return 1');
```

`prettier --check` 与 `git diff --check` 均通过。
