### PR TITLE
fix(workflow): isolate tool runtime state and restore interactive memory

### DIFF
--- a/packages/global/core/workflow/runtime/utils.ts
+++ b/packages/global/core/workflow/runtime/utils.ts
@@ -419,10 +419,12 @@ export function rewriteNodeOutputByHistories(
       outputs: node.outputs.map((output: FlowNodeOutputItemType) => {
         return {
           ...output,
-          value:
-            interactive?.nodeOutputs?.find(
+          value: (() => {
+            const nodeOutput = interactive.nodeOutputs?.find(
               (item: NodeOutputItemType) => item.nodeId === node.nodeId && item.key === output.key
-            )?.value || output?.value
+            );
+            return nodeOutput ? nodeOutput.value : output.value;
+          })()
         };
       })
     };

--- a/packages/service/core/workflow/dispatch/ai/agentLoopCore/application/runtime/workflowToolRunner.ts
+++ b/packages/service/core/workflow/dispatch/ai/agentLoopCore/application/runtime/workflowToolRunner.ts
@@ -19,6 +19,11 @@ import type { AgentLoopCoreToolRunFlowResponse } from '../../adapter/nodeRespons
 import { normalizeAgentLoopCoreDatasetSearchResult } from './systemToolHelpers';
 import { cloneDeep } from 'lodash-es';
 import { compileToolRuntime, mergeToolRuntimeParams } from '@fastgpt/global/core/app/tool/runtime';
+import { rewriteNodeOutputByHistories } from '@fastgpt/global/core/workflow/runtime/utils';
+import {
+  createContainerRunStateSnapshot,
+  syncContainerRunState
+} from '../../../../utils/containerRunState';
 
 export type AgentLoopCoreWorkflowToolRunResponse<TChildrenResponse = unknown> = {
   flowResponses: NonNullable<DispatchFlowResponse['flatNodeResponses']>;
@@ -310,8 +315,8 @@ export const createAgentLoopCoreWorkflowSystemToolExecutor = <TChildrenResponse 
  * ToolCall 和未来的简化 Agent 都可以把“某个 runtime node 作为工具入口运行”的能力交给这里。
  * 节点外壳只负责提供实际 runWorkflow 函数、展示信息和缓存/流式回调。
  *
- * 已知问题：普通 Workflow Tool 的首次执行和交互恢复都会复用并修改父流程的 runtime graph。
- * 当前保留原有状态传递行为，后续需要通过子流程快照和显式同步完成隔离。
+ * 普通调用和交互恢复均隔离输入、入口和连线状态；本次改变的节点输出显式回写父图。
+ * 全局变量继续使用调用方传入的共享 variableState，不随 runtime graph 复制。
  */
 export const createAgentLoopCoreWorkflowToolRunner = <TChildrenResponse = unknown>({
   runtimeNodes,
@@ -320,6 +325,61 @@ export const createAgentLoopCoreWorkflowToolRunner = <TChildrenResponse = unknow
   runWorkflowTool,
   cacheToolFlowResponse
 }: CreateAgentLoopCoreWorkflowToolRunnerParams<TChildrenResponse>) => {
+  /**
+   * 在独立子图上执行，并提交本轮改变的输出值。Workflow Tool 没有容器专属的节点集合，
+   * 工具自身及其他节点的输出都可能被父流程引用，因此保留所有现存节点的输出同步。
+   * 仅同步相对调用开始发生变化的值，避免旧快照覆盖其他调用已更新的无关输出。
+   */
+  const runIsolatedWorkflowTool = async ({
+    entryNodeIds,
+    startParams,
+    lastInteractive
+  }: {
+    entryNodeIds: string[];
+    startParams?: Record<string, any>;
+    lastInteractive?: TChildrenResponse;
+  }) => {
+    const isolatedRuntimeNodes = cloneDeep(runtimeNodes);
+    const isolatedRuntimeEdges = cloneDeep(runtimeEdges);
+    const stateSnapshot = createContainerRunStateSnapshot({
+      nodes: isolatedRuntimeNodes,
+      childrenNodeIdList: []
+    });
+    if (lastInteractive) {
+      const interactive = lastInteractive as {
+        nodeOutputs?: any[];
+        memoryEdges?: RuntimeEdgeItemType[];
+      };
+      const restoredNodes = rewriteNodeOutputByHistories(isolatedRuntimeNodes, interactive as any);
+      isolatedRuntimeNodes.splice(0, isolatedRuntimeNodes.length, ...restoredNodes);
+      if (interactive.memoryEdges?.length) {
+        isolatedRuntimeEdges.splice(
+          0,
+          isolatedRuntimeEdges.length,
+          ...cloneDeep(interactive.memoryEdges)
+        );
+      }
+    }
+    initAgentLoopCoreWorkflowToolNodes(isolatedRuntimeNodes, entryNodeIds, startParams);
+    initAgentLoopCoreWorkflowToolEdges(isolatedRuntimeEdges, entryNodeIds);
+
+    try {
+      return await runWorkflowTool({
+        runtimeNodes: isolatedRuntimeNodes,
+        runtimeEdges: isolatedRuntimeEdges,
+        ...(lastInteractive !== undefined ? { lastInteractive } : {})
+      });
+    } finally {
+      // 暂停或后续执行失败也保留已经发生的输出更新，与全局变量的即时写入语义一致。
+      await syncContainerRunState({
+        sourceNodes: isolatedRuntimeNodes,
+        targetNodes: runtimeNodes,
+        childrenNodeIdList: [],
+        stateSnapshot
+      });
+    }
+  };
+
   const runTool = async ({
     call
   }: {
@@ -351,12 +411,9 @@ export const createAgentLoopCoreWorkflowToolRunner = <TChildrenResponse = unknow
     }
 
     const startParams = parseJsonArgs(call.function.arguments) ?? {};
-    initAgentLoopCoreWorkflowToolNodes(runtimeNodes, [toolInfo.rawData.nodeId], startParams);
-    initAgentLoopCoreWorkflowToolEdges(runtimeEdges, [toolInfo.rawData.nodeId]);
-
-    const toolRunResponse = await runWorkflowTool({
-      runtimeNodes,
-      runtimeEdges
+    const toolRunResponse = await runIsolatedWorkflowTool({
+      entryNodeIds: [toolInfo.rawData.nodeId],
+      startParams
     });
     const { result, flowResponse } = toToolRunResult<TChildrenResponse>(toolRunResponse);
 
@@ -379,12 +436,8 @@ export const createAgentLoopCoreWorkflowToolRunner = <TChildrenResponse = unknow
     const entryNodeIds = (childrenResponse as { entryNodeIds?: string[] }).entryNodeIds ?? [];
 
     // 交互恢复沿用原 toolCallId，最终仍由统一 tool_run_end 落 SSE 和运行详情。
-    initAgentLoopCoreWorkflowToolNodes(runtimeNodes, entryNodeIds);
-    initAgentLoopCoreWorkflowToolEdges(runtimeEdges, entryNodeIds);
-
-    const toolRunResponse = await runWorkflowTool({
-      runtimeNodes,
-      runtimeEdges,
+    const toolRunResponse = await runIsolatedWorkflowTool({
+      entryNodeIds,
       lastInteractive: childrenResponse
     });
     const { result, flowResponse } = toToolRunResult<TChildrenResponse>(toolRunResponse);

--- a/packages/service/core/workflow/dispatch/index.ts
+++ b/packages/service/core/workflow/dispatch/index.ts
@@ -1521,7 +1521,7 @@ export class WorkflowQueue {
     const nodeOutputs: NodeOutputItemType[] = [];
     this.data.runtimeNodes.forEach((node) => {
       node.outputs.forEach((output) => {
-        if (output.value) {
+        if (output.value !== undefined) {
           nodeOutputs.push({
             nodeId: node.nodeId,
             key: output.key as NodeOutputKeyEnum,

--- a/packages/service/core/workflow/dispatch/utils/containerRunState.ts
+++ b/packages/service/core/workflow/dispatch/utils/containerRunState.ts
@@ -26,7 +26,7 @@ const createExternalOutputSnapshot = ({
   nodes.forEach((node) => {
     if (childrenSet.has(node.nodeId)) return;
 
-    node.outputs.forEach((output) => {
+    (node.outputs ?? []).forEach((output) => {
       snapshot.set(
         getOutputSnapshotKey({ nodeId: node.nodeId, outputId: output.id }),
         cloneDeep(output.value)
@@ -83,8 +83,10 @@ const syncExternalNodeOutputs = ({
     const sourceNode = sourceNodesMap.get(targetNode.nodeId);
     if (!sourceNode) return;
 
-    const sourceOutputMap = new Map(sourceNode.outputs.map((output) => [output.id, output]));
-    targetNode.outputs.forEach((targetOutput) => {
+    const sourceOutputMap = new Map(
+      (sourceNode.outputs ?? []).map((output) => [output.id, output])
+    );
+    (targetNode.outputs ?? []).forEach((targetOutput) => {
       const sourceOutput = sourceOutputMap.get(targetOutput.id);
       if (!sourceOutput) return;
 

--- a/packages/service/test/core/workflow/dispatch/ai/agentLoopCore/runtime/workflowToolRunner.test.ts
+++ b/packages/service/test/core/workflow/dispatch/ai/agentLoopCore/runtime/workflowToolRunner.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createAgentLoopCoreWorkflowToolRunner } from '@fastgpt/service/core/workflow/dispatch/ai/agentLoopCore/application/runtime/workflowToolRunner';
+import { dispatchUpdateVariable } from '@fastgpt/service/core/workflow/dispatch/tools/runUpdateVar';
 
 const createCall = ({
   id = 'call_1',
@@ -49,6 +50,144 @@ const createRunner = ({
 describe('createAgentLoopCoreWorkflowToolRunner', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it.each(['call', 'resume'] as const)(
+    'syncs real variable-update writes to parent outputs during %s without leaking inputs',
+    async (mode) => {
+      const runtimeNodes = [
+        { nodeId: 'search', inputs: [], outputs: [] },
+        {
+          nodeId: 'parent',
+          inputs: [],
+          outputs: [
+            { id: 'count', value: 10 },
+            { id: 'enabled', value: true },
+            { id: 'text', value: 'old' }
+          ]
+        }
+      ];
+      const runtimeEdges = [{ target: 'search', status: 'waiting' }];
+      const originalOutput = runtimeNodes[1].outputs[0];
+      const runWorkflowTool = vi.fn(async ({ runtimeNodes: childNodes, runtimeEdges }) => {
+        await dispatchUpdateVariable({
+          params: {
+            updateList: [
+              { variable: ['parent', 'count'], value: ['', 0], valueType: 'number' },
+              { variable: ['parent', 'enabled'], value: ['', false], valueType: 'boolean' },
+              { variable: ['parent', 'text'], value: ['', ''], valueType: 'string' }
+            ].map((item) => ({ ...item, renderType: 'input' }))
+          },
+          runtimeNodesMap: new Map(childNodes.map((node: any) => [node.nodeId, node])),
+          variableState: { toRuntimeRecord: () => ({}), toStoreRecord: () => ({}) },
+          runningAppInfo: {}
+        } as any);
+        childNodes[0].inputs.push({ key: 'leaked', value: 'bad' });
+        runtimeEdges[0].status = 'skipped';
+        return {
+          flowResponses: [],
+          flowUsages: [],
+          assistantResponses: [],
+          toolResponses: 'updated',
+          workflowInteractiveResponse: { entryNodeIds: ['search'] }
+        };
+      });
+      const runner = createRunner({
+        runtimeNodes,
+        runtimeEdges,
+        runWorkflowTool,
+        getToolInfo: () => ({ type: 'user', rawData: { nodeId: 'search' } })
+      });
+      if (mode === 'call') {
+        await runner.runTool({ call: createCall() });
+      } else {
+        await runner.runInteractiveTool({
+          childrenResponse: { entryNodeIds: ['search'] },
+          toolParams: { toolCallId: 'resume' }
+        } as any);
+      }
+
+      expect(runtimeNodes[1].outputs).toEqual([
+        { id: 'count', value: 0 },
+        { id: 'enabled', value: false },
+        { id: 'text', value: '' }
+      ]);
+      expect(runtimeNodes[1].outputs[0]).toBe(originalOutput);
+      expect(runtimeNodes[0].inputs).toEqual([]);
+      expect(runtimeNodes[0]).not.toHaveProperty('isEntry');
+      expect(runtimeEdges[0].status).toBe('waiting');
+    }
+  );
+
+  it('retains completed output writes when a later execution step throws', async () => {
+    const runtimeNodes = [{ nodeId: 'search', inputs: [], outputs: [{ id: 'value', value: 1 }] }];
+    const error = new Error('later step failed');
+    const runner = createRunner({
+      runtimeNodes,
+      getToolInfo: () => ({ type: 'user', rawData: { nodeId: 'search' } }),
+      runWorkflowTool: vi.fn(async ({ runtimeNodes }) => {
+        runtimeNodes[0].outputs[0].value = 2;
+        throw error;
+      })
+    });
+    await expect(runner.runTool({ call: createCall() })).rejects.toBe(error);
+    expect(runtimeNodes[0].outputs[0].value).toBe(2);
+  });
+
+  it('does not overwrite unrelated output changes from another concurrent call', async () => {
+    const runtimeNodes = [
+      {
+        nodeId: 'search',
+        inputs: [],
+        outputs: [
+          { id: 'first', value: { count: 0 } },
+          { id: 'second', value: { count: 0 } }
+        ]
+      }
+    ];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let firstChild: any;
+    const runWorkflowTool = vi
+      .fn()
+      .mockImplementationOnce(async ({ runtimeNodes }) => {
+        firstChild = runtimeNodes;
+        runtimeNodes[0].outputs[0].value.count = 1;
+        await firstGate;
+        return {
+          flowResponses: [],
+          flowUsages: [],
+          assistantResponses: [],
+          toolResponses: 'first'
+        };
+      })
+      .mockImplementationOnce(async ({ runtimeNodes }) => {
+        runtimeNodes[0].outputs[1].value.count = 2;
+        return {
+          flowResponses: [],
+          flowUsages: [],
+          assistantResponses: [],
+          toolResponses: 'second'
+        };
+      });
+    const runner = createRunner({
+      runtimeNodes,
+      runWorkflowTool,
+      getToolInfo: () => ({ type: 'user', rawData: { nodeId: 'search' } })
+    });
+    const first = runner.runTool({ call: createCall() });
+    await runner.runTool({ call: createCall({ id: 'second' }) });
+    releaseFirst();
+    await first;
+
+    expect(runtimeNodes[0].outputs.map((output) => output.value)).toEqual([
+      { count: 1 },
+      { count: 2 }
+    ]);
+    firstChild[0].outputs[0].value.count = 99;
+    expect(runtimeNodes[0].outputs[0].value.count).toBe(1);
   });
 
   it('returns a stable not-found result without caching flow response', async () => {
@@ -158,6 +297,7 @@ describe('createAgentLoopCoreWorkflowToolRunner', () => {
     const runtimeNodes = [
       {
         nodeId: 'search',
+        outputs: [],
         inputs: [
           {
             key: 'q',
@@ -238,19 +378,34 @@ describe('createAgentLoopCoreWorkflowToolRunner', () => {
 
     expect(runtimeNodes[0]).toEqual({
       nodeId: 'search',
-      isEntry: true,
+      outputs: [],
       inputs: [
         {
           key: 'q',
           renderTypeList: ['input', 'agentGenerated'],
           selectedType: 'agentGenerated',
-          value: 'FastGPT'
+          value: 'old'
         }
       ]
     });
-    expect(runtimeEdges[0]).toEqual({
-      target: 'search',
-      status: 'active'
+    expect(runtimeEdges[0]).toEqual({ target: 'search' });
+    expect(runWorkflowTool).toHaveBeenCalledWith({
+      runtimeNodes: [
+        {
+          nodeId: 'search',
+          outputs: [],
+          isEntry: true,
+          inputs: [
+            {
+              key: 'q',
+              renderTypeList: ['input', 'agentGenerated'],
+              selectedType: 'agentGenerated',
+              value: 'FastGPT'
+            }
+          ]
+        }
+      ],
+      runtimeEdges: [{ target: 'search', status: 'active' }]
     });
     expect(result.response).toBe(JSON.stringify({ answer: 'workflow ok' }, null, 2));
     expect(result.usages).toEqual([usage]);
@@ -316,5 +471,79 @@ describe('createAgentLoopCoreWorkflowToolRunner', () => {
       interactive: undefined,
       stop: false
     });
+    expect(runtimeNodes[0].inputs[0].value).toBe('old');
+    expect(runtimeNodes[0]).not.toHaveProperty('isEntry');
+    expect(runtimeEdges[0]).not.toHaveProperty('status');
+  });
+
+  it('isolates input values between repeated calls to the same tool', async () => {
+    const runtimeNodes = [
+      {
+        nodeId: 'search',
+        outputs: [],
+        inputs: [
+          { key: 'query', value: 'default', renderTypeList: ['agentGenerated'] },
+          { key: 'filter', value: 'default-filter', renderTypeList: ['agentGenerated'] }
+        ]
+      }
+    ];
+    const runtimeEdges = [{ target: 'search' }];
+    const runWorkflowTool = vi.fn().mockResolvedValue({
+      toolResponses: 'ok',
+      assistantResponses: [],
+      flowUsages: [],
+      flowResponses: []
+    });
+    const { runTool } = createRunner({
+      runtimeNodes,
+      runtimeEdges,
+      runWorkflowTool,
+      getToolInfo: () => ({ type: 'user', rawData: { nodeId: 'search' } })
+    });
+
+    await runTool({ call: createCall({ args: '{"query":"A","filter":"x"}' }) });
+    await runTool({ call: createCall({ id: 'call_2', args: '{"query":"B"}' }) });
+
+    expect(runtimeNodes[0].inputs).toEqual([
+      { key: 'query', value: 'default', renderTypeList: ['agentGenerated'] },
+      { key: 'filter', value: 'default-filter', renderTypeList: ['agentGenerated'] }
+    ]);
+    expect(runWorkflowTool.mock.calls[1][0].runtimeNodes[0].inputs).toEqual([
+      { key: 'query', value: 'B', renderTypeList: ['agentGenerated'] },
+      { key: 'filter', value: 'default-filter', renderTypeList: ['agentGenerated'] }
+    ]);
+  });
+
+  it('restores child interactive output and edge memory before resuming', async () => {
+    const runtimeNodes = [
+      { nodeId: 'search', inputs: [], outputs: [{ id: 'result', key: 'result', value: 'parent' }] }
+    ];
+    const runtimeEdges = [{ source: 'before', target: 'search', status: 'waiting' }];
+    let received: any;
+    const { runInteractiveTool } = createRunner({
+      runtimeNodes,
+      runtimeEdges,
+      getToolInfo: () => ({ type: 'user', rawData: { nodeId: 'search' } }),
+      runWorkflowTool: vi.fn(async (params) => {
+        received = params;
+        return { flowResponses: [], flowUsages: [], assistantResponses: [], toolResponses: 'ok' };
+      })
+    });
+
+    await runInteractiveTool({
+      childrenResponse: {
+        entryNodeIds: ['search'],
+        memoryEdges: [{ source: 'before', target: 'search', status: 'active' }],
+        nodeOutputs: [{ nodeId: 'search', key: 'result', value: false }]
+      },
+      toolParams: { toolCallId: 'resume' }
+    } as any);
+
+    expect(received.runtimeEdges).toEqual([
+      { source: 'before', target: 'search', status: 'active' }
+    ]);
+    expect(received.runtimeNodes[0].outputs[0].value).toBe(false);
+    expect(runtimeEdges[0].status).toBe('waiting');
+    expect(runtimeNodes[0].outputs[0].value).toBe(false);
   });
 });

--- a/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeUserSelect.tsx
+++ b/projects/app/src/pageComponents/app/detail/WorkflowComponents/Flow/nodes/NodeUserSelect.tsx
@@ -103,7 +103,9 @@ const NodeUserSelect = ({ data, selected }: NodeProps<FlowNodeItemType>) => {
                     nodeId={nodeId}
                     handleId={getHandleId(nodeId, 'source', item.key)}
                     position={Position.Right}
-                    translate={[34, 0]}
+                    // Handler 渲染在 DraggableInputList 的 flex 输入容器内；右侧删除按钮和 gap
+                    // 使该容器比节点内容区域缩进 24px，需要补偿后才能与节点右边缘对齐。
+                    translate={[58, 0]}
                   />
                 )
               }


### PR DESCRIPTION
## 问题
同一轮 Agent 对话内重复调用同一工具时，第二次 `tool_calls.arguments` 省略的参数会继承第一次调用写入 runtime node 的值，导致 MCP、插件和 Workflow Tool 收到错误参数。

## 修改
- 每次工具调用和交互恢复使用隔离的 runtime nodes/edges 快照。
- 将子流程实际变更的节点 outputs 显式同步回父流程，保留变量更新节点对其他节点输出的既有能力。
- 交互恢复时恢复子图的 `memoryEdges` 和 `nodeOutputs`。
- 修复交互 memory 对 `0`、`false`、空字符串的保存与恢复。
- 增加重复调用、交互恢复、失败同步和并发调用回归测试。

## 验证
- `workflowToolRunner.test.ts`（11 tests）
- `createToolCallToolProvider.test.ts`（5 tests）
- `runUpdateVar.test.ts`（43 tests）
- `variables.test.ts`（18 tests）
- `index.persistence.test.ts`（10 tests）
- `runtime/utils.test.ts`（138 tests）
- ESLint、Prettier、`git diff --check`
