### PR TITLE
ci: allow manual release tags

### DIFF
--- a/.github/workflows/build-admin.yml
+++ b/.github/workflows/build-admin.yml
@@ -2,6 +2,11 @@ name: Release FastGPT-pro
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Image version tag (e.g. v1.0.0)'
+        required: true
+        type: string
   push:
     tags:
       - "v*"
@@ -15,12 +20,21 @@ jobs:
       - name: Validate release version
         id: version
         env:
-          VERSION: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
           REF_TYPE: ${{ github.ref_type }}
-          CURRENT_REF: ${{ github.ref }}
+          TAG_VERSION: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [[ "$REF_TYPE" != "tag" || ! "$VERSION" =~ ^v ]]; then
-            echo "::error::Release workflow must run on a tag starting with v. Current ref: ${CURRENT_REF}"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            VERSION="$INPUT_VERSION"
+          elif [[ "$REF_TYPE" == "tag" ]]; then
+            VERSION="$TAG_VERSION"
+          else
+            echo "::error::Workflow must be triggered by a tag or workflow_dispatch. Current event: ${EVENT_NAME}"
+            exit 1
+          fi
+          if [[ ! "$VERSION" =~ ^v ]]; then
+            echo "::error::Version must start with v. Current value: ${VERSION}"
             exit 1
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-fastgpt.yml
+++ b/.github/workflows/build-fastgpt.yml
@@ -2,6 +2,11 @@ name: Release FastGPT
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Image version tag (e.g. v1.0.0)'
+        required: true
+        type: string
   push:
     paths:
       - 'projects/app/**'
@@ -18,12 +23,21 @@ jobs:
       - name: Validate release version
         id: version
         env:
-          VERSION: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
           REF_TYPE: ${{ github.ref_type }}
-          CURRENT_REF: ${{ github.ref }}
+          TAG_VERSION: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [[ "$REF_TYPE" != "tag" || ! "$VERSION" =~ ^v ]]; then
-            echo "::error::Release workflow must run on a tag starting with v. Current ref: ${CURRENT_REF}"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            VERSION="$INPUT_VERSION"
+          elif [[ "$REF_TYPE" == "tag" ]]; then
+            VERSION="$TAG_VERSION"
+          else
+            echo "::error::Workflow must be triggered by a tag or workflow_dispatch. Current event: ${EVENT_NAME}"
+            exit 1
+          fi
+          if [[ ! "$VERSION" =~ ^v ]]; then
+            echo "::error::Version must start with v. Current value: ${VERSION}"
             exit 1
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 变更

- `Release FastGPT` 支持通过 `workflow_dispatch` 手动输入 `version`，无需先创建 Git tag 或 GitHub Release。
- `Release FastGPT-pro` 支持相同的手动输入方式。
- 通过 tag push 触发时仍使用原有的 tag，并保持 `v*` 校验。
- Forgejo 的 `build-fastgpt` 已具备相同的手动版本输入逻辑，无需额外修改；`build-admin` 当前没有 Forgejo 对应 workflow。

## 使用方式

在 GitHub Actions 中选择对应 workflow，点击 `Run workflow`，输入例如 `v4.17.1` 的版本 tag 即可执行镜像构建和发布，不需要创建 Git tag。

## 验证

- Prettier workflow 格式检查通过。
- `git diff --check` 通过。
