### PR TITLE
fix(workflow): isolate tool runtime nodes so same-turn calls keep their own params

### DIFF
--- a/packages/service/core/workflow/dispatch/ai/agentLoopCore/application/runtime/workflowToolRunner.ts
+++ b/packages/service/core/workflow/dispatch/ai/agentLoopCore/application/runtime/workflowToolRunner.ts
@@ -310,8 +310,8 @@ export const createAgentLoopCoreWorkflowSystemToolExecutor = <TChildrenResponse 
  * ToolCall 和未来的简化 Agent 都可以把“某个 runtime node 作为工具入口运行”的能力交给这里。
  * 节点外壳只负责提供实际 runWorkflow 函数、展示信息和缓存/流式回调。
  *
- * 已知问题：普通 Workflow Tool 的首次执行和交互恢复都会复用并修改父流程的 runtime graph。
- * 当前保留原有状态传递行为，后续需要通过子流程快照和显式同步完成隔离。
+ * runTool 每次执行使用子图快照，避免同一轮内多次调用时污染共享 runtimeNodes 的 inputs。
+ * 交互恢复仍复用并修改父流程 runtime graph（与历史行为一致）。
  */
 export const createAgentLoopCoreWorkflowToolRunner = <TChildrenResponse = unknown>({
   runtimeNodes,
@@ -351,12 +351,19 @@ export const createAgentLoopCoreWorkflowToolRunner = <TChildrenResponse = unknow
     }
 
     const startParams = parseJsonArgs(call.function.arguments) ?? {};
-    initAgentLoopCoreWorkflowToolNodes(runtimeNodes, [toolInfo.rawData.nodeId], startParams);
-    initAgentLoopCoreWorkflowToolEdges(runtimeEdges, [toolInfo.rawData.nodeId]);
+    // 与 dataset_search 一致：隔离本次 tool 的 runtime 状态，避免入口参数残留到同轮后续调用。
+    const isolatedRuntimeNodes = cloneDeep(runtimeNodes);
+    const isolatedRuntimeEdges = cloneDeep(runtimeEdges);
+    initAgentLoopCoreWorkflowToolNodes(
+      isolatedRuntimeNodes,
+      [toolInfo.rawData.nodeId],
+      startParams
+    );
+    initAgentLoopCoreWorkflowToolEdges(isolatedRuntimeEdges, [toolInfo.rawData.nodeId]);
 
     const toolRunResponse = await runWorkflowTool({
-      runtimeNodes,
-      runtimeEdges
+      runtimeNodes: isolatedRuntimeNodes,
+      runtimeEdges: isolatedRuntimeEdges
     });
     const { result, flowResponse } = toToolRunResult<TChildrenResponse>(toolRunResponse);
 

--- a/packages/service/core/workflow/dispatch/ai/agentLoopCore/application/runtime/workflowToolRunner.ts
+++ b/packages/service/core/workflow/dispatch/ai/agentLoopCore/application/runtime/workflowToolRunner.ts
@@ -305,13 +305,60 @@ export const createAgentLoopCoreWorkflowSystemToolExecutor = <TChildrenResponse 
 };
 
 /**
+ * 将工具隔离子图上的副作用回写到父 runtime graph。
+ *
+ * 隔离保证本次 agent 注入的入口参数不会污染父图；回写保证变量更新写入的
+ * 节点 outputs、交互节点 isEntry，以及边 status 等仍能传递给父流程和后续恢复。
+ * 入口节点的 inputs 刻意不同步，避免同轮第二次调用残留上一次的 agent 参数。
+ */
+export const syncIsolatedWorkflowToolRuntimeSideEffects = ({
+  parentNodes,
+  parentEdges,
+  isolatedNodes,
+  isolatedEdges,
+  entryNodeIds
+}: {
+  parentNodes: RuntimeNodeItemType[];
+  parentEdges: RuntimeEdgeItemType[];
+  isolatedNodes: RuntimeNodeItemType[];
+  isolatedEdges: RuntimeEdgeItemType[];
+  entryNodeIds: string[];
+}) => {
+  const entryNodeIdSet = new Set(entryNodeIds);
+  const isolatedNodeMap = new Map(isolatedNodes.map((node) => [node.nodeId, node]));
+
+  parentNodes.forEach((parentNode) => {
+    const isolatedNode = isolatedNodeMap.get(parentNode.nodeId);
+    if (!isolatedNode) return;
+
+    parentNode.isEntry = isolatedNode.isEntry;
+    parentNode.outputs = cloneDeep(isolatedNode.outputs);
+
+    if (!entryNodeIdSet.has(parentNode.nodeId)) {
+      parentNode.inputs = cloneDeep(isolatedNode.inputs);
+    }
+  });
+
+  const getEdgeKey = (edge: RuntimeEdgeItemType) =>
+    `${edge.source ?? ''}-${edge.sourceHandle ?? ''}-${edge.target ?? ''}-${edge.targetHandle ?? ''}`;
+
+  const isolatedEdgeMap = new Map(isolatedEdges.map((edge) => [getEdgeKey(edge), edge]));
+
+  parentEdges.forEach((parentEdge, index) => {
+    const isolatedEdge = isolatedEdgeMap.get(getEdgeKey(parentEdge)) ?? isolatedEdges[index];
+    if (!isolatedEdge) return;
+    parentEdge.status = isolatedEdge.status;
+  });
+};
+
+/**
  * 创建 workflow 子工具执行器。
  *
  * ToolCall 和未来的简化 Agent 都可以把“某个 runtime node 作为工具入口运行”的能力交给这里。
  * 节点外壳只负责提供实际 runWorkflow 函数、展示信息和缓存/流式回调。
  *
- * runTool 每次执行使用子图快照，避免同一轮内多次调用时污染共享 runtimeNodes 的 inputs。
- * 交互恢复仍复用并修改父流程 runtime graph（与历史行为一致）。
+ * runTool / runInteractiveTool 均使用子图快照隔离执行，结束后将 outputs、isEntry、边 status
+ * 等副作用显式回写到父 runtime graph；入口节点 inputs 不同步，以避免同轮参数残留。
  */
 export const createAgentLoopCoreWorkflowToolRunner = <TChildrenResponse = unknown>({
   runtimeNodes,
@@ -350,21 +397,27 @@ export const createAgentLoopCoreWorkflowToolRunner = <TChildrenResponse = unknow
       };
     }
 
+    const entryNodeIds = [toolInfo.rawData.nodeId];
     const startParams = parseJsonArgs(call.function.arguments) ?? {};
     // 与 dataset_search 一致：隔离本次 tool 的 runtime 状态，避免入口参数残留到同轮后续调用。
     const isolatedRuntimeNodes = cloneDeep(runtimeNodes);
     const isolatedRuntimeEdges = cloneDeep(runtimeEdges);
-    initAgentLoopCoreWorkflowToolNodes(
-      isolatedRuntimeNodes,
-      [toolInfo.rawData.nodeId],
-      startParams
-    );
-    initAgentLoopCoreWorkflowToolEdges(isolatedRuntimeEdges, [toolInfo.rawData.nodeId]);
+    initAgentLoopCoreWorkflowToolNodes(isolatedRuntimeNodes, entryNodeIds, startParams);
+    initAgentLoopCoreWorkflowToolEdges(isolatedRuntimeEdges, entryNodeIds);
 
     const toolRunResponse = await runWorkflowTool({
       runtimeNodes: isolatedRuntimeNodes,
       runtimeEdges: isolatedRuntimeEdges
     });
+
+    syncIsolatedWorkflowToolRuntimeSideEffects({
+      parentNodes: runtimeNodes,
+      parentEdges: runtimeEdges,
+      isolatedNodes: isolatedRuntimeNodes,
+      isolatedEdges: isolatedRuntimeEdges,
+      entryNodeIds
+    });
+
     const { result, flowResponse } = toToolRunResult<TChildrenResponse>(toolRunResponse);
 
     /**
@@ -385,15 +438,26 @@ export const createAgentLoopCoreWorkflowToolRunner = <TChildrenResponse = unknow
   }: AgentLoopChildrenInteractiveParams<TChildrenResponse>) => {
     const entryNodeIds = (childrenResponse as { entryNodeIds?: string[] }).entryNodeIds ?? [];
 
-    // 交互恢复沿用原 toolCallId，最终仍由统一 tool_run_end 落 SSE 和运行详情。
-    initAgentLoopCoreWorkflowToolNodes(runtimeNodes, entryNodeIds);
-    initAgentLoopCoreWorkflowToolEdges(runtimeEdges, entryNodeIds);
+    // 交互恢复同样走隔离 + 回写，保证与 runTool 一致，且不把入口 inputs 写回父图。
+    const isolatedRuntimeNodes = cloneDeep(runtimeNodes);
+    const isolatedRuntimeEdges = cloneDeep(runtimeEdges);
+    initAgentLoopCoreWorkflowToolNodes(isolatedRuntimeNodes, entryNodeIds);
+    initAgentLoopCoreWorkflowToolEdges(isolatedRuntimeEdges, entryNodeIds);
 
     const toolRunResponse = await runWorkflowTool({
-      runtimeNodes,
-      runtimeEdges,
+      runtimeNodes: isolatedRuntimeNodes,
+      runtimeEdges: isolatedRuntimeEdges,
       lastInteractive: childrenResponse
     });
+
+    syncIsolatedWorkflowToolRuntimeSideEffects({
+      parentNodes: runtimeNodes,
+      parentEdges: runtimeEdges,
+      isolatedNodes: isolatedRuntimeNodes,
+      isolatedEdges: isolatedRuntimeEdges,
+      entryNodeIds
+    });
+
     const { result, flowResponse } = toToolRunResult<TChildrenResponse>(toolRunResponse);
 
     cacheToolFlowResponse?.({

--- a/packages/service/test/core/workflow/dispatch/ai/agentLoopCore/runtime/workflowToolRunner.test.ts
+++ b/packages/service/test/core/workflow/dispatch/ai/agentLoopCore/runtime/workflowToolRunner.test.ts
@@ -236,20 +236,19 @@ describe('createAgentLoopCoreWorkflowToolRunner', () => {
 
     const result = await runTool({ call });
 
-    // runTool 使用子图快照，不应污染父流程共享的 runtimeNodes/runtimeEdges。
-    expect(runtimeNodes[0]).toEqual({
-      nodeId: 'search',
-      inputs: [
-        {
-          key: 'q',
-          value: 'old',
-          renderTypeList: ['input', 'agentGenerated'],
-          selectedType: 'agentGenerated'
-        }
-      ]
-    });
+    // 入口 agent 参数不得写回父图；isEntry / 边 status 等副作用需要回写。
+    expect(runtimeNodes[0].inputs).toEqual([
+      {
+        key: 'q',
+        value: 'old',
+        renderTypeList: ['input', 'agentGenerated'],
+        selectedType: 'agentGenerated'
+      }
+    ]);
+    expect(runtimeNodes[0].isEntry).toBe(true);
     expect(runtimeEdges[0]).toEqual({
-      target: 'search'
+      target: 'search',
+      status: 'active'
     });
     expect(runWorkflowTool).toHaveBeenCalledWith({
       runtimeNodes: [
@@ -337,6 +336,90 @@ describe('createAgentLoopCoreWorkflowToolRunner', () => {
       interactive: undefined,
       stop: false
     });
+    // 交互恢复同样隔离执行；入口 inputs 仍不得被写回父图。
+    expect(runtimeNodes[0].inputs).toEqual([
+      {
+        key: 'q',
+        value: 'old',
+        renderTypeList: ['input', 'agentGenerated'],
+        selectedType: 'agentGenerated'
+      }
+    ]);
+  });
+
+  it('syncs non-entry side effects from isolated tool run back to parent', async () => {
+    const runtimeNodes = [
+      {
+        nodeId: 'tool_entry',
+        inputs: [
+          {
+            key: 'q',
+            value: 'default',
+            renderTypeList: ['input', 'agentGenerated'],
+            selectedType: 'agentGenerated'
+          }
+        ],
+        outputs: [{ id: 'out1', key: 'out1', value: undefined }]
+      },
+      {
+        nodeId: 'other_node',
+        inputs: [{ key: 'x', value: 'keep' }],
+        outputs: [{ id: 'var1', key: 'var1', value: 'before' }]
+      }
+    ];
+    const runtimeEdges = [
+      {
+        source: 'a',
+        sourceHandle: 's',
+        target: 'tool_entry',
+        targetHandle: 't',
+        status: 'waiting'
+      }
+    ];
+    const runWorkflowTool = vi.fn(async ({ runtimeNodes: nodes, runtimeEdges: edges }) => {
+      // 模拟变量更新节点写非入口节点 output，以及交互相关 runtime 状态变更。
+      nodes[1].outputs[0].value = 'after-update';
+      nodes[1].inputs[0].value = 'mutated-input';
+      nodes[1].isEntry = true;
+      edges[0].status = 'active';
+      return {
+        toolResponses: 'ok',
+        assistantResponses: [],
+        flowUsages: [],
+        flowResponses: []
+      };
+    });
+    const { runTool } = createRunner({
+      runtimeNodes,
+      runtimeEdges,
+      runWorkflowTool,
+      getToolInfo: () => ({
+        type: 'user',
+        name: 'Tool',
+        avatar: 'tool-avatar',
+        rawData: {
+          nodeId: 'tool_entry'
+        }
+      })
+    });
+
+    await runTool({
+      call: createCall({
+        id: 'call_1',
+        name: 'tool_entry',
+        args: '{"q":"from-agent"}'
+      })
+    });
+
+    // 入口 agent 参数不得粘在父图上。
+    expect(runtimeNodes[0].inputs).toEqual([
+      expect.objectContaining({ key: 'q', value: 'default' })
+    ]);
+    // 非入口节点的 inputs/outputs/isEntry 与边 status 需要回写。
+    expect(runtimeNodes[1].outputs[0].value).toBe('after-update');
+    expect(runtimeNodes[1].inputs[0].value).toBe('mutated-input');
+    expect(runtimeNodes[1].isEntry).toBe(true);
+    expect(runtimeEdges[0].status).toBe('active');
   });
 
   it('does not retain omitted agent-generated params across same-turn tool calls', async () => {

--- a/packages/service/test/core/workflow/dispatch/ai/agentLoopCore/runtime/workflowToolRunner.test.ts
+++ b/packages/service/test/core/workflow/dispatch/ai/agentLoopCore/runtime/workflowToolRunner.test.ts
@@ -236,21 +236,42 @@ describe('createAgentLoopCoreWorkflowToolRunner', () => {
 
     const result = await runTool({ call });
 
+    // runTool 使用子图快照，不应污染父流程共享的 runtimeNodes/runtimeEdges。
     expect(runtimeNodes[0]).toEqual({
       nodeId: 'search',
-      isEntry: true,
       inputs: [
         {
           key: 'q',
+          value: 'old',
           renderTypeList: ['input', 'agentGenerated'],
-          selectedType: 'agentGenerated',
-          value: 'FastGPT'
+          selectedType: 'agentGenerated'
         }
       ]
     });
     expect(runtimeEdges[0]).toEqual({
-      target: 'search',
-      status: 'active'
+      target: 'search'
+    });
+    expect(runWorkflowTool).toHaveBeenCalledWith({
+      runtimeNodes: [
+        {
+          nodeId: 'search',
+          isEntry: true,
+          inputs: [
+            {
+              key: 'q',
+              renderTypeList: ['input', 'agentGenerated'],
+              selectedType: 'agentGenerated',
+              value: 'FastGPT'
+            }
+          ]
+        }
+      ],
+      runtimeEdges: [
+        {
+          target: 'search',
+          status: 'active'
+        }
+      ]
     });
     expect(result.response).toBe(JSON.stringify({ answer: 'workflow ok' }, null, 2));
     expect(result.usages).toEqual([usage]);
@@ -316,5 +337,77 @@ describe('createAgentLoopCoreWorkflowToolRunner', () => {
       interactive: undefined,
       stop: false
     });
+  });
+
+  it('does not retain omitted agent-generated params across same-turn tool calls', async () => {
+    const runtimeNodes = [
+      {
+        nodeId: 'mcp_tool',
+        inputs: [
+          {
+            key: 'query',
+            value: '',
+            renderTypeList: ['input', 'agentGenerated'],
+            selectedType: 'agentGenerated'
+          },
+          {
+            key: 'filter',
+            value: '',
+            renderTypeList: ['input', 'agentGenerated'],
+            selectedType: 'agentGenerated'
+          }
+        ]
+      }
+    ];
+    const runtimeEdges = [{ target: 'mcp_tool' }];
+    const runWorkflowTool = vi.fn().mockResolvedValue({
+      toolResponses: 'ok',
+      assistantResponses: [],
+      flowUsages: [],
+      flowResponses: []
+    });
+    const { runTool } = createRunner({
+      runtimeNodes,
+      runtimeEdges,
+      runWorkflowTool,
+      getToolInfo: () => ({
+        type: 'user',
+        name: 'MCP tool',
+        avatar: 'tool-avatar',
+        rawData: {
+          nodeId: 'mcp_tool'
+        }
+      })
+    });
+
+    await runTool({
+      call: createCall({
+        id: 'call_1',
+        name: 'mcp_tool',
+        args: '{"query":"A","filter":"x"}'
+      })
+    });
+    await runTool({
+      call: createCall({
+        id: 'call_2',
+        name: 'mcp_tool',
+        args: '{"query":"B"}'
+      })
+    });
+
+    expect(runWorkflowTool).toHaveBeenCalledTimes(2);
+    expect(runWorkflowTool.mock.calls[0][0].runtimeNodes[0].inputs).toEqual([
+      expect.objectContaining({ key: 'query', value: 'A' }),
+      expect.objectContaining({ key: 'filter', value: 'x' })
+    ]);
+    // 第二次 LLM 未传 filter 时，应回退节点默认值，而不是残留第一次的 "x"。
+    expect(runWorkflowTool.mock.calls[1][0].runtimeNodes[0].inputs).toEqual([
+      expect.objectContaining({ key: 'query', value: 'B' }),
+      expect.objectContaining({ key: 'filter', value: '' })
+    ]);
+    expect(runtimeNodes[0].inputs).toEqual([
+      expect.objectContaining({ key: 'query', value: '' }),
+      expect.objectContaining({ key: 'filter', value: '' })
+    ]);
   });
 });


### PR DESCRIPTION
## What Problem
Fixes #7722

In the same agent turn, a second workflow-tool call can keep parameter values left over from the previous tool call when the LLM omits those keys.

## Why
`runTool` was writing LLM params onto the shared `runtimeNodes` graph. Later tools in the same turn then saw the mutated nodes. Dataset search already cloned; workflow tools did not.

## How Verified
- Added/updated unit coverage in `workflowToolRunner.test.ts` for same-turn residual params
- `pnpm --filter @fastgpt/service exec vitest run -c vitest.config.ts test/core/workflow/dispatch/ai/agentLoopCore/runtime/workflowToolRunner.test.ts` → 6/6 passed