### PR TITLE
fix(web): 取消全选会清掉其他页的选中项

### DIFF
--- a/packages/web/hooks/useTableMultipleSelect.tsx
+++ b/packages/web/hooks/useTableMultipleSelect.tsx
@@ -70,11 +70,13 @@ export const useTableMultipleSelect = <T = any,>({
   // Select all items
   const selectAllTrigger = useCallback(() => {
     if (isSelecteAll) {
-      setSelectedItems([]);
+      // 勾选只加当前 list，取消也只减当前 list，否则分页/搜索后取消全选会连带清掉其他页的选中项
+      const listIds = new Set(list.map((item) => getItemId(item)));
+      setSelectedItems((pre) => pre.filter((item) => !listIds.has(getItemId(item))));
     } else {
       setSelectedItems((pre) => [...pre, ...list.filter((item) => !isSelected(item))]);
     }
-  }, [isSelecteAll, list, isSelected]);
+  }, [isSelecteAll, list, isSelected, getItemId]);
 
   const selectedCount = selectedItems.length;
   // Check if has selections

--- a/packages/web/test/hooks/useTableMultipleSelect.test.ts
+++ b/packages/web/test/hooks/useTableMultipleSelect.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const reactGlobals = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+reactGlobals.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}));
+
+vi.mock('@chakra-ui/react', () => ({
+  Box: () => null,
+  Flex: () => null,
+  Checkbox: () => null
+}));
+
+import { useTableMultipleSelect } from '../../hooks/useTableMultipleSelect';
+
+type Item = { _id: string };
+
+describe('useTableMultipleSelect', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const renderSelectHook = () => {
+    let api: ReturnType<typeof useTableMultipleSelect<Item>> | undefined;
+    let updateList: React.Dispatch<React.SetStateAction<Item[]>> | undefined;
+
+    const Harness = () => {
+      const [list, setList] = React.useState<Item[]>([]);
+      updateList = setList;
+      api = useTableMultipleSelect<Item>({ list, getItemId: (item) => item._id });
+      return null;
+    };
+
+    act(() => {
+      root.render(React.createElement(Harness));
+    });
+
+    return {
+      getApi: () => api!,
+      getSelectedIds: () => api!.selectedItems.map((item) => item._id),
+      setList: (next: Item[]) =>
+        act(() => {
+          updateList!(next);
+        })
+    };
+  };
+
+  it('取消全选时只清除当前列表的选中项', () => {
+    const page1: Item[] = [{ _id: 'a' }, { _id: 'b' }];
+    const page2: Item[] = [{ _id: 'c' }, { _id: 'd' }];
+    const { getApi, getSelectedIds, setList } = renderSelectHook();
+
+    // 第 1 页勾选一条
+    setList(page1);
+    act(() => {
+      getApi().toggleSelect(page1[0]);
+    });
+    expect(getSelectedIds()).toEqual(['a']);
+
+    // 翻到第 2 页并全选本页，第 1 页的选中项保留
+    setList(page2);
+    act(() => {
+      getApi().selectAllTrigger();
+    });
+    expect(getSelectedIds()).toEqual(['a', 'c', 'd']);
+    expect(getApi().isSelecteAll).toBe(true);
+
+    // 再点一次取消全选，只应该取消第 2 页
+    act(() => {
+      getApi().selectAllTrigger();
+    });
+    expect(getSelectedIds()).toEqual(['a']);
+    expect(getApi().isSelecteAll).toBe(false);
+  });
+
+  it('单页场景下取消全选仍然清空所有选中项', () => {
+    const list: Item[] = [{ _id: 'a' }, { _id: 'b' }];
+    const { getApi, getSelectedIds, setList } = renderSelectHook();
+
+    setList(list);
+    act(() => {
+      getApi().selectAllTrigger();
+    });
+    expect(getSelectedIds()).toEqual(['a', 'b']);
+    expect(getApi().hasSelections).toBe(true);
+
+    act(() => {
+      getApi().selectAllTrigger();
+    });
+    expect(getSelectedIds()).toEqual([]);
+    expect(getApi().hasSelections).toBe(false);
+  });
+});


### PR DESCRIPTION
## 现象

在「应用 → 对话日志」里：

1. 第 1 页勾选几条记录，底部显示「已选 3 条」
2. 翻到第 2 页，点表头/底部的「全选」把本页也选上（已选 3 + 本页）
3. 再点一次取消全选

第 1 页勾选的记录也一起没了，计数直接归零，只能重新翻回去勾一遍。

同一个 hook 还用在知识库集合列表、模型表格、工具批量更新抽屉上，凡是 `list` 会因为翻页或搜索变化的地方都会遇到；搜索场景更容易踩到：勾了几行 → 输入关键词让列表变短 → 全选 → 取消全选，之前勾的行被清掉。

## 原因

`packages/web/hooks/useTableMultipleSelect.tsx` 里勾选和取消不对称：

```js
const selectAllTrigger = useCallback(() => {
  if (isSelecteAll) {
    setSelectedItems([]);                                                  // 清空全部
  } else {
    setSelectedItems((pre) => [...pre, ...list.filter((item) => !isSelected(item))]);  // 只加当前 list
  }
}, [isSelecteAll, list, isSelected]);
```

`isSelecteAll` 的语义是 `list.length > 0 && list.every(isSelected)`，也就是「当前 list 全选中」，勾选也只作用于当前 `list`；取消却是全局清空。`selectedItems` 本身会跨 `list` 变化累积（`toggleSelect` 不会重置），所以差异就暴露出来了。

## 修改

取消时只过滤掉当前 `list` 的 id，和勾选保持对称：

```js
const listIds = new Set(list.map((item) => getItemId(item)));
setSelectedItems((pre) => pre.filter((item) => !listIds.has(getItemId(item))));
```

`list` 就是全部数据的单页场景下，两种写法结果一致，行为不变。

## 验证

新增 `packages/web/test/hooks/useTableMultipleSelect.test.ts`，用 jsdom 渲染一个只调用该 hook 的壳组件，模拟翻页（切换 `list`）：

```
cd packages/web
vitest run --config vitest.config.ts --coverage.enabled=false --maxWorkers=1 --no-fileParallelism \
  test/hooks/useTableMultipleSelect.test.ts
```

- 修改前（只加测试、不改实现）：`Tests 1 failed | 1 passed (2)`

  ```
  FAIL  取消全选时只清除当前列表的选中项
  AssertionError: expected [] to deeply equal [ 'a' ]
  ```

- 修改后，跑完整 `test/hooks` 目录：`Test Files 7 passed (7)`，`Tests 21 passed (21)`

两个用例分别钉住了跨页取消只影响当前页、以及单页取消仍然清空，避免以后改回去。

`prettier --check` 与 `git diff --check` 均通过。
