### PR TITLE
fix: HTML 表格转 Markdown 时表头列数没有补齐，导致表格缺列

### DIFF
--- a/packages/global/common/string/markdown.ts
+++ b/packages/global/common/string/markdown.ts
@@ -89,9 +89,14 @@ export const htmlTable2Md = (content: string): string => {
       });
       const chunks: string[] = [];
 
+      // 表头行可能比后面的数据行窄（首行只有标题单元格），列数不足会让分隔行
+      // 少于数据列，Markdown 渲染时多出来的列会被丢弃，这里和数据行一样补齐。
       const headerCells = tableData[0]
         .slice(0, maxColumns)
         .map((cell) => (cell === '^^' ? ' ' : cell || ' '));
+      while (headerCells.length < maxColumns) {
+        headerCells.push(' ');
+      }
       const headerRow = '| ' + headerCells.join(' | ') + ' |';
       chunks.push(headerRow);
 

--- a/packages/global/test/common/string/markdown.test.ts
+++ b/packages/global/test/common/string/markdown.test.ts
@@ -153,6 +153,24 @@ describe('markdown 字符串处理函数测试', () => {
       expect(result).toContain('| D |'); // 自动填充空列
     });
 
+    it('应该在表头列数少于数据行时补齐表头和分隔行', () => {
+      const html = `
+        <table>
+          <tr><td>季度报表</td></tr>
+          <tr><td>Q1</td><td>Q2</td><td>Q3</td></tr>
+          <tr><td>1</td><td>2</td><td>3</td></tr>
+        </table>
+      `;
+      const lines = htmlTable2Md(html).trim().split('\n');
+      const countColumns = (line: string) => line.split('|').length - 2;
+
+      expect(lines[0]).toContain('季度报表');
+      expect(countColumns(lines[0])).toBe(3);
+      expect(lines[1]).toBe('| --- | --- | --- |');
+      expect(lines[2]).toBe('| Q1 | Q2 | Q3 |');
+      expect(lines[3]).toBe('| 1 | 2 | 3 |');
+    });
+
     it('应该处理无效的表格 HTML', () => {
       const invalidHtml = '<table><tr>invalid</tr></table>';
       const result = htmlTable2Md(invalidHtml);


### PR DESCRIPTION
## 现象

用 Doc2X 解析的文档入知识库后，表格会少列。触发条件是表格首行的单元格比后面的数据行少 —— PDF/Word 里很常见的「首行是一个标题格，下面才是真正的表头/数据」。

```html
<table>
  <tr><td>季度报表</td></tr>
  <tr><td>Q1</td><td>Q2</td><td>Q3</td></tr>
  <tr><td>1</td><td>2</td><td>3</td></tr>
</table>
```

`htmlTable2Md` 现在输出：

```
| 季度报表 |
| --- |
| Q1 | Q2 | Q3 |
| 1 | 2 | 3 |
```

Markdown 表格是按**分隔行**确定列数的，分隔行只有一列，渲染时 Q2 / Q3 两整列会被丢掉，分块和检索到的也只剩第一列。

## 原因

`packages/global/common/string/markdown.ts` 里，数据行会补齐到最终列数：

```js
const paddedRow = row.slice(0, maxColumns).map(...);
while (paddedRow.length < maxColumns) {
  paddedRow.push(' ');
}
```

表头行没有这一步。`maxColumns` 是遍历完所有行才确定的，而行内那段 `for (let i = 0; i < maxColumns; i++)` 补空列时用的是「到当前行为止」的 `maxColumns`，所以首行窄于后续行时，`tableData[0]` 的长度会停在 1，分隔行也跟着只生成一列。

## 修改

按数据行同样的方式，把表头补齐到 `maxColumns`（3 行）。输出变成：

```
| 季度报表 |   |   |
| --- | --- | --- |
| Q1 | Q2 | Q3 |
| 1 | 2 | 3 |
```

只补列，不动已有的 colspan / rowspan / 空单元格逻辑。

> 顺带记一下：`<th>` 单元格目前不会被 `<td[^>]*>` 匹配到，是另一个独立问题，本 PR 不处理。

## 验证

```
cd packages/global
vitest run --config vitest.config.ts --coverage.enabled=false --maxWorkers=1 --no-fileParallelism \
  test/common/string/markdown.test.ts
```

- 修改前（只加测试、不改实现）：`Tests 1 failed | 47 passed (48)`，失败信息 `AssertionError: expected 1 to be 3`（表头列数）
- 修改后，跑完整目录 `test/common/string`：`Test Files 7 passed (7)`，`Tests 129 passed (129)`

原有的 colspan / rowspan / 空单元格 / 不规则表格 / 多表格用例都保持通过。

`prettier --check` 与 `git diff --check` 均通过。
